### PR TITLE
Clean up generators, deprecated, and use named values

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ConstructorGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ConstructorGenerator.java
@@ -21,19 +21,8 @@ import software.amazon.smithy.model.traits.ErrorTrait;
  * <p>The constructor expects to take only one argument, a static {@code Builder} class
  * Use the {@link BuilderGenerator} class to generate this static builder.
  */
-final class ConstructorGenerator implements Runnable {
-
-    private final JavaWriter writer;
-    private final Shape shape;
-    private final SymbolProvider symbolProvider;
-    private final Model model;
-
-    ConstructorGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolProvider, Model model) {
-        this.writer = writer;
-        this.shape = shape;
-        this.symbolProvider = symbolProvider;
-        this.model = model;
-    }
+record ConstructorGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolProvider, Model model) implements
+    Runnable {
 
     @Override
     public void run() {

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ExceptionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ExceptionGenerator.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.codegen.generators;
 
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.directed.GenerateErrorDirective;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
@@ -13,7 +12,6 @@ import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
-import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -27,56 +25,66 @@ public final class ExceptionGenerator
             writer.pushState(new ClassSection(shape));
             writer.putContext("shape", directive.symbol());
             writer.putContext("sdkException", ModeledSdkException.class);
-            writer.putContext("biConsumer", BiConsumer.class);
-            writer.putContext("shapeSerializer", ShapeSerializer.class);
-            writer.write(
-                """
-                    public final class ${shape:T} extends ${sdkException:T} {
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        @Override
-                        public SdkSchema schema() {
-                            return SCHEMA;
-                        }
-
-                        @Override
-                        public void serializeMembers(${shapeSerializer:T} serializer) {
-                            ${C|}
-                        }
-
-                        ${C|}
-                    }
-                    """,
-                writer.consumer(w -> w.writeIdString(shape)),
+            writer.putContext("id", writer.consumer(w -> w.writeIdString(shape)));
+            writer.putContext(
+                "schemas",
                 new SchemaGenerator(
                     writer,
                     directive.shape(),
                     directive.symbolProvider(),
                     directive.model(),
                     directive.context()
-                ),
-                new PropertyGenerator(writer, shape, directive.symbolProvider()),
-                new ConstructorGenerator(writer, shape, directive.symbolProvider(), directive.model()),
-                new GetterGenerator(writer, shape, directive.symbolProvider(), directive.model()),
-                writer.consumer(JavaWriter::writeToString),
+                )
+            );
+            writer.putContext("properties", new PropertyGenerator(writer, shape, directive.symbolProvider()));
+            writer.putContext(
+                "constructor",
+                new ConstructorGenerator(writer, shape, directive.symbolProvider(), directive.model())
+            );
+            writer.putContext(
+                "getters",
+                new GetterGenerator(writer, shape, directive.symbolProvider(), directive.model())
+            );
+            writer.putContext("toString", writer.consumer(JavaWriter::writeToString));
+            writer.putContext(
+                "memberSerializer",
                 new StructureSerializerGenerator(
                     writer,
                     directive.symbolProvider(),
                     directive.model(),
                     directive.shape(),
                     directive.service()
-                ),
+                )
+            );
+            writer.putContext(
+                "builder",
                 new BuilderGenerator(writer, shape, directive.symbolProvider(), directive.model(), directive.service())
+            );
+            writer.write(
+                """
+                    public final class ${shape:T} extends ${sdkException:T} {
+                        ${id:C|}
+
+                        ${schemas:C|}
+
+                        ${properties:C|}
+
+                        ${constructor:C|}
+
+                        ${getters:C|}
+
+                        ${toString:C|}
+
+                        @Override
+                        public SdkSchema schema() {
+                            return SCHEMA;
+                        }
+
+                        ${memberSerializer:C|}
+
+                        ${builder:C|}
+                    }
+                    """
             );
             writer.popState();
         });

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/GetterGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/GetterGenerator.java
@@ -22,18 +22,7 @@ import software.amazon.smithy.model.traits.ErrorTrait;
 /**
  * Generates getters for a shape.
  */
