### PR TITLE
Fix builder defaults to use a static final field

### DIFF
--- a/codegen/core/src/it/resources/META-INF/smithy/structures/string-members/strings.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/structures/string-members/strings.smithy
@@ -7,6 +7,9 @@ operation Strings {
         @required
         requiredString: String
 
+        @default("default")
+        defaultString: String
+
         optionalString: String
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -58,6 +58,7 @@ public final class CodegenUtils {
             .name(clazz.getSimpleName())
             .namespace(clazz.getCanonicalName().replace("." + clazz.getSimpleName(), ""), ".")
             .putProperty(SymbolProperties.IS_PRIMITIVE, clazz.isPrimitive())
+            .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, true)
             .build();
     }
 
@@ -72,6 +73,7 @@ public final class CodegenUtils {
         return fromClass(unboxed).toBuilder()
             .putProperty(SymbolProperties.IS_PRIMITIVE, true)
             .putProperty(SymbolProperties.BOXED_TYPE, fromClass(boxed))
+            .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)
             .build();
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
@@ -102,6 +102,7 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
             .toBuilder()
             .putProperty(SymbolProperties.IS_JAVA_ARRAY, true)
             .putProperty(SymbolProperties.IS_PRIMITIVE, true)
+            .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)
             .build();
     }
 
@@ -119,6 +120,7 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
                 .putProperty(SymbolProperties.COLLECTION_COPY_METHOD, "unmodifiableSet")
                 .putProperty(SymbolProperties.COLLECTION_IMPLEMENTATION_CLASS, LinkedHashSet.class)
                 .putProperty(SymbolProperties.COLLECTION_EMPTY_METHOD, "emptySet()")
+                .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)
                 .addReference(listShape.getMember().accept(this))
                 .build();
         }
@@ -127,6 +129,7 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
             .putProperty(SymbolProperties.COLLECTION_COPY_METHOD, "unmodifiableList")
             .putProperty(SymbolProperties.COLLECTION_IMPLEMENTATION_CLASS, ArrayList.class)
             .putProperty(SymbolProperties.COLLECTION_EMPTY_METHOD, "emptyList()")
+            .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)
             .addReference(listShape.getMember().accept(this))
             .build();
     }
@@ -138,6 +141,7 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
             .putProperty(SymbolProperties.COLLECTION_COPY_METHOD, "unmodifiableMap")
             .putProperty(SymbolProperties.COLLECTION_IMPLEMENTATION_CLASS, LinkedHashMap.class)
             .putProperty(SymbolProperties.COLLECTION_EMPTY_METHOD, "emptyMap()")
+            .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)
             .addReference(mapShape.getKey().accept(this))
             .addReference(mapShape.getValue().accept(this))
             .build();
@@ -266,6 +270,7 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
         return Symbol.builder()
             .name(name)
             .putProperty(SymbolProperties.IS_PRIMITIVE, false)
+            .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, true)
             .namespace(format("%s.model", packageNamespace), ".")
             .declarationFile(format("./%s/model/%s.java", packageNamespace.replace(".", "/"), name))
             .build();

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/SymbolProperties.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/SymbolProperties.java
@@ -48,5 +48,10 @@ public final class SymbolProperties {
      */
     public static final Property<String> COLLECTION_EMPTY_METHOD = Property.named("collection-empty");
 
+    /**
+     * Indicates that a type should define a static default value.
+     */
+    public static final Property<Boolean> REQUIRES_STATIC_DEFAULT = Property.named("requires-static-default");
+
     private SymbolProperties() {}
 }


### PR DESCRIPTION
### Description of changes
Switches the Builder default values to be static final constants. The previous version erroneously added these values in the definition of the value fields which caused them to be re-instantiated for each new builder instance which was tanking serde benchmarks.

Also updates all timestamp defaults to use `ofEpochMilli ` for instantiating default timestamps as this avoids ever parsing a timestamp string in the generated code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
