### PR TITLE
Serialize documents as document w/ separate serde

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -169,9 +169,9 @@ public interface ShapeSerializer extends Flushable {
     /**
      * Serialize a document shape.
      *
+     * <p>The underlying contents of the document can be serialized using {@link Document#serializeContents}.
+     *
      * @param value  Value to serialize.
      */
-    default void writeDocument(Document value) {
-        writeShape(value);
-    }
+    void writeDocument(Document value);
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
@@ -217,9 +217,10 @@ public final class ToStringSerializer implements ShapeSerializer {
 
     @Override
     public void writeDocument(Document value) {
-        append("Document (" + value.type()).append(") :");
-        append(System.lineSeparator());
+        append("Document (" + value.type()).append("):");
         indent();
-        value.serialize(this);
+        append(System.lineSeparator());
+        value.serializeContents(this);
+        dedent();
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentParser.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentParser.java
@@ -155,5 +155,10 @@ final class DocumentParser implements ShapeSerializer {
     }
 
     @Override
+    public void writeDocument(Document value) {
+        value.serializeContents(this);
+    }
+
+    @Override
     public void flush() {}
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -35,7 +35,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBoolean(PreludeSchemas.BOOLEAN, value);
         }
     }
@@ -87,7 +87,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeByte(PreludeSchemas.BYTE, value);
         }
     }
@@ -139,7 +139,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeShort(PreludeSchemas.SHORT, value);
         }
     }
@@ -191,7 +191,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeInteger(PreludeSchemas.INTEGER, value);
         }
     }
@@ -243,7 +243,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeLong(PreludeSchemas.LONG, value);
         }
     }
@@ -295,7 +295,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeFloat(PreludeSchemas.FLOAT, value);
         }
     }
@@ -347,7 +347,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeDouble(PreludeSchemas.DOUBLE, value);
         }
     }
@@ -399,7 +399,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBigInteger(PreludeSchemas.BIG_INTEGER, value);
         }
     }
@@ -451,7 +451,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBigDecimal(PreludeSchemas.BIG_DECIMAL, value);
         }
     }
@@ -468,7 +468,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeString(PreludeSchemas.STRING, value);
         }
     }
@@ -485,7 +485,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBlob(PreludeSchemas.BLOB, value);
         }
 
@@ -520,7 +520,7 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.writeTimestamp(PreludeSchemas.TIMESTAMP, value);
         }
     }
@@ -537,8 +537,12 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
-            serializer.beginList(PreludeSchemas.DOCUMENT, ser -> values().forEach(value -> value.serialize(ser)));
+        public void serializeContents(ShapeSerializer serializer) {
+            serializer.beginList(PreludeSchemas.DOCUMENT, ser -> {
+                for (var element : values) {
+                    element.serializeContents(ser);
+                }
+            });
         }
     }
 
