### PR TITLE
Add state to deser consumers to remove captures

### DIFF
--- a/core/src/jmh/java/software/amazon/smithy/java/runtime/core/schema/model/Person.java
+++ b/core/src/jmh/java/software/amazon/smithy/java/runtime/core/schema/model/Person.java
@@ -197,22 +197,22 @@ public final class Person implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> name(de.readString(member));
-                    case 1 -> favoriteColor(de.readString(member));
-                    case 2 -> age(de.readInteger(member));
-                    case 3 -> birthday(de.readTimestamp(member));
-                    case 4 -> binary(de.readBlob(member));
+                    case 0 -> builder.name(de.readString(member));
+                    case 1 -> builder.favoriteColor(de.readString(member));
+                    case 2 -> builder.age(de.readInteger(member));
+                    case 3 -> builder.birthday(de.readTimestamp(member));
+                    case 4 -> builder.binary(de.readBlob(member));
                     case 5 -> {
                         Map<String, List<String>> result = new LinkedHashMap<>();
-                        de.readStringMap(SCHEMA_QUERY_PARAMS, (key, v) -> {
-                            v.readList(SharedSchemas.MAP_LIST_STRING.member("member"), list -> {
-                                result.computeIfAbsent(key, k -> new ArrayList<>())
-                                    .add(list.readString(SharedSchemas.LIST_OF_STRING.member("member")));
+                        de.readStringMap(SCHEMA_QUERY_PARAMS, result, (mapData, key, v) -> {
+                            List<String> listValue = mapData.computeIfAbsent(key, k -> new ArrayList<>());
+                            v.readList(SharedSchemas.MAP_LIST_STRING.member("member"), listValue, (list, ser) -> {
+                                list.add(ser.readString(SharedSchemas.LIST_OF_STRING.member("member")));
                             });
                         });
-                        queryParams(result);
+                        builder.queryParams(result);
                     }
                     default -> {
                         // TODO: Log periodically

--- a/core/src/jmh/java/software/amazon/smithy/java/runtime/core/schema/model/UnvalidatedPojo.java
+++ b/core/src/jmh/java/software/amazon/smithy/java/runtime/core/schema/model/UnvalidatedPojo.java
@@ -108,11 +108,11 @@ public final class UnvalidatedPojo implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> string(de.readString(member));
-                    case 1 -> boxedInteger(de.readInteger(member));
-                    case 2 -> integer(de.readInteger(member));
+                    case 0 -> builder.string(de.readString(member));
+                    case 1 -> builder.boxedInteger(de.readInteger(member));
+                    case 2 -> builder.integer(de.readInteger(member));
                     default -> {
                         // TODO: Log periodically
                     }

--- a/core/src/jmh/java/software/amazon/smithy/java/runtime/core/schema/model/ValidatedPojo.java
+++ b/core/src/jmh/java/software/amazon/smithy/java/runtime/core/schema/model/ValidatedPojo.java
@@ -113,11 +113,11 @@ public final class ValidatedPojo implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> string(de.readString(member));
-                    case 1 -> boxedInteger(de.readInteger(member));
-                    case 2 -> integer(de.readInteger(member));
+                    case 0 -> builder.string(de.readString(member));
+                    case 1 -> builder.boxedInteger(de.readInteger(member));
+                    case 2 -> builder.integer(de.readInteger(member));
                     default -> {
                         // TODO: Log periodically
                     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
@@ -8,8 +8,6 @@ package software.amazon.smithy.java.runtime.core.serde;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
@@ -17,36 +15,162 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
  * Deserializes a shape by emitted the Smithy data model from the shape, aided by schemas.
  */
 public interface ShapeDeserializer {
-
+    /**
+     * Attempt to read a boolean value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     boolean readBoolean(SdkSchema schema);
 
+    /**
+     * Attempt to read a blob value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     byte[] readBlob(SdkSchema schema);
 
+    /**
+     * Attempt to read a byte value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     byte readByte(SdkSchema schema);
 
+    /**
+     * Attempt to read a short value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     short readShort(SdkSchema schema);
 
+    /**
+     * Attempt to read an integer or intEnum value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     int readInteger(SdkSchema schema);
 
+    /**
+     * Attempt to read a long value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     long readLong(SdkSchema schema);
 
+    /**
+     * Attempt to read a float value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     float readFloat(SdkSchema schema);
 
+    /**
+     * Attempt to read a double value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     double readDouble(SdkSchema schema);
 
+    /**
+     * Attempt to read a bigInteger value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     BigInteger readBigInteger(SdkSchema schema);
 
+    /**
+     * Attempt to read a bigDecimal value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     BigDecimal readBigDecimal(SdkSchema schema);
 
+    /**
+     * Attempt to read a string or enum value.
+     *
+     * @param schema Schema of the shape.
+     * @return the read value.
+     */
     String readString(SdkSchema schema);
 
+    /**
+     * Attempt to read a document value.
+     *
+     * @return the read value.
+     */
     Document readDocument();
 
+    /**
+     * Attempt to read a timestamp value.
+     *
+     * @return the read value.
+     */
     Instant readTimestamp(SdkSchema schema);
 
-    void readStruct(SdkSchema schema, BiConsumer<SdkSchema, ShapeDeserializer> eachEntry);
+    /**
+     * Attempt to read a structure or union value.
+     *
+     * @param schema   Schema of the shape.
+     * @param state    State to pass to the consumer.
+     * @param consumer Consumer that receives the state, member schema, and deserializer.
+     */
+    <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> consumer);
 
-    void readList(SdkSchema schema, Consumer<ShapeDeserializer> eachElement);
+    /**
+     * Attempt to read a list value.
+     *
+     * @param schema   Schema of the shape.
+     * @param state    State to pass to the consumer.
+     * @param consumer Consumer that receives the state and deserializer.
+     */
+    <T> void readList(SdkSchema schema, T state, ListMemberConsumer<T> consumer);
 
-    void readStringMap(SdkSchema schema, BiConsumer<String, ShapeDeserializer> eachEntry);
+    /**
+     * Attempt to read a map value.
+     *
+     * @param schema   Schema of the shape.
+     * @param state    State to pass to the consumer.
+     * @param consumer Consumer that receives the state, map key, and deserializer.
+     */
+    <T> void readStringMap(SdkSchema schema, T state, MapMemberConsumer<String, T> consumer);
+
+    /**
+     * Consumer of a structure member.
+     *
+     * @param <T> Passed in state value to avoid capturing external state.
+     */
+    @FunctionalInterface
+    interface StructMemberConsumer<T> {
+        void accept(T state, SdkSchema memberSchema, ShapeDeserializer memberDeserializer);
+    }
+
+    /**
+     * Consumer of list member.
+     *
+     * @param <T> Passed in state value to avoid capturing external state.
+     */
+    @FunctionalInterface
+    interface ListMemberConsumer<T> {
+        void accept(T state, ShapeDeserializer memberDeserializer);
+    }
+
+    /**
+     * Consumer of map member.
+     *
+     * @param <T> Passed in state value to avoid capturing external state.
+     */
+    @FunctionalInterface
+    interface MapMemberConsumer<K, T> {
+        void accept(T state, K key, ShapeDeserializer memberDeserializer);
+    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
@@ -8,8 +8,6 @@ package software.amazon.smithy.java.runtime.core.serde;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
@@ -91,17 +89,17 @@ public abstract class SpecificShapeDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public void readStruct(SdkSchema schema, BiConsumer<SdkSchema, ShapeDeserializer> eachEntry) {
+    public <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> consumer) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void readList(SdkSchema schema, Consumer<ShapeDeserializer> eachElement) {
+    public <T> void readList(SdkSchema schema, T state, ListMemberConsumer<T> consumer) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void readStringMap(SdkSchema schema, BiConsumer<String, ShapeDeserializer> eachEntry) {
+    public <T> void readStringMap(SdkSchema schema, T state, MapMemberConsumer<String, T> consumer) {
         throw throwForInvalidState(schema);
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
@@ -8,8 +8,6 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 
@@ -102,27 +100,27 @@ public class DocumentDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public void readStruct(SdkSchema schema, BiConsumer<SdkSchema, ShapeDeserializer> eachEntry) {
+    public <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
         for (var memberSchema : schema.members()) {
             var memberValue = value.getMember(memberSchema.memberName());
             if (memberValue != null) {
-                eachEntry.accept(memberSchema, deserializer(memberValue));
+                structMemberConsumer.accept(state, memberSchema, deserializer(memberValue));
             }
         }
     }
 
     @Override
-    public void readList(SdkSchema schema, Consumer<ShapeDeserializer> eachElement) {
+    public <T> void readList(SdkSchema schema, T state, ListMemberConsumer<T> listMemberConsumer) {
         for (var element : value.asList()) {
-            eachElement.accept(deserializer(element));
+            listMemberConsumer.accept(state, deserializer(element));
         }
     }
 
     @Override
-    public void readStringMap(SdkSchema schema, BiConsumer<String, ShapeDeserializer> eachEntry) {
+    public <T> void readStringMap(SdkSchema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
         var map = value.asStringMap();
         for (var entry : map.entrySet()) {
-            eachEntry.accept(entry.getKey(), deserializer(entry.getValue()));
+            mapMemberConsumer.accept(state, entry.getKey(), deserializer(entry.getValue()));
         }
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
@@ -40,12 +40,12 @@ public class ToStringSerializerTest {
             .age(102)
             .birthday(Instant.EPOCH)
             .binary("hello".getBytes(StandardCharsets.UTF_8))
-            .tags(tags)
+            .queryParams(Map.of("a", List.of("1", "2")))
             .build();
 
         assertThat(
             person.toString(),
-            equalTo("Person[name=Mike, age=102, birthday=*REDACTED*, binary=68656c6c6f, tags={a=[b, c], b=[d], c=[]}]")
+            equalTo("Person[name=Mike, age=102, binary=68656c6c6f, birthday=*REDACTED*, queryParams={a=[1, 2]}]")
         );
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
@@ -294,7 +294,9 @@ public class DocumentTest {
         DocumentDeserializer deserializer = new DocumentDeserializer(value);
         List<String> result = new ArrayList<>();
 
-        deserializer.readList(PreludeSchemas.DOCUMENT, c -> result.add(c.readString(PreludeSchemas.STRING)));
+        deserializer.readList(PreludeSchemas.DOCUMENT, result, (listResult, c) -> {
+            listResult.add(c.readString(PreludeSchemas.STRING));
+        });
 
         assertThat(result, contains("a", "b"));
     }
@@ -307,7 +309,8 @@ public class DocumentTest {
 
         deserializer.readStringMap(
             PreludeSchemas.DOCUMENT,
-            (k, v) -> result.put(k, v.readString(PreludeSchemas.STRING))
+            result,
+            (resultMap, k, v) -> resultMap.put(k, v.readString(PreludeSchemas.STRING))
         );
 
         assertThat(result, equalTo(Map.of("a", "v")));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
@@ -71,9 +71,9 @@ public final class Bird implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> name(de.readString(member));
+                    case 0 -> builder.name(de.readString(member));
                 }
             });
             return this;

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
@@ -110,11 +110,11 @@ public final class UnvalidatedPojo implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> string(de.readString(member));
-                    case 1 -> boxedInteger(de.readInteger(member));
-                    case 2 -> integer(de.readInteger(member));
+                    case 0 -> builder.string(de.readString(member));
+                    case 1 -> builder.boxedInteger(de.readInteger(member));
+                    case 2 -> builder.integer(de.readInteger(member));
                 }
             });
             return this;

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
@@ -118,11 +118,11 @@ public final class ValidatedPojo implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> string(de.readString(member));
-                    case 1 -> boxedInteger(de.readInteger(member));
-                    case 2 -> integer(de.readInteger(member));
+                    case 0 -> builder.string(de.readString(member));
+                    case 1 -> builder.boxedInteger(de.readInteger(member));
+                    case 2 -> builder.integer(de.readInteger(member));
                 }
             });
             return this;

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageInput.java
@@ -71,9 +71,9 @@ public final class GetPersonImageInput implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> name(de.readString(member));
+                    case 0 -> builder.name(de.readString(member));
                 }
             });
             return this;

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/GetPersonImageOutput.java
@@ -98,9 +98,9 @@ public final class GetPersonImageOutput implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> name(de.readString(member));
+                    case 0 -> builder.name(de.readString(member));
                 }
             });
             return this;

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageInput.java
@@ -145,11 +145,15 @@ public final class PutPersonImageInput implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> name(de.readString(member));
-                    case 1 -> de.readList(SCHEMA_TAGS, ser -> tags.add(ser.readString(SCHEMA_TAGS)));
-                    case 2 -> de.readList(SCHEMA_MORE_TAGS, ser -> moreTags.add(ser.readString(SCHEMA_MORE_TAGS)));
+                    case 0 -> builder.name(de.readString(member));
+                    case 1 -> de.readList(SCHEMA_TAGS, builder, (builder2, ser) -> {
+                        builder2.tags.add(ser.readString(SCHEMA_TAGS));
+                    });
+                    case 2 -> de.readList(SCHEMA_MORE_TAGS, builder, (builder2, ser) -> {
+                        builder2.moreTags.add(ser.readString(SCHEMA_MORE_TAGS));
+                    });
                 }
             });
             return this;

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonImageOutput.java
@@ -49,8 +49,7 @@ public final class PutPersonImageOutput implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
-            });
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {});
             return this;
         }
     }

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonInput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonInput.java
@@ -190,22 +190,22 @@ public final class PutPersonInput implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> name(de.readString(member));
-                    case 1 -> favoriteColor(de.readString(member));
-                    case 2 -> age(de.readInteger(member));
-                    case 3 -> birthday(de.readTimestamp(member));
-                    case 4 -> binary(de.readBlob(member));
+                    case 0 -> builder.name(de.readString(member));
+                    case 1 -> builder.favoriteColor(de.readString(member));
+                    case 2 -> builder.age(de.readInteger(member));
+                    case 3 -> builder.birthday(de.readTimestamp(member));
+                    case 4 -> builder.binary(de.readBlob(member));
                     case 5 -> {
                         Map<String, List<String>> result = new LinkedHashMap<>();
-                        de.readStringMap(SCHEMA_QUERY_PARAMS, (key, v) -> {
-                            v.readList(SharedSchemas.MAP_LIST_STRING.member("member"), list -> {
-                                result.computeIfAbsent(key, k -> new ArrayList<>())
-                                    .add(list.readString(SharedSchemas.LIST_OF_STRING.member("member")));
+                        de.readStringMap(SCHEMA_QUERY_PARAMS, result, (mapData, key, v) -> {
+                            List<String> listValue = mapData.computeIfAbsent(key, k -> new ArrayList<>());
+                            v.readList(SharedSchemas.MAP_LIST_STRING.member("member"), listValue, (list, ser) -> {
+                                list.add(ser.readString(SharedSchemas.LIST_OF_STRING.member("member")));
                             });
                         });
-                        queryParams(result);
+                        builder.queryParams(result);
                     }
                 }
             });

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonOutput.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/PutPersonOutput.java
@@ -141,13 +141,13 @@ public final class PutPersonOutput implements SerializableShape {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> name(de.readString(member));
-                    case 1 -> favoriteColor(de.readString(member));
-                    case 2 -> age(de.readInteger(member));
-                    case 3 -> birthday(de.readTimestamp(member));
-                    case 4 -> status(de.readInteger(member));
+                    case 0 -> builder.name(de.readString(member));
+                    case 1 -> builder.favoriteColor(de.readString(member));
+                    case 2 -> builder.age(de.readInteger(member));
+                    case 3 -> builder.birthday(de.readTimestamp(member));
+                    case 4 -> builder.status(de.readInteger(member));
                 }
             });
             return this;

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/ValidationError.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/model/ValidationError.java
@@ -67,9 +67,9 @@ public final class ValidationError extends ModeledSdkException {
 
         @Override
         public Builder deserialize(ShapeDeserializer decoder) {
-            decoder.readStruct(SCHEMA, (member, de) -> {
+            decoder.readStruct(SCHEMA, this, (builder, member, de) -> {
                 switch (member.memberIndex()) {
-                    case 0 -> message(de.readString(member));
+                    case 0 -> builder.message(de.readString(member));
                 }
             });
             return this;

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderDeserializer.java
@@ -10,8 +10,6 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
@@ -107,17 +105,17 @@ final class HttpHeaderDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public void readStruct(SdkSchema schema, BiConsumer<SdkSchema, ShapeDeserializer> eachEntry) {
+    public <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
         throw new UnsupportedOperationException("Structures are not supported in HTTP header bindings");
     }
 
     @Override
-    public void readList(SdkSchema schema, Consumer<ShapeDeserializer> eachElement) {
+    public <T> void readList(SdkSchema schema, T state, ListMemberConsumer<T> listMemberConsumer) {
         throw new UnsupportedOperationException("List header support not yet implemented");
     }
 
     @Override
-    public void readStringMap(SdkSchema schema, BiConsumer<String, ShapeDeserializer> eachEntry) {
+    public <T> void readStringMap(SdkSchema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
         throw new UnsupportedOperationException("List map support not yet implemented");
     }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDocument.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDocument.java
@@ -15,13 +15,11 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
-import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
@@ -245,14 +243,14 @@ final class JsonDocument implements Document {
         }
 
         @Override
-        public void readStruct(SdkSchema schema, BiConsumer<SdkSchema, ShapeDeserializer> eachEntry) {
+        public <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
             for (var member : schema.members()) {
                 var jsonName = member.hasTrait(JsonNameTrait.class)
                     ? member.getTrait(JsonNameTrait.class).getValue()
                     : member.memberName();
                 var value = getMember(jsonName);
                 if (value != null) {
-                    eachEntry.accept(member, new DocumentDeserializer(value));
+                    structMemberConsumer.accept(state, member, new DocumentDeserializer(value));
                 }
             }
         }


### PR DESCRIPTION
Avoid state capturing by passing in a T state to deserialization consumers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
