### PR TITLE
Add SerializableStruct for structure/union

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SerializableStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SerializableStruct.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.schema;
+
+import java.util.function.BiConsumer;
+import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+
+/**
+ * A structure or union shape.
+ */
+public interface SerializableStruct extends SerializableShape {
+
+    @Override
+    default void serialize(ShapeSerializer encoder) {
+        encoder.writeStruct(schema(), this);
+    }
+
+    /**
+     * Get the schema of the shape.
+     *
+     * @return the schema.
+     */
+    SdkSchema schema();
+
+    /**
+     * Serializes the members of the structure or union.
+     *
+     * @param serializer Serializer to write to.
+     */
+    void serializeMembers(ShapeSerializer serializer);
+
+    /**
+     * Create a serializable struct from a schema and BiConsumer.
+     *
+     * @param schema Schema of the structure / union.
+     * @param memberWriter BiConsumer that writes members to the given serializer.
+     * @return the created SerializableStruct.
+     */
+    static SerializableStruct create(SdkSchema schema, BiConsumer<SdkSchema, ShapeSerializer> memberWriter) {
+        return new SerializableStruct() {
+            @Override
+            public SdkSchema schema() {
+                return schema;
+            }
+
+            @Override
+            public void serializeMembers(ShapeSerializer serializer) {
+                memberWriter.accept(schema, serializer);
+            }
+        };
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Validator.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Validator.java
@@ -213,15 +213,15 @@ public final class Validator {
         }
 
         @Override
-        public <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
+        public void writeStruct(SdkSchema schema, SerializableStruct struct) {
             // Track the current schema and count.
             var previousSchema = currentSchema;
             var previousCount = elementCount;
             currentSchema = schema;
             elementCount = 0; // note that we don't track the count of structure members.
             switch (schema.type()) {
-                case STRUCTURE -> ValidatorOfStruct.validate(this, schema, structState, consumer);
-                case UNION -> ValidatorOfUnion.validate(this, schema, structState, consumer);
+                case STRUCTURE -> ValidatorOfStruct.validate(this, schema, struct);
+                case UNION -> ValidatorOfUnion.validate(this, schema, struct);
                 default -> checkType(schema, ShapeType.STRUCTURE); // this is guaranteed to fail type checking.
             }
             currentSchema = previousSchema;

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
@@ -26,22 +26,9 @@ final class ValidatorOfStruct implements ShapeSerializer {
         this.structValidator = structValidator;
     }
 
-    static <T> void validate(
-        Validator.ShapeValidator validator,
-        SdkSchema schema,
-        T structState,
-        BiConsumer<T, ShapeSerializer> consumer
-    ) {
+    static void validate(Validator.ShapeValidator validator, SdkSchema schema, SerializableStruct struct) {
         var tracker = PresenceTracker.of(schema);
-        consumer.accept(structState, new ValidatorOfStruct(validator, tracker));
-        checkResult(validator, schema, tracker);
-    }
-
-    private static void checkResult(
-        Validator.ShapeValidator validator,
-        SdkSchema schema,
-        PresenceTracker tracker
-    ) {
+        struct.serializeMembers(new ValidatorOfStruct(validator, tracker));
         if (!tracker.allSet()) {
             for (var member : tracker.getMissingMembers()) {
                 validator.addError(
@@ -172,10 +159,10 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeStruct(SdkSchema member, T structState, BiConsumer<T, ShapeSerializer> consumer) {
+    public void writeStruct(SdkSchema member, SerializableStruct struct) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
-        validator.writeStruct(member, structState, consumer);
+        validator.writeStruct(member, struct);
         validator.popPath();
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
@@ -27,14 +27,9 @@ final class ValidatorOfUnion implements ShapeSerializer {
         this.schema = schema;
     }
 
-    static <T> void validate(
-        Validator.ShapeValidator validator,
-        SdkSchema schema,
-        T unionState,
-        BiConsumer<T, ShapeSerializer> consumer
-    ) {
+    static void validate(Validator.ShapeValidator validator, SdkSchema schema, SerializableStruct struct) {
         var unionValidator = new ValidatorOfUnion(validator, schema);
-        consumer.accept(unionState, unionValidator);
+        struct.serializeMembers(unionValidator);
         unionValidator.checkResult();
     }
 
@@ -201,10 +196,10 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeStruct(SdkSchema member, T structState, BiConsumer<T, ShapeSerializer> consumer) {
-        validator.pushPath(member.memberName());
+    public void writeStruct(SdkSchema member, SerializableStruct struct) {
+        validator.pushPath(member);
         if (validateSetValue(member)) {
-            validator.writeStruct(member, structState, consumer);
+            validator.writeStruct(member, struct);
         }
         validator.popPath();
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
@@ -36,8 +37,8 @@ public abstract class InterceptingSerializer implements ShapeSerializer {
     protected void after(SdkSchema schema) {}
 
     @Override
-    public final <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
-        before(schema).writeStruct(schema, structState, consumer);
+    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
+        before(schema).writeStruct(schema, struct);
         after(schema);
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.IntConsumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
@@ -48,9 +49,9 @@ public final class ListSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
+    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
         beforeWrite();
-        delegate.writeStruct(schema, structState, consumer);
+        delegate.writeStruct(schema, struct);
     }
 
     @Override

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/NullSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/NullSerializer.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
@@ -22,7 +23,7 @@ final class NullSerializer implements ShapeSerializer {
     static final NullSerializer INSTANCE = new NullSerializer();
 
     @Override
-    public <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {}
+    public void writeStruct(SdkSchema schema, SerializableStruct struct) {}
 
     @Override
     public <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
@@ -37,17 +38,28 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
     @Override
     default void close() {}
 
+    // TODO: Remove this once codegen has been updated.
+    @Deprecated
+    default <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Writes a structure or union using the given member schema.
+     *
+     * @param schema A member schema that targets the given struct.
+     * @param struct Structure to serialize.
+     */
+    void writeStruct(SdkSchema schema, SerializableStruct struct);
+
     /**
      * Writes a structure or union.
      *
-     * <p>Each shape written to the given consumer <em>must</em> use a schema that has a member name.
-     * The member name is used to write field names.
-     *
-     * @param schema      Schema to serialize.
-     * @param structState State to pass into the consumer.
-     * @param consumer    Receives the struct serializer and writes members.
+     * @param struct Structure to serialize.
      */
-    <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer);
+    default void writeStruct(SerializableStruct struct) {
+        writeStruct(struct.schema(), struct);
+    }
 
     /**
      * Begin a list and write zero or more values into it using the provided serializer.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
@@ -32,7 +33,7 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
+    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
         throw throwForInvalidState(schema);
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 
@@ -47,9 +48,9 @@ public final class ToStringSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
+    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
         builder.append(schema.id().getName()).append('[');
-        consumer.accept(structState, new StructureWriter(this));
+        struct.serializeMembers(new StructureWriter(this));
         builder.append(']');
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentParser.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentParser.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.InterceptingSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ListSerializer;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
@@ -42,13 +43,13 @@ final class DocumentParser implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
+    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
         if (schema.type() != ShapeType.STRUCTURE && schema.type() != ShapeType.UNION) {
             throw new SdkSerdeException("Expected a structure or union for this document, but found " + schema);
         }
 
         Map<String, Document> members = new LinkedHashMap<>();
-        consumer.accept(structState, new StructureParser(members));
+        struct.serializeMembers(new StructureParser(members));
 
         setResult(new Documents.StructureDocument(schema, members));
     }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.testmodels.Bird;
 import software.amazon.smithy.java.runtime.core.testmodels.Person;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -71,8 +72,8 @@ public class ToStringSerializerTest {
             .build();
 
         var str = ToStringSerializer.serialize(e -> {
-            e.writeStruct(schema, null, (ignored, ser) -> {
-                ser.writeMap(schema.member("foo"), mapSchema, (innerMapSchema, map) -> {
+            e.writeStruct(SerializableStruct.create(schema, (s, ser) -> {
+                ser.writeMap(s.member("foo"), mapSchema, (innerMapSchema, map) -> {
                     map.writeEntry(innerMapSchema.member("key"), "a", innerMapSchema, (mapSchema2, ms) -> {
                         ms.writeString(mapSchema2.member("value"), "hi");
                     });
@@ -80,7 +81,7 @@ public class ToStringSerializerTest {
                         ms.writeNull(mapSchema2.member("value"));
                     });
                 });
-            });
+            }));
         });
 
         assertThat(str, equalTo("Struct[foo={*REDACTED*=*REDACTED*, *REDACTED*=null}]"));
@@ -100,9 +101,9 @@ public class ToStringSerializerTest {
             .build();
 
         var str = ToStringSerializer.serialize(e -> {
-            e.writeStruct(schema, schema.member("foo"), (member, ser) -> {
-                ser.writeBlob(member, "abc".getBytes(StandardCharsets.UTF_8));
-            });
+            e.writeStruct(SerializableStruct.create(schema, (s, ser) -> {
+                ser.writeBlob(s.member("foo"), "abc".getBytes(StandardCharsets.UTF_8));
+            }));
         });
 
         assertThat(str, equalTo("Struct[foo=*REDACTED*]"));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
 
@@ -32,10 +33,10 @@ public class TypedDocumentTest {
             .build();
 
         return encoder -> {
-            encoder.writeStruct(structSchema, structSchema, (schema, s) -> {
+            encoder.writeStruct(SerializableStruct.create(structSchema, (schema, s) -> {
                 s.writeString(schema.member("a"), "1");
                 s.writeString(schema.member("b"), "2");
-            });
+            }));
         };
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
@@ -8,14 +8,14 @@ package software.amazon.smithy.java.runtime.core.testmodels;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ToStringSerializer;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 
-public final class Bird implements SerializableShape {
+public final class Bird implements SerializableStruct {
 
     public static final ShapeId ID = ShapeId.from("smithy.example#Bird");
     private static final SdkSchema SCHEMA_NAME = SdkSchema.memberBuilder("name", PreludeSchemas.STRING)
@@ -47,10 +47,13 @@ public final class Bird implements SerializableShape {
     }
 
     @Override
-    public void serialize(ShapeSerializer serializer) {
-        serializer.writeStruct(SCHEMA, this, (pojo, structSerializer) -> {
-            structSerializer.writeString(SCHEMA_NAME, pojo.name);
-        });
+    public SdkSchema schema() {
+        return SCHEMA;
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        serializer.writeString(SCHEMA_NAME, name);
     }
 
     public static final class Builder implements SdkShapeBuilder<Bird> {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
@@ -12,11 +12,10 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -28,7 +27,7 @@ import software.amazon.smithy.model.traits.LengthTrait;
 import software.amazon.smithy.model.traits.RangeTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 
-public final class Person implements SerializableShape {
+public final class Person implements SerializableStruct {
 
     public static final ShapeId ID = ShapeId.from("smithy.example#Person");
     private static final SdkSchema SCHEMA_NAME = SdkSchema.memberBuilder("name", PreludeSchemas.STRING)
@@ -115,29 +114,25 @@ public final class Person implements SerializableShape {
     }
 
     @Override
-    public void serialize(ShapeSerializer serializer) {
-        serializer.writeStruct(SCHEMA, this, WriteShape.INSTANCE);
+    public SdkSchema schema() {
+        return SCHEMA;
     }
 
-    private static final class WriteShape implements BiConsumer<Person, ShapeSerializer> {
-        private static final WriteShape INSTANCE = new WriteShape();
-
-        @Override
-        public void accept(Person shape, ShapeSerializer serializer) {
-            serializer.writeString(SCHEMA_NAME, shape.name);
-            serializer.writeInteger(SCHEMA_AGE, shape.age);
-            if (shape.favoriteColor != null) {
-                serializer.writeString(SCHEMA_FAVORITE_COLOR, shape.favoriteColor);
-            }
-            if (shape.binary != null) {
-                serializer.writeBlob(SCHEMA_BINARY, shape.binary);
-            }
-            if (shape.birthday != null) {
-                serializer.writeTimestamp(SCHEMA_BIRTHDAY, shape.birthday);
-            }
-            if (!shape.queryParams.isEmpty()) {
-                serializer.writeMap(SCHEMA_QUERY_PARAMS, shape, Person::writeQueryParamsMember);
-            }
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        serializer.writeString(SCHEMA_NAME, name);
+        serializer.writeInteger(SCHEMA_AGE, age);
+        if (favoriteColor != null) {
+            serializer.writeString(SCHEMA_FAVORITE_COLOR, favoriteColor);
+        }
+        if (binary != null) {
+            serializer.writeBlob(SCHEMA_BINARY, binary);
+        }
+        if (birthday != null) {
+            serializer.writeTimestamp(SCHEMA_BIRTHDAY, birthday);
+        }
+        if (!queryParams.isEmpty()) {
+            serializer.writeMap(SCHEMA_QUERY_PARAMS, this, Person::writeQueryParamsMember);
         }
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
@@ -12,7 +12,7 @@ import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -21,7 +21,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.RequiredTrait;
 
-public final class PojoWithValidatedCollection implements SerializableShape {
+public final class PojoWithValidatedCollection implements SerializableStruct {
 
     public static final ShapeId ID = ShapeId.from("smithy.example#PojoWithValidatedCollection");
 
@@ -83,18 +83,14 @@ public final class PojoWithValidatedCollection implements SerializableShape {
     }
 
     @Override
-    public void serialize(ShapeSerializer serializer) {
-        serializer.writeStruct(SCHEMA, this, InnerSerializer.INSTANCE);
+    public SdkSchema schema() {
+        return SCHEMA;
     }
 
-    private static final class InnerSerializer implements BiConsumer<PojoWithValidatedCollection, ShapeSerializer> {
-        private static final InnerSerializer INSTANCE = new InnerSerializer();
-
-        @Override
-        public void accept(PojoWithValidatedCollection pojo, ShapeSerializer st) {
-            st.writeList(SCHEMA_LIST, pojo.list, InnerListSerializer.INSTANCE);
-            st.writeMap(SCHEMA_MAP, pojo.map, InnerMapSerializer.INSTANCE);
-        }
+    @Override
+    public void serializeMembers(ShapeSerializer st) {
+        st.writeList(SCHEMA_LIST, list, InnerListSerializer.INSTANCE);
+        st.writeMap(SCHEMA_MAP, map, InnerMapSerializer.INSTANCE);
     }
 
     private static final class InnerListSerializer implements BiConsumer<List<ValidatedPojo>, ShapeSerializer> {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
@@ -5,11 +5,10 @@
 
 package software.amazon.smithy.java.runtime.core.testmodels;
 
-import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ToStringSerializer;
@@ -19,7 +18,7 @@ import software.amazon.smithy.model.shapes.ShapeType;
 /**
  * A POJO with no validation constraints.
  */
-public final class UnvalidatedPojo implements SerializableShape {
+public final class UnvalidatedPojo implements SerializableStruct {
 
     public static final ShapeId ID = ShapeId.from("smithy.example#UnvalidatedPojo");
     private static final SdkSchema SCHEMA_STRING = SdkSchema.memberBuilder("string", PreludeSchemas.STRING)
@@ -70,20 +69,16 @@ public final class UnvalidatedPojo implements SerializableShape {
     }
 
     @Override
-    public void serialize(ShapeSerializer serializer) {
-        serializer.writeStruct(SCHEMA, this, WriteShape.INSTANCE);
+    public SdkSchema schema() {
+        return SCHEMA;
     }
 
-    private static final class WriteShape implements BiConsumer<UnvalidatedPojo, ShapeSerializer> {
-        private static final WriteShape INSTANCE = new WriteShape();
-
-        @Override
-        public void accept(UnvalidatedPojo shape, ShapeSerializer serializer) {
-            if (shape.boxedInteger != null) {
-                serializer.writeInteger(SCHEMA_BOXED_INTEGER, shape.boxedInteger);
-            }
-            serializer.writeInteger(SCHEMA_INTEGER, shape.integer);
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        if (boxedInteger != null) {
+            serializer.writeInteger(SCHEMA_BOXED_INTEGER, boxedInteger);
         }
+        serializer.writeInteger(SCHEMA_INTEGER, integer);
     }
 
     public static final class Builder implements SdkShapeBuilder<UnvalidatedPojo> {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
@@ -6,11 +6,10 @@
 package software.amazon.smithy.java.runtime.core.testmodels;
 
 import java.math.BigDecimal;
-import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ToStringSerializer;
@@ -20,7 +19,7 @@ import software.amazon.smithy.model.traits.LengthTrait;
 import software.amazon.smithy.model.traits.RangeTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 
-public final class ValidatedPojo implements SerializableShape {
+public final class ValidatedPojo implements SerializableStruct {
 
     public static final ShapeId ID = ShapeId.from("smithy.example#ValidatedPojo");
     private static final SdkSchema SCHEMA_STRING = SdkSchema.memberBuilder("string", PreludeSchemas.STRING)
@@ -74,23 +73,19 @@ public final class ValidatedPojo implements SerializableShape {
     }
 
     @Override
-    public void serialize(ShapeSerializer serializer) {
-        serializer.writeStruct(SCHEMA, this, InnerSerializer.INSTANCE);
+    public SdkSchema schema() {
+        return SCHEMA;
     }
 
-    private static final class InnerSerializer implements BiConsumer<ValidatedPojo, ShapeSerializer> {
-        private static final InnerSerializer INSTANCE = new InnerSerializer();
-
-        @Override
-        public void accept(ValidatedPojo pojo, ShapeSerializer st) {
-            if (pojo.string != null) {
-                st.writeString(SCHEMA_STRING, pojo.string);
-            }
-            if (pojo.boxedInteger != null) {
-                st.writeInteger(SCHEMA_BOXED_INTEGER, pojo.boxedInteger);
-            }
-            st.writeInteger(SCHEMA_INTEGER, pojo.integer);
+    @Override
+    public void serializeMembers(ShapeSerializer st) {
+        if (string != null) {
+            st.writeString(SCHEMA_STRING, string);
         }
+        if (boxedInteger != null) {
+            st.writeInteger(SCHEMA_BOXED_INTEGER, boxedInteger);
+        }
+        st.writeInteger(SCHEMA_INTEGER, integer);
     }
 
     public static final class Builder implements SdkShapeBuilder<ValidatedPojo> {

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
@@ -15,6 +15,7 @@ import java.util.Base64;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ListSerializer;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
@@ -23,9 +24,9 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 final class JsonSerializer implements ShapeSerializer {
 
-    private JsonStream stream;
-    private final JsonFieldMapper fieldMapper;
-    private final TimestampResolver timestampResolver;
+    JsonStream stream;
+    final JsonFieldMapper fieldMapper;
+    final TimestampResolver timestampResolver;
     private final Consumer<JsonStream> returnHandle;
 
     JsonSerializer(
@@ -165,10 +166,10 @@ final class JsonSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
+    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
         try {
             stream.writeObjectStart();
-            consumer.accept(structState, new JsonStructSerializer(this, stream, fieldMapper));
+            struct.serializeMembers(new JsonStructSerializer(this));
             stream.writeObjectEnd();
         } catch (JsonException | IOException e) {
             throw new SdkSerdeException(e);

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonTestData.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonTestData.java
@@ -21,9 +21,20 @@ public final class JsonTestData {
         .id(BIRD_ID)
         .traits(new JsonNameTrait("Color"))
         .build();
+    static final SdkSchema BIRD_NESTED = SdkSchema.memberBuilder("nested", PreludeSchemas.STRING).id(BIRD_ID).build();
     static final SdkSchema BIRD = SdkSchema.builder()
         .id(BIRD_ID)
         .type(ShapeType.STRUCTURE)
-        .members(BIRD_NAME, BIRD_COLOR)
+        .members(BIRD_NAME, BIRD_COLOR, BIRD_NESTED)
+        .build();
+
+    static final ShapeId NESTED_ID = ShapeId.from("smithy.example#Nested");
+    static final SdkSchema NESTED_NUMBER = SdkSchema.memberBuilder("number", PreludeSchemas.INTEGER)
+        .id(NESTED_ID)
+        .build();
+    static final SdkSchema NESTED = SdkSchema.builder()
+        .id(NESTED_ID)
+        .type(ShapeType.STRUCTURE)
+        .members(NESTED_NUMBER)
         .build();
 }


### PR DESCRIPTION
Rather than rely on a BiConsumer to serialize structure and union members, this change introduces a subtype of SerializableShape specifically for structures and unions. With the BiConsumer approach, in order to serialize a nested structure member, we had to reach into the package-private inner serializers of a structure so that we could serialize the member name from a member schema and then serialize just the members of the target structure. This was a kind of implicit contract and wouldn't work if the structure was from another package.

Now a structure/union shape exposes its schema using `schema()`, a default method for serializing the structure/union via the inherited `serialize()` method, and `serializeMembers()` to just write members to a given serializer.

Performance is basically the same as before, though occasionally jit inlining doesn't kick in.

A bug related to nested structure serialization in the JSON codec was also fixed in this commit.

TODO: follow up commit to update codegen and remove the deprecated method from ShapeSerializer.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