@@ -565,11 +569,11 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer serializer) {
+        public void serializeContents(ShapeSerializer serializer) {
             serializer.beginMap(PreludeSchemas.DOCUMENT, s -> {
                 for (var entry : members.entrySet()) {
                     Document key = entry.getKey();
-                    Consumer<ShapeSerializer> valueSer = ser -> entry.getValue().serialize(ser);
+                    Consumer<ShapeSerializer> valueSer = ser -> entry.getValue().serializeContents(ser);
                     switch (key.type()) {
                         case STRING, ENUM -> s.entry(entry.getKey().asString(), valueSer);
                         case INTEGER, INT_ENUM -> s.entry(entry.getKey().asInteger(), valueSer);
@@ -602,11 +606,10 @@ final class Documents {
         }
 
         @Override
-        public void serialize(ShapeSerializer encoder) {
+        public void serializeContents(ShapeSerializer encoder) {
             var structSerializer = encoder.beginStruct(PreludeSchemas.DOCUMENT);
-            var i = 0;
             for (var entry : members.entrySet()) {
-                structSerializer.member(syntheticMember(entry.getKey()), entry.getValue()::serialize);
+                structSerializer.member(syntheticMember(entry.getKey()), entry.getValue()::serializeContents);
             }
             structSerializer.endStruct();
         }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMember.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMember.java
@@ -47,7 +47,7 @@ final class TypedDocumentMember implements Document {
     }
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
+    public void serializeContents(ShapeSerializer encoder) {
         memberWriter.accept(encoder);
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BigDecimalDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BigDecimalDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,18 @@ public class BigDecimalDocumentTest {
     public void serializesShape() {
         var document = Document.of(new BigDecimal(10));
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        var document = Document.of(new BigDecimal(10));
+
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
             public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
@@ -39,6 +52,6 @@ public class BigDecimalDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BigIntegerDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BigIntegerDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,18 @@ public class BigIntegerDocumentTest {
     public void serializesShape() {
         var document = Document.of(BigInteger.valueOf(10));
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        var document = Document.of(BigInteger.valueOf(10));
+
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
             public void writeBigInteger(SdkSchema schema, BigInteger value) {
@@ -39,6 +52,6 @@ public class BigIntegerDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,18 @@ public class BlobDocumentTest {
     public void serializesShape() {
         var document = Document.of("hi".getBytes(StandardCharsets.UTF_8));
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContents() {
+        var document = Document.of("hi".getBytes(StandardCharsets.UTF_8));
+
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
             public void writeBlob(SdkSchema schema, byte[] value) {
@@ -39,6 +52,6 @@ public class BlobDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BooleanDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BooleanDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -29,6 +30,18 @@ public class BooleanDocumentTest {
     public void serializesShape() {
         var document = Document.of(true);
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        var document = Document.of(true);
+
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
             public void writeBoolean(SdkSchema schema, boolean value) {
@@ -37,6 +50,6 @@ public class BooleanDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ByteDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ByteDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -30,6 +31,18 @@ public class ByteDocumentTest {
     public void serializesShape() {
         var document = Document.of((byte) 1);
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        var document = Document.of((byte) 1);
+
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
             public void writeByte(SdkSchema schema, byte value) {
@@ -38,7 +51,7 @@ public class ByteDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 
     @Test

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentMapTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentMapTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.util.HashMap;
 import java.util.List;
@@ -23,10 +24,10 @@ import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 public class DocumentMapTest {
     @ParameterizedTest
     @MethodSource("mapProvider")
-    public void serializesMaps(Map<Document, Document> mapOfXtoString) {
+    public void serializesMapContents(Map<Document, Document> mapOfXtoString) {
         var document = Document.ofMap(mapOfXtoString);
         Map<Document, Document> received = new HashMap<>();
-        document.serialize(new SpecificShapeSerializer() {
+        document.serializeContents(new SpecificShapeSerializer() {
             @Override
             public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
                 consumer.accept(new MapSerializer() {
@@ -63,7 +64,16 @@ public class DocumentMapTest {
             }
         });
 
+        // Ensure the contents were serialized as expected.
         assertThat(received, equalTo(mapOfXtoString));
+
+        // Ensure documents are always serialized as a document.
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
     }
 
     public static List<Arguments> mapProvider() {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DoubleDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DoubleDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -30,6 +31,18 @@ public class DoubleDocumentTest {
     public void serializesShape() {
         var document = Document.of(1.0);
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        var document = Document.of(1.0);
+
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
             public void writeDouble(SdkSchema schema, double value) {
@@ -38,6 +51,6 @@ public class DoubleDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/FloatDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/FloatDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -30,6 +31,18 @@ public class FloatDocumentTest {
     public void serializesShape() {
         var document = Document.of(1.0f);
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        var document = Document.of(1.0f);
+
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
             public void writeFloat(SdkSchema schema, float value) {
@@ -38,7 +51,7 @@ public class FloatDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 
     @Test

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/IntegerDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/IntegerDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -28,6 +29,18 @@ public class IntegerDocumentTest {
 
     @Test
     public void serializesShape() {
+        var document = Document.of(1);
+
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
         var document = Document.of(10);
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
@@ -38,7 +51,7 @@ public class IntegerDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 
     @Test

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +34,18 @@ public class ListDocumentTest {
 
     @Test
     public void serializesShape() {
+        var document = Document.of(List.of(Document.of("a"), Document.of("b")));
+
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContents() {
         List<Document> values = List.of(Document.of("a"), Document.of("b"));
         var document = Document.of(values);
 
@@ -52,7 +65,7 @@ public class ListDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
 
         assertThat(writtenStrings, contains("a", "b"));
     }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/LongDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/LongDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -28,6 +29,18 @@ public class LongDocumentTest {
 
     @Test
     public void serializesShape() {
+        var document = Document.of(1L);
+
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
         var document = Document.of(10L);
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
@@ -38,6 +51,6 @@ public class LongDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
@@ -48,8 +48,26 @@ public class MapDocumentTest {
         );
         var map = Document.ofMap(entries);
 
-        var keys = new ArrayList<>();
         map.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(map));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        Map<Document, Document> entries = Map.of(
+            Document.of("a"),
+            Document.of(1),
+            Document.of("b"),
+            Document.of(2)
+        );
+        var map = Document.ofMap(entries);
+
+        var keys = new ArrayList<>();
+        map.serializeContents(new SpecificShapeSerializer() {
             @Override
             public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
                 assertThat(schema, equalTo(PreludeSchemas.DOCUMENT));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ShortDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ShortDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -30,6 +31,18 @@ public class ShortDocumentTest {
     public void serializesShape() {
         var document = Document.of((short) 10);
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        var document = Document.of((short) 10);
+
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
             public void writeShort(SdkSchema schema, short value) {
@@ -38,7 +51,7 @@ public class ShortDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 
     @Test

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/StringDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/StringDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -30,6 +31,18 @@ public class StringDocumentTest {
     public void serializesShape() {
         var document = Document.of("hi");
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        var document = Document.of("hi");
+
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
             public void writeString(SdkSchema schema, String value) {
@@ -38,6 +51,6 @@ public class StringDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/StructDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/StructDocumentTest.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -62,9 +63,24 @@ public class StructDocumentTest {
         entries.put("b", Document.of(1));
         var document = Document.ofStruct(entries);
 
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
+        Map<String, Document> entries = new LinkedHashMap<>();
+        entries.put("a", Document.of("a"));
+        entries.put("b", Document.of(1));
+        var document = Document.ofStruct(entries);
+
         List<String> actions = new ArrayList<>();
 
-        document.serialize(new SpecificShapeSerializer() {
+        document.serializeContents(new SpecificShapeSerializer() {
             @Override
             public StructSerializer beginStruct(SdkSchema schema) {
                 assertThat(schema, equalTo(PreludeSchemas.DOCUMENT));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TimestampDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TimestampDocumentTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -37,6 +38,18 @@ public class TimestampDocumentTest {
 
     @Test
     public void serializesShape() {
+        var document = Document.of(getTestTime());
+
+        document.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(document));
+            }
+        });
+    }
+
+    @Test
+    public void serializesContent() {
         var time = getTestTime();
         var document = Document.of(time);
 
@@ -48,6 +61,6 @@ public class TimestampDocumentTest {
             }
         };
 
-        document.serialize(serializer);
+        document.serializeContents(serializer);
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -17,6 +18,7 @@ import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
 
 public class TypedDocumentTest {
@@ -38,7 +40,7 @@ public class TypedDocumentTest {
     }
 
     @Test
-    public void wrapsStructWithTypeAndSchema() {
+    public void wrapsStructContentWithTypeAndSchema() {
         SerializableShape serializableShape = encoder -> {
             var s = encoder.beginStruct(PreludeSchemas.DOCUMENT);
             var aMember = SdkSchema.memberBuilder("a", PreludeSchemas.STRING).id(PreludeSchemas.DOCUMENT.id()).build();
@@ -72,6 +74,14 @@ public class TypedDocumentTest {
         assertThat(result, not(equalTo("X")));
         assertThat(result, equalTo(Document.ofStruct(serializableShape)));
         assertThat(result.hashCode(), equalTo(Document.ofStruct(serializableShape).hashCode()));
+
+        // Writes as document unless getting contents.
+        result.serialize(new SpecificShapeSerializer() {
+            @Override
+            public void writeDocument(Document value) {
+                assertThat(value, is(result));
+            }
+        });
 
         var copy1 = Document.ofValue(result);
         var copy2 = Document.ofValue(result);

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDocument.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDocument.java
@@ -190,7 +190,7 @@ final class JsonDocument implements Document {
     }
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
+    public void serializeContents(ShapeSerializer encoder) {
         switch (type()) {
             case BOOLEAN -> encoder.writeBoolean(schema, asBoolean());
             case BYTE -> encoder.writeByte(schema, asByte());

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.StructSerializer;
 import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
+import software.amazon.smithy.java.runtime.core.serde.document.Document;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 
 final class JsonSerializer implements ShapeSerializer {
@@ -194,5 +195,11 @@ final class JsonSerializer implements ShapeSerializer {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Override
+    public void writeDocument(Document value) {
+        // Document values in JSON are serialized inline by receiving the data model contents of the document.
+        value.serializeContents(this);
     }
 }


### PR DESCRIPTION
Documents are now serialized as a document when serialized through a ShapeSerializer. The contents and inner data model contained within a document can be accessed using Document#serializeContents. This allows ShapeSerializer to receive documents as just documents and the schema of a document matches the data model type written to the serializer. It also allows serializers to, if they care, access the contents of the document. This change makes documents more principled and paves the way towards implementing validation without lots of special casing.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
