### PR TITLE
Improve documents, JSON, and timestamp formatter

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/Codec.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/Codec.java
@@ -14,7 +14,11 @@ import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 /**
  * Generic shape serialization and deserialization.
  */
-public interface Codec {
+public interface Codec extends AutoCloseable {
+
+    @Override
+    default void close() {}
+
     /**
      * Returns the default media type used by this codec.
      *

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
@@ -14,7 +14,11 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
 /**
  * Deserializes a shape by emitted the Smithy data model from the shape, aided by schemas.
  */
-public interface ShapeDeserializer {
+public interface ShapeDeserializer extends AutoCloseable {
+
+    @Override
+    default void close() {}
+
     /**
      * Attempt to read a boolean value.
      *

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.core.serde;
 
-import java.io.Closeable;
 import java.io.Flushable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -21,7 +20,7 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
  * <p>Note: null values should only ever be written using {@link #writeNull(SdkSchema)}. Every other method expects
  * a non-null value or a value type.
  */
-public interface ShapeSerializer extends Flushable, Closeable {
+public interface ShapeSerializer extends Flushable, AutoCloseable {
 
     /**
      * Create a serializer that serializes nothing.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -51,6 +51,11 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBoolean(schema, value);
         }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.BOOLEAN ? this : Document.super.normalize();
+        }
     }
 
     record ByteDocument(SdkSchema schema, byte value) implements Document {
@@ -102,6 +107,11 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeByte(schema, value);
+        }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.BYTE ? this : Document.super.normalize();
         }
     }
 
@@ -155,6 +165,11 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeShort(schema, value);
         }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.SHORT ? this : Document.super.normalize();
+        }
     }
 
     record IntegerDocument(SdkSchema schema, int value) implements Document {
@@ -206,6 +221,11 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeInteger(schema, value);
+        }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.INTEGER ? this : Document.super.normalize();
         }
     }
 
@@ -259,6 +279,11 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeLong(schema, value);
         }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.LONG ? this : Document.super.normalize();
+        }
     }
 
     record FloatDocument(SdkSchema schema, float value) implements Document {
@@ -310,6 +335,11 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeFloat(schema, value);
+        }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.FLOAT ? this : Document.super.normalize();
         }
     }
 
@@ -363,6 +393,11 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeDouble(schema, value);
         }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.DOUBLE ? this : Document.super.normalize();
+        }
     }
 
     record BigIntegerDocument(SdkSchema schema, BigInteger value) implements Document {
@@ -414,6 +449,11 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBigInteger(schema, value);
+        }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.BIG_INTEGER ? this : Document.super.normalize();
         }
     }
 
@@ -467,6 +507,11 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBigDecimal(schema, value);
         }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.BIG_DECIMAL ? this : Document.super.normalize();
+        }
     }
 
     record StringDocument(SdkSchema schema, String value) implements Document {
@@ -483,6 +528,11 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeString(schema, value);
+        }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.STRING ? this : Document.super.normalize();
         }
     }
 
@@ -519,6 +569,11 @@ final class Documents {
         public int hashCode() {
             return Arrays.hashCode(value);
         }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.BLOB ? this : Document.super.normalize();
+        }
     }
 
     record TimestampDocument(SdkSchema schema, Instant value) implements Document {
@@ -535,6 +590,11 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeTimestamp(schema, value);
+        }
+
+        @Override
+        public Document normalize() {
+            return schema == PreludeSchemas.TIMESTAMP ? this : Document.super.normalize();
         }
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
@@ -54,4 +54,11 @@ public class BlobDocumentTest {
 
         document.serializeContents(serializer);
     }
+
+    @Test
+    public void normalizeReturnsSelf() {
+        var doc = Document.createBlob("a".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(doc.normalize(), is(doc));
+    }
 }

--- a/examples/restjson-example/src/jmh/java/software/amazon/smithy/java/runtime/SerdeBenchmarks.java
+++ b/examples/restjson-example/src/jmh/java/software/amazon/smithy/java/runtime/SerdeBenchmarks.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.java.runtime;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -41,8 +43,11 @@ public class SerdeBenchmarks {
     }
 
     @Benchmark
-    public void shapeToJson(Blackhole bh) {
-        bh.consume(codec.serializeToString(input));
+    public void shapeToJson(Blackhole bh) throws IOException {
+        try (var sink = new ByteArrayOutputStream(); var serializer = codec.createSerializer(sink)) {
+            input.serialize(serializer);
+            bh.consume(sink.size());
+        }
     }
 
     @Benchmark

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderDeserializer.java
@@ -101,7 +101,7 @@ final class HttpHeaderDeserializer implements ShapeDeserializer {
         TimestampFormatter formatter = trait != null
             ? TimestampFormatter.of(trait)
             : TimestampFormatter.Prelude.HTTP_DATE;
-        return formatter.parseFromString(value, false); // headers always are strings.
+        return formatter.readFromString(value, false); // headers always are strings.
     }
 
     @Override

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
@@ -102,7 +102,7 @@ final class HttpHeaderSerializer extends SpecificShapeSerializer {
                 TimestampFormatter formatter = trait != null
                     ? TimestampFormatter.of(trait)
                     : TimestampFormatter.Prelude.HTTP_DATE;
-                return formatter.formatToString(value);
+                return formatter.writeString(value);
             }
         );
     }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpLabelSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpLabelSerializer.java
@@ -79,6 +79,6 @@ final class HttpLabelSerializer extends SpecificShapeSerializer {
         TimestampFormatter formatter = trait != null
             ? TimestampFormatter.of(trait)
             : TimestampFormatter.Prelude.DATE_TIME;
-        labelReceiver.accept(schema.memberName(), formatter.formatToString(value));
+        labelReceiver.accept(schema.memberName(), formatter.writeString(value));
     }
 }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
@@ -100,6 +100,6 @@ final class HttpQuerySerializer extends SpecificShapeSerializer {
         TimestampFormatter formatter = trait != null
             ? TimestampFormatter.of(trait)
             : TimestampFormatter.Prelude.DATE_TIME;
-        writeQuery(schema, () -> formatter.formatToString(value));
+        writeQuery(schema, () -> formatter.writeString(value));
     }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
@@ -5,7 +5,10 @@
 
 package software.amazon.smithy.java.runtime.json;
 
+import com.jsoniter.JsonIterator;
+import com.jsoniter.output.JsonStream;
 import java.io.OutputStream;
+import java.util.Objects;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -15,24 +18,27 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait;
 
 /**
  * Handles JSON serialization and deserialization.
- * <p>
- * Support for using {@link JsonNameTrait} can be enabled using {@link Builder#useJsonName(boolean)}.
- * The default timestamp format of epoch-seconds can be changed using
+ *
+ * <p>Support for using {@link JsonNameTrait} can be enabled using {@link Builder#useJsonName(boolean)}.
+ *
+ * <p>Support for respecting the {@link TimestampFormatTrait} can be enabled using
+ * {@link Builder#useTimestampFormat(boolean)}. The default timestamp format of epoch-seconds can be changed using
  * {@link Builder#defaultTimestampFormat(TimestampFormatter)}.
- * <p>
- * Support for respecting the {@link TimestampFormatTrait}
- * can be enabled using {@link Builder#useTimestampFormat(boolean)}.
+ *
+ * <p>Blobs are base64 encoded as strings.
  */
 public final class JsonCodec implements Codec {
 
-    private final boolean useJsonName;
-    private final boolean useTimestampFormat;
-    private final TimestampFormatter defaultTimestampFormat;
+    private final TimestampResolver timestampResolver;
+    private final JsonFieldMapper fieldMapper;
 
     private JsonCodec(Builder builder) {
-        this.useJsonName = builder.useJsonName;
-        this.useTimestampFormat = builder.useTimestampFormat;
-        this.defaultTimestampFormat = builder.defaultTimestampFormat;
+        timestampResolver = builder.useTimestampFormat
+            ? new TimestampResolver.UseTimestampFormatTrait(builder.defaultTimestampFormat)
+            : new TimestampResolver.StaticFormat(builder.defaultTimestampFormat);
+        fieldMapper = builder.useJsonName
+            ? new JsonFieldMapper.UseJsonNameTrait()
+            : JsonFieldMapper.UseMemberName.INSTANCE;
     }
 
     public static Builder builder() {
@@ -46,12 +52,30 @@ public final class JsonCodec implements Codec {
 
     @Override
     public ShapeSerializer createSerializer(OutputStream sink) {
-        return new JsonSerializer(sink, useJsonName, defaultTimestampFormat, useTimestampFormat);
+        var stream = createStream(sink);
+        return new JsonSerializer(stream, fieldMapper, timestampResolver, this::returnStream);
     }
 
     @Override
     public ShapeDeserializer createDeserializer(byte[] source) {
-        return new JsonDeserializer(source, useJsonName, defaultTimestampFormat, useTimestampFormat);
+        return new JsonDeserializer(createIterator(source), timestampResolver, fieldMapper, this::returnIterator);
+    }
+
+    // TODO: Implement virtual thread friendly pooling (JsonIter's pooling is done using ThreadLocals).
+    private JsonStream createStream(OutputStream sink) {
+        return new JsonStream(sink, 1024);
+    }
+
+    private JsonIterator createIterator(byte[] source) {
+        return JsonIterator.parse(source);
+    }
+
+    private void returnStream(JsonStream stream) {
+        // TODO: Implement pooling.
+    }
+
+    private void returnIterator(JsonIterator iterator) {
+        // TODO: Implement pooling.
     }
 
     public static final class Builder {
@@ -59,8 +83,7 @@ public final class JsonCodec implements Codec {
         private boolean useTimestampFormat = false;
         private TimestampFormatter defaultTimestampFormat = TimestampFormatter.Prelude.EPOCH_SECONDS;
 
-        private Builder() {
-        }
+        private Builder() {}
 
         public JsonCodec build() {
             return new JsonCodec(this);
@@ -77,7 +100,7 @@ public final class JsonCodec implements Codec {
         }
 
         public Builder defaultTimestampFormat(TimestampFormatter defaultTimestampFormat) {
-            this.defaultTimestampFormat = defaultTimestampFormat;
+            this.defaultTimestampFormat = Objects.requireNonNull(defaultTimestampFormat);
             return this;
         }
     }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonFieldMapper.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonFieldMapper.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.json;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+
+/**
+ * Provides a mapping to and from members and JSON field names.
+ */
+sealed interface JsonFieldMapper {
+    /**
+     * Determines the schema of a member inside a container based on a JSON field name.
+     *
+     * @param container Container that contains members.
+     * @param field     JSON object field name.
+     * @return the resolved member schema or null if not found.
+     */
+    SdkSchema fieldToMember(SdkSchema container, String field);
+
+    /**
+     * Converts a member schema a JSON object field name.
+     *
+     * @param member Member to convert to a field.
+     * @return the resolved object field name.
+     */
+    String memberToField(SdkSchema member);
+
+    /**
+     * Uses the member name and ignores the jsonName trait.
+     */
+    final class UseMemberName implements JsonFieldMapper {
+        static final UseMemberName INSTANCE = new UseMemberName();
+
+        @Override
+        public SdkSchema fieldToMember(SdkSchema container, String field) {
+            return container.member(field);
+        }
+
+        @Override
+        public String memberToField(SdkSchema member) {
+            return member.memberName();
+        }
+
+        @Override
+        public String toString() {
+            return "FieldMapper{useJsonName=false}";
+        }
+    }
+
+    /**
+     * Uses the jsonName trait if present, otherwise falls back to the member name.
+     */
+    final class UseJsonNameTrait implements JsonFieldMapper {
+
+        private final Map<SdkSchema, Map<String, SdkSchema>> jsonNameCache = new ConcurrentHashMap<>();
+
+        @Override
+        public SdkSchema fieldToMember(SdkSchema container, String field) {
+            return jsonNameCache.computeIfAbsent(container, schema -> {
+                Map<String, SdkSchema> map = new HashMap<>(schema.members().size());
+                for (SdkSchema m : schema.members()) {
+                    var jsonName = m.getTrait(JsonNameTrait.class);
+                    if (jsonName != null) {
+                        map.put(jsonName.getValue(), m);
+                    } else {
+                        map.put(m.memberName(), m);
+                    }
+                }
+                return map;
+            }).get(field);
+        }
+
+        @Override
+        public String memberToField(SdkSchema member) {
+            var jsonName = member.getTrait(JsonNameTrait.class);
+            return jsonName == null ? member.memberName() : jsonName.getValue();
+        }
+
+        @Override
+        public String toString() {
+            return "FieldMapper{useJsonName=true}";
+        }
+    }
+}

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonMapSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonMapSerializer.java
@@ -6,11 +6,12 @@
 package software.amazon.smithy.java.runtime.json;
 
 import com.jsoniter.output.JsonStream;
+import com.jsoniter.spi.JsonException;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
+import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 
 final class JsonMapSerializer implements MapSerializer {
@@ -35,8 +36,8 @@ final class JsonMapSerializer implements MapSerializer {
             beforeWrite();
             stream.writeObjectField(key);
             valueSerializer.accept(state, parent);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
@@ -6,47 +6,57 @@
 package software.amazon.smithy.java.runtime.json;
 
 import com.jsoniter.output.JsonStream;
+import com.jsoniter.spi.JsonException;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.serde.ListSerializer;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
+import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
-import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
-import software.amazon.smithy.model.traits.TimestampFormatTrait;
 
 final class JsonSerializer implements ShapeSerializer {
 
-    private final boolean useJsonName;
-    private final JsonStream stream;
-    private final TimestampFormatter defaultTimestampFormat;
-    private final boolean useTimestampFormat;
+    private JsonStream stream;
+    private final JsonFieldMapper fieldMapper;
+    private final TimestampResolver timestampResolver;
+    private final Consumer<JsonStream> returnHandle;
 
     JsonSerializer(
-        OutputStream sink,
-        boolean useJsonName,
-        TimestampFormatter defaultTimestampFormat,
-        boolean useTimestampFormat
+        JsonStream stream,
+        JsonFieldMapper fieldMapper,
+        TimestampResolver timestampResolver,
+        Consumer<JsonStream> returnHandle
     ) {
-        this.useJsonName = useJsonName;
-        this.stream = new JsonStream(sink, 2048);
-        this.useTimestampFormat = useTimestampFormat;
-        this.defaultTimestampFormat = defaultTimestampFormat;
+        this.stream = stream;
+        this.timestampResolver = timestampResolver;
+        this.fieldMapper = fieldMapper;
+        this.returnHandle = returnHandle;
     }
 
     @Override
     public void flush() {
         try {
             stream.flush();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            stream.close();
+            returnHandle.accept(stream);
+            stream = null;
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -54,8 +64,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeBoolean(SdkSchema schema, boolean value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -63,8 +73,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeByte(SdkSchema schema, byte value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -72,8 +82,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeShort(SdkSchema schema, short value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -81,8 +91,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeBlob(SdkSchema schema, byte[] value) {
         try {
             stream.writeVal(Base64.getEncoder().encodeToString(value));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -90,8 +100,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeInteger(SdkSchema schema, int value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -99,8 +109,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeLong(SdkSchema schema, long value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -108,8 +118,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeFloat(SdkSchema schema, float value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -117,8 +127,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeDouble(SdkSchema schema, double value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -126,8 +136,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeBigInteger(SdkSchema schema, BigInteger value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -135,8 +145,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -144,27 +154,24 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeString(SdkSchema schema, String value) {
         try {
             stream.writeVal(value);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
     @Override
     public void writeTimestamp(SdkSchema schema, Instant value) {
-        var formatter = useTimestampFormat && schema.hasTrait(TimestampFormatTrait.class)
-            ? TimestampFormatter.of(schema.getTrait(TimestampFormatTrait.class))
-            : defaultTimestampFormat;
-        formatter.serializeToUnderlyingFormat(schema, value, this);
+        timestampResolver.resolve(schema).writeToSerializer(schema, value, this);
     }
 
     @Override
     public <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
         try {
             stream.writeObjectStart();
-            consumer.accept(structState, new JsonStructSerializer(this, stream, useJsonName));
+            consumer.accept(structState, new JsonStructSerializer(this, stream, fieldMapper));
             stream.writeObjectEnd();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -174,8 +181,8 @@ final class JsonSerializer implements ShapeSerializer {
             stream.writeArrayStart();
             consumer.accept(listState, new ListSerializer(this, this::writeComma));
             stream.writeArrayEnd();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -183,7 +190,7 @@ final class JsonSerializer implements ShapeSerializer {
         if (position > 0) {
             try {
                 stream.writeMore();
-            } catch (IOException e) {
+            } catch (JsonException | IOException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -195,8 +202,8 @@ final class JsonSerializer implements ShapeSerializer {
             stream.writeObjectStart();
             consumer.accept(mapState, new JsonMapSerializer(this, stream));
             stream.writeObjectEnd();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 
@@ -210,8 +217,8 @@ final class JsonSerializer implements ShapeSerializer {
     public void writeNull(SdkSchema schema) {
         try {
             stream.writeNull();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (JsonException | IOException e) {
+            throw new SdkSerdeException(e);
         }
     }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/TimestampResolver.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/TimestampResolver.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.json;
+
+import com.jsoniter.any.Any;
+import com.jsoniter.spi.JsonException;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+
+/**
+ * Resolves the timestamp format to use for a shape.
+ */
+sealed interface TimestampResolver {
+    /**
+     * Determine the formatter of a shape.
+     *
+     * @param schema Shape to resolve.
+     * @return resolved formatter.
+     */
+    TimestampFormatter resolve(SdkSchema schema);
+
+    /**
+     * Get the default formatter.
+     *
+     * @return default formatter.
+     */
+    TimestampFormatter defaultFormat();
+
+    /**
+     * Reusable method to parse timestamps from an iterator using a specific formatter.
+     *
+     * @param any    JSON any type to read from.
+     * @param format Formatter used to parse the timestamp.
+     * @return the parsed Instant.
+     * @throws SdkSerdeException if the timestamp format or type is invalid.
+     */
+    static Instant readTimestamp(Any any, TimestampFormatter format) {
+        try {
+            return switch (any.valueType()) {
+                case NUMBER -> format.readFromNumber(any.toDouble());
+                case STRING -> format.readFromString(any.toString(), true);
+                default -> {
+                    throw new SdkSerdeException(
+                        "Expected a timestamp, but found " + any.valueType().toString().toLowerCase(Locale.ENGLISH)
+                    );
+                }
+            };
+        } catch (JsonException e) {
+            throw new SdkSerdeException(e);
+        }
+    }
+
+    /**
+     * Always returns the same default timestamp format and ignores the timestampFormat trait.
+     */
+    record StaticFormat(TimestampFormatter defaultFormat) implements TimestampResolver {
+        @Override
+        public TimestampFormatter resolve(SdkSchema schema) {
+            return defaultFormat;
+        }
+
+        @Override
+        public TimestampFormatter defaultFormat() {
+            return defaultFormat;
+        }
+
+        @Override
+        public String toString() {
+            return "TimestampResolver{useTimestampFormat=false; default=" + defaultFormat + '}';
+        }
+    }
+
+    /**
+     * Uses the timestampFormat trait if present, otherwise uses a configurable default format.
+     */
+    final class UseTimestampFormatTrait implements TimestampResolver {
+        private final ConcurrentHashMap<SdkSchema, TimestampFormatter> cache = new ConcurrentHashMap<>();
+        private final TimestampFormatter defaultFormat;
+
+        UseTimestampFormatTrait(TimestampFormatter defaultFormat) {
+            this.defaultFormat = defaultFormat;
+        }
+
+        @Override
+        public TimestampFormatter defaultFormat() {
+            return defaultFormat;
+        }
+
+        @Override
+        public TimestampFormatter resolve(SdkSchema schema) {
+            return cache.computeIfAbsent(schema, s -> {
+                var trait = schema.getTrait(TimestampFormatTrait.class);
+                return trait != null ? TimestampFormatter.of(trait) : defaultFormat;
+            });
+        }
+
+        @Override
+        public String toString() {
+            return "TimestampResolver{useTimestampFormat=true; default=" + defaultFormat + '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            } else if (o == null || getClass() != o.getClass()) {
+                return false;
+            } else {
+                return defaultFormat.equals(((UseTimestampFormatTrait) o).defaultFormat);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(defaultFormat);
+        }
+    }
+}

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDeserializerTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDeserializerTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.json;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+
+public class JsonDeserializerTest {
+    @Test
+    public void deserializesByte() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readByte(PreludeSchemas.BYTE), is((byte) 1));
+        }
+    }
+
+    @Test
+    public void deserializesShort() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readShort(PreludeSchemas.SHORT), is((short) 1));
+        }
+    }
+
+    @Test
+    public void deserializesInteger() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readInteger(PreludeSchemas.INTEGER), is(1));
+        }
+    }
+
+    @Test
+    public void deserializesLong() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readLong(PreludeSchemas.LONG), is(1L));
+        }
+    }
+
+    @Test
+    public void deserializesFloat() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readFloat(PreludeSchemas.FLOAT), is(1.0f));
+        }
+    }
+
+    @Test
+    public void deserializesDouble() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readDouble(PreludeSchemas.DOUBLE), is(1.0));
+        }
+    }
+
+    @Test
+    public void deserializesBigInteger() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readBigInteger(PreludeSchemas.BIG_INTEGER), is(BigInteger.ONE));
+        }
+    }
+
+    @Test
+    public void deserializesBigIntegerOnlyFromRawNumbersByDefault() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("\"1\"".getBytes(StandardCharsets.UTF_8));
+            Assertions.assertThrows(SdkSerdeException.class, () -> de.readBigInteger(PreludeSchemas.BIG_INTEGER));
+        }
+    }
+
+    @Test
+    public void deserializesBigDecimal() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readBigDecimal(PreludeSchemas.BIG_DECIMAL), is(BigDecimal.ONE));
+        }
+    }
+
+    @Test
+    public void deserializesBigDecimalOnlyFromRawNumbersByDefault() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("\"1\"".getBytes(StandardCharsets.UTF_8));
+            Assertions.assertThrows(SdkSerdeException.class, () -> de.readBigDecimal(PreludeSchemas.BIG_DECIMAL));
+        }
+    }
+
+    @Test
+    public void deserializesTimestamp() {
+        try (var codec = JsonCodec.builder().build()) {
+            var sink = new ByteArrayOutputStream();
+            try (var ser = codec.createSerializer(sink)) {
+                ser.writeTimestamp(PreludeSchemas.TIMESTAMP, Instant.EPOCH);
+            }
+
+            var de = codec.createDeserializer(sink.toByteArray());
+            assertThat(de.readTimestamp(PreludeSchemas.TIMESTAMP), equalTo(Instant.EPOCH));
+        }
+    }
+
+    @Test
+    public void deserializesBlob() {
+        try (var codec = JsonCodec.builder().build()) {
+            var str = "foo";
+            var expected = Base64.getEncoder().encodeToString(str.getBytes());
+            var de = codec.createDeserializer(("\"" + expected + "\"").getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readBlob(PreludeSchemas.BLOB), equalTo(str.getBytes(StandardCharsets.UTF_8)));
+        }
+    }
+
+    @Test
+    public void deserializesBoolean() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("true".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readBoolean(PreludeSchemas.BOOLEAN), is(true));
+        }
+    }
+
+    @Test
+    public void deserializesString() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("\"foo\"".getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readString(PreludeSchemas.STRING), equalTo("foo"));
+        }
+    }
+
+    @Test
+    public void deserializesList() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("[\"foo\",\"bar\"]".getBytes(StandardCharsets.UTF_8));
+            List<String> values = new ArrayList<>();
+
+            de.readList(PreludeSchemas.DOCUMENT, null, (ignore, firstList) -> {
+                values.add(firstList.readString(PreludeSchemas.STRING));
+            });
+
+            assertThat(values, equalTo(List.of("foo", "bar")));
+        }
+    }
+
+    @Test
+    public void deserializesMap() {
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("{\"foo\":\"bar\",\"baz\":\"bam\"}".getBytes(StandardCharsets.UTF_8));
+            Map<String, String> result = new LinkedHashMap<>();
+
+            de.readStringMap(PreludeSchemas.DOCUMENT, result, (map, key, mapde) -> {
+                map.put(key, mapde.readString(PreludeSchemas.STRING));
+            });
+
+            assertThat(result.values(), hasSize(2));
+            assertThat(result, hasKey("foo"));
+            assertThat(result, hasKey("baz"));
+            assertThat(result.get("foo"), equalTo("bar"));
+            assertThat(result.get("baz"), equalTo("bam"));
+        }
+    }
+
+    @Test
+    public void deserializesStruct() {
+        try (var codec = JsonCodec.builder().useJsonName(true).build()) {
+            var de = codec.createDeserializer("{\"name\":\"Sam\",\"Color\":\"red\"}".getBytes(StandardCharsets.UTF_8));
+            Set<String> members = new LinkedHashSet<>();
+
+            de.readStruct(JsonTestData.BIRD, members, (memberResult, member, deser) -> {
+                memberResult.add(member.memberName());
+                switch (member.memberName()) {
+                    case "name" -> assertThat(deser.readString(JsonTestData.BIRD.member("name")), equalTo("Sam"));
+                    case "color" -> assertThat(deser.readString(JsonTestData.BIRD.member("color")), equalTo("red"));
+                    default -> throw new IllegalStateException("Unexpected member: " + member);
+                }
+            });
+
+            assertThat(members, contains("name", "color"));
+        }
+    }
+
+    @Test
+    public void skipsUnknownMembers() {
+        try (var codec = JsonCodec.builder().useJsonName(true).build()) {
+            var de = codec.createDeserializer(
+                "{\"name\":\"Sam\",\"Ignore\":[1,2,3],\"Color\":\"rainbow\"}".getBytes(StandardCharsets.UTF_8)
+            );
+            Set<String> members = new LinkedHashSet<>();
+
+            de.readStruct(JsonTestData.BIRD, members, (memberResult, member, deser) -> {
+                memberResult.add(member.memberName());
+                switch (member.memberName()) {
+                    case "name" -> assertThat(deser.readString(JsonTestData.BIRD.member("name")), equalTo("Sam"));
+                    case "color" -> assertThat(deser.readString(JsonTestData.BIRD.member("color")), equalTo("rainbow"));
+                    default -> throw new IllegalStateException("Unexpected member: " + member);
+                }
+            });
+
+            assertThat(members, contains("name", "color"));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("deserializesBirdWithJsonNameOrNotSource")
+    public void deserializesBirdWithJsonNameOrNot(boolean useJsonName, String input) {
+        try (var codec = JsonCodec.builder().useJsonName(useJsonName).build()) {
+            var de = codec.createDeserializer(input.getBytes(StandardCharsets.UTF_8));
+            Set<String> members = new LinkedHashSet<>();
+            de.readStruct(JsonTestData.BIRD, members, (memberResult, member, deser) -> {
+                memberResult.add(member.memberName());
+                switch (member.memberName()) {
+                    case "name" -> assertThat(deser.readString(JsonTestData.BIRD.member("name")), equalTo("Sam"));
+                    case "color" -> assertThat(deser.readString(JsonTestData.BIRD.member("color")), equalTo("red"));
+                    default -> throw new IllegalStateException("Unexpected member: " + member);
+                }
+            });
+            assertThat(members, contains("name", "color"));
+        }
+    }
+
+    public static List<Arguments> deserializesBirdWithJsonNameOrNotSource() {
+        return List.of(
+            Arguments.of(true, "{\"name\":\"Sam\",\"Color\":\"red\"}"),
+            Arguments.of(false, "{\"name\":\"Sam\",\"color\":\"red\"}")
+        );
+    }
+
+    @Test
+    public void readsDocuments() {
+        var json = "{\"name\":\"Sam\",\"color\":\"red\"}".getBytes(StandardCharsets.UTF_8);
+
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer(json);
+            var document = de.readDocument();
+
+            assertThat(document.type(), is(ShapeType.MAP));
+            var map = document.asStringMap();
+            assertThat(map.values(), hasSize(2));
+            assertThat(map.get("name").asString(), equalTo("Sam"));
+            assertThat(map.get("color").asString(), equalTo("red"));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("deserializesWithTimestampFormatSource")
+    public void deserializesWithTimestampFormat(
+        boolean useTrait,
+        TimestampFormatTrait trait,
+        TimestampFormatter defaultFormat,
+        String json
+    ) {
+        SdkSchema.Builder schemaBuilder = SdkSchema.builder()
+            .type(ShapeType.TIMESTAMP)
+            .id("smithy.foo#Time");
+
+        if (trait != null) {
+            schemaBuilder.traits(trait);
+        }
+
+        var schema = schemaBuilder.build();
+        var codecBuilder = JsonCodec.builder().useTimestampFormat(useTrait);
+        if (defaultFormat != null) {
+            codecBuilder.defaultTimestampFormat(defaultFormat);
+        }
+
+        try (var codec = codecBuilder.build()) {
+            var de = codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8));
+            assertThat(de.readTimestamp(schema), equalTo(Instant.EPOCH));
+        }
+    }
+
+    public static List<Arguments> deserializesWithTimestampFormatSource() {
+        var epochSeconds = Double.toString(((double) Instant.EPOCH.toEpochMilli()) / 1000);
+
+        return List.of(
+            // boolean useTrait, TimestampFormatTrait trait, TimestampFormatter defaultFormat, String json
+            Arguments.of(false, null, null, epochSeconds),
+            Arguments.of(false, new TimestampFormatTrait(TimestampFormatTrait.EPOCH_SECONDS), null, epochSeconds),
+            Arguments.of(
+                false,
+                new TimestampFormatTrait(TimestampFormatTrait.EPOCH_SECONDS),
+                TimestampFormatter.Prelude.EPOCH_SECONDS,
+                epochSeconds
+            ),
+            Arguments.of(
+                true,
+                new TimestampFormatTrait(TimestampFormatTrait.EPOCH_SECONDS),
+                TimestampFormatter.Prelude.EPOCH_SECONDS,
+                epochSeconds
+            ),
+            Arguments.of(true, new TimestampFormatTrait(TimestampFormatTrait.EPOCH_SECONDS), null, epochSeconds),
+            Arguments.of(
+                true,
+                new TimestampFormatTrait(TimestampFormatTrait.EPOCH_SECONDS),
+                TimestampFormatter.Prelude.DATE_TIME,
+                epochSeconds
+            ),
+            Arguments.of(
+                false,
+                new TimestampFormatTrait(TimestampFormatTrait.EPOCH_SECONDS),
+                TimestampFormatter.Prelude.DATE_TIME,
+                "\"" + Instant.EPOCH + "\""
+            ),
+            Arguments.of(
+                true,
+                new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME),
+                TimestampFormatter.Prelude.EPOCH_SECONDS,
+                "\"" + Instant.EPOCH + "\""
+            )
+        );
+    }
+
+    @Test
+    public void throwsWhenTimestampIsWrongType() {
+        SdkSchema schema = SdkSchema.builder()
+            .type(ShapeType.TIMESTAMP)
+            .id("smithy.foo#Time")
+            .build();
+
+        try (var codec = JsonCodec.builder().build()) {
+            var de = codec.createDeserializer("true".getBytes(StandardCharsets.UTF_8));
+            var e = Assertions.assertThrows(SdkSerdeException.class, () -> de.readTimestamp(schema));
+            assertThat(e.getMessage(), equalTo("Expected a timestamp, but found boolean"));
+        }
+    }
+}

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.json;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
+import software.amazon.smithy.java.runtime.core.serde.document.Document;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+
+public class JsonDocumentTest {
+
+    private static final String FOO_B64 = "Zm9v";
+
+    @Test
+    public void convertsNumberToNumber() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("120".getBytes(StandardCharsets.UTF_8));
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.INTEGER));
+        assertThat(document.asByte(), is((byte) 120));
+        assertThat(document.asShort(), is((short) 120));
+        assertThat(document.asInteger(), is(120));
+        assertThat(document.asLong(), is(120L));
+        assertThat(document.asFloat(), is(120f));
+        assertThat(document.asDouble(), is(120.0));
+        assertThat(document.asBigInteger(), equalTo(BigInteger.valueOf(120)));
+        assertThat(document.asBigDecimal(), equalTo(BigDecimal.valueOf(120.0)));
+    }
+
+    @Test
+    public void convertsDoubleToNumber() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("1.1".getBytes(StandardCharsets.UTF_8));
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.DOUBLE));
+        assertThat(document.asFloat(), is(1.1f));
+        assertThat(document.asDouble(), is(1.1));
+    }
+
+    @Test
+    public void convertsToBoolean() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("true".getBytes(StandardCharsets.UTF_8));
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.BOOLEAN));
+        assertThat(document.asBoolean(), is(true));
+    }
+
+    @Test
+    public void convertsToTimestampWithEpochSeconds() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("0".getBytes(StandardCharsets.UTF_8));
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.INTEGER));
+        assertThat(document.asTimestamp(), equalTo(Instant.EPOCH));
+    }
+
+    @Test
+    public void convertsToTimestampWithDefaultStringFormat() {
+        var now = Instant.now();
+        var codec = JsonCodec.builder().defaultTimestampFormat(TimestampFormatter.Prelude.DATE_TIME).build();
+        var de = codec.createDeserializer(("\"" + now + "\"").getBytes(StandardCharsets.UTF_8));
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.STRING));
+        assertThat(document.asTimestamp(), equalTo(now));
+    }
+
+    @Test
+    public void convertsToTimestampFailsOnUnknownType() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("true".getBytes(StandardCharsets.UTF_8));
+        var document = de.readDocument();
+
+        var e = Assertions.assertThrows(SdkSerdeException.class, document::asTimestamp);
+        assertThat(e.getMessage(), containsString("Expected a timestamp, but found boolean"));
+    }
+
+    @Test
+    public void convertsToBlob() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer(("\"" + FOO_B64 + "\"").getBytes(StandardCharsets.UTF_8));
+        var document = de.readDocument();
+
+        assertThat(document.type(), is(ShapeType.STRING));
+
+        // Reading here as a blob will base64 decode the value.
+        assertThat(document.asBlob(), equalTo("foo".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void convertsToList() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("[1, 2, 3]".getBytes(StandardCharsets.UTF_8));
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.LIST));
+
+        var list = document.asList();
+        assertThat(list, hasSize(3));
+        assertThat(list.get(0).type(), is(ShapeType.INTEGER));
+        assertThat(list.get(0).asInteger(), is(1));
+        assertThat(list.get(1).asInteger(), is(2));
+        assertThat(list.get(2).asInteger(), is(3));
+    }
+
+    @Test
+    public void convertsToMap() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("{\"a\":1,\"b\":true}".getBytes(StandardCharsets.UTF_8));
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.MAP));
+
+        var map = document.asStringMap();
+        assertThat(map.keySet(), hasSize(2));
+        assertThat(map.get("a").type(), is(ShapeType.INTEGER));
+        assertThat(map.get("a").asInteger(), is(1));
+        assertThat(document.getMember("a").type(), is(ShapeType.INTEGER));
+
+        assertThat(map.get("b").type(), is(ShapeType.BOOLEAN));
+        assertThat(map.get("b").asBoolean(), is(true));
+        assertThat(document.getMember("b").type(), is(ShapeType.BOOLEAN));
+    }
+
+    @Test
+    public void nullAndMissingMapMembersReturnsNull() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("{\"a\":null}".getBytes(StandardCharsets.UTF_8));
+
+        var document = de.readDocument();
+        assertThat(document.getMember("c"), nullValue());
+        assertThat(document.getMember("d"), nullValue());
+    }
+
+    @ParameterizedTest
+    @MethodSource("failToConvertSource")
+    public void failToConvert(String json, Consumer<Document> consumer) {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8));
+        var document = de.readDocument();
+
+        Assertions.assertThrows(SdkSerdeException.class, () -> consumer.accept(document));
+    }
+
+    public static List<Arguments> failToConvertSource() {
+        return List.of(
+            Arguments.of("1", (Consumer<Document>) Document::asBoolean),
+            Arguments.of("1", (Consumer<Document>) Document::asBlob),
+            Arguments.of("1", (Consumer<Document>) Document::asString),
+            Arguments.of("1", (Consumer<Document>) Document::asList),
+            Arguments.of("1", (Consumer<Document>) Document::asStringMap),
+            Arguments.of("1", (Consumer<Document>) Document::asBlob),
+
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asBoolean),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asList),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asStringMap),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asBlob),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asBoolean),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asByte),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asShort),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asInteger),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asLong),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asFloat),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asDouble),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asBigInteger),
+            Arguments.of("\"1\"", (Consumer<Document>) Document::asBigDecimal)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("serializeContentSource")
+    public void serializeContent(String json) {
+        var codec = JsonCodec.builder().build();
+        var sink = new ByteArrayOutputStream();
+        var se = codec.createSerializer(sink);
+        var de = codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8));
+        var document = de.readDocument();
+        document.serializeContents(se);
+        se.flush();
+
+        assertThat(sink.toString(StandardCharsets.UTF_8), equalTo(json));
+    }
+
+    @ParameterizedTest
+    @MethodSource("serializeContentSource")
+    public void serializeDocument(String json) {
+        var codec = JsonCodec.builder().build();
+        var sink = new ByteArrayOutputStream();
+        var se = codec.createSerializer(sink);
+        var de = codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8));
+        var document = de.readDocument();
+        document.serialize(se);
+        se.flush();
+
+        assertThat(sink.toString(StandardCharsets.UTF_8), equalTo(json));
+    }
+
+    public static List<Arguments> serializeContentSource() {
+        return List.of(
+            Arguments.of("true"),
+            Arguments.of("false"),
+            Arguments.of("1"),
+            Arguments.of("1.1"),
+            Arguments.of("[1,2,3]"),
+            Arguments.of("{\"a\":1,\"b\":[1,true,-20,\"hello\"]}")
+        );
+    }
+
+    @Test
+    public void deserializesIntoBuilderWithJsonNameAndTimestampFormat() {
+        String date = Instant.EPOCH.toString();
+        var json = "{\"name\":\"Hank\",\"BINARY\":\"" + FOO_B64 + "\",\"date\":\"" + date + "\",\"numbers\":[1,2,3]}";
+        var codec = JsonCodec.builder().useTimestampFormat(true).useJsonName(true).build();
+        var de = codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8));
+        var document = de.readDocument();
+
+        var builder = new TestPojo.Builder();
+        document.deserializeInto(builder);
+        var pojo = builder.build();
+
+        assertThat(pojo.name, equalTo("Hank"));
+        assertThat(pojo.binary, equalTo("foo".getBytes(StandardCharsets.UTF_8)));
+        assertThat(pojo.date, equalTo(Instant.EPOCH));
+        assertThat(pojo.numbers, equalTo(List.of(1, 2, 3)));
+    }
+
+    @Test
+    public void deserializesIntoBuilder() {
+        var json = "{\"name\":\"Hank\",\"binary\":\"" + FOO_B64 + "\",\"date\":0,\"numbers\":[1,2,3]}";
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8));
+        var document = de.readDocument();
+
+        var builder = new TestPojo.Builder();
+        document.deserializeInto(builder);
+        var pojo = builder.build();
+
+        assertThat(pojo.name, equalTo("Hank"));
+        assertThat(pojo.binary, equalTo("foo".getBytes(StandardCharsets.UTF_8)));
+        assertThat(pojo.date, equalTo(Instant.EPOCH));
+        assertThat(pojo.numbers, equalTo(List.of(1, 2, 3)));
+    }
+
+    private static final class TestPojo implements SerializableShape {
+
+        private static final ShapeId ID = ShapeId.from("smithy.example#Foo");
+
+        private static final SdkSchema NAME = SdkSchema.memberBuilder("name", PreludeSchemas.STRING)
+            .id(ID)
+            .build();
+
+        private static final SdkSchema BINARY = SdkSchema.memberBuilder("binary", PreludeSchemas.BLOB)
+            .id(ID)
+            .traits(new JsonNameTrait("BINARY"))
+            .build();
+
+        private static final SdkSchema DATE = SdkSchema.memberBuilder("date", PreludeSchemas.TIMESTAMP)
+            .id(ID)
+            .traits(new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME))
+            .build();
+
+        private static final SdkSchema NUMBERS_LIST = SdkSchema.builder()
+            .type(ShapeType.LIST)
+            .id("smithy.example#Numbers")
+            .members(SdkSchema.memberBuilder("member", PreludeSchemas.INTEGER))
+            .build();
+
+        private static final SdkSchema NUMBERS = SdkSchema.memberBuilder("numbers", NUMBERS_LIST)
+            .id(ID)
+            .build();
+
+        private static final SdkSchema SCHEMA = SdkSchema.builder()
+            .id(ID)
+            .type(ShapeType.STRUCTURE)
+            .members(NAME, BINARY, DATE, NUMBERS)
+            .build();
+
+        private final String name;
+        private final byte[] binary;
+        private final Instant date;
+        private final List<Integer> numbers;
+
+        TestPojo(Builder builder) {
+            this.name = builder.name;
+            this.binary = builder.binary;
+            this.date = builder.date;
+            this.numbers = builder.numbers;
+        }
+
+        @Override
+        public void serialize(ShapeSerializer encoder) {
+            throw new UnsupportedOperationException();
+        }
+
+        private static final class Builder implements SdkShapeBuilder<TestPojo> {
+
+            private String name;
+            private byte[] binary;
+            private Instant date;
+            private final List<Integer> numbers = new ArrayList<>();
+
+            @Override
+            public Builder deserialize(ShapeDeserializer decoder) {
+                decoder.readStruct(SCHEMA, this, (pojo, member, deser) -> {
+                    switch (member.memberName()) {
+                        case "name" -> pojo.name = deser.readString(NAME);
+                        case "binary" -> pojo.binary = deser.readBlob(BINARY);
+                        case "date" -> pojo.date = deser.readTimestamp(DATE);
+                        case "numbers" -> {
+                            deser.readList(NUMBERS, pojo.numbers, (values, de) -> {
+                                values.add(de.readInteger(NUMBERS_LIST.member("member")));
+                            });
+                        }
+                        default -> throw new UnsupportedOperationException(member.toString());
+                    }
+                });
+                return this;
+            }
+
+            @Override
+            public TestPojo build() {
+                return new TestPojo(this);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("checkEqualitySource")
+    public void checkEquality(String left, String right, boolean equal) {
+        var codec = JsonCodec.builder().build();
+
+        var de1 = codec.createDeserializer(left.getBytes(StandardCharsets.UTF_8));
+        var leftValue = de1.readDocument();
+
+        var de2 = codec.createDeserializer(right.getBytes(StandardCharsets.UTF_8));
+        var rightValue = de2.readDocument();
+
+        assertThat(leftValue.equals(rightValue), is(equal));
+    }
+
+    public static List<Arguments> checkEqualitySource() {
+        return List.of(
+            Arguments.of("1", "1", true),
+            Arguments.of("1", "1.1", false),
+            Arguments.of("true", "true", true),
+            Arguments.of("true", "false", false),
+            Arguments.of("1", "false", false),
+            Arguments.of("1", "\"1\"", false),
+            Arguments.of("\"foo\"", "\"foo\"", true),
+            Arguments.of("[\"foo\"]", "[\"foo\"]", true),
+            Arguments.of("{\"foo\":\"foo\"}", "{\"foo\":\"foo\"}", true),
+            Arguments.of("{\"foo\":\"foo\"}", "{\"foo\":\"bar\"}", false)
+        );
+    }
+
+    @Test
+    public void onlyEqualIfBothUseTimestampFormat() {
+        var de1 = JsonCodec.builder()
+            .useTimestampFormat(true)
+            .build()
+            .createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+        var de2 = JsonCodec.builder()
+            .useTimestampFormat(false)
+            .build()
+            .createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+
+        var leftValue = de1.readDocument();
+        var rightValue = de2.readDocument();
+
+        assertThat(leftValue, not(equalTo(rightValue)));
+    }
+
+    @Test
+    public void onlyEqualIfBothUseJsonName() {
+        var de1 = JsonCodec.builder()
+            .useJsonName(true)
+            .build()
+            .createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+        var de2 = JsonCodec.builder()
+            .useJsonName(false)
+            .build()
+            .createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+
+        var leftValue = de1.readDocument();
+        var rightValue = de2.readDocument();
+
+        assertThat(leftValue, not(equalTo(rightValue)));
+    }
+
+    @Test
+    public void canNormalizeJsonDocuments() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("true".getBytes(StandardCharsets.UTF_8));
+        var json = de.readDocument();
+
+        assertThat(json.normalize(), equalTo(Document.createBoolean(true)));
+    }
+}

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonTestData.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonTestData.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.json;
+
+import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+
+public final class JsonTestData {
+
+    static final ShapeId BIRD_ID = ShapeId.from("smithy.example#Bird");
+    static final SdkSchema BIRD_NAME = SdkSchema.memberBuilder("name", PreludeSchemas.STRING)
+        .id(BIRD_ID)
+        .build();
+    static final SdkSchema BIRD_COLOR = SdkSchema.memberBuilder("color", PreludeSchemas.STRING)
+        .id(BIRD_ID)
+        .traits(new JsonNameTrait("Color"))
+        .build();
+    static final SdkSchema BIRD = SdkSchema.builder()
+        .id(BIRD_ID)
+        .type(ShapeType.STRUCTURE)
+        .members(BIRD_NAME, BIRD_COLOR)
+        .build();
+}


### PR DESCRIPTION
This commit adds fairly extensive test coverage to the JSON codec, and minor performance improvments around things like reading and writing member names that may or may not take jsonName traits into account. Various bug fixes were made along the way.

Codec, ShapeSerializer, and ShapeDeserializer now implement AutoClosable so that they can potentially support caching in the future (there's a TODO hook for us to support caching of byte buffers for the JSON codec).

Some cleanup was done to TimestampFormatter to improve the API and couple the "of" method to known formats from the TimestampFormatTrait.

A "normalize" method was added to Document to take a document and create a normalized version of it that has no schema or protocol details, making it easier to compare documents.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
