### PR TITLE
Wire example to execute codegen plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,11 +7,15 @@ repositories {
     gradlePluginPortal()
 }
 
+configurations {
+    implementation {
+        exclude module: 'groovy-all'
+    }
+}
+
 dependencies {
-    // Cannot currently use version catalog correctly with
-    // convention plugins
-    // see: https://github.com/gradle/gradle/issues/17963
-    implementation 'com.adarshr:gradle-test-logger-plugin:4.0.0'
-    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.9'
-    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
+    implementation(libs.test.logger.plugin)
+    implementation(libs.spotbugs)
+    implementation(libs.spotless)
+    implementation(libs.smithy.gradle.base)
 }

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.parallel=true
+org.gradle.jvmargs='-Dfile.encoding=UTF-8'

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,9 @@
+
+// Ensure version library is available to buildSrc plugins
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/smithy-java.codegen-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/smithy-java.codegen-test-conventions.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'smithy-java.java-conventions'
+    id "smithy-java.integ-test-conventions"
+    id 'software.amazon.smithy.gradle.smithy-base'
+}
+
+dependencies {
+    smithyBuild(project(":codegen"))
+}
+
+// Add generated Java sources to the main sourceset
+afterEvaluate {
+    var outputPath = smithy.getPluginProjectionPath(smithy.sourceProjection.get(), "java-codegen")
+    sourceSets {
+        main {
+            java {
+                srcDir(outputPath)
+            }
+        }
+    }
+}
+
+tasks.named("compileJava") {
+    dependsOn("smithyBuild")
+}

