### PR TITLE
Make all fields transient

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/PropertyGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/PropertyGenerator.java
@@ -37,7 +37,7 @@ final class PropertyGenerator implements Runnable {
             writer.pushState();
             writer.putContext("isNullable", CodegenUtils.isNullableMember(member));
             writer.write(
-                "private final ${?isNullable}$1B${/isNullable}${^isNullable}$1T${/isNullable} $2L;",
+                "private transient final ${?isNullable}$1B${/isNullable}${^isNullable}$1T${/isNullable} $2L;",
                 symbolProvider.toSymbol(member),
                 memberName
             );

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/NamingTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/NamingTest.java
@@ -92,9 +92,9 @@ public class NamingTest {
     void escapesMemberNames() {
         var fileStr = getFileStringForClass("ReservedWordMembersInput");
         var expected = """
-                private final Byte byteMember;
-                private final String staticMember;
-                private final Double doubleMember;
+                private transient final Byte byteMember;
+                private transient final String staticMember;
+                private transient final Double doubleMember;
             """;
         assertTrue(fileStr.contains(expected));
     }


### PR DESCRIPTION
For discussion. We talked offline about marking structure fields transient to prevent them from being used with external serialization libraries. This will let us change our structure internals later without needing to worry about how other libraries may use reflection to discover our class layouts, hierarchies, implementation details, etc.