### PR TITLE
Permit up to 64 required fields in the regular presence tracker

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/PresenceTracker.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/PresenceTracker.java
@@ -53,7 +53,7 @@ public abstract sealed class PresenceTracker {
     static PresenceTracker of(SdkSchema schema) {
         if (schema.requiredMemberCount == 0) {
             return NoOpPresenceTracker.INSTANCE;
-        } else if (schema.requiredMemberCount < 64) {
+        } else if (schema.requiredMemberCount <= 64) {
             return new PresenceTracker.RequiredMemberPresenceTracker(schema);
         } else {
             return new PresenceTracker.BigRequiredMemberPresenceTracker(schema);
@@ -65,7 +65,7 @@ public abstract sealed class PresenceTracker {
      *
      * <p>Should be used for shapes with no required fields.
      */
-    private static final class NoOpPresenceTracker extends PresenceTracker {
+    static final class NoOpPresenceTracker extends PresenceTracker {
         private static final NoOpPresenceTracker INSTANCE = new NoOpPresenceTracker();
 
         @Override
@@ -92,7 +92,7 @@ public abstract sealed class PresenceTracker {
     /**
      * Tracker for structures with less than 64 members
      */
-    private static final class RequiredMemberPresenceTracker extends PresenceTracker {
+    static final class RequiredMemberPresenceTracker extends PresenceTracker {
         private long setBitfields = 0L;
         private final SdkSchema schema;
 
@@ -107,7 +107,7 @@ public abstract sealed class PresenceTracker {
 
         @Override
         public boolean checkMember(SdkSchema schema) {
-            return (setBitfields << ~schema.memberIndex()) < 0;
+            return (setBitfields & schema.memberIndex()) != 0;
         }
 
         @Override
@@ -130,7 +130,7 @@ public abstract sealed class PresenceTracker {
     /**
      * Tracker for structures with greater than 64 required members.
      */
-    private static final class BigRequiredMemberPresenceTracker extends PresenceTracker {
+    static final class BigRequiredMemberPresenceTracker extends PresenceTracker {
         private final BitSet bitSet;
         private final SdkSchema schema;
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SdkSchema.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SdkSchema.java
@@ -175,7 +175,7 @@ public final class SdkSchema {
         // We only need to use the slow version of required member validation if there are > 64 required members.
         this.requiredMemberCount = computeRequiredMemberCount(this.type, this.memberTarget, this.memberList);
 
-        if ((requiredMemberCount > 0) && (requiredMemberCount < 64) && type == ShapeType.STRUCTURE) {
+        if ((requiredMemberCount > 0) && (requiredMemberCount <= 64) && type == ShapeType.STRUCTURE) {
             this.requiredStructureMemberBitfield = computeRequiredBitField(members());
         } else {
             this.requiredStructureMemberBitfield = 0;

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 import software.amazon.smithy.java.runtime.core.testmodels.Person;
@@ -1232,6 +1234,24 @@ public class ValidatorTest {
         for (var e : errors) {
             assertThat(e, instanceOf(ValidationError.RequiredValidationFailure.class));
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 63, 64, 65, 128})
+    public void presenceTrackerType(int requiredFields) {
+        Class<?> expected;
+        if (requiredFields == 0) {
+            expected = PresenceTracker.NoOpPresenceTracker.class;
+        } else if (requiredFields <= 64) {
+            expected = PresenceTracker.RequiredMemberPresenceTracker.class;
+        } else {
+            expected = PresenceTracker.BigRequiredMemberPresenceTracker.class;
+        }
+
+        assertEquals(
+            expected,
+            PresenceTracker.of(createBigRequiredSchema(requiredFields, requiredFields, 0)).getClass()
+        );
     }
 
     static List<Arguments> validatesRequiredMembersOfBigStructsProvider() {


### PR DESCRIPTION
We were previously fitting 63 fields in the long, leaving the high bit unused.