### PR TITLE
Use consumers for serde state management

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
@@ -54,21 +54,21 @@ public final class ListSerializer implements ShapeSerializer {
     }
 
     @Override
-    public StructSerializer beginStruct(SdkSchema schema) {
+    public void writeStruct(SdkSchema schema, Consumer<StructSerializer> consumer) {
         beforeWrite();
-        return delegate.beginStruct(schema);
+        delegate.writeStruct(schema, consumer);
     }
 
     @Override
-    public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
+    public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
         beforeWrite();
-        delegate.beginList(schema, consumer);
+        delegate.writeList(schema, consumer);
     }
 
     @Override
-    public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+    public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
         beforeWrite();
-        delegate.beginMap(schema, consumer);
+        delegate.writeMap(schema, consumer);
     }
 
     @Override

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/RequiredWriteSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/RequiredWriteSerializer.java
@@ -39,20 +39,20 @@ public final class RequiredWriteSerializer implements ShapeSerializer {
     }
 
     @Override
-    public StructSerializer beginStruct(SdkSchema schema) {
-        wroteSomething = true;
-        return delegate.beginStruct(schema);
-    }
-
-    @Override
-    public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
-        delegate.beginList(schema, consumer);
+    public void writeStruct(SdkSchema schema, Consumer<StructSerializer> consumer) {
+        delegate.writeStruct(schema, consumer);
         wroteSomething = true;
     }
 
     @Override
-    public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
-        delegate.beginMap(schema, consumer);
+    public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
+        delegate.writeList(schema, consumer);
+        wroteSomething = true;
+    }
+
+    @Override
+    public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+        delegate.writeMap(schema, consumer);
         wroteSomething = true;
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -18,17 +18,13 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
  * Serializes a shape by receiving the Smithy data model and writing output to a receiver owned by the serializer.
  */
 public interface ShapeSerializer extends Flushable {
-
     /**
-     * Creates a structure serializer that is closed externally.
+     * Writes a structure or union.
      *
-     * <p>{@link StructSerializer#endStruct()} must be called when finished or else the serializer will be in an
-     * undefined state.
-     *
-     * @param schema Schema to serialize.
-     * @return Returns the created serializer.
+     * @param schema   Schema to serialize.
+     * @param consumer Receives the struct serializer and writes members.
      */
-    StructSerializer beginStruct(SdkSchema schema);
+    void writeStruct(SdkSchema schema, Consumer<StructSerializer> consumer);
 
     /**
      * Begin a list and write zero or more values into it using the provided serializer.
@@ -36,7 +32,7 @@ public interface ShapeSerializer extends Flushable {
      * @param schema   List schema.
      * @param consumer Received in the context of the list and writes zero or more values.
      */
-    void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer);
+    void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer);
 
     /**
      * Begin a map and write zero or more entries into it using the provided serializer.
@@ -44,7 +40,7 @@ public interface ShapeSerializer extends Flushable {
      * @param schema   List schema.
      * @param consumer Received in the context of the map and writes zero or more entries.
      */
-    void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer);
+    void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer);
 
     /**
      * Serialize a boolean.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
@@ -32,17 +32,17 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
     public void flush() {}
 
     @Override
-    public StructSerializer beginStruct(SdkSchema schema) {
+    public void writeStruct(SdkSchema schema, Consumer<StructSerializer> consumer) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
+    public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+    public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
         throw throwForInvalidState(schema);
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/StructSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/StructSerializer.java
@@ -19,22 +19,12 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
  * <p>Each serialization method requires an SdkSchema that is a member and should handle writing member names and
  * values on each write.
  */
