### PR TITLE
Fix bug in withAddedHeaders

### DIFF
--- a/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpMessage.java
+++ b/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpMessage.java
@@ -71,6 +71,6 @@ public interface SmithyHttpMessage {
             String value = fieldAndValues[i + 1];
             current.computeIfAbsent(field, f -> new ArrayList<>()).add(value);
         }
-        return withAddedHeaders(HttpHeaders.of(current, (k, v) -> true));
+        return withHeaders(HttpHeaders.of(current, (k, v) -> true));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`withAddedHeaders` was calling `withAddedHeaders` again, causing the header value to be attempted to be added twice. It would actually fail as it was trying to add header value to an immutable collection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
