### PR TITLE
Remove consumer that manages StructSerializer

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/RequiredWriteSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/RequiredWriteSerializer.java
@@ -39,12 +39,6 @@ public final class RequiredWriteSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void beginStruct(SdkSchema schema, Consumer<StructSerializer> consumer) {
-        delegate.beginStruct(schema, consumer);
-        wroteSomething = true;
-    }
-
-    @Override
     public StructSerializer beginStruct(SdkSchema schema) {
         wroteSomething = true;
         return delegate.beginStruct(schema);

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -20,21 +20,6 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
 public interface ShapeSerializer extends Flushable {
 
     /**
-     * Writes a structure or union inside the given consumer.
-     *
-     * <p>Closing the structure is handled automatically; consumers must not call
-     * {@link StructSerializer#endStruct()}.
-     *
-     * @param schema   Schema to write.
-     * @param consumer Consumer that accepts the created serializer and writes members.
-     */
-    default void beginStruct(SdkSchema schema, Consumer<StructSerializer> consumer) {
-        StructSerializer serializer = beginStruct(schema);
-        consumer.accept(serializer);
-        serializer.endStruct();
-    }
-
-    /**
      * Creates a structure serializer that is closed externally.
      *
      * <p>{@link StructSerializer#endStruct()} must be called when finished or else the serializer will be in an

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
@@ -36,13 +36,6 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
         throw throwForInvalidState(schema);
     }
 
-    // You can only override the method that returns a struct serializer. This ensures that implementations only
-    // need to implement a single method to support both structure calling patterns.
-    @Override
-    public final void beginStruct(SdkSchema schema, Consumer<StructSerializer> structSerializerConsumer) {
-        ShapeSerializer.super.beginStruct(schema, structSerializerConsumer);
-    }
-
     @Override
     public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
         throw throwForInvalidState(schema);

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
@@ -48,9 +48,9 @@ public final class Bird implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA, st -> {
-            st.stringMember(SCHEMA_NAME, name);
-        });
+        var st = serializer.beginStruct(SCHEMA);
+        st.stringMember(SCHEMA_NAME, name);
+        st.endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<Bird> {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
@@ -99,21 +99,21 @@ public final class Person implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA, st -> {
-            st.stringMember(SCHEMA_NAME, name);
-            st.integerMember(SCHEMA_AGE, age);
-            st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
-            st.blobMemberIf(SCHEMA_BINARY, binary);
-            if (!tags.isEmpty()) {
-                st.mapMember(SCHEMA_QUERY_PARAMS, m -> {
-                    tags.forEach((k, v) -> m.entry(k, mv -> {
-                        mv.beginList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
-                            v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
-                        });
-                    }));
-                });
-            }
-        });
+        var st = serializer.beginStruct(SCHEMA);
+        st.stringMember(SCHEMA_NAME, name);
+        st.integerMember(SCHEMA_AGE, age);
+        st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
+        st.blobMemberIf(SCHEMA_BINARY, binary);
+        if (!tags.isEmpty()) {
+            st.mapMember(SCHEMA_QUERY_PARAMS, m -> {
+                tags.forEach((k, v) -> m.entry(k, mv -> {
+                    mv.beginList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
+                        v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
+                    });
+                }));
+            });
+        }
+        st.endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<Person> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageInput.java
@@ -47,9 +47,9 @@ public final class GetPersonImageInput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA, st -> {
-            st.stringMember(SCHEMA_NAME, name);
-        });
+        var st = serializer.beginStruct(SCHEMA);
+        st.stringMember(SCHEMA_NAME, name);
+        st.endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<GetPersonImageInput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageOutput.java
@@ -63,9 +63,9 @@ public final class GetPersonImageOutput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA, st -> {
-            st.stringMemberIf(SCHEMA_NAME, name);
-        });
+        var st = serializer.beginStruct(SCHEMA);
+        st.stringMemberIf(SCHEMA_NAME, name);
+        st.endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<GetPersonImageOutput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageInput.java
@@ -88,15 +88,15 @@ public final class PutPersonImageInput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA, st -> {
-            st.stringMember(SCHEMA_NAME, name);
-            st.listMember(SCHEMA_TAGS, ser -> {
-                tags.forEach(tag -> ser.writeString(SCHEMA_TAGS, tag));
-            });
-            st.listMember(SCHEMA_MORE_TAGS, ser -> {
-                moreTags.forEach(tag -> ser.writeString(SCHEMA_MORE_TAGS, tag));
-            });
+        var st = serializer.beginStruct(SCHEMA);
+        st.stringMember(SCHEMA_NAME, name);
+        st.listMember(SCHEMA_TAGS, ser -> {
+            tags.forEach(tag -> ser.writeString(SCHEMA_TAGS, tag));
         });
+        st.listMember(SCHEMA_MORE_TAGS, ser -> {
+            moreTags.forEach(tag -> ser.writeString(SCHEMA_MORE_TAGS, tag));
+        });
+        st.endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<PutPersonImageInput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageOutput.java
@@ -33,8 +33,7 @@ public final class PutPersonImageOutput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA, st -> {
-        });
+        serializer.beginStruct(SCHEMA).endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<PutPersonImageOutput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonInput.java
@@ -117,22 +117,22 @@ public final class PutPersonInput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA, st -> {
-            st.stringMember(SCHEMA_NAME, name);
-            st.integerMember(SCHEMA_AGE, age);
-            st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
-            st.stringMemberIf(SCHEMA_FAVORITE_COLOR, favoriteColor);
-            st.blobMemberIf(SCHEMA_BINARY, binary);
-            if (!queryParams.isEmpty()) {
-                st.mapMember(SCHEMA_QUERY_PARAMS, m -> {
-                    queryParams.forEach((k, v) -> m.entry(k, mv -> {
-                        mv.beginList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
-                            v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
-                        });
-                    }));
-                });
-            }
-        });
+        var st = serializer.beginStruct(SCHEMA);
+        st.stringMember(SCHEMA_NAME, name);
+        st.integerMember(SCHEMA_AGE, age);
+        st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
+        st.stringMemberIf(SCHEMA_FAVORITE_COLOR, favoriteColor);
+        st.blobMemberIf(SCHEMA_BINARY, binary);
+        if (!queryParams.isEmpty()) {
+            st.mapMember(SCHEMA_QUERY_PARAMS, m -> {
+                queryParams.forEach((k, v) -> m.entry(k, mv -> {
+                    mv.beginList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
+                        v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
+                    });
+                }));
+            });
+        }
+        st.endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<PutPersonInput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonOutput.java
@@ -89,13 +89,13 @@ public final class PutPersonOutput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA, st -> {
-            st.stringMemberIf(SCHEMA_NAME, name);
-            st.integerMember(SCHEMA_AGE, age);
-            st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
-            st.stringMemberIf(SCHEMA_FAVORITE_COLOR, favoriteColor);
-            st.integerMember(SCHEMA_STATUS, status);
-        });
+        var st = serializer.beginStruct(SCHEMA);
+        st.stringMemberIf(SCHEMA_NAME, name);
+        st.integerMember(SCHEMA_AGE, age);
+        st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
+        st.stringMemberIf(SCHEMA_FAVORITE_COLOR, favoriteColor);
+        st.integerMember(SCHEMA_STATUS, status);
+        st.endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<PutPersonOutput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/ValidationError.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/ValidationError.java
@@ -43,9 +43,9 @@ public final class ValidationError extends ModeledSdkException {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA, st -> {
-            st.stringMember(SCHEMA_MESSAGE, getMessage());
-        });
+        var st = serializer.beginStruct(SCHEMA);
+        st.stringMember(SCHEMA_MESSAGE, getMessage());
+        st.endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<ValidationError> {

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDocument.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDocument.java
@@ -224,7 +224,8 @@ final class JsonDocument implements Document {
                     entry.serialize(c);
                 }
             });
-            case STRUCTURE, UNION -> encoder.beginStruct(schema, structSerializer -> {
+            case STRUCTURE, UNION -> {
+                var structSerializer = encoder.beginStruct(schema);
                 for (var entry : any.asMap().entrySet()) {
                     var k = entry.getKey();
                     var v = new JsonDocument(entry.getValue(), useJsonName, defaultTimestampFormat, useTimestampFormat);
@@ -232,7 +233,8 @@ final class JsonDocument implements Document {
                     var member = SdkSchema.memberBuilder(k, v.schema).id(PreludeSchemas.DOCUMENT.id()).build();
                     structSerializer.member(member, v::serialize);
                 }
-            });
+                structSerializer.endStruct();
+            }
             default -> throw new SdkSerdeException("Cannot serialize unexpected JSON value: " + any);
         }
     }


### PR DESCRIPTION
Having two methods do the same thing could make it confusing to extend and it's also one less allocation to just manage the structure directly than in a consumer.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
