### PR TITLE
Update serde generation to account for new SerializableStruct interface

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ExceptionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ExceptionGenerator.java
@@ -28,7 +28,7 @@ public final class ExceptionGenerator
             writer.putContext("shape", directive.symbol());
             writer.putContext("sdkException", ModeledSdkException.class);
             writer.putContext("biConsumer", BiConsumer.class);
-            writer.putContext("serializer", ShapeSerializer.class);
+            writer.putContext("shapeSerializer", ShapeSerializer.class);
             writer.write(
                 """
                     public final class ${shape:T} extends ${sdkException:T} {
@@ -36,7 +36,6 @@ public final class ExceptionGenerator
 
                         ${C|}
 
-                       private static final InnerSerializer INNER_SERIALIZER = new InnerSerializer();
                         ${C|}
 
                         ${C|}
@@ -46,15 +45,13 @@ public final class ExceptionGenerator
                         ${C|}
 
                         @Override
-                        public void serialize(${serializer:T} serializer) {
-                            serializer.writeStruct(SCHEMA, this, INNER_SERIALIZER);
+                        public SdkSchema schema() {
+                            return SCHEMA;
                         }
 
-                        private static final class InnerSerializer implements ${biConsumer:T}<${shape:T}, ${serializer:T}> {
-                            @Override
-                            public void accept(${shape:T} shape, ${serializer:T} serializer) {
-                                ${C|}
-                            }
+                        @Override
+                        public void serializeMembers(${shapeSerializer:T} serializer) {
+                            ${C|}
                         }
 
                         ${C|}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
@@ -175,10 +175,7 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
 
     @Override
     public Void structureShape(StructureShape structureShape) {
-        writer.write(
-            "${serializer:L}.writeStruct(${schema:L}, ${state:L}, $T.InnerSerializer.INSTANCE)",
-            provider.toSymbol(structureShape)
-        );
+        writer.write("${serializer:L}.writeStruct(${schema:L}, ${state:L})");
         return null;
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -12,7 +12,7 @@ import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -27,12 +27,12 @@ public final class StructureGenerator
         directive.context().writerDelegator().useShapeWriter(shape, writer -> {
             writer.pushState(new ClassSection(shape));
             writer.putContext("shape", directive.symbol());
-            writer.putContext("serializable", SerializableShape.class);
+            writer.putContext("serializableStruct", SerializableStruct.class);
             writer.putContext("biConsumer", BiConsumer.class);
-            writer.putContext("serializer", ShapeSerializer.class);
+            writer.putContext("shapeSerializer", ShapeSerializer.class);
             writer.write(
                 """
-                    public final class ${shape:T} implements ${serializable:T} {
+                    public final class ${shape:T} implements ${serializableStruct:T} {
                         ${C|}
 
                         ${C|}
@@ -50,17 +50,13 @@ public final class StructureGenerator
                         ${C|}
 
                         @Override
-                        public void serialize(${serializer:T} serializer) {
-                            serializer.writeStruct(SCHEMA, this, InnerSerializer.INSTANCE);
+                        public SdkSchema schema() {
+                            return SCHEMA;
                         }
 
-                        static final class InnerSerializer implements ${biConsumer:T}<${shape:T}, ${serializer:T}> {
-                            static final InnerSerializer INSTANCE = new InnerSerializer();
-
-                            @Override
-                            public void accept(${shape:T} shape, ${serializer:T} serializer) {
-                                ${C|}
-                            }
+                        @Override
+                        public void serializeMembers(${shapeSerializer:T} serializer) {
+                            ${C|}
                         }
 
                         ${C|}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
@@ -19,26 +19,13 @@ import software.amazon.smithy.model.traits.ErrorTrait;
  * {@link software.amazon.smithy.java.runtime.core.schema.SerializableShape#serialize(ShapeSerializer)}
  * method for a structure class.
  */
-final class StructureSerializerGenerator implements Runnable {
-    private final JavaWriter writer;
-    private final SymbolProvider symbolProvider;
-    private final Model model;
-    private final StructureShape shape;
-    private final ServiceShape service;
-
-    public StructureSerializerGenerator(
-        JavaWriter writer,
-        SymbolProvider symbolProvider,
-        Model model,
-        StructureShape shape,
-        ServiceShape service
-    ) {
-        this.writer = writer;
-        this.symbolProvider = symbolProvider;
-        this.model = model;
-        this.shape = shape;
-        this.service = service;
-    }
+record StructureSerializerGenerator(
+    JavaWriter writer,
+    SymbolProvider symbolProvider,
+    Model model,
+    StructureShape shape,
+    ServiceShape service
+) implements Runnable {
 
     @Override
     public void run() {
@@ -59,7 +46,7 @@ final class StructureSerializerGenerator implements Runnable {
                 model,
                 member,
                 "serializer",
-                "shape." + stateName,
+                stateName,
                 service
             );
 
@@ -67,7 +54,7 @@ final class StructureSerializerGenerator implements Runnable {
                 // If the member is nullable, check for existence first.
                 writer.write(
                     """
-                        if (shape.$L != null) {
+                        if ($L != null) {
                             ${C|};
                         }""",
                     stateName,

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -95,7 +95,7 @@ public class JavadocIntegrationTest {
              */
             @Deprecated(since = "1.3")
             @SmithyGenerated
-            public final class DeprecatedInput implements SerializableShape {
+            public final class DeprecatedInput implements SerializableStruct {
             """));
 
         // Check that member headers match expected
@@ -132,7 +132,7 @@ public class JavadocIntegrationTest {
         var fileContents = getFileStringForClass("SmithyGeneratedInput");
         assertThat(fileContents, containsString("""
             @SmithyGenerated
-            public final class SmithyGeneratedInput implements SerializableShape {
+            public final class SmithyGeneratedInput implements SerializableStruct {
             """));
     }
 
@@ -144,7 +144,7 @@ public class JavadocIntegrationTest {
              * @since 4.5
              */
             @SmithyGenerated
-            public final class SinceInput implements SerializableShape {
+            public final class SinceInput implements SerializableStruct {
             """));
         assertThat(fileContents, containsString("""
                 /**
@@ -163,7 +163,7 @@ public class JavadocIntegrationTest {
              * @see <a href="https://example.com">Example</a>
              */
             @SmithyGenerated
-            public final class ExternalDocumentationInput implements SerializableShape {
+            public final class ExternalDocumentationInput implements SerializableStruct {
             """));
         assertThat(fileContents, containsString("""
                 /**
@@ -179,7 +179,7 @@ public class JavadocIntegrationTest {
         assertThat(fileContents, containsString("""
             @SmithyUnstableApi
             @SmithyGenerated
-            public final class UnstableInput implements SerializableShape {
+            public final class UnstableInput implements SerializableStruct {
             """));
         assertThat(fileContents, containsString("""
                 @SmithyUnstableApi
@@ -203,7 +203,7 @@ public class JavadocIntegrationTest {
             @SmithyUnstableApi
             @Deprecated(since = "sometime")
             @SmithyGenerated
-            public final class RollupInput implements SerializableShape {
+            public final class RollupInput implements SerializableStruct {
             """));
         assertThat(fileContents, containsString("""
                 /**

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ModeledSdkException.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ModeledSdkException.java
@@ -10,7 +10,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 /**
  * The top-level exception that should be used to throw modeled errors from clients and servers.
  */
-public abstract class ModeledSdkException extends SdkException implements SerializableShape {
+public abstract class ModeledSdkException extends SdkException implements SerializableStruct {
 
     private final ShapeId shapeId;
 


### PR DESCRIPTION
### Description of changes
Updates code generated serde to use the new `SerializableStruct` interface added in #103 .

Generated example shape: https://github.com/smithy-lang/smithy-java/pull/109

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