-final class GetterGenerator implements Runnable {
-    private final JavaWriter writer;
-    private final Shape shape;
-    private final SymbolProvider symbolProvider;
-    private final Model model;
-
-    GetterGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolProvider, Model model) {
-        this.shape = shape;
-        this.symbolProvider = symbolProvider;
-        this.writer = writer;
-        this.model = model;
-    }
+record GetterGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolProvider, Model model) implements Runnable {
 
     @Override
     public void run() {

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/HashCodeGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/HashCodeGenerator.java
@@ -13,17 +13,7 @@ import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.model.shapes.Shape;
 
-final class HashCodeGenerator implements Runnable {
-
-    private final JavaWriter writer;
-    private final Shape shape;
-    private final SymbolProvider symbolProvider;
-
-    HashCodeGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolProvider) {
-        this.writer = writer;
-        this.shape = shape;
-        this.symbolProvider = symbolProvider;
-    }
+record HashCodeGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolProvider) implements Runnable {
 
     @Override
     public void run() {

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -79,10 +79,9 @@ public final class ListGenerator
                             writer,
                             directive.symbolProvider(),
                             directive.model(),
+                            directive.service(),
                             directive.shape().getMember(),
-                            "serializer",
-                            "value",
-                            directive.service()
+                            "value"
                         ),
                         new DeserializerGenerator(
                             writer,

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
@@ -101,10 +101,9 @@ public class MapGenerator
                             writer,
                             directive.symbolProvider(),
                             directive.model(),
+                            directive.service(),
                             directive.shape().getValue(),
-                            "serializer",
-                            "values",
-                            directive.service()
+                            "values"
                         ),
                         new DeserializerGenerator(
                             writer,

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/PropertyGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/PropertyGenerator.java
@@ -14,17 +14,7 @@ import software.amazon.smithy.model.traits.ErrorTrait;
 /**
  * Generates properties for a Java class from Smithy shape members
  */
-final class PropertyGenerator implements Runnable {
-
-    private final JavaWriter writer;
-    private final Shape shape;
-    private final SymbolProvider symbolProvider;
-
-    PropertyGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolProvider) {
-        this.writer = writer;
-        this.shape = shape;
-        this.symbolProvider = symbolProvider;
-    }
+record PropertyGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolProvider) implements Runnable {
 
     @Override
     public void run() {

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.codegen.generators;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
-import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
@@ -37,27 +36,24 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
     private final JavaWriter writer;
     private final SymbolProvider provider;
     private final Model model;
-    private final MemberShape memberShape;
-    private final String serializer;
-    private final String state;
     private final ServiceShape service;
+    private final MemberShape memberShape;
+    private final String state;
 
     SerializerMemberGenerator(
         JavaWriter writer,
         SymbolProvider provider,
         Model model,
+        ServiceShape service,
         MemberShape memberShape,
-        String serializer,
-        String state,
-        ServiceShape service
+        String state
     ) {
         this.writer = writer;
         this.provider = provider;
         this.model = model;
-        this.memberShape = memberShape;
-        this.serializer = serializer;
-        this.state = state;
         this.service = service;
+        this.memberShape = memberShape;
+        this.state = state;
     }
 
     @Override
@@ -72,8 +68,6 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
         } else {
             writer.putContext("schema", CodegenUtils.toMemberSchemaName(memberName));
         }
-        writer.putContext("shapeSerializer", ShapeSerializer.class);
-        writer.putContext("serializer", serializer);
         writer.putContext("state", state);
         memberShape.accept(this);
         writer.popState();
@@ -85,20 +79,20 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
         if (CodegenUtils.isStreamingBlob(blobShape)) {
             return null;
         }
-        writer.write("${serializer:L}.writeBlob(${schema:L}, ${state:L})");
+        writer.write("serializer.writeBlob(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void booleanShape(BooleanShape booleanShape) {
-        writer.write("${serializer:L}.writeBoolean(${schema:L}, ${state:L})");
+        writer.write("serializer.writeBoolean(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void listShape(ListShape listShape) {
         writer.write(
-            "${serializer:L}.writeList(${schema:L}, ${state:L}, SharedSerde.$USerializer.INSTANCE)",
+            "serializer.writeList(${schema:L}, ${state:L}, SharedSerde.$USerializer.INSTANCE)",
             CodegenUtils.getDefaultName(listShape, service)
         );
         return null;
@@ -107,7 +101,7 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
     @Override
     public Void mapShape(MapShape mapShape) {
         writer.write(
-            "${serializer:L}.writeMap(${schema:L}, ${state:L}, SharedSerde.$USerializer.INSTANCE)",
+            "serializer.writeMap(${schema:L}, ${state:L}, SharedSerde.$USerializer.INSTANCE)",
             CodegenUtils.getDefaultName(mapShape, service)
         );
         return null;
@@ -115,73 +109,73 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
 
     @Override
     public Void byteShape(ByteShape byteShape) {
-        writer.write("${serializer:L}.writeByte(${schema:L}, ${state:L})");
+        writer.write("serializer.writeByte(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void shortShape(ShortShape shortShape) {
-        writer.write("${serializer:L}.writeShort(${schema:L}, ${state:L})");
+        writer.write("serializer.writeShort(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void integerShape(IntegerShape integerShape) {
-        writer.write("${serializer:L}.writeInteger(${schema:L}, ${state:L})");
+        writer.write("serializer.writeInteger(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void longShape(LongShape longShape) {
-        writer.write("${serializer:L}.writeLong(${schema:L}, ${state:L})");
+        writer.write("serializer.writeLong(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void floatShape(FloatShape floatShape) {
-        writer.write("${serializer:L}.writeFloat(${schema:L}, ${state:L})");
+        writer.write("serializer.writeFloat(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void documentShape(DocumentShape documentShape) {
-        writer.write("${serializer:L}.writeDocument(${schema:L}, ${state:L})");
+        writer.write("serializer.writeDocument(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void doubleShape(DoubleShape doubleShape) {
-        writer.write("${serializer:L}.writeDouble(${schema:L}, ${state:L})");
+        writer.write("serializer.writeDouble(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void bigIntegerShape(BigIntegerShape bigIntegerShape) {
-        writer.write("${serializer:L}.writeBigInteger(${schema:L}, ${state:L})");
+        writer.write("serializer.writeBigInteger(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void bigDecimalShape(BigDecimalShape bigDecimalShape) {
-        writer.write("${serializer:L}.writeBigDecimal(${schema:L}, ${state:L})");
+        writer.write("serializer.writeBigDecimal(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void stringShape(StringShape stringShape) {
-        writer.write("${serializer:L}.writeString(${schema:L}, ${state:L})");
+        writer.write("serializer.writeString(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void structureShape(StructureShape structureShape) {
-        writer.write("${serializer:L}.writeStruct(${schema:L}, ${state:L})");
+        writer.write("serializer.writeStruct(${schema:L}, ${state:L})");
         return null;
     }
 
     @Override
     public Void unionShape(UnionShape unionShape) {
-        writer.write("${memberName:L}.serialize(${serializer:L})");
+        writer.write("${memberName:L}.serialize(serializer)");
         return null;
     }
 
@@ -189,7 +183,7 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
     public Void memberShape(MemberShape shape) {
         // The error `message` member must be accessed from parent class.
         if (memberShape.hasTrait(ErrorTrait.class) && provider.toMemberName(memberShape).equals("message")) {
-            writer.write("${serializer:L}.writeString(SCHEMA_MESSAGE, ${state:L}.getMessage())");
+            writer.write("serializer.writeString(SCHEMA_MESSAGE, ${state:L}.getMessage())");
             return null;
         }
         return model.expectShape(memberShape.getTarget()).accept(this);

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.codegen.generators;
 
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.directed.GenerateStructureDirective;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
@@ -13,7 +12,6 @@ import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
-import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -23,67 +21,76 @@ public final class StructureGenerator
     @Override
     public void accept(GenerateStructureDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
         var shape = directive.shape();
-
         directive.context().writerDelegator().useShapeWriter(shape, writer -> {
             writer.pushState(new ClassSection(shape));
             writer.putContext("shape", directive.symbol());
             writer.putContext("serializableStruct", SerializableStruct.class);
-            writer.putContext("biConsumer", BiConsumer.class);
-            writer.putContext("shapeSerializer", ShapeSerializer.class);
-            writer.write(
-                """
-                    public final class ${shape:T} implements ${serializableStruct:T} {
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        ${C|}
-
-                        @Override
-                        public SdkSchema schema() {
-                            return SCHEMA;
-                        }
-
-                        @Override
-                        public void serializeMembers(${shapeSerializer:T} serializer) {
-                            ${C|}
-                        }
-
-                        ${C|}
-                    }
-                    """,
-                writer.consumer(w -> w.writeIdString(shape)),
+            writer.putContext("id", writer.consumer(w -> w.writeIdString(shape)));
+            writer.putContext(
+                "schemas",
                 new SchemaGenerator(
                     writer,
                     directive.shape(),
                     directive.symbolProvider(),
                     directive.model(),
                     directive.context()
-                ),
-                new PropertyGenerator(writer, shape, directive.symbolProvider()),
-                new ConstructorGenerator(writer, shape, directive.symbolProvider(), directive.model()),
-                new GetterGenerator(writer, shape, directive.symbolProvider(), directive.model()),
-                writer.consumer(JavaWriter::writeToString),
-                new EqualsGenerator(writer, directive.shape(), directive.symbolProvider()),
-                new HashCodeGenerator(writer, directive.shape(), directive.symbolProvider()),
+                )
+            );
+            writer.putContext("properties", new PropertyGenerator(writer, shape, directive.symbolProvider()));
+            writer.putContext(
+                "constructor",
+                new ConstructorGenerator(writer, shape, directive.symbolProvider(), directive.model())
+            );
+            writer.putContext(
+                "getters",
+                new GetterGenerator(writer, shape, directive.symbolProvider(), directive.model())
+            );
+            writer.putContext("equals", new EqualsGenerator(writer, directive.shape(), directive.symbolProvider()));
+            writer.putContext("hashCode", new HashCodeGenerator(writer, directive.shape(), directive.symbolProvider()));
+            writer.putContext("toString", writer.consumer(JavaWriter::writeToString));
+            writer.putContext(
+                "memberSerializer",
                 new StructureSerializerGenerator(
                     writer,
                     directive.symbolProvider(),
                     directive.model(),
                     directive.shape(),
                     directive.service()
-                ),
+                )
+            );
+            writer.putContext(
+                "builder",
                 new BuilderGenerator(writer, shape, directive.symbolProvider(), directive.model(), directive.service())
+            );
+            writer.write(
+                """
+                    public final class ${shape:T} implements ${serializableStruct:T} {
+                        ${id:C|}
+
+                        ${schemas:C|}
+
+                        ${properties:C|}
+
+                        ${constructor:C|}
+
+                        ${getters:C|}
+
+                        ${toString:C|}
+
+                        ${equals:C|}
+
+                        ${hashCode:C|}
+
+                        @Override
+                        public SdkSchema schema() {
+                            return SCHEMA;
+                        }
+
+                        ${memberSerializer:C|}
+
+                        ${builder:C|}
+                    }
+                    """
             );
             writer.popState();
         });

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/TraitInitializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/TraitInitializerGenerator.java
@@ -83,18 +83,18 @@ record TraitInitializerGenerator(JavaWriter writer, Shape shape, Set<ShapeId> ru
         writer.pushState();
         writer.putContext("shapeId", ShapeId.class);
         writer.putContext("node", Node.class);
+        writer.putContext("name", traitProviderClass.getSimpleName());
+        writer.putContext("type", traitProviderClass);
+        writer.putContext("id", trait.toShapeId());
         if (traitProviderClass.isMemberClass()) {
             writer.putContext("enclosing", traitProviderClass.getEnclosingClass());
         }
         writer.writeInline(
             """
-                new ${?enclosing}${enclosing:T}.$1L${/enclosing}${^enclosing}$2T${/enclosing}().createTrait(
-                    ${shapeId:T}.from($3S),
-                    ${4C|}
+                new ${?enclosing}${enclosing:T}.${name:L}${/enclosing}${^enclosing}${type:T}${/enclosing}().createTrait(
+                    ${shapeId:T}.from(${id:S}),
+                    ${C|}
                 )""",
-            traitProviderClass.getSimpleName(),
-            traitProviderClass,
-            trait.toShapeId(),
             writer.consumer(w -> trait.toNode().accept(new NodeWriter(writer)))
         );
         writer.popState();

--- a/codegen/server/build.gradle
+++ b/codegen/server/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation(project(":codegen:client"))
     implementation(libs.smithy.codegen)
     api(libs.smithy.aws.traits)
-    testImplementation(project(":codegen:core").sourceSets.test.output)
 }
 
 // Execute building of Java classes using an executable class

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -38,12 +38,6 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
     @Override
     default void close() {}
 
-    // TODO: Remove this once codegen has been updated.
-    @Deprecated
-    default <T> void writeStruct(SdkSchema schema, T structState, BiConsumer<T, ShapeSerializer> consumer) {
-        throw new UnsupportedOperationException();
-    }
-
     /**
      * Writes a structure or union using the given member schema.
      *


### PR DESCRIPTION
### Description of changes
Cleans up codegen. In particular switching to using named parameters in a number of places to improve clarity of templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
