### PR TITLE
Use SerializableStruct for input/output params

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ApiCallTimeoutTransport.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ApiCallTimeoutTransport.java
@@ -11,7 +11,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import software.amazon.smithy.java.runtime.core.schema.SdkException;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
  * A {@link ClientTransport} that wraps another transport to time out a request if it takes longer than
@@ -31,7 +31,7 @@ public final class ApiCallTimeoutTransport implements ClientTransport {
     }
 
     @Override
-    public <I extends SerializableShape, O extends SerializableShape> O send(ClientCall<I, O> call) {
+    public <I extends SerializableStruct, O extends SerializableStruct> O send(ClientCall<I, O> call) {
         var timeout = call.context().get(CallContext.API_CALL_TIMEOUT);
 
         if (timeout == null) {

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/CallContext.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/CallContext.java
@@ -12,7 +12,7 @@ import software.amazon.smithy.java.runtime.client.endpoint.api.EndpointResolver;
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.schema.SdkException;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
  * Context parameters made available to underlying transports like HTTP clients.
@@ -21,12 +21,12 @@ public final class CallContext {
     /**
      * Contains the input of the operation being sent.
      */
-    public static final Context.Key<SerializableShape> INPUT = Context.key("Input shape");
+    public static final Context.Key<SerializableStruct> INPUT = Context.key("Input shape");
 
     /**
      * Deserialized output of the call.
      */
-    public static final Context.Key<SerializableShape> OUTPUT = Context.key("Output");
+    public static final Context.Key<SerializableStruct> OUTPUT = Context.key("Output");
 
     /**
      * Error encountered by the call that will be thrown.
@@ -37,16 +37,6 @@ public final class CallContext {
      * Contains the schema of the operation being sent.
      */
     public static final Context.Key<SdkSchema> OPERATION_SCHEMA = Context.key("Operation schema");
-
-    /**
-     * Contains the input schema of the operation being sent.
-     */
-    public static final Context.Key<SdkSchema> INPUT_SCHEMA = Context.key("Input schema");
-
-    /**
-     * Contains the output schema of the operation being sent.
-     */
-    public static final Context.Key<SdkSchema> OUTPUT_SCHEMA = Context.key("Output schema");
 
     /**
      * The total amount of time to wait for an API call to complete, including retries, and serialization.

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
@@ -24,7 +24,7 @@ import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
 import software.amazon.smithy.java.runtime.core.schema.SdkOperation;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
 
 /**
@@ -33,7 +33,7 @@ import software.amazon.smithy.java.runtime.core.serde.DataStream;
  * @param <I> Input to send.
  * @param <O> Output to return.
  */
-public final class ClientCall<I extends SerializableShape, O extends SerializableShape> {
+public final class ClientCall<I extends SerializableStruct, O extends SerializableStruct> {
 
     private final I input;
     private final EndpointResolver endpointResolver;
@@ -67,8 +67,6 @@ public final class ClientCall<I extends SerializableShape, O extends Serializabl
         // Initialize the context.
         context.put(CallContext.INPUT, input());
         context.put(CallContext.OPERATION_SCHEMA, operation().schema());
-        context.put(CallContext.INPUT_SCHEMA, operation().inputSchema());
-        context.put(CallContext.OUTPUT_SCHEMA, operation().outputSchema());
         context.put(CallContext.CLIENT_INTERCEPTOR, interceptor());
     }
 
@@ -79,7 +77,7 @@ public final class ClientCall<I extends SerializableShape, O extends Serializabl
      * @param <I> Input type.
      * @param <O> Output type.
      */
-    public static <I extends SerializableShape, O extends SerializableShape> Builder<I, O> builder() {
+    public static <I extends SerializableStruct, O extends SerializableStruct> Builder<I, O> builder() {
         return new Builder<>();
     }
 
@@ -215,7 +213,7 @@ public final class ClientCall<I extends SerializableShape, O extends Serializabl
      * @param <I> Input to send.
      * @param <O> Expected output.
      */
-    public static final class Builder<I extends SerializableShape, O extends SerializableShape> {
+    public static final class Builder<I extends SerializableStruct, O extends SerializableStruct> {
 
         private I input;
         private EndpointResolver endpointResolver;
@@ -230,8 +228,7 @@ public final class ClientCall<I extends SerializableShape, O extends Serializabl
         private Object requestEventStream;
         private ExecutorService executor;
 
-        private Builder() {
-        }
+        private Builder() {}
 
         /**
          * Set the input of the call.

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
@@ -9,7 +9,7 @@ import java.net.URI;
 import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.schema.SdkException;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 public interface ClientProtocol<RequestT, ResponseT> {
 
@@ -66,7 +66,7 @@ public interface ClientProtocol<RequestT, ResponseT> {
      * @return the deserialized output shape.
      * @throws SdkException if an error occurs, including deserialized modeled errors and protocol errors.
      */
-    <I extends SerializableShape, O extends SerializableShape> O deserializeResponse(
+    <I extends SerializableStruct, O extends SerializableStruct> O deserializeResponse(
         ClientCall<I, O> call,
         RequestT request,
         ResponseT response

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientTransport.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientTransport.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.java.runtime.client.core;
 
 import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
 import software.amazon.smithy.java.runtime.core.schema.SdkException;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
  * Serializes inputs, sends requests on the wire, and deserializes responses.
@@ -23,7 +23,7 @@ public interface ClientTransport {
      * @throws ModeledSdkException if a modeled error occurs.
      * @throws SdkException if an error occurs.
      */
-    <I extends SerializableShape, O extends SerializableShape> O send(ClientCall<I, O> call);
+    <I extends SerializableStruct, O extends SerializableStruct> O send(ClientCall<I, O> call);
 
     /**
      * Marker interface to indicate that the transport is SRA compliant.

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/SraPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/SraPipeline.java
@@ -20,7 +20,7 @@ import software.amazon.smithy.java.runtime.client.endpoint.api.EndpointResolverP
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.Either;
 import software.amazon.smithy.java.runtime.core.schema.SdkException;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
  * Handles the requests/response pipeline to turn an input into a request, emit the appropriate SRA interceptors,
@@ -35,7 +35,7 @@ import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
  */
 // TODO: Should more of this class be separated out into pieces (like resolving auth)?
 // TODO: Implement the real SRA interceptors workflow and error handling.
-public final class SraPipeline<I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> {
+public final class SraPipeline<I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> {
 
     private static final System.Logger LOGGER = System.getLogger(SraPipeline.class.getName());
     private static final URI UNRESOLVED;
@@ -66,7 +66,7 @@ public final class SraPipeline<I extends SerializableShape, O extends Serializab
         this.responseKey = protocol.responseKey();
     }
 
-    public static <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> O send(
+    public static <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> O send(
         ClientCall<I, O> call,
         ClientProtocol<RequestT, ResponseT> protocol,
         Function<RequestT, ResponseT> wireTransport
@@ -116,7 +116,7 @@ public final class SraPipeline<I extends SerializableShape, O extends Serializab
     }
 
     @SuppressWarnings("unchecked")
-    private <I extends SerializableShape, O extends SerializableShape> ResolvedScheme<?, RequestT> resolveAuthScheme(
+    private <I extends SerializableStruct, O extends SerializableStruct> ResolvedScheme<?, RequestT> resolveAuthScheme(
         ClientCall<I, O> call,
         RequestT request
     ) {
@@ -165,7 +165,7 @@ public final class SraPipeline<I extends SerializableShape, O extends Serializab
         }
     }
 
-    private <I extends SerializableShape, O extends SerializableShape> O deserialize(
+    private <I extends SerializableStruct, O extends SerializableStruct> O deserialize(
         ClientCall<I, O> call,
         RequestT request,
         ResponseT response,
@@ -258,7 +258,9 @@ public final class SraPipeline<I extends SerializableShape, O extends Serializab
     }
 
     // TODO: Add more parameters here somehow from the caller.
-    private <I extends SerializableShape, O extends SerializableShape> Endpoint resolveEndpoint(ClientCall<I, O> call) {
+    private <I extends SerializableStruct, O extends SerializableStruct> Endpoint resolveEndpoint(
+        ClientCall<I, O> call
+    ) {
         var operation = call.operation().schema();
         var request = EndpointResolverParams.builder().operationName(operation.id().getName()).build();
         return call.endpointResolver().resolveEndpoint(request);

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptor.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptor.java
@@ -12,7 +12,7 @@ import java.util.List;
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.Either;
 import software.amazon.smithy.java.runtime.core.schema.SdkException;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
  * An interceptor allows injecting code into the clien'ts request execution pipeline.
@@ -77,7 +77,7 @@ public interface ClientInterceptor {
      * @param input The modeled input of the call.
      * @param <I> Input type.
      */
-    default <I extends SerializableShape> void readBeforeExecution(Context context, I input) {}
+    default <I extends SerializableStruct> void readBeforeExecution(Context context, I input) {}
 
     /**
      * A hook called before the input message is serialized into a transport message.
@@ -102,7 +102,7 @@ public interface ClientInterceptor {
      * @return the updated input.
      * @param <I> Input type.
      */
-    default <I extends SerializableShape> I modifyBeforeSerialization(Context context, I input) {
+    default <I extends SerializableStruct> I modifyBeforeSerialization(Context context, I input) {
         return input;
     }
 
@@ -122,7 +122,7 @@ public interface ClientInterceptor {
      * @param input The modeled input of the call.
      * @param <I> Input type.
      */
-    default <I extends SerializableShape> void readBeforeSerialization(Context context, I input) {}
+    default <I extends SerializableStruct> void readBeforeSerialization(Context context, I input) {}
 
     /**
      * A hook called after the input message is marshalled into a protocol-specific request.
@@ -143,7 +143,7 @@ public interface ClientInterceptor {
      * @param <I> Input type.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <I extends SerializableShape, RequestT> void readAfterSerialization(
+    default <I extends SerializableStruct, RequestT> void readAfterSerialization(
         Context context,
         I input,
         Value<RequestT> request
@@ -167,7 +167,7 @@ public interface ClientInterceptor {
      * @param <I> Input type.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <I extends SerializableShape, RequestT> Value<RequestT> modifyBeforeRetryLoop(
+    default <I extends SerializableStruct, RequestT> Value<RequestT> modifyBeforeRetryLoop(
         Context context,
         I input,
         Value<RequestT> request
@@ -195,7 +195,7 @@ public interface ClientInterceptor {
      * @param <I> Input type.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <I extends SerializableShape, RequestT> void readBeforeAttempt(
+    default <I extends SerializableStruct, RequestT> void readBeforeAttempt(
         Context context,
         I input,
         Value<RequestT> request
@@ -221,7 +221,7 @@ public interface ClientInterceptor {
      * @param <I> Input type.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <I extends SerializableShape, RequestT> Value<RequestT> modifyBeforeSigning(
+    default <I extends SerializableStruct, RequestT> Value<RequestT> modifyBeforeSigning(
         Context context,
         I input,
         Value<RequestT> request
@@ -247,7 +247,7 @@ public interface ClientInterceptor {
      * @param <I>Input type.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <I extends SerializableShape, RequestT> void readBeforeSigning(
+    default <I extends SerializableStruct, RequestT> void readBeforeSigning(
         Context context,
         I input,
         Value<RequestT> request
@@ -271,7 +271,7 @@ public interface ClientInterceptor {
      * @param <I> Input type.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <I extends SerializableShape, RequestT> void readAfterSigning(
+    default <I extends SerializableStruct, RequestT> void readAfterSigning(
         Context context,
         I input,
         Value<RequestT> request
@@ -299,7 +299,7 @@ public interface ClientInterceptor {
      * @param <I> Input type.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <I extends SerializableShape, RequestT> Value<RequestT> modifyBeforeTransmit(
+    default <I extends SerializableStruct, RequestT> Value<RequestT> modifyBeforeTransmit(
         Context context,
         I input,
         Value<RequestT> request
@@ -326,7 +326,7 @@ public interface ClientInterceptor {
      * @param <I> Input type.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <I extends SerializableShape, RequestT> void readBeforeTransmit(
+    default <I extends SerializableStruct, RequestT> void readBeforeTransmit(
         Context context,
         I input,
         Value<RequestT> request
@@ -355,7 +355,7 @@ public interface ClientInterceptor {
      * @param <RequestT> Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableShape, RequestT, ResponseT> void readAfterTransmit(
+    default <I extends SerializableStruct, RequestT, ResponseT> void readAfterTransmit(
         Context context,
         I input,
         Value<RequestT> request,
@@ -386,7 +386,7 @@ public interface ClientInterceptor {
      * @param <RequestT> Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableShape, RequestT, ResponseT> Value<ResponseT> modifyBeforeDeserialization(
+    default <I extends SerializableStruct, RequestT, ResponseT> Value<ResponseT> modifyBeforeDeserialization(
         Context context,
         I input,
         Value<RequestT> request,
@@ -417,7 +417,7 @@ public interface ClientInterceptor {
      * @param <RequestT> Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableShape, RequestT, ResponseT> void readBeforeDeserialization(
+    default <I extends SerializableStruct, RequestT, ResponseT> void readBeforeDeserialization(
         Context context,
         I input,
         Value<RequestT> request,
@@ -447,7 +447,7 @@ public interface ClientInterceptor {
      * @param <RequestT> Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> void readAfterDeserialization(
+    default <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> void readAfterDeserialization(
         Context context,
         I input,
         Value<RequestT> request,
@@ -478,7 +478,7 @@ public interface ClientInterceptor {
      * @param <RequestT> Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> Either<SdkException, O> modifyBeforeAttemptCompletion(
+    default <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<SdkException, O> modifyBeforeAttemptCompletion(
         Context context,
         I input,
         Value<RequestT> request,
@@ -512,7 +512,7 @@ public interface ClientInterceptor {
      * @param <RequestT>  Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> void readAfterAttempt(
+    default <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> void readAfterAttempt(
         Context context,
         I input,
         Value<RequestT> request,
@@ -544,7 +544,7 @@ public interface ClientInterceptor {
      * @param <RequestT>  Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> Either<SdkException, O> modifyBeforeCompletion(
+    default <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<SdkException, O> modifyBeforeCompletion(
         Context context,
         I input,
         Value<RequestT> requestIfAvailable,
@@ -578,7 +578,7 @@ public interface ClientInterceptor {
      * @param <RequestT>  Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> void readAfterExecution(
+    default <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> void readAfterExecution(
         Context context,
         I input,
         Value<RequestT> requestIfAvailable,

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptorChain.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptorChain.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.Either;
 import software.amazon.smithy.java.runtime.core.schema.SdkException;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 final class ClientInterceptorChain implements ClientInterceptor {
 
@@ -24,7 +24,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape> void readBeforeExecution(Context context, I input) {
+    public <I extends SerializableStruct> void readBeforeExecution(Context context, I input) {
         applyToEachThrowLastError(interceptor -> interceptor.readBeforeExecution(context, input));
     }
 
@@ -48,7 +48,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape> I modifyBeforeSerialization(Context context, I input) {
+    public <I extends SerializableStruct> I modifyBeforeSerialization(Context context, I input) {
         for (var interceptor : interceptors) {
             input = interceptor.modifyBeforeSerialization(context, input);
         }
@@ -56,14 +56,14 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape> void readBeforeSerialization(Context context, I input) {
+    public <I extends SerializableStruct> void readBeforeSerialization(Context context, I input) {
         for (var interceptor : interceptors) {
             interceptor.readBeforeSerialization(context, input);
         }
     }
 
     @Override
-    public <I extends SerializableShape, RequestT> void readAfterSerialization(
+    public <I extends SerializableStruct, RequestT> void readAfterSerialization(
         Context context,
         I input,
         Value<RequestT> request
@@ -74,7 +74,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT> Value<RequestT> modifyBeforeRetryLoop(
+    public <I extends SerializableStruct, RequestT> Value<RequestT> modifyBeforeRetryLoop(
         Context context,
         I input,
         Value<RequestT> request
@@ -86,7 +86,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT> void readBeforeAttempt(
+    public <I extends SerializableStruct, RequestT> void readBeforeAttempt(
         Context context,
         I input,
         Value<RequestT> request
@@ -95,7 +95,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT> Value<RequestT> modifyBeforeSigning(
+    public <I extends SerializableStruct, RequestT> Value<RequestT> modifyBeforeSigning(
         Context context,
         I input,
         Value<RequestT> request
@@ -107,7 +107,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT> void readBeforeSigning(
+    public <I extends SerializableStruct, RequestT> void readBeforeSigning(
         Context context,
         I input,
         Value<RequestT> request
@@ -118,7 +118,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT> void readAfterSigning(
+    public <I extends SerializableStruct, RequestT> void readAfterSigning(
         Context context,
         I input,
         Value<RequestT> request
@@ -129,7 +129,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT> Value<RequestT> modifyBeforeTransmit(
+    public <I extends SerializableStruct, RequestT> Value<RequestT> modifyBeforeTransmit(
         Context context,
         I input,
         Value<RequestT> request
@@ -141,7 +141,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT> void readBeforeTransmit(
+    public <I extends SerializableStruct, RequestT> void readBeforeTransmit(
         Context context,
         I input,
         Value<RequestT> request
@@ -152,7 +152,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT, ResponseT> void readAfterTransmit(
+    public <I extends SerializableStruct, RequestT, ResponseT> void readAfterTransmit(
         Context context,
         I input,
         Value<RequestT> request,
@@ -164,7 +164,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT, ResponseT> Value<ResponseT> modifyBeforeDeserialization(
+    public <I extends SerializableStruct, RequestT, ResponseT> Value<ResponseT> modifyBeforeDeserialization(
         Context context,
         I input,
         Value<RequestT> request,
@@ -177,7 +177,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, RequestT, ResponseT> void readBeforeDeserialization(
+    public <I extends SerializableStruct, RequestT, ResponseT> void readBeforeDeserialization(
         Context context,
         I input,
         Value<RequestT> request,
@@ -189,7 +189,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> void readAfterDeserialization(
+    public <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> void readAfterDeserialization(
         Context context,
         I input,
         Value<RequestT> request,
@@ -202,7 +202,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> Either<SdkException, O> modifyBeforeAttemptCompletion(
+    public <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<SdkException, O> modifyBeforeAttemptCompletion(
         Context context,
         I input,
         Value<RequestT> request,
@@ -216,7 +216,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> void readAfterAttempt(
+    public <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> void readAfterAttempt(
         Context context,
         I input,
         Value<RequestT> request,
@@ -229,7 +229,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> Either<SdkException, O> modifyBeforeCompletion(
+    public <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<SdkException, O> modifyBeforeCompletion(
         Context context,
         I input,
         Value<RequestT> requestIfAvailable,
@@ -249,7 +249,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableShape, O extends SerializableShape, RequestT, ResponseT> void readAfterExecution(
+    public <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> void readAfterExecution(
         Context context,
         I input,
         Value<RequestT> requestIfAvailable,

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
@@ -12,7 +12,7 @@ import software.amazon.smithy.java.runtime.client.core.ClientCall;
 import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
 import software.amazon.smithy.java.runtime.core.schema.SdkException;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
@@ -47,7 +47,7 @@ public class HttpBindingClientProtocol extends HttpClientProtocol {
     }
 
     @Override
-    public <I extends SerializableShape, O extends SerializableShape> O deserializeResponse(
+    public <I extends SerializableStruct, O extends SerializableStruct> O deserializeResponse(
         ClientCall<I, O> call,
         SmithyHttpRequest request,
         SmithyHttpResponse response

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/JavaHttpClientTransport.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/JavaHttpClientTransport.java
@@ -16,7 +16,7 @@ import software.amazon.smithy.java.runtime.client.core.ClientProtocol;
 import software.amazon.smithy.java.runtime.client.core.ClientTransport;
 import software.amazon.smithy.java.runtime.client.core.SraPipeline;
 import software.amazon.smithy.java.runtime.core.Context;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
@@ -42,7 +42,7 @@ public class JavaHttpClientTransport implements ClientTransport, ClientTransport
     }
 
     @Override
-    public <I extends SerializableShape, O extends SerializableShape> O send(ClientCall<I, O> call) {
+    public <I extends SerializableStruct, O extends SerializableStruct> O send(ClientCall<I, O> call) {
         return SraPipeline.send(call, protocol, request -> {
             LOGGER.log(System.Logger.Level.TRACE, "Sending HTTP request: %s", request.startLine());
             var javaRequest = createJavaRequest(call.context(), request);

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/SerdeTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/SerdeTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 import software.amazon.smithy.java.runtime.json.JsonCodec;
@@ -101,7 +102,7 @@ public class SerdeTest {
 
     @ParameterizedTest
     @MethodSource("source")
-    <T extends SerializableShape> void pojoToDocumentRoundTrip(T pojo) {
+    <T extends SerializableStruct> void pojoToDocumentRoundTrip(T pojo) {
         var document = Document.createTyped(pojo);
         SdkShapeBuilder<T> builder = getBuilder(pojo);
         document.deserializeInto(builder);

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SdkOperation.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SdkOperation.java
@@ -11,7 +11,7 @@ package software.amazon.smithy.java.runtime.core.schema;
  * @param <I> Operation input shape type.
  * @param <O> Operation output shape type.
  */
-public interface SdkOperation<I extends SerializableShape, O extends SerializableShape> {
+public interface SdkOperation<I extends SerializableStruct, O extends SerializableStruct> {
     /**
      * Create a builder used to create the input of the operation.
      *

--- a/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
+++ b/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
@@ -18,7 +18,7 @@ import software.amazon.smithy.java.runtime.client.http.JavaHttpClientTransport;
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
 import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.schema.TypeRegistry;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
@@ -147,7 +147,7 @@ public class GenericTest {
     public void supportsInterceptors() throws Exception {
         var interceptor = new ClientInterceptor() {
             @Override
-            public <I extends SerializableShape, RequestT> void readBeforeTransmit(
+            public <I extends SerializableStruct, RequestT> void readBeforeTransmit(
                 Context context,
                 I input,
                 Context.Value<RequestT> request
@@ -156,7 +156,7 @@ public class GenericTest {
             }
 
             @Override
-            public <I extends SerializableShape, RequestT> Context.Value<RequestT> modifyBeforeTransmit(
+            public <I extends SerializableStruct, RequestT> Context.Value<RequestT> modifyBeforeTransmit(
                 Context context,
                 I input,
                 Context.Value<RequestT> request

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/PersonDirectoryClient.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/PersonDirectoryClient.java
@@ -25,7 +25,7 @@ import software.amazon.smithy.java.runtime.client.endpoint.api.EndpointResolver;
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
 import software.amazon.smithy.java.runtime.core.schema.SdkOperation;
-import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.schema.TypeRegistry;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.example.model.GetPersonImage;
@@ -105,7 +105,7 @@ public final class PersonDirectoryClient implements PersonDirectory {
      * @param <I> Input shape.
      * @param <O> Output shape.
      */
-    private <I extends SerializableShape, O extends SerializableShape> O call(
+    private <I extends SerializableStruct, O extends SerializableStruct> O call(
         I input,
         DataStream inputStream,
         Object eventStream,


### PR DESCRIPTION
Anywhere that previoulsy was generically typed on SerializableShape and represents top-level input or output is now typed on SerializableStruct since I/O has to be structures in Smithy.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