--- a/codegen/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
+++ b/codegen/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
@@ -31,7 +31,7 @@ public record JavaCodegenSettings(
      * @return Parsed settings
      */
     public static JavaCodegenSettings fromNode(ObjectNode settingsNode) {
-        settingsNode.warnIfAdditionalProperties(List.of(SERVICE));
+        settingsNode.warnIfAdditionalProperties(List.of(SERVICE, NAMESPACE));
         return new JavaCodegenSettings(
             settingsNode.expectStringMember(SERVICE).expectShapeId(),
             settingsNode.expectStringMember(NAMESPACE).getValue()

--- a/codegen/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
+++ b/codegen/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
@@ -178,12 +178,14 @@ public final class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolPro
 
     @Override
     public Symbol operationShape(OperationShape operationShape) {
+        // TODO: Implement
         return null;
     }
 
     @Override
     public Symbol resourceShape(ResourceShape resourceShape) {
-        throw new UnsupportedOperationException("Resource shapes do not generate Java types.");
+        // Resource shapes do not generate a Java type
+        return null;
     }
 
     @Override

--- a/examples/restjson-example/build.gradle
+++ b/examples/restjson-example/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id "smithy-java.java-conventions"
-    id "smithy-java.integ-test-conventions"
+    id "smithy-java.codegen-test-conventions"
     alias(libs.plugins.jmh)
 }
 
@@ -16,6 +15,12 @@ jmh {
 
 // TODO: eventually re-enable
 // Disable spotbugs
-tasks.named("spotbugsMain") {
-    enabled = false
+tasks {
+    spotbugsMain {
+        enabled = false
+    }
+
+    spotbugsIt {
+        enabled = false
+    }
 }

--- a/examples/restjson-example/model/common.smithy
+++ b/examples/restjson-example/model/common.smithy
@@ -1,0 +1,18 @@
+$version: "2"
+
+namespace smithy.example
+
+@streaming
+blob Stream
+
+@sensitive
+timestamp Birthday
+
+map MapListString {
+    key: String
+    value: ListOfString
+}
+
+list ListOfString {
+    member: String
+}

--- a/examples/restjson-example/model/errors.smithy
+++ b/examples/restjson-example/model/errors.smithy
@@ -1,0 +1,9 @@
+$version: "2"
+
+namespace smithy.example
+
+@error("server")
+structure ValidationError {
+    @required
+    message: String
+}

--- a/examples/restjson-example/model/main.smithy
+++ b/examples/restjson-example/model/main.smithy
@@ -1,0 +1,13 @@
+$version: "2"
+
+namespace smithy.example
+
+service PersonDirectory {
+    version: "01-01-2040"
+    resources: [
+        Person
+    ]
+    errors: [
+        ValidationError
+    ]
+}

--- a/examples/restjson-example/model/person-image.smithy
+++ b/examples/restjson-example/model/person-image.smithy
@@ -1,0 +1,49 @@
+$version: "2"
+
+namespace smithy.example
+
+resource PersonImage {
+    identifiers: { name: String }
+    read: GetPersonImage
+    put: PutPersonImage
+}
+
+@readonly
+@http(method: "GET", uri: "/persons/{name}/image", code: 200)
+operation GetPersonImage {
+    input := for PersonImage {
+        @required
+        @httpLabel
+        $name
+    }
+
+    output := for PersonImage {
+        @required
+        @httpHeader("Person-Name")
+        $name
+
+        @default(null)
+        @httpPayload
+        image: Stream
+    }
+}
+
+@idempotent
+@http(method: "PUT", uri: "/persons/{name}/images", code: 200)
+operation PutPersonImage {
+    input := for PersonImage {
+        @required
+        @httpLabel
+        $name
+
+        @httpHeader("Tags")
+        tags: String
+
+        @httpQuery("MoreTags")
+        moreTags: String
+
+        @default(null)
+        @httpPayload
+        image: Stream
+    }
+}

--- a/examples/restjson-example/model/person.smithy
+++ b/examples/restjson-example/model/person.smithy
@@ -1,0 +1,54 @@
+$version: "2"
+
+namespace smithy.example
+
+resource Person {
+    identifiers: { name: String }
+    properties: { favoriteColor: String, age: Integer, birthday: Birthday }
+    put: PutPerson
+    resources: [
+        PersonImage
+    ]
+}
+
+@idempotent
+@http(method: "PUT", uri: "/persons/{name}", code: 200)
+operation PutPerson {
+    input := for Person {
+        @httpLabel
+        @required
+        $name
+
+        @httpQuery("favoriteColor")
+        $favoriteColor
+
+        @jsonName("Age")
+        $age
+
+        $birthday
+
+        @notProperty
+        binary: Blob
+
+        @notProperty
+        @httpQueryParams
+        queryParams: MapListString
+    }
+
+    output := for Person {
+        @required
+        $name
+
+        @httpHeader("X-Favorite-Color")
+        $favoriteColor
+
+        @jsonName("Age")
+        $age
+
+        $birthday
+
+        @notProperty
+        @httpResponseCode
+        status: Integer
+    }
+}

--- a/examples/restjson-example/smithy-build.json
+++ b/examples/restjson-example/smithy-build.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "plugins": {
+    "java-codegen": {
+      "service": "smithy.example#PersonDirectory",
+      "namespace": "software.amazon.smithy.java.runtime.example.codegen"
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.parallel=true
+org.gradle.jvmargs='-Dfile.encoding=UTF-8'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,10 @@ hamcrest = "2.1"
 smithy = "1.47.0"
 jmh = "0.7.2"
 jsoniter = "0.9.23"
+test-logger-plugin = "4.0.0"
+spotbugs = "6.0.9"
+spotless = "6.25.0"
+smithy-gradle = "1.0.0"
 
 [libraries]
 smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy" }
@@ -17,6 +21,11 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 
+# plugin artifacts for buildsrc plugins
+test-logger-plugin = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "test-logger-plugin" }
+spotbugs = { module = "com.github.spotbugs.snom:spotbugs-gradle-plugin", version.ref = "spotbugs" }
+spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+smithy-gradle-base = { module = "software.amazon.smithy.gradle:smithy-base", version.ref = "smithy-gradle" }
 
 [plugins]
 jmh = { id = "me.champeau.jmh", version.ref = "jmh" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
*Description of changes:*
Adds a new buildSrc plugin that allows us to wire up examples to generate code using the code generation plugin and use that generated code. 

Also tweaks some gradle settings to improve build performance and allow buildSrc to use version library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
