### PR TITLE
Add back in deserializer unique item check

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/SerdeTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/SerdeTest.java
@@ -156,7 +156,7 @@ public class SerdeTest {
             );
 
             var exc = assertThrows(SdkSerdeException.class, () -> SetsInput.builder().deserialize(de));
-            assertTrue(exc.getMessage().contains("Member must have unique items"));
+            assertTrue(exc.getMessage().contains("Member must have unique values"));
         }
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -75,7 +75,7 @@ public final class ListGenerator
                                 @Override
                                 public void accept(${shape:T} state, ${shapeDeserializer:T} deserializer) {
                                     ${?unique}if (${/unique}state.add($C)${^unique};${/unique}${?unique}) {
-                                        throw new ${serdeException:T}("Member must have unique items");
+                                        throw new ${serdeException:T}("Member must have unique values");
                                     }${/unique}
                                 }
                             }


### PR DESCRIPTION
### Description of changes
Adds back in the deserialization check for unique items that was accidentally removed in the process of updating serde code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
