### PR TITLE
Adding toBuilder to structures

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/BuilderTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/BuilderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.smithy.codegen.test.model.ListsInput;
+import io.smithy.codegen.test.model.MapsInput;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+
+public class BuilderTest {
+
+    @Test
+    public void testToBuilderList() {
+
+        ListsInput original = ListsInput.builder()
+            .requiredList(List.of("A"))
+            .build();
+        var copy = original.toBuilder().optionalList(List.of("1")).build();
+        assertThat(copy)
+            .returns(original.requiredList(), ListsInput::requiredList)
+            .returns(List.of("1"), ListsInput::optionalList);
+    }
+
+    @Test
+    public void testToBuilderMap() {
+        MapsInput original = MapsInput.builder()
+            .requiredMap(Map.of("A", "B"))
+            .build();
+        var copy = original.toBuilder().optionalMap(Map.of("1", "2")).build();
+        assertThat(copy)
+            .returns(original.requiredMap(), MapsInput::requiredMap)
+            .returns(Map.of("1", "2"), MapsInput::optionalMap);
+    }
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/GetterGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/GetterGenerator.java
@@ -95,8 +95,8 @@ record GetterGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolProv
             writer.putContext("isNullable", CodegenUtils.isNullableMember(member));
             writer.write(
                 """
-                    public ${symbol:T} ${memberName:L}() {
-                        ${?isNullable}if (${memberName:L} == null) {
+                    public ${symbol:T} ${memberName:L}() {${?isNullable}
+                        if (${memberName:L} == null) {
                             return ${collections:T}.${empty:L};
                         }${/isNullable}
                         return ${collections:T}.${wrapper:L}(${memberName:L});

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -62,6 +62,10 @@ public final class StructureGenerator
                 "builder",
                 new BuilderGenerator(writer, shape, directive.symbolProvider(), directive.model(), directive.service())
             );
+            writer.putContext(
+                "toBuilder",
+                new ToBuilderGenerator(writer, shape, directive.symbolProvider(), directive.model())
+            );
             writer.write(
                 """
                     public final class ${shape:T} implements ${serializableStruct:T} {
@@ -89,6 +93,8 @@ public final class StructureGenerator
                         ${memberSerializer:C|}
 
                         ${builder:C|}
+
+                        ${toBuilder:C|}
                     }
                     """
             );

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ToBuilderGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ToBuilderGenerator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.generators;
+
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+final class ToBuilderGenerator implements Runnable {
+    private final JavaWriter writer;
+    private final StructureShape shape;
+    private final SymbolProvider symbolProvider;
+    private final Model model;
+
+    public ToBuilderGenerator(JavaWriter writer, StructureShape shape, SymbolProvider symbolProvider, Model model) {
+        this.writer = writer;
+        this.shape = shape;
+        this.symbolProvider = symbolProvider;
+        this.model = model;
+    }
+
+    @Override
+    public void run() {
+        writer.write(
+            """
+                public Builder toBuilder() {
+                    var builder =  new Builder();
+                    ${C|}
+                    return builder;
+                }
+                """,
+            (Runnable) this::copyBuilderProperties
+        );
+    }
+
+    private void copyBuilderProperties() {
+        for (var member : shape.members()) {
+            writer.pushState();
+            writer.putContext("member", symbolProvider.toMemberName(member));
+            writer.write("builder.${member:L}(this.${member:L});");
+            writer.popState();
+        }
+    }
+}

--- a/codegen/server/src/it/java/software/amazon/smithy/java/codegen/server/ServiceBuilderTest.java
+++ b/codegen/server/src/it/java/software/amazon/smithy/java/codegen/server/ServiceBuilderTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import smithy.java.codegen.server.test.model.Beer;
 import smithy.java.codegen.server.test.model.EchoInput;
 import smithy.java.codegen.server.test.model.EchoOutput;
+import smithy.java.codegen.server.test.model.EchoPayload;
 import smithy.java.codegen.server.test.model.GetBeerInput;
 import smithy.java.codegen.server.test.model.GetBeerOutput;
 import smithy.java.codegen.server.test.service.EchoOperation;
@@ -30,7 +31,8 @@ public class ServiceBuilderTest {
     private static final class EchoImpl implements EchoOperation {
         @Override
         public EchoOutput echo(EchoInput input, RequestContext context) {
-            return EchoOutput.builder().string(input.string()).build();
+            var output = input.value().toBuilder().echoCount(input.value().echoCount() + 1).build();
+            return EchoOutput.builder().value(output).build();
         }
     }
 
@@ -60,8 +62,10 @@ public class ServiceBuilderTest {
 
         Operation<EchoInput, EchoOutput> echo = service.getOperation("Echo");
         assertThat("Echo").isEqualTo(echo.name());
-        var echoOutput = echo.function().apply(EchoInput.builder().string("A").build(), null);
-        assertThat(echoOutput).isEqualTo(EchoOutput.builder().string("A").build());
+        var echoOutput = echo.function()
+            .apply(EchoInput.builder().value(EchoPayload.builder().string("A").build()).build(), null);
+        assertThat(echoOutput.value().echoCount()).isEqualTo(1);
+        assertThat(echoOutput.value().string()).isEqualTo("A");
     }
 
     @Test

--- a/codegen/server/src/it/resources/META-INF/smithy/main.smithy
+++ b/codegen/server/src/it/resources/META-INF/smithy/main.smithy
@@ -18,11 +18,18 @@ operation Echo {
 }
 
 structure EchoInput {
-    string: String
+    value: EchoPayload
 }
 
 structure EchoOutput {
+    value: EchoPayload
+}
+
+structure EchoPayload {
     string: String
+    @required
+    @default(0)
+    echoCount: Integer
 }
 
 structure Beer {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a `toBuilder` method to structures, which allows creating a Builder from an existing POJO, giving an easy way to copy a structure.

Also fixed an extra line in collection getters.

Generated structures update, https://github.com/smithy-lang/smithy-java/pull/116


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