+@FunctionalInterface
 public interface StructSerializer {
-
-    /**
-     * Explicitly ends the struct.
-     *
-     * <p>Calling this method should only be called when struct serialization is externally driven by
-     * {@link ShapeSerializer#beginStruct(SdkSchema)}. Calling this method in other contexts will cause undefined
-     * behavior.
-     */
-    void endStruct();
-
     /**
      * The primary method that handles writing members to a shape serializer.
      *
-     * <p>Implementations should use {@link RequiredWriteSerializer} to ensure the consumer writes something when
-     * called. If this assertion is not made, the serialization process can enter an undefined state.
+     * <p>A caller must write something to the ShapeSerializer sent to the memberWriter.
      *
      * @param member       Member schema to write.
      * @param memberWriter Consumer that writes. The consumer is required to write something.
@@ -182,10 +172,10 @@ public interface StructSerializer {
     }
 
     default void listMember(SdkSchema member, Consumer<ShapeSerializer> consumer) {
-        member(member, writer -> writer.beginList(member, consumer));
+        member(member, writer -> writer.writeList(member, consumer));
     }
 
     default void mapMember(SdkSchema member, Consumer<MapSerializer> consumer) {
-        member(member, writer -> writer.beginMap(member, consumer));
+        member(member, writer -> writer.writeMap(member, consumer));
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -538,7 +538,7 @@ final class Documents {
 
         @Override
         public void serializeContents(ShapeSerializer serializer) {
-            serializer.beginList(PreludeSchemas.DOCUMENT, ser -> {
+            serializer.writeList(PreludeSchemas.DOCUMENT, ser -> {
                 for (var element : values) {
                     element.serializeContents(ser);
                 }
@@ -570,7 +570,7 @@ final class Documents {
 
         @Override
         public void serializeContents(ShapeSerializer serializer) {
-            serializer.beginMap(PreludeSchemas.DOCUMENT, s -> {
+            serializer.writeMap(PreludeSchemas.DOCUMENT, s -> {
                 for (var entry : members.entrySet()) {
                     Document key = entry.getKey();
                     Consumer<ShapeSerializer> valueSer = ser -> entry.getValue().serializeContents(ser);
@@ -607,11 +607,11 @@ final class Documents {
 
         @Override
         public void serializeContents(ShapeSerializer encoder) {
-            var structSerializer = encoder.beginStruct(PreludeSchemas.DOCUMENT);
-            for (var entry : members.entrySet()) {
-                structSerializer.member(syntheticMember(entry.getKey()), entry.getValue()::serializeContents);
-            }
-            structSerializer.endStruct();
+            encoder.writeStruct(PreludeSchemas.DOCUMENT, structSerializer -> {
+                for (var entry : members.entrySet()) {
+                    structSerializer.member(syntheticMember(entry.getKey()), entry.getValue()::serializeContents);
+                }
+            });
         }
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocument.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocument.java
@@ -32,17 +32,11 @@ final class TypedDocument implements Document {
             }
 
             @Override
-            public StructSerializer beginStruct(SdkSchema schema) {
+            public void writeStruct(SdkSchema schema, Consumer<StructSerializer> consumer) {
                 this.documentSchema = schema;
-                return new StructSerializer() {
-                    @Override
-                    public void endStruct() {}
-
-                    @Override
-                    public void member(SdkSchema member, Consumer<ShapeSerializer> memberWriter) {
-                        members.put(member.memberName(), Pair.of(member, memberWriter));
-                    }
-                };
+                consumer.accept((member, memberWriter) -> {
+                    members.put(member.memberName(), Pair.of(member, memberWriter));
+                });
             }
         };
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMember.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMember.java
@@ -561,7 +561,7 @@ final class TypedDocumentMember implements Document {
             private final List<Document> values = new ArrayList<>();
 
             @Override
-            public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
+            public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
                 values.add(new TypedDocumentMember(schema.documentMember("member"), consumer));
             }
         };
@@ -575,7 +575,7 @@ final class TypedDocumentMember implements Document {
             private final Map<Document, Document> values = new LinkedHashMap<>();
 
             @Override
-            public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+            public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
                 var valueMember = schema.documentMember("value");
                 consumer.accept(new MapSerializer() {
                     @Override
@@ -617,7 +617,7 @@ final class TypedDocumentMember implements Document {
             private Document result;
 
             @Override
-            public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+            public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
                 consumer.accept(new MapSerializer() {
                     @Override
                     public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {
@@ -636,18 +636,12 @@ final class TypedDocumentMember implements Document {
             }
 
             @Override
-            public StructSerializer beginStruct(SdkSchema schema) {
-                return new StructSerializer() {
-                    @Override
-                    public void endStruct() {}
-
-                    @Override
-                    public void member(SdkSchema member, Consumer<ShapeSerializer> memberWriter) {
-                        if (member.memberName().equals(memberName)) {
-                            result = new TypedDocumentMember(member, memberWriter);
-                        }
+            public void writeStruct(SdkSchema schema, Consumer<StructSerializer> consumer) {
+                consumer.accept((member, memberWriter) -> {
+                    if (member.memberName().equals(memberName)) {
+                        result = new TypedDocumentMember(member, memberWriter);
                     }
-                };
+                });
             }
         };
         memberWriter.accept(expect);

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentMapTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentMapTest.java
@@ -29,7 +29,7 @@ public class DocumentMapTest {
         Map<Document, Document> received = new HashMap<>();
         document.serializeContents(new SpecificShapeSerializer() {
             @Override
-            public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+            public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
                 consumer.accept(new MapSerializer() {
                     @Override
                     public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
@@ -53,7 +53,7 @@ public class ListDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
+            public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
                 assertThat(schema, equalTo(PreludeSchemas.DOCUMENT));
                 consumer.accept(new SpecificShapeSerializer() {
                     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
@@ -69,7 +69,7 @@ public class MapDocumentTest {
         var keys = new ArrayList<>();
         map.serializeContents(new SpecificShapeSerializer() {
             @Override
-            public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+            public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
                 assertThat(schema, equalTo(PreludeSchemas.DOCUMENT));
                 consumer.accept(new MapSerializer() {
                     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
@@ -32,11 +32,11 @@ public class TypedDocumentMemberTest {
     @Test
     public void equalityAndHashTest() {
         SerializableShape serializableShape = encoder -> {
-            var s = encoder.beginStruct(PreludeSchemas.DOCUMENT);
-            var schema = PreludeSchemas.getSchemaForType(ShapeType.STRING);
-            var member = schema.documentMember("foo");
-            s.member(member, c -> c.writeString(PreludeSchemas.STRING, "Hi"));
-            s.endStruct();
+            encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
+                var schema = PreludeSchemas.getSchemaForType(ShapeType.STRING);
+                var member = schema.documentMember("foo");
+                s.member(member, c -> c.writeString(PreludeSchemas.STRING, "Hi"));
+            });
         };
 
         var document = Document.ofStruct(serializableShape);
@@ -55,19 +55,19 @@ public class TypedDocumentMemberTest {
     @Test
     public void inEqualityAndHashTest() {
         var document1 = Document.ofStruct(encoder -> {
-            var s = encoder.beginStruct(PreludeSchemas.DOCUMENT);
-            var schema = PreludeSchemas.getSchemaForType(ShapeType.STRING);
-            var member = schema.documentMember("foo", PreludeSchemas.STRING);
-            s.member(member, c -> c.writeString(PreludeSchemas.STRING, "Hi"));
-            s.endStruct();
+            encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
+                var schema = PreludeSchemas.getSchemaForType(ShapeType.STRING);
+                var member = schema.documentMember("foo", PreludeSchemas.STRING);
+                s.member(member, c -> c.writeString(PreludeSchemas.STRING, "Hi"));
+            });
         });
 
         var document2 = Document.ofStruct(encoder -> {
-            var s = encoder.beginStruct(PreludeSchemas.DOCUMENT);
-            var schema = PreludeSchemas.getSchemaForType(ShapeType.STRING);
-            var member = schema.documentMember("foo", PreludeSchemas.INTEGER);
-            s.member(member, c -> c.writeInteger(PreludeSchemas.INTEGER, 1));
-            s.endStruct();
+            encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
+                var schema = PreludeSchemas.getSchemaForType(ShapeType.STRING);
+                var member = schema.documentMember("foo", PreludeSchemas.INTEGER);
+                s.member(member, c -> c.writeInteger(PreludeSchemas.INTEGER, 1));
+            });
         });
 
         assertThat(document1.getMember("foo"), not(equalTo(null)));
@@ -83,11 +83,11 @@ public class TypedDocumentMemberTest {
         Function<Document, Object> extractor
     ) {
         SerializableShape serializableShape = encoder -> {
-            var s = encoder.beginStruct(PreludeSchemas.DOCUMENT);
-            var schema = PreludeSchemas.getSchemaForType(type);
-            var aMember = SdkSchema.memberBuilder("a", schema).id(PreludeSchemas.DOCUMENT.id()).build();
-            s.member(aMember, writer);
-            s.endStruct();
+            encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
+                var schema = PreludeSchemas.getSchemaForType(type);
+                var aMember = SdkSchema.memberBuilder("a", schema).id(PreludeSchemas.DOCUMENT.id()).build();
+                s.member(aMember, writer);
+            });
         };
         var document = Document.ofStruct(serializableShape);
 
@@ -530,7 +530,7 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 ShapeType.DOCUMENT,
                 List.of(Document.of(1)),
-                (Consumer<ShapeSerializer>) s -> s.beginList(
+                (Consumer<ShapeSerializer>) s -> s.writeList(
                     PreludeSchemas.DOCUMENT,
                     c -> c.writeInteger(PreludeSchemas.INTEGER, 1)
                 ),
@@ -541,7 +541,7 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 ShapeType.DOCUMENT,
                 Map.of(Document.of("a"), Document.of(1)),
-                (Consumer<ShapeSerializer>) s -> s.beginMap(
+                (Consumer<ShapeSerializer>) s -> s.writeMap(
                     PreludeSchemas.DOCUMENT,
                     m -> m.entry("a", c -> c.writeInteger(PreludeSchemas.INTEGER, 1))
                 ),
@@ -554,7 +554,7 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 ShapeType.DOCUMENT,
                 Map.of(Document.of(1), Document.of(1)),
-                (Consumer<ShapeSerializer>) s -> s.beginMap(
+                (Consumer<ShapeSerializer>) s -> s.writeMap(
                     PreludeSchemas.DOCUMENT,
                     m -> m.entry(1, c -> c.writeInteger(PreludeSchemas.INTEGER, 1))
                 ),
@@ -567,7 +567,7 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 ShapeType.DOCUMENT,
                 Map.of(Document.of(1L), Document.of(1)),
-                (Consumer<ShapeSerializer>) s -> s.beginMap(
+                (Consumer<ShapeSerializer>) s -> s.writeMap(
                     PreludeSchemas.DOCUMENT,
                     m -> m.entry(1L, c -> c.writeInteger(PreludeSchemas.INTEGER, 1))
                 ),
@@ -580,7 +580,7 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 ShapeType.DOCUMENT,
                 Document.of(1),
-                (Consumer<ShapeSerializer>) s -> s.beginMap(
+                (Consumer<ShapeSerializer>) s -> s.writeMap(
                     PreludeSchemas.DOCUMENT,
                     m -> m.entry("a", c -> c.writeInteger(PreludeSchemas.INTEGER, 1))
                 ),
@@ -592,16 +592,16 @@ public class TypedDocumentMemberTest {
                 ShapeType.DOCUMENT,
                 Document.of("b"),
                 (Consumer<ShapeSerializer>) s -> {
-                    var ser = s.beginStruct(PreludeSchemas.DOCUMENT);
-                    ser.member(
-                        PreludeSchemas.DOCUMENT.documentMember("foo"),
-                        c -> c.writeString(PreludeSchemas.STRING, "a")
-                    );
-                    ser.member(
-                        PreludeSchemas.DOCUMENT.documentMember("bar"),
-                        c -> c.writeString(PreludeSchemas.STRING, "b")
-                    );
-                    ser.endStruct();
+                    s.writeStruct(PreludeSchemas.DOCUMENT, ser -> {
+                        ser.member(
+                            PreludeSchemas.DOCUMENT.documentMember("foo"),
+                            c -> c.writeString(PreludeSchemas.STRING, "a")
+                        );
+                        ser.member(
+                            PreludeSchemas.DOCUMENT.documentMember("bar"),
+                            c -> c.writeString(PreludeSchemas.STRING, "b")
+                        );
+                    });
                 },
                 (Function<Document, Object>) d -> Document.ofValue(d.getMember("bar"))
             )

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
@@ -42,12 +42,16 @@ public class TypedDocumentTest {
     @Test
     public void wrapsStructContentWithTypeAndSchema() {
         SerializableShape serializableShape = encoder -> {
-            var s = encoder.beginStruct(PreludeSchemas.DOCUMENT);
-            var aMember = SdkSchema.memberBuilder("a", PreludeSchemas.STRING).id(PreludeSchemas.DOCUMENT.id()).build();
-            s.member(aMember, c -> c.writeString(PreludeSchemas.STRING, "1"));
-            var bMember = SdkSchema.memberBuilder("b", PreludeSchemas.STRING).id(PreludeSchemas.DOCUMENT.id()).build();
-            s.member(bMember, c -> c.writeString(PreludeSchemas.STRING, "2"));
-            s.endStruct();
+            encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
+                var aMember = SdkSchema.memberBuilder("a", PreludeSchemas.STRING)
+                    .id(PreludeSchemas.DOCUMENT.id())
+                    .build();
+                s.member(aMember, c -> c.writeString(PreludeSchemas.STRING, "1"));
+                var bMember = SdkSchema.memberBuilder("b", PreludeSchemas.STRING)
+                    .id(PreludeSchemas.DOCUMENT.id())
+                    .build();
+                s.member(bMember, c -> c.writeString(PreludeSchemas.STRING, "2"));
+            });
         };
 
         var result = Document.ofStruct(serializableShape);

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
@@ -48,9 +48,9 @@ public final class Bird implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        var st = serializer.beginStruct(SCHEMA);
-        st.stringMember(SCHEMA_NAME, name);
-        st.endStruct();
+        serializer.writeStruct(SCHEMA, st -> {
+            st.stringMember(SCHEMA_NAME, name);
+        });
     }
 
     public static final class Builder implements SdkShapeBuilder<Bird> {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
@@ -99,21 +99,21 @@ public final class Person implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        var st = serializer.beginStruct(SCHEMA);
-        st.stringMember(SCHEMA_NAME, name);
-        st.integerMember(SCHEMA_AGE, age);
-        st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
-        st.blobMemberIf(SCHEMA_BINARY, binary);
-        if (!tags.isEmpty()) {
-            st.mapMember(SCHEMA_QUERY_PARAMS, m -> {
-                tags.forEach((k, v) -> m.entry(k, mv -> {
-                    mv.beginList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
-                        v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
-                    });
-                }));
-            });
-        }
-        st.endStruct();
+        serializer.writeStruct(SCHEMA, st -> {
+            st.stringMember(SCHEMA_NAME, name);
+            st.integerMember(SCHEMA_AGE, age);
+            st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
+            st.blobMemberIf(SCHEMA_BINARY, binary);
+            if (!tags.isEmpty()) {
+                st.mapMember(SCHEMA_QUERY_PARAMS, m -> {
+                    tags.forEach((k, v) -> m.entry(k, mv -> {
+                        mv.writeList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
+                            v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
+                        });
+                    }));
+                });
+            }
+        });
     }
 
     public static final class Builder implements SdkShapeBuilder<Person> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageInput.java
@@ -47,9 +47,9 @@ public final class GetPersonImageInput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        var st = serializer.beginStruct(SCHEMA);
-        st.stringMember(SCHEMA_NAME, name);
-        st.endStruct();
+        serializer.writeStruct(SCHEMA, st -> {
+            st.stringMember(SCHEMA_NAME, name);
+        });
     }
 
     public static final class Builder implements SdkShapeBuilder<GetPersonImageInput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageOutput.java
@@ -63,9 +63,9 @@ public final class GetPersonImageOutput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        var st = serializer.beginStruct(SCHEMA);
-        st.stringMemberIf(SCHEMA_NAME, name);
-        st.endStruct();
+        serializer.writeStruct(SCHEMA, st -> {
+            st.stringMemberIf(SCHEMA_NAME, name);
+        });
     }
 
     public static final class Builder implements SdkShapeBuilder<GetPersonImageOutput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageInput.java
@@ -88,15 +88,15 @@ public final class PutPersonImageInput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        var st = serializer.beginStruct(SCHEMA);
-        st.stringMember(SCHEMA_NAME, name);
-        st.listMember(SCHEMA_TAGS, ser -> {
-            tags.forEach(tag -> ser.writeString(SCHEMA_TAGS, tag));
+        serializer.writeStruct(SCHEMA, st -> {
+            st.stringMember(SCHEMA_NAME, name);
+            st.listMember(SCHEMA_TAGS, ser -> {
+                tags.forEach(tag -> ser.writeString(SCHEMA_TAGS, tag));
+            });
+            st.listMember(SCHEMA_MORE_TAGS, ser -> {
+                moreTags.forEach(tag -> ser.writeString(SCHEMA_MORE_TAGS, tag));
+            });
         });
-        st.listMember(SCHEMA_MORE_TAGS, ser -> {
-            moreTags.forEach(tag -> ser.writeString(SCHEMA_MORE_TAGS, tag));
-        });
-        st.endStruct();
     }
 
     public static final class Builder implements SdkShapeBuilder<PutPersonImageInput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageOutput.java
@@ -33,7 +33,7 @@ public final class PutPersonImageOutput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        serializer.beginStruct(SCHEMA).endStruct();
+        serializer.writeStruct(SCHEMA, st -> {});
     }
 
     public static final class Builder implements SdkShapeBuilder<PutPersonImageOutput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonInput.java
@@ -117,22 +117,22 @@ public final class PutPersonInput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        var st = serializer.beginStruct(SCHEMA);
-        st.stringMember(SCHEMA_NAME, name);
-        st.integerMember(SCHEMA_AGE, age);
-        st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
-        st.stringMemberIf(SCHEMA_FAVORITE_COLOR, favoriteColor);
-        st.blobMemberIf(SCHEMA_BINARY, binary);
-        if (!queryParams.isEmpty()) {
-            st.mapMember(SCHEMA_QUERY_PARAMS, m -> {
-                queryParams.forEach((k, v) -> m.entry(k, mv -> {
-                    mv.beginList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
-                        v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
-                    });
-                }));
-            });
-        }
-        st.endStruct();
+        serializer.writeStruct(SCHEMA, st -> {
+            st.stringMember(SCHEMA_NAME, name);
+            st.integerMember(SCHEMA_AGE, age);
+            st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
+            st.stringMemberIf(SCHEMA_FAVORITE_COLOR, favoriteColor);
+            st.blobMemberIf(SCHEMA_BINARY, binary);
+            if (!queryParams.isEmpty()) {
+                st.mapMember(SCHEMA_QUERY_PARAMS, m -> {
+                    queryParams.forEach((k, v) -> m.entry(k, mv -> {
+                        mv.writeList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
+                            v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
+                        });
+                    }));
+                });
+            }
+        });
     }
 
     public static final class Builder implements SdkShapeBuilder<PutPersonInput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonOutput.java
@@ -89,13 +89,13 @@ public final class PutPersonOutput implements SerializableShape {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        var st = serializer.beginStruct(SCHEMA);
-        st.stringMemberIf(SCHEMA_NAME, name);
-        st.integerMember(SCHEMA_AGE, age);
-        st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
-        st.stringMemberIf(SCHEMA_FAVORITE_COLOR, favoriteColor);
-        st.integerMember(SCHEMA_STATUS, status);
-        st.endStruct();
+        serializer.writeStruct(SCHEMA, st -> {
+            st.stringMemberIf(SCHEMA_NAME, name);
+            st.integerMember(SCHEMA_AGE, age);
+            st.timestampMemberIf(SCHEMA_BIRTHDAY, birthday);
+            st.stringMemberIf(SCHEMA_FAVORITE_COLOR, favoriteColor);
+            st.integerMember(SCHEMA_STATUS, status);
+        });
     }
 
     public static final class Builder implements SdkShapeBuilder<PutPersonOutput> {

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/ValidationError.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/ValidationError.java
@@ -43,9 +43,9 @@ public final class ValidationError extends ModeledSdkException {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        var st = serializer.beginStruct(SCHEMA);
-        st.stringMember(SCHEMA_MESSAGE, getMessage());
-        st.endStruct();
+        serializer.writeStruct(SCHEMA, st -> {
+            st.stringMember(SCHEMA_MESSAGE, getMessage());
+        });
     }
 
     public static final class Builder implements SdkShapeBuilder<ValidationError> {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
@@ -34,7 +34,7 @@ final class HttpHeaderSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
+    public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
         consumer.accept(new ListSerializer(this, position -> {}));
     }
 

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpPrefixHeadersSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpPrefixHeadersSerializer.java
@@ -34,7 +34,7 @@ final class HttpPrefixHeadersSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+    public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
         consumer.accept(new MapSerializer() {
             @Override
             public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsSerializer.java
@@ -29,7 +29,7 @@ final class HttpQueryParamsSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+    public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
         consumer.accept(new MapSerializer() {
             @Override
             public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {
@@ -45,7 +45,7 @@ final class HttpQueryParamsSerializer extends SpecificShapeSerializer {
                     }
 
                     @Override
-                    public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
+                    public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
                         consumer.accept(new SpecificShapeSerializer() {
                             @Override
                             protected RuntimeException throwForInvalidState(SdkSchema schema) {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
@@ -34,7 +34,7 @@ final class HttpQuerySerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
+    public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
         consumer.accept(new ListSerializer(this, position -> {}));
     }
 

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
@@ -155,17 +155,18 @@ final class JsonSerializer implements ShapeSerializer {
     }
 
     @Override
-    public StructSerializer beginStruct(SdkSchema schema) {
+    public void writeStruct(SdkSchema schema, Consumer<StructSerializer> consumer) {
         try {
             stream.writeObjectStart();
-            return new JsonStructSerializer(this, stream, useJsonName);
+            consumer.accept(new JsonStructSerializer(this, stream, useJsonName));
+            stream.writeObjectEnd();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
     @Override
-    public void beginList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
+    public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
         try {
             stream.writeArrayStart();
             consumer.accept(new ListSerializer(this, this::writeComma));
@@ -186,7 +187,7 @@ final class JsonSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void beginMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
+    public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
         try {
             stream.writeObjectStart();
             var keySchema = schema.member("key");

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
@@ -22,7 +22,6 @@ class JsonStructSerializer implements StructSerializer {
     private final ShapeSerializer parent;
     private final JsonStream stream;
     private boolean wroteValues = false;
-    private boolean isClosed;
 
     JsonStructSerializer(ShapeSerializer parent, JsonStream stream, boolean useJsonName) {
         this.parent = parent;
@@ -39,10 +38,6 @@ class JsonStructSerializer implements StructSerializer {
     }
 
     void startMember(SdkSchema member) throws IOException {
-        if (isClosed) {
-            throw new IllegalStateException("Attempted to write to a closed JSON structure");
-        }
-
         // Write commas when needed.
         if (wroteValues) {
             stream.writeMore();
@@ -50,16 +45,6 @@ class JsonStructSerializer implements StructSerializer {
             wroteValues = true;
         }
         stream.writeObjectField(getMemberName(member));
-    }
-
-    @Override
-    public void endStruct() {
-        try {
-            isClosed = true;
-            stream.writeObjectEnd();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
     @Override


### PR DESCRIPTION
This is a partial revert of the last commit. The goal there was to consolidate the logic to serialize a structure, but it ended up making struct serialization different from list and map, and it also introduced the need to manage struct state to ensure they're closed. By using only the consumer based API, there is a clear hook for before, during, and after that removes the need for state management. It also does not have any measurable performance impact to use the consumer API. Another benefit is that now StructSerializer can be a FunctionalInterface.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
