### PR TITLE
Throw when document conversions overflow

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
@@ -141,6 +141,7 @@ public interface Document extends SerializableShape {
      *
      * @return the byte value.
      * @throws SdkSerdeException if the Document is not a number.
+     * @throws ArithmeticException if the value is out of range for this type.
      */
     default byte asByte() {
         throw new SdkSerdeException("Expected a byte document, but found " + type());
@@ -153,6 +154,7 @@ public interface Document extends SerializableShape {
      *
      * @return the short value.
      * @throws SdkSerdeException if the Document is not a number.
+     * @throws ArithmeticException if the value is out of range for this type.
      */
     default short asShort() {
         throw new SdkSerdeException("Expected a short document, but found " + type());
@@ -165,6 +167,7 @@ public interface Document extends SerializableShape {
      *
      * @return the integer value.
      * @throws SdkSerdeException if the Document is not a number.
+     * @throws ArithmeticException if the value is out of range for this type.
      */
     default int asInteger() {
         throw new SdkSerdeException("Expected an integer document, but found " + type());
@@ -177,6 +180,7 @@ public interface Document extends SerializableShape {
      *
      * @return the long value.
      * @throws SdkSerdeException if the Document is not a number.
+     * @throws ArithmeticException if the value is out of range for this type.
      */
     default long asLong() {
         throw new SdkSerdeException("Expected a long document, but found " + type());
@@ -189,6 +193,7 @@ public interface Document extends SerializableShape {
      *
      * @return the float value.
      * @throws SdkSerdeException if the Document is not a number.
+     * @throws ArithmeticException if the value is out of range for this type.
      */
     default float asFloat() {
         throw new SdkSerdeException("Expected a float document, but found " + type());
@@ -201,6 +206,7 @@ public interface Document extends SerializableShape {
      *
      * @return the double value.
      * @throws SdkSerdeException if the Document is not a number.
+     * @throws ArithmeticException if the value is out of range for this type.
      */
     default double asDouble() {
         throw new SdkSerdeException("Expected a double document, but found " + type());

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -59,6 +59,30 @@ final class Documents {
         }
     }
 
+    private static byte toByteExact(ShapeType source, long value) {
+        var converted = (byte) value;
+        if (value != converted) {
+            throw new ArithmeticException(source + " value is out of range of byte");
+        }
+        return converted;
+    }
+
+    private static short toShortExact(ShapeType source, long value) {
+        var converted = (short) value;
+        if (value != converted) {
+            throw new ArithmeticException(source + " value is out of range of short");
+        }
+        return converted;
+    }
+
+    private static int toIntExact(ShapeType source, long value) {
+        var converted = (int) value;
+        if (value != converted) {
+            throw new ArithmeticException(source + " value is out of range of integer");
+        }
+        return converted;
+    }
+
     record ByteDocument(SdkSchema schema, byte value) implements Document {
         @Override
         public ShapeType type() {
@@ -124,7 +148,7 @@ final class Documents {
 
         @Override
         public byte asByte() {
-            return (byte) value;
+            return toByteExact(type(), value);
         }
 
         @Override
@@ -181,12 +205,12 @@ final class Documents {
 
         @Override
         public byte asByte() {
-            return (byte) value;
+            return toByteExact(type(), value);
         }
 
         @Override
         public short asShort() {
-            return (short) value;
+            return toShortExact(type(), value);
         }
 
         @Override
@@ -238,17 +262,17 @@ final class Documents {
 
         @Override
         public byte asByte() {
-            return (byte) value;
+            return toByteExact(type(), value);
         }
 
         @Override
         public short asShort() {
-            return (short) value;
+            return toShortExact(type(), value);
         }
 
         @Override
         public int asInteger() {
-            return (int) value;
+            return toIntExact(type(), value);
         }
 
         @Override
@@ -288,6 +312,14 @@ final class Documents {
     }
 
     record FloatDocument(SdkSchema schema, float value) implements Document {
+
+        private static long convertFloatToLong(ShapeType dest, float value) {
+            if (!Float.isFinite(value)) {
+                throw new ArithmeticException("Value must be finite to convert to " + dest);
+            }
+            return (long) value;
+        }
+
         @Override
         public ShapeType type() {
             return ShapeType.FLOAT;
@@ -295,22 +327,22 @@ final class Documents {
 
         @Override
         public byte asByte() {
-            return (byte) value;
+            return toByteExact(type(), convertFloatToLong(ShapeType.BYTE, value));
         }
 
         @Override
         public short asShort() {
-            return (short) value;
+            return toShortExact(type(), convertFloatToLong(ShapeType.SHORT, value));
         }
 
         @Override
         public int asInteger() {
-            return (int) value;
+            return toIntExact(type(), convertFloatToLong(ShapeType.INTEGER, value));
         }
 
         @Override
         public long asLong() {
-            return (long) value;
+            return convertFloatToLong(ShapeType.LONG, value);
         }
 
         @Override
@@ -325,7 +357,7 @@ final class Documents {
 
         @Override
         public BigInteger asBigInteger() {
-            return BigInteger.valueOf((long) value);
+            return asBigDecimal().toBigInteger();
         }
 
         @Override
@@ -345,6 +377,14 @@ final class Documents {
     }
 
     record DoubleDocument(SdkSchema schema, double value) implements Document {
+
+        private static long convertDoubleToLong(ShapeType dest, double value) {
+            if (!Double.isFinite(value)) {
+                throw new ArithmeticException("Value must be finite to convert to " + dest);
+            }
+            return (long) value;
+        }
+
         @Override
         public ShapeType type() {
             return ShapeType.DOUBLE;
@@ -352,27 +392,39 @@ final class Documents {
 
         @Override
         public byte asByte() {
-            return (byte) value;
+            return toByteExact(type(), convertDoubleToLong(ShapeType.BYTE, value));
         }
 
         @Override
         public short asShort() {
-            return (short) value;
+            return toShortExact(type(), convertDoubleToLong(ShapeType.SHORT, value));
         }
 
         @Override
         public int asInteger() {
-            return (int) value;
+            return toIntExact(type(), convertDoubleToLong(ShapeType.INTEGER, value));
         }
 
         @Override
         public long asLong() {
-            return (long) value;
+            return convertDoubleToLong(ShapeType.LONG, value);
         }
 
         @Override
         public float asFloat() {
-            return (float) value;
+            if (Double.isFinite(value)) {
+                var converted = (float) value;
+                if (converted != value) {
+                    throw new ArithmeticException("Value of double exceeds float");
+                }
+                return converted;
+            } else if (Double.isNaN(value)) {
+                return Float.NaN;
+            } else if (value < 0) {
+                return Float.NEGATIVE_INFINITY;
+            } else {
+                return Float.POSITIVE_INFINITY;
+            }
         }
 
         @Override
@@ -382,7 +434,7 @@ final class Documents {
 
         @Override
         public BigInteger asBigInteger() {
-            return BigInteger.valueOf((long) value);
+            return asBigDecimal().toBigInteger();
         }
 
         @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DoubleDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DoubleDocumentTest.java
@@ -9,7 +9,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -52,5 +57,48 @@ public class DoubleDocumentTest {
         };
 
         document.serializeContents(serializer);
+    }
+
+    @ParameterizedTest
+    @MethodSource("floatProvider")
+    public void floatConversion(double value, boolean isValid) {
+        try {
+            var document = Document.createDouble(value);
+            document.asFloat();
+            if (!isValid) {
+                Assertions.fail("Expected " + value + " conversion to fail");
+            }
+        } catch (ArithmeticException e) {
+            if (isValid) {
+                throw e;
+            }
+        }
+    }
+
+    static List<Arguments> floatProvider() {
+        return List.of(
+            Arguments.of(Double.MAX_VALUE, false),
+            Arguments.of(1.0d, true),
+            Arguments.of(-1.0d, true),
+            Arguments.of(-10000d, true),
+            Arguments.of(-10000, true),
+            Arguments.of(Float.MAX_VALUE, true),
+            Arguments.of(Float.MIN_VALUE, true),
+            Arguments.of(Double.POSITIVE_INFINITY, true),
+            Arguments.of(Double.NEGATIVE_INFINITY, true),
+            Arguments.of(Double.NaN, true)
+        );
+    }
+
+    @Test
+    public void convertsInfinite() {
+        assertThat(Document.createDouble(Double.NaN).asFloat(), equalTo(Float.NaN));
+        assertThat(Document.createDouble(Double.NEGATIVE_INFINITY).asFloat(), equalTo(Float.NEGATIVE_INFINITY));
+        assertThat(Document.createDouble(Double.POSITIVE_INFINITY).asFloat(), equalTo(Float.POSITIVE_INFINITY));
+    }
+
+    @Test
+    public void lossyConversionsAreFine() {
+        assertThat(Document.createDouble(1.1111).asInteger(), is(1));
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/FloatDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/FloatDocumentTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
@@ -59,5 +60,10 @@ public class FloatDocumentTest {
         var document = Document.createFloat(1.0f);
 
         assertThat(document.asDouble(), equalTo(1.0));
+    }
+
+    @Test
+    public void detectsOverflow() {
+        Assertions.assertThrows(ArithmeticException.class, () -> Document.createFloat(Float.MAX_VALUE).asInteger());
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/IntegerDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/IntegerDocumentTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
@@ -61,5 +62,10 @@ public class IntegerDocumentTest {
         assertThat(document.asLong(), equalTo(10L));
         assertThat(document.asFloat(), equalTo(10f));
         assertThat(document.asDouble(), equalTo(10.0));
+    }
+
+    @Test
+    public void detectsOverflow() {
+        Assertions.assertThrows(ArithmeticException.class, () -> Document.createInteger(Integer.MAX_VALUE).asShort());
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/LongDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/LongDocumentTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
@@ -52,5 +53,10 @@ public class LongDocumentTest {
         };
 
         document.serializeContents(serializer);
+    }
+
+    @Test
+    public void detectsOverflow() {
+        Assertions.assertThrows(ArithmeticException.class, () -> Document.createLong(Long.MAX_VALUE).asInteger());
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ShortDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ShortDocumentTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
@@ -63,5 +64,10 @@ public class ShortDocumentTest {
         assertThat(document.asLong(), equalTo(1L));
         assertThat(document.asFloat(), equalTo(1f));
         assertThat(document.asDouble(), equalTo(1.0));
+    }
+
+    @Test
+    public void detectsOverflow() {
+        Assertions.assertThrows(ArithmeticException.class, () -> Document.createShort(Short.MAX_VALUE).asByte());
     }
 }


### PR DESCRIPTION
Rather than overflow and truncate, which can do unexpected things like change positive values to negatives, we now throw when a numeric document conversion would overflow the target type. Note that a loss in precision (e.g., float -> integer is acceptable).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
