### PR TITLE
Add support for enum and intEnum schema values

### DIFF
--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/SdkSchemaTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/SdkSchemaTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.schema;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.shapes.ShapeType;
+
+public class SdkSchemaTest {
+    @Test
+    public void intEnumRequiresIntEnumSchema() {
+        Assertions.assertThrows(SdkException.class, () -> {
+            SdkSchema.builder()
+                .type(ShapeType.STRING)
+                .id("smithy.example#Foo")
+                .intEnumValues(1, 2, 3)
+                .build();
+        });
+    }
+
+    @Test
+    public void enumRequiresStringSchema() {
+        Assertions.assertThrows(SdkException.class, () -> {
+            SdkSchema.builder()
+                .type(ShapeType.INTEGER)
+                .id("smithy.example#Foo")
+                .stringEnumValues("a", "b")
+                .build();
+        });
+    }
+
+    @Test
+    public void enumWorksWithEnumSchema() {
+        var schema = SdkSchema.builder()
+            .id("smithy.example#Foo")
+            .type(ShapeType.ENUM)
+            .stringEnumValues("a", "b")
+            .build();
+
+        assertThat(schema.stringEnumValues(), containsInAnyOrder("a", "b"));
+    }
+
+    @Test
+    public void intEnumWorksWithIntEnumSchema() {
+        var schema = SdkSchema.builder()
+            .id("smithy.example#Foo")
+            .type(ShapeType.INT_ENUM)
+            .intEnumValues(1, 2, 3)
+            .build();
+
+        assertThat(schema.intEnumValues(), containsInAnyOrder(1, 2, 3));
+    }
+}


### PR DESCRIPTION
The Smithy data model is more primitive than enum and intEnum shapes, so this adds access to their variants through SdkSchema.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
