### PR TITLE
Add map key schema, writeNull, cleanup SdkSchema

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ConsolidatedSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ConsolidatedSerializer.java
@@ -104,4 +104,9 @@ final class ConsolidatedSerializer implements ShapeSerializer {
     public void writeDocument(SdkSchema schema, Document value) {
         write(schema, ser -> ser.writeDocument(schema, value));
     }
+
+    @Override
+    public void writeNull(SdkSchema schema) {
+        write(schema, ser -> ser.writeNull(schema));
+    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
@@ -142,4 +142,10 @@ public final class ListSerializer implements ShapeSerializer {
         beforeWrite();
         delegate.writeDocument(schema, value);
     }
+
+    @Override
+    public void writeNull(SdkSchema schema) {
+        beforeWrite();
+        delegate.writeNull(schema);
+    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/MapSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/MapSerializer.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.runtime.core.serde;
 
 import java.util.function.Consumer;
+import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 
 /**
  * Serializes a map shape.
@@ -14,24 +15,27 @@ public interface MapSerializer {
     /**
      * Writes a string key for the map, and the valueSerializer is called and required to serialize the value.
      *
+     * @param keySchema       Schema of the map key. The same schema should be provided for every map key entry.
      * @param key             Key to write.
      * @param valueSerializer Serializer used to serialize the map value. A value must be serialized.
      */
-    void entry(String key, Consumer<ShapeSerializer> valueSerializer);
+    void writeEntry(SdkSchema keySchema, String key, Consumer<ShapeSerializer> valueSerializer);
 
     /**
      * Writes an integer key for the map, and the valueSerializer is called and required to serialize the value.
      *
+     * @param keySchema       Schema of the map key. The same schema should be provided for every map key entry.
      * @param key             Key to write.
      * @param valueSerializer Serializer used to serialize the map value. A value must be serialized.
      */
-    void entry(int key, Consumer<ShapeSerializer> valueSerializer);
+    void writeEntry(SdkSchema keySchema, int key, Consumer<ShapeSerializer> valueSerializer);
 
     /**
      * Writes a long key for the map, and the valueSerializer is called and required to serialize the value.
      *
+     * @param keySchema       Schema of the map key. The same schema should be provided for every map key entry.
      * @param key             Key to write.
      * @param valueSerializer Serializer used to serialize the map value. A value must be serialized.
      */
-    void entry(long key, Consumer<ShapeSerializer> valueSerializer);
+    void writeEntry(SdkSchema keySchema, long key, Consumer<ShapeSerializer> valueSerializer);
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/RequiredWriteSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/RequiredWriteSerializer.java
@@ -132,4 +132,10 @@ public final class RequiredWriteSerializer implements ShapeSerializer {
         delegate.writeDocument(schema, value);
         wroteSomething = true;
     }
+
+    @Override
+    public void writeNull(SdkSchema schema) {
+        delegate.writeNull(schema);
+        wroteSomething = true;
+    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -17,6 +17,9 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
  * Serializes a shape by receiving the Smithy data model and writing output to a receiver owned by the serializer.
+ *
+ * <p>Note: null values should only ever be written using {@link #writeNull(SdkSchema)}. Every other method expects
+ * a non-null value or a value type.
  */
 public interface ShapeSerializer extends Flushable {
 
@@ -184,6 +187,13 @@ public interface ShapeSerializer extends Flushable {
     default void writeDocument(Document value) {
         writeDocument(PreludeSchemas.DOCUMENT, value);
     }
+
+    /**
+     * Writes a null value.
+     *
+     * @param schema Schema of the null value.
+     */
+    void writeNull(SdkSchema schema);
 
     /**
      * Write to the serializer if the given value is not null.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
@@ -23,8 +23,12 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
      * @param schema Unexpected encountered schema.
      * @return Returns an exception to throw.
      */
-    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-        throw new SdkSerdeException("Unexpected schema type: " + schema);
+    protected RuntimeException throwForInvalidState(String message, SdkSchema schema) {
+        throw new SdkSerdeException(message);
+    }
+
+    private RuntimeException throwForInvalidState(SdkSchema schema) {
+        return throwForInvalidState("Unexpected schema type: " + schema, schema);
     }
 
     @Override
@@ -105,6 +109,11 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
     @Override
     public void writeDocument(SdkSchema schema, Document value) {
         throw throwForInvalidState(schema);
+    }
+
+    @Override
+    public void writeNull(SdkSchema schema) {
+        throw throwForInvalidState("Unexpected null value written for " + schema, schema);
     }
 
     // Delegates to writing with a schema. Only override writing a document with a schema.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
@@ -111,7 +111,7 @@ public final class ToStringSerializer implements ShapeSerializer {
 
         consumer.accept(new MapSerializer() {
             @Override
-            public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, String key, Consumer<ShapeSerializer> valueSerializer) {
                 writeString(schema.member("key"), key);
                 append(": ");
                 valueSerializer.accept(ToStringSerializer.this);
@@ -119,7 +119,7 @@ public final class ToStringSerializer implements ShapeSerializer {
             }
 
             @Override
-            public void entry(int key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, int key, Consumer<ShapeSerializer> valueSerializer) {
                 writeInteger(schema.member("key"), key);
                 append(": ");
                 valueSerializer.accept(ToStringSerializer.this);
@@ -127,7 +127,7 @@ public final class ToStringSerializer implements ShapeSerializer {
             }
 
             @Override
-            public void entry(long key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, long key, Consumer<ShapeSerializer> valueSerializer) {
                 writeLong(schema.member("key"), key);
                 append(": ");
                 valueSerializer.accept(ToStringSerializer.this);
@@ -205,5 +205,10 @@ public final class ToStringSerializer implements ShapeSerializer {
         append(System.lineSeparator());
         value.serializeContents(this);
         dedent();
+    }
+
+    @Override
+    public void writeNull(SdkSchema schema) {
+        append(schema, "null");
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentParser.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentParser.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.serde.ListSerializer;
@@ -24,7 +23,7 @@ final class DocumentParser implements ShapeSerializer {
     private Document result;
 
     Document getResult() {
-        return Objects.requireNonNull(result, "result was not set by the shape serializer");
+        return result;
     }
 
     @Override
@@ -63,21 +62,21 @@ final class DocumentParser implements ShapeSerializer {
         Map<Document, Document> entries = new LinkedHashMap<>();
         consumer.accept(new MapSerializer() {
             @Override
-            public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, String key, Consumer<ShapeSerializer> valueSerializer) {
                 DocumentParser p = new DocumentParser();
                 valueSerializer.accept(p);
                 entries.put(Document.of(key), p.result);
             }
 
             @Override
-            public void entry(int key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, int key, Consumer<ShapeSerializer> valueSerializer) {
                 DocumentParser p = new DocumentParser();
                 valueSerializer.accept(p);
                 entries.put(Document.of(key), p.result);
             }
 
             @Override
-            public void entry(long key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, long key, Consumer<ShapeSerializer> valueSerializer) {
                 DocumentParser p = new DocumentParser();
                 valueSerializer.accept(p);
                 entries.put(Document.of(key), p.result);
@@ -149,5 +148,10 @@ final class DocumentParser implements ShapeSerializer {
     @Override
     public void writeDocument(SdkSchema schema, Document value) {
         value.serializeContents(this);
+    }
+
+    @Override
+    public void writeNull(SdkSchema schema) {
+        result = null;
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocument.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocument.java
@@ -26,8 +26,8 @@ final class TypedDocument implements Document {
             private final Map<String, Pair<SdkSchema, Consumer<ShapeSerializer>>> members = new LinkedHashMap<>();
 
             @Override
-            protected RuntimeException throwForInvalidState(SdkSchema schema) {
-                return new SdkSerdeException("Typed documents can only wrap structures. Found: " + schema);
+            protected RuntimeException throwForInvalidState(String message, SdkSchema schema) {
+                return new SdkSerdeException("Typed documents can only wrap structures. " + message);
             }
 
             @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentMapTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentMapTest.java
@@ -32,7 +32,7 @@ public class DocumentMapTest {
             public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
                 consumer.accept(new MapSerializer() {
                     @Override
-                    public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {
+                    public void writeEntry(SdkSchema keySchema, String key, Consumer<ShapeSerializer> valueSerializer) {
                         valueSerializer.accept(new SpecificShapeSerializer() {
                             @Override
                             public void writeString(SdkSchema schema, String value) {
@@ -42,7 +42,7 @@ public class DocumentMapTest {
                     }
 
                     @Override
-                    public void entry(int key, Consumer<ShapeSerializer> valueSerializer) {
+                    public void writeEntry(SdkSchema keySchema, int key, Consumer<ShapeSerializer> valueSerializer) {
                         valueSerializer.accept(new SpecificShapeSerializer() {
                             @Override
                             public void writeString(SdkSchema schema, String value) {
@@ -52,7 +52,7 @@ public class DocumentMapTest {
                     }
 
                     @Override
-                    public void entry(long key, Consumer<ShapeSerializer> valueSerializer) {
+                    public void writeEntry(SdkSchema keySchema, long key, Consumer<ShapeSerializer> valueSerializer) {
                         valueSerializer.accept(new SpecificShapeSerializer() {
                             @Override
                             public void writeString(SdkSchema schema, String value) {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
@@ -73,7 +73,7 @@ public class MapDocumentTest {
                 assertThat(schema, equalTo(PreludeSchemas.DOCUMENT));
                 consumer.accept(new MapSerializer() {
                     @Override
-                    public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {
+                    public void writeEntry(SdkSchema keySchema, String key, Consumer<ShapeSerializer> valueSerializer) {
                         keys.add(key);
                         valueSerializer.accept(new SpecificShapeSerializer() {
                             @Override
@@ -89,12 +89,12 @@ public class MapDocumentTest {
                     }
 
                     @Override
-                    public void entry(int key, Consumer<ShapeSerializer> valueSerializer) {
+                    public void writeEntry(SdkSchema keySchema, int key, Consumer<ShapeSerializer> valueSerializer) {
                         throw new UnsupportedOperationException("Expected a string key");
                     }
 
                     @Override
-                    public void entry(long key, Consumer<ShapeSerializer> valueSerializer) {
+                    public void writeEntry(SdkSchema keySchema, long key, Consumer<ShapeSerializer> valueSerializer) {
                         throw new UnsupportedOperationException("Expected a string key");
                     }
                 });

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
@@ -34,7 +34,7 @@ public class TypedDocumentMemberTest {
         SerializableShape serializableShape = encoder -> {
             encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
                 var target = PreludeSchemas.getSchemaForType(ShapeType.STRING);
-                var member = PreludeSchemas.DOCUMENT.documentMember("foo", target);
+                var member = PreludeSchemas.DOCUMENT.getOrCreateDocumentMember("foo", target);
                 s.writeString(member, "Hi");
             });
         };
@@ -57,7 +57,7 @@ public class TypedDocumentMemberTest {
         var document1 = Document.ofStruct(encoder -> {
             encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
                 var target = PreludeSchemas.getSchemaForType(ShapeType.STRING);
-                var member = PreludeSchemas.DOCUMENT.documentMember("foo", target);
+                var member = PreludeSchemas.DOCUMENT.getOrCreateDocumentMember("foo", target);
                 s.writeString(member, "Hi");
             });
         });
@@ -65,7 +65,7 @@ public class TypedDocumentMemberTest {
         var document2 = Document.ofStruct(encoder -> {
             encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
                 var target = PreludeSchemas.getSchemaForType(ShapeType.INTEGER);
-                var member = PreludeSchemas.DOCUMENT.documentMember("foo", target);
+                var member = PreludeSchemas.DOCUMENT.getOrCreateDocumentMember("foo", target);
                 s.writeInteger(member, 1);
             });
         });
@@ -85,7 +85,7 @@ public class TypedDocumentMemberTest {
         SerializableShape serializableShape = encoder -> {
             encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
                 var target = PreludeSchemas.getSchemaForType(type);
-                var aMember = SdkSchema.memberBuilder("a", target).id(PreludeSchemas.DOCUMENT.id()).build();
+                var aMember = SdkSchema.memberBuilder(-1, "a", target).id(PreludeSchemas.DOCUMENT.id()).build();
                 writer.accept(aMember, s);
             });
         };
@@ -549,7 +549,11 @@ public class TypedDocumentMemberTest {
                 Map.of(Document.of("a"), Document.of(1)),
                 (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
-                    m -> m.entry("a", c -> c.writeInteger(PreludeSchemas.INTEGER, 1))
+                    m -> m.writeEntry(
+                        schema.getOrCreateDocumentMember("key", PreludeSchemas.STRING),
+                        "a",
+                        c -> c.writeInteger(PreludeSchemas.INTEGER, 1)
+                    )
                 ),
                 (Function<Document, Object>) d -> Document.ofValue(
                     Document.ofMap(d.asMap())
@@ -562,7 +566,11 @@ public class TypedDocumentMemberTest {
                 Map.of(Document.of(1), Document.of(1)),
                 (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
-                    m -> m.entry(1, c -> c.writeInteger(PreludeSchemas.INTEGER, 1))
+                    m -> m.writeEntry(
+                        schema.getOrCreateDocumentMember("key", PreludeSchemas.INTEGER),
+                        1,
+                        c -> c.writeInteger(PreludeSchemas.INTEGER, 1)
+                    )
                 ),
                 (Function<Document, Object>) d -> Document.ofValue(
                     Document.ofMap(d.asMap())
@@ -575,7 +583,11 @@ public class TypedDocumentMemberTest {
                 Map.of(Document.of(1L), Document.of(1)),
                 (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
-                    m -> m.entry(1L, c -> c.writeInteger(PreludeSchemas.INTEGER, 1))
+                    m -> m.writeEntry(
+                        schema.getOrCreateDocumentMember("key", PreludeSchemas.LONG),
+                        1L,
+                        c -> c.writeInteger(PreludeSchemas.INTEGER, 1)
+                    )
                 ),
                 (Function<Document, Object>) d -> Document.ofValue(
                     Document.ofMap(d.asMap())
@@ -588,7 +600,11 @@ public class TypedDocumentMemberTest {
                 Document.of(1),
                 (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
-                    m -> m.entry("a", c -> c.writeInteger(PreludeSchemas.INTEGER, 1))
+                    m -> m.writeEntry(
+                        schema.getOrCreateDocumentMember("key", PreludeSchemas.STRING),
+                        "a",
+                        c -> c.writeInteger(PreludeSchemas.INTEGER, 1)
+                    )
                 ),
                 (Function<Document, Object>) d -> Document.ofValue(d.getMember("a"))
             ),
@@ -599,8 +615,14 @@ public class TypedDocumentMemberTest {
                 Document.of("b"),
                 (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> {
                     s.writeStruct(schema, ser -> {
-                        ser.writeString(PreludeSchemas.DOCUMENT.documentMember("foo", PreludeSchemas.STRING), "a");
-                        ser.writeString(PreludeSchemas.DOCUMENT.documentMember("bar", PreludeSchemas.STRING), "b");
+                        ser.writeString(
+                            PreludeSchemas.DOCUMENT.getOrCreateDocumentMember("foo", PreludeSchemas.STRING),
+                            "a"
+                        );
+                        ser.writeString(
+                            PreludeSchemas.DOCUMENT.getOrCreateDocumentMember("bar", PreludeSchemas.STRING),
+                            "b"
+                        );
                     });
                 },
                 (Function<Document, Object>) d -> Document.ofValue(d.getMember("bar"))

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
@@ -43,11 +43,11 @@ public class TypedDocumentTest {
     public void wrapsStructContentWithTypeAndSchema() {
         SerializableShape serializableShape = encoder -> {
             encoder.writeStruct(PreludeSchemas.DOCUMENT, s -> {
-                var aMember = SdkSchema.memberBuilder("a", PreludeSchemas.STRING)
+                var aMember = SdkSchema.memberBuilder(-1, "a", PreludeSchemas.STRING)
                     .id(PreludeSchemas.DOCUMENT.id())
                     .build();
                 s.writeString(aMember, "1");
-                var bMember = SdkSchema.memberBuilder("b", PreludeSchemas.STRING)
+                var bMember = SdkSchema.memberBuilder(-1, "b", PreludeSchemas.STRING)
                     .id(PreludeSchemas.DOCUMENT.id())
                     .build();
                 s.writeString(bMember, "2");

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
@@ -72,10 +72,7 @@ public final class Bird implements SerializableShape {
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
             decoder.readStruct(SCHEMA, (member, de) -> {
-                int index = member.memberIndex() == -1
-                    ? SCHEMA.member(member.memberName()).memberIndex()
-                    : member.memberIndex();
-                switch (index) {
+                switch (SCHEMA.lookupMemberIndex(member)) {
                     case 0 -> name(de.readString(member));
                 }
             });

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
@@ -106,8 +106,10 @@ public final class Person implements SerializableShape {
             ShapeSerializer.writeIfNotNull(st, SCHEMA_BINARY, binary);
             if (!tags.isEmpty()) {
                 st.writeMap(SCHEMA_QUERY_PARAMS, m -> {
-                    tags.forEach((k, v) -> m.entry(k, mv -> {
-                        mv.writeList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
+                    var keyMember = SharedSchemas.MAP_LIST_STRING.member("key");
+                    var valueMember = SharedSchemas.MAP_LIST_STRING.member("value");
+                    tags.forEach((k, v) -> m.writeEntry(keyMember, k, mv -> {
+                        mv.writeList(valueMember, mvl -> {
                             v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
                         });
                     }));
@@ -160,10 +162,7 @@ public final class Person implements SerializableShape {
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
             decoder.readStruct(SCHEMA, (member, de) -> {
-                int index = member.memberIndex() == -1
-                    ? SCHEMA.member(member.memberName()).memberIndex()
-                    : member.memberIndex();
-                switch (index) {
+                switch (SCHEMA.lookupMemberIndex(member)) {
                     case 0 -> name(de.readString(member));
                     case 1 -> age(de.readInteger(member));
                     case 2 -> birthday(de.readTimestamp(member));

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageInput.java
@@ -72,10 +72,7 @@ public final class GetPersonImageInput implements SerializableShape {
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
             decoder.readStruct(SCHEMA, (member, de) -> {
-                int index = member.memberIndex() == -1
-                    ? SCHEMA.member(member.memberName()).memberIndex()
-                    : member.memberIndex();
-                switch (index) {
+                switch (SCHEMA.lookupMemberIndex(member)) {
                     case 0 -> name(de.readString(member));
                 }
             });

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageOutput.java
@@ -99,10 +99,7 @@ public final class GetPersonImageOutput implements SerializableShape {
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
             decoder.readStruct(SCHEMA, (member, de) -> {
-                int index = member.memberIndex() == -1
-                    ? SCHEMA.member(member.memberName()).memberIndex()
-                    : member.memberIndex();
-                switch (index) {
+                switch (SCHEMA.lookupMemberIndex(member)) {
                     case 0 -> name(de.readString(member));
                 }
             });

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageInput.java
@@ -142,10 +142,7 @@ public final class PutPersonImageInput implements SerializableShape {
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
             decoder.readStruct(SCHEMA, (member, de) -> {
-                int index = member.memberIndex() == -1
-                    ? SCHEMA.member(member.memberName()).memberIndex()
-                    : member.memberIndex();
-                switch (index) {
+                switch (SCHEMA.lookupMemberIndex(member)) {
                     case 0 -> name(de.readString(member));
                     case 1 -> de.readList(SCHEMA_TAGS, ser -> tags.add(ser.readString(SCHEMA_TAGS)));
                     case 2 -> de.readList(SCHEMA_MORE_TAGS, ser -> moreTags.add(ser.readString(SCHEMA_MORE_TAGS)));

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonInput.java
@@ -125,7 +125,8 @@ public final class PutPersonInput implements SerializableShape {
             ShapeSerializer.writeIfNotNull(st, SCHEMA_BINARY, binary);
             if (!queryParams.isEmpty()) {
                 st.writeMap(SCHEMA_QUERY_PARAMS, m -> {
-                    queryParams.forEach((k, v) -> m.entry(k, mv -> {
+                    var key = SharedSchemas.MAP_LIST_STRING.member("key");
+                    queryParams.forEach((k, v) -> m.writeEntry(key, k, mv -> {
                         mv.writeList(SharedSchemas.MAP_LIST_STRING.member("value"), mvl -> {
                             v.forEach(value -> mvl.writeString(SharedSchemas.LIST_OF_STRING.member("member"), value));
                         });
@@ -185,10 +186,7 @@ public final class PutPersonInput implements SerializableShape {
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
             decoder.readStruct(SCHEMA, (member, de) -> {
-                int index = member.memberIndex() == -1
-                    ? SCHEMA.member(member.memberName()).memberIndex()
-                    : member.memberIndex();
-                switch (index) {
+                switch (SCHEMA.lookupMemberIndex(member)) {
                     case 0 -> name(de.readString(member));
                     case 1 -> favoriteColor(de.readString(member));
                     case 2 -> age(de.readInteger(member));

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonOutput.java
@@ -142,10 +142,7 @@ public final class PutPersonOutput implements SerializableShape {
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
             decoder.readStruct(SCHEMA, (member, de) -> {
-                int index = member.memberIndex() == -1
-                    ? SCHEMA.member(member.memberName()).memberIndex()
-                    : member.memberIndex();
-                switch (index) {
+                switch (SCHEMA.lookupMemberIndex(member)) {
                     case 0 -> name(de.readString(member));
                     case 1 -> favoriteColor(de.readString(member));
                     case 2 -> age(de.readInteger(member));

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpBindingSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpBindingSerializer.java
@@ -77,11 +77,6 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
     }
 
     @Override
-    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-        return new UnsupportedOperationException("HTTP bindings must start with a structure. Found " + schema);
-    }
-
-    @Override
     public void writeStruct(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
         boolean foundBody = false;
         for (var member : schema.members()) {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
@@ -29,11 +29,6 @@ final class HttpHeaderSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-        throw new UnsupportedOperationException(schema + " is not supported in HTTP headers");
-    }
-
-    @Override
     public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
         consumer.accept(new ListSerializer(this, position -> {}));
     }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpLabelSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpLabelSerializer.java
@@ -24,11 +24,6 @@ final class HttpLabelSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-        throw new UnsupportedOperationException(schema + " is not supported in HTTP labels");
-    }
-
-    @Override
     public void writeBoolean(SdkSchema schema, boolean value) {
         labelReceiver.accept(schema.memberName(), Boolean.toString(value));
     }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpPrefixHeadersSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpPrefixHeadersSerializer.java
@@ -29,21 +29,11 @@ final class HttpPrefixHeadersSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-        throw new UnsupportedOperationException("Expected a map for prefix headers, found " + schema);
-    }
-
-    @Override
     public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
         consumer.accept(new MapSerializer() {
             @Override
-            public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, String key, Consumer<ShapeSerializer> valueSerializer) {
                 valueSerializer.accept(new SpecificShapeSerializer() {
-                    @Override
-                    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-                        throw new UnsupportedOperationException("Expected a string header, found " + schema);
-                    }
-
                     @Override
                     public void writeString(SdkSchema schema, String value) {
                         headerConsumer.accept(prefix + key, value);
@@ -52,12 +42,12 @@ final class HttpPrefixHeadersSerializer extends SpecificShapeSerializer {
             }
 
             @Override
-            public void entry(int key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, int key, Consumer<ShapeSerializer> valueSerializer) {
                 throw new UnsupportedOperationException("Prefix headers expects maps with string keys: " + schema);
             }
 
             @Override
-            public void entry(long key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, long key, Consumer<ShapeSerializer> valueSerializer) {
                 throw new UnsupportedOperationException("Prefix headers expects maps with string keys: " + schema);
             }
         });

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsSerializer.java
@@ -24,21 +24,11 @@ final class HttpQueryParamsSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-        throw new UnsupportedOperationException(schema + " is not value for httpQueryParam");
-    }
-
-    @Override
     public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
         consumer.accept(new MapSerializer() {
             @Override
-            public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, String key, Consumer<ShapeSerializer> valueSerializer) {
                 valueSerializer.accept(new SpecificShapeSerializer() {
-                    @Override
-                    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-                        throw new UnsupportedOperationException("Expected map of string or list of string: " + schema);
-                    }
-
                     @Override
                     public void writeString(SdkSchema schema, String value) {
                         queryWriter.accept(key, value);
@@ -47,11 +37,6 @@ final class HttpQueryParamsSerializer extends SpecificShapeSerializer {
                     @Override
                     public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
                         consumer.accept(new SpecificShapeSerializer() {
-                            @Override
-                            protected RuntimeException throwForInvalidState(SdkSchema schema) {
-                                throw new UnsupportedOperationException("Expected map of list of string: " + schema);
-                            }
-
                             @Override
                             public void writeString(SdkSchema schema, String value) {
                                 queryWriter.accept(key, value);
@@ -62,12 +47,12 @@ final class HttpQueryParamsSerializer extends SpecificShapeSerializer {
             }
 
             @Override
-            public void entry(int key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, int key, Consumer<ShapeSerializer> valueSerializer) {
                 throw new UnsupportedOperationException("Query params requires a map of string keys: " + schema);
             }
 
             @Override
-            public void entry(long key, Consumer<ShapeSerializer> valueSerializer) {
+            public void writeEntry(SdkSchema keySchema, long key, Consumer<ShapeSerializer> valueSerializer) {
                 throw new UnsupportedOperationException("Query params requires a map of string keys: " + schema);
             }
         });

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
@@ -29,11 +29,6 @@ final class HttpQuerySerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-        throw new UnsupportedOperationException(schema + " is not supported in HTTP query");
-    }
-
-    @Override
     public void writeList(SdkSchema schema, Consumer<ShapeSerializer> consumer) {
         consumer.accept(new ListSerializer(this, position -> {}));
     }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseStatusSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseStatusSerializer.java
@@ -18,11 +18,6 @@ final class ResponseStatusSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    protected RuntimeException throwForInvalidState(SdkSchema schema) {
-        throw new UnsupportedOperationException(schema + " is not a value response status code member");
-    }
-
-    @Override
     public void writeInteger(SdkSchema schema, int value) {
         consumer.accept(value);
     }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDeserializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDeserializer.java
@@ -173,18 +173,16 @@ final class JsonDeserializer implements ShapeDeserializer {
     }
 
     private SdkSchema resolveMember(SdkSchema schema, String field) {
-        SdkSchema member = null;
-        if (useJsonName) {
-            member = schema.findMember(
-                m -> m.hasTrait(JsonNameTrait.class) && m.getTrait(JsonNameTrait.class).getValue().equals(field)
-            );
+        for (SdkSchema m : schema.members()) {
+            if (useJsonName && m.hasTrait(JsonNameTrait.class)) {
+                if (m.getTrait(JsonNameTrait.class).getValue().equals(field)) {
+                    return m;
+                }
+            } else if (m.memberName().equals(field)) {
+                return m;
+            }
         }
-
-        if (member == null) {
-            member = schema.member(field);
-        }
-
-        return member;
+        return null;
     }
 
     @Override

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonMapSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonMapSerializer.java
@@ -20,13 +20,13 @@ final class JsonMapSerializer implements MapSerializer {
     private final JsonStream stream;
     private boolean wroteValue = false;
 
-    JsonMapSerializer(SdkSchema keySchema, ShapeSerializer parent, JsonStream stream) {
+    JsonMapSerializer(ShapeSerializer parent, JsonStream stream) {
         this.parent = parent;
         this.stream = stream;
     }
 
     @Override
-    public void entry(String key, Consumer<ShapeSerializer> valueSerializer) {
+    public void writeEntry(SdkSchema keySchema, String key, Consumer<ShapeSerializer> valueSerializer) {
         try {
             beforeWrite();
             stream.writeObjectField(key);
@@ -50,12 +50,12 @@ final class JsonMapSerializer implements MapSerializer {
     }
 
     @Override
-    public void entry(int key, Consumer<ShapeSerializer> valueSerializer) {
-        entry(Integer.toString(key), valueSerializer);
+    public void writeEntry(SdkSchema keySchema, int key, Consumer<ShapeSerializer> valueSerializer) {
+        writeEntry(keySchema, Integer.toString(key), valueSerializer);
     }
 
     @Override
-    public void entry(long key, Consumer<ShapeSerializer> valueSerializer) {
-        entry(Long.toString(key), valueSerializer);
+    public void writeEntry(SdkSchema keySchema, long key, Consumer<ShapeSerializer> valueSerializer) {
+        writeEntry(keySchema, Long.toString(key), valueSerializer);
     }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
@@ -193,8 +193,7 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeMap(SdkSchema schema, Consumer<MapSerializer> consumer) {
         try {
             stream.writeObjectStart();
-            var keySchema = schema.member("key");
-            consumer.accept(new JsonMapSerializer(keySchema, this, stream));
+            consumer.accept(new JsonMapSerializer(this, stream));
             stream.writeObjectEnd();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -205,5 +204,14 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeDocument(SdkSchema schema, Document value) {
         // Document values in JSON are serialized inline by receiving the data model contents of the document.
         value.serializeContents(this);
+    }
+
+    @Override
+    public void writeNull(SdkSchema schema) {
+        try {
+            stream.writeNull();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
@@ -148,4 +148,10 @@ class JsonStructSerializer implements ShapeSerializer {
         startMember(member);
         parent.writeDocument(member, value);
     }
+
+    @Override
+    public void writeNull(SdkSchema member) {
+        startMember(member);
+        parent.writeNull(member);
+    }
 }


### PR DESCRIPTION
MapSerializer now sends the key schema when writing an entry to avoid needing to look it up each time an entry is serialized. The method entry was also renamed to writeEntry to match the other serialization methods.

Added writeNull to ShapeSerializer to explicitly capture null value serialization. This is used specifically to serialize null values in sparse lists and maps.

Various cleanup was made to SdkSchema.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
