### PR TITLE
Add missing Document schema to prelude schemas

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/PreludeSchemas.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/PreludeSchemas.java
@@ -41,7 +41,8 @@ public final class PreludeSchemas {
         .type(ShapeType.BIG_DECIMAL)
         .id("smithy.api#BigDecimal")
         .build();
-
+    public static final SdkSchema DOCUMENT = SdkSchema.builder().type(ShapeType.DOCUMENT).id("smithy.api#Document").build();
+    
     // Primitive types
     public static final SdkSchema PRIMITIVE_BOOLEAN = SdkSchema.builder()
         .type(ShapeType.BOOLEAN)


### PR DESCRIPTION
*Description of changes:*
Add missing prelude document type to prelude schemas.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
