### PR TITLE
Remove schema from public API and clean up

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ExceptionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ExceptionGenerator.java
@@ -56,7 +56,6 @@ public final class ExceptionGenerator
                     directive.service()
                 )
             );
-            writer.putContext("schemaGetter", writer.consumer(JavaWriter::writeSchemaGetter));
             writer.putContext("builderGetter", writer.consumer(JavaWriter::writeBuilderGetter));
             writer.putContext(
                 "builder",
@@ -90,8 +89,6 @@ public final class ExceptionGenerator
                         ${getters:C|}
 
                         ${toString:C|}
-
-                        ${schemaGetter:C|}
 
                         ${memberSerializer:C|}
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -48,7 +48,6 @@ public final class StructureGenerator
             writer.putContext("equals", new EqualsGenerator(writer, directive.shape(), directive.symbolProvider()));
             writer.putContext("hashCode", new HashCodeGenerator(writer, directive.shape(), directive.symbolProvider()));
             writer.putContext("toString", writer.consumer(JavaWriter::writeToString));
-            writer.putContext("schemaGetter", writer.consumer(JavaWriter::writeSchemaGetter));
             writer.putContext(
                 "memberSerializer",
                 new StructureSerializerGenerator(
@@ -100,8 +99,6 @@ public final class StructureGenerator
                         ${equals:C|}
 
                         ${hashCode:C|}
-
-                        ${schemaGetter:C|}
 
                         ${memberSerializer:C|}
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -52,7 +52,6 @@ public final class UnionGenerator
                 )
             );
             writer.putContext("memberEnum", new MemberEnumGenerator(writer, directive.symbolProvider(), shape));
-            writer.putContext("schemaGetter", writer.consumer(JavaWriter::writeSchemaGetter));
             writer.putContext("toString", writer.consumer(JavaWriter::writeToString));
             writer.putContext("valueCasters", new ValueCasterGenerator(writer, directive.symbolProvider(), shape));
             writer.putContext(
@@ -93,8 +92,6 @@ public final class UnionGenerator
                     }
 
                     ${memberEnum:C|}
-
-                    ${schemaGetter:C|}
 
                     ${toString:C|}
 
@@ -185,6 +182,11 @@ public final class UnionGenerator
                             public ${memberName:U}Member(${member:T} value) {
                                 super(Member.${enumValue:L});
                                 this.value = ${^primitive}${objects:T}.requireNonNull(${/primitive}value${^primitive}, "Union value cannot be null")${/primitive};
+                            }
+
+                            @Override
+                            public void serialize(${shapeSerializer:T} serializer) {
+                                serializer.writeStruct(SCHEMA, this);
                             }
 
                             @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/writer/JavaWriter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/writer/JavaWriter.java
@@ -13,7 +13,6 @@ import software.amazon.smithy.codegen.core.SymbolWriter;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.SymbolProperties;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
 import software.amazon.smithy.java.runtime.core.serde.ToStringSerializer;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -115,22 +114,6 @@ public class JavaWriter extends DeferredSymbolWriter<JavaWriter, JavaImportConta
             return dupe.getName();
         }
         return dupe.getFullName();
-    }
-
-    /**
-     * TODO: Docs
-     * @param writer
-     */
-    public void writeSchemaGetter() {
-        pushState();
-        putContext("sdkSchema", SdkSchema.class);
-        write("""
-            @Override
-            public ${sdkSchema:T} schema() {
-                return SCHEMA;
-            }
-            """);
-        popState();
     }
 
     public void writeBuilderGetter() {

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SerializableStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SerializableStruct.java
@@ -12,19 +12,6 @@ import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
  * A structure or union shape.
  */
 public interface SerializableStruct extends SerializableShape {
-
-    @Override
-    default void serialize(ShapeSerializer encoder) {
-        encoder.writeStruct(schema(), this);
-    }
-
-    /**
-     * Get the schema of the shape.
-     *
-     * @return the schema.
-     */
-    SdkSchema schema();
-
     /**
      * Serializes the members of the structure or union.
      *
@@ -42,8 +29,8 @@ public interface SerializableStruct extends SerializableShape {
     static SerializableStruct create(SdkSchema schema, BiConsumer<SdkSchema, ShapeSerializer> memberWriter) {
         return new SerializableStruct() {
             @Override
-            public SdkSchema schema() {
-                return schema;
+            public void serialize(ShapeSerializer encoder) {
+                encoder.writeStruct(schema, this);
             }
 
             @Override

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
@@ -138,7 +138,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     public void writeDocument(SdkSchema member, Document value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
-        validator.writeDocument(value);
+        validator.writeDocument(member, value);
         validator.popPath();
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
@@ -172,7 +172,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     public void writeDocument(SdkSchema member, Document value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member, value)) {
-            validator.writeDocument(value);
+            validator.writeDocument(member, value);
         }
         validator.popPath();
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
@@ -133,11 +133,6 @@ public abstract class InterceptingSerializer implements ShapeSerializer {
     }
 
     @Override
-    public final void writeDocument(Document value) {
-        ShapeSerializer.super.writeDocument(value);
-    }
-
-    @Override
     public final void writeNull(SdkSchema schema) {
         before(schema).writeNull(schema);
         after(schema);

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -47,15 +47,6 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
     void writeStruct(SdkSchema schema, SerializableStruct struct);
 
     /**
-     * Writes a structure or union.
-     *
-     * @param struct Structure to serialize.
-     */
-    default void writeStruct(SerializableStruct struct) {
-        writeStruct(struct.schema(), struct);
-    }
-
-    /**
      * Begin a list and write zero or more values into it using the provided serializer.
      *
      * @param schema    List schema.
@@ -174,29 +165,11 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      *
      * <p>The underlying contents of the document can be serialized using {@link Document#serializeContents}.
      *
-     * @param schema Schema of the shape. Generally this is {@link PreludeSchemas#DOCUMENT} unless the document
-     *               wraps a modeled shape.
+     * @param schema Schema of the shape. Generally, this should be set to {@link PreludeSchemas#DOCUMENT} unless the
+     *               document wraps a modeled shape.
      * @param value  Value to serialize.
      */
     void writeDocument(SdkSchema schema, Document value);
-
-    /**
-     * Serialize a document shape using the schema {@link PreludeSchemas#DOCUMENT}.
-     *
-     * <p>This method is simply a shorter way to call:
-     *
-     * <pre>
-     * serializer.writeDocument(PreludeSchemas.DOCUMENT, value);
-     * </pre>
-     *
-     * <p>This method should not be used when writing structures because member names are used when writing
-     * structures, and the prelude schema for documents has no member name.
-     *
-     * @param value  Value to serialize.
-     */
-    default void writeDocument(Document value) {
-        writeDocument(PreludeSchemas.DOCUMENT, value);
-    }
 
     /**
      * Writes a null value.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
@@ -116,10 +116,4 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
     public void writeNull(SdkSchema schema) {
         throw throwForInvalidState("Unexpected null value written for " + schema, schema);
     }
-
-    // Delegates to writing with a schema. Only override writing a document with a schema.
-    @Override
-    public final void writeDocument(Document value) {
-        ShapeSerializer.super.writeDocument(value);
-    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
@@ -94,7 +94,7 @@ public interface Document extends SerializableShape {
      */
     @Override
     default void serialize(ShapeSerializer serializer) {
-        serializer.writeDocument(this);
+        serializer.writeDocument(PreludeSchemas.DOCUMENT, this);
     }
 
     /**

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
@@ -241,7 +241,7 @@ public class ValidatorTest {
         Validator validator = Validator.builder().build();
 
         var errors = validator.validate(encoder -> {
-            encoder.writeStruct(SerializableStruct.create(struct, (schema, serializer) -> {
+            encoder.writeStruct(struct, SerializableStruct.create(struct, (schema, serializer) -> {
                 // write the first required member but leave out the rest.
                 serializer.writeString(schema.member("a"), "hi");
             }));
@@ -265,7 +265,7 @@ public class ValidatorTest {
 
         Validator validator = Validator.builder().build();
         var errors = validator.validate(encoder -> {
-            encoder.writeStruct(SerializableStruct.create(struct, (schema, serializer) -> {}));
+            encoder.writeStruct(struct, SerializableStruct.create(struct, (schema, serializer) -> {}));
         });
 
         assertThat(errors, hasSize(1));
@@ -495,7 +495,7 @@ public class ValidatorTest {
         Validator validator = Validator.builder().build();
         var unionSchema = getTestUnionSchema();
         var errors = validator.validate(s -> {
-            s.writeStruct(SerializableStruct.create(unionSchema, (schema, writer) -> {}));
+            s.writeStruct(unionSchema, SerializableStruct.create(unionSchema, (schema, writer) -> {}));
         });
 
         assertThat(errors, hasSize(1));
@@ -509,7 +509,7 @@ public class ValidatorTest {
         var unionSchema = getTestUnionSchema();
 
         var errors = validator.validate(s -> {
-            s.writeStruct(SerializableStruct.create(unionSchema, (schema, serializer) -> {
+            s.writeStruct(unionSchema, SerializableStruct.create(unionSchema, (schema, serializer) -> {
                 serializer.writeString(schema.member("a"), "hi");
                 serializer.writeString(schema.member("b"), "byte");
             }));
@@ -526,7 +526,7 @@ public class ValidatorTest {
         var unionSchema = getTestUnionSchema();
 
         var errors = validator.validate(s -> {
-            s.writeStruct(SerializableStruct.create(unionSchema, (schema, serializer) -> {
+            s.writeStruct(unionSchema, SerializableStruct.create(unionSchema, (schema, serializer) -> {
                 serializer.writeString(schema.member("a"), "ok!");
             }));
         });
@@ -540,7 +540,7 @@ public class ValidatorTest {
         var unionSchema = getTestUnionSchema();
 
         var errors = validator.validate(s -> {
-            s.writeStruct(SerializableStruct.create(unionSchema, (schema, serializer) -> {
+            s.writeStruct(unionSchema, SerializableStruct.create(unionSchema, (schema, serializer) -> {
                 serializer.writeString(schema.member("a"), "this is too long!");
             }));
         });
@@ -559,7 +559,7 @@ public class ValidatorTest {
         var unionSchema = getTestUnionSchema();
 
         var errors = validator.validate(s -> {
-            s.writeStruct(SerializableStruct.create(unionSchema, (schema, serializer) -> {
+            s.writeStruct(unionSchema, SerializableStruct.create(unionSchema, (schema, serializer) -> {
                 serializer.writeString(schema.member("a"), null); // ignore it
                 serializer.writeNull(schema.member("b"));         // ignore it
                 serializer.writeString(schema.member("c"), "ok"); // it's set, it's the only non-null value.
@@ -613,7 +613,7 @@ public class ValidatorTest {
             .build();
 
         var errors = validator.validate(s -> {
-            s.writeStruct(SerializableStruct.create(schema, (passedSchema, serializer) -> {
+            s.writeStruct(schema, SerializableStruct.create(schema, (passedSchema, serializer) -> {
                 serializer.writeNull(passedSchema.member("foo")); // fine
             }));
         });
@@ -768,6 +768,7 @@ public class ValidatorTest {
             Arguments.of(
                 ShapeType.STRUCTURE,
                 (Consumer<ShapeSerializer>) serializer -> serializer.writeStruct(
+                    PreludeSchemas.STRING,
                     SerializableStruct.create(PreludeSchemas.STRING, (a, b) -> {})
                 )
             ),
@@ -1228,7 +1229,7 @@ public class ValidatorTest {
         Validator validator = Validator.builder().build();
 
         var errors = validator.validate(encoder -> {
-            encoder.writeStruct(SerializableStruct.create(struct, (schema, writer) -> {}));
+            encoder.writeStruct(struct, SerializableStruct.create(struct, (schema, writer) -> {}));
         });
 
         assertThat(errors, hasSize(failures));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
@@ -72,7 +72,7 @@ public class ToStringSerializerTest {
             .build();
 
         var str = ToStringSerializer.serialize(e -> {
-            e.writeStruct(SerializableStruct.create(schema, (s, ser) -> {
+            e.writeStruct(schema, SerializableStruct.create(schema, (s, ser) -> {
                 ser.writeMap(s.member("foo"), mapSchema, (innerMapSchema, map) -> {
                     map.writeEntry(innerMapSchema.member("key"), "a", innerMapSchema, (mapSchema2, ms) -> {
                         ms.writeString(mapSchema2.member("value"), "hi");
@@ -101,7 +101,7 @@ public class ToStringSerializerTest {
             .build();
 
         var str = ToStringSerializer.serialize(e -> {
-            e.writeStruct(SerializableStruct.create(schema, (s, ser) -> {
+            e.writeStruct(schema, SerializableStruct.create(schema, (s, ser) -> {
                 ser.writeBlob(s.member("foo"), "abc".getBytes(StandardCharsets.UTF_8));
             }));
         });

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
@@ -40,6 +40,7 @@ public class TypedDocumentMemberTest {
 
         SerializableShape serializableShape = encoder -> {
             encoder.writeStruct(
+                structSchema,
                 SerializableStruct.create(structSchema, (schema, s) -> s.writeString(schema.member("foo"), "Hi"))
             );
         };
@@ -72,12 +73,14 @@ public class TypedDocumentMemberTest {
 
         var document1 = Document.createTyped(encoder -> {
             encoder.writeStruct(
+                structSchema1,
                 SerializableStruct.create(structSchema1, (schema, s) -> s.writeString(schema.member("foo"), "Hi"))
             );
         });
 
         var document2 = Document.createTyped(encoder -> {
             encoder.writeStruct(
+                structSchema2,
                 SerializableStruct.create(structSchema2, (schema, s) -> s.writeInteger(schema.member("foo"), 1))
             );
         });
@@ -113,7 +116,7 @@ public class TypedDocumentMemberTest {
             .members(SdkSchema.memberBuilder("a", targetSchema))
             .build();
         var document = Document.createTyped(encoder -> {
-            encoder.writeStruct(SerializableStruct.create(structSchema, (schema, serializer) -> {
+            encoder.writeStruct(structSchema, SerializableStruct.create(structSchema, (schema, serializer) -> {
                 writer.accept(schema.member("a"), serializer);
             }));
         });
@@ -602,7 +605,7 @@ public class TypedDocumentMemberTest {
                     .build(),
                 "b",
                 (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> {
-                    s.writeStruct(SerializableStruct.create(schema, (passedSchema, ser) -> {
+                    s.writeStruct(schema, SerializableStruct.create(schema, (passedSchema, ser) -> {
                         ser.writeString(passedSchema.member("foo"), "a");
                         ser.writeString(passedSchema.member("bar"), "b");
                     }));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
@@ -33,7 +33,7 @@ public class TypedDocumentTest {
             .build();
 
         return encoder -> {
-            encoder.writeStruct(SerializableStruct.create(structSchema, (schema, s) -> {
+            encoder.writeStruct(structSchema, SerializableStruct.create(structSchema, (schema, s) -> {
                 s.writeString(schema.member("a"), "1");
                 s.writeString(schema.member("b"), "2");
             }));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
@@ -47,8 +47,8 @@ public final class Bird implements SerializableStruct {
     }
 
     @Override
-    public SdkSchema schema() {
-        return SCHEMA;
+    public void serialize(ShapeSerializer encoder) {
+        encoder.writeStruct(SCHEMA, this);
     }
 
     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
@@ -114,8 +114,8 @@ public final class Person implements SerializableStruct {
     }
 
     @Override
-    public SdkSchema schema() {
-        return SCHEMA;
+    public void serialize(ShapeSerializer encoder) {
+        encoder.writeStruct(SCHEMA, this);
     }
 
     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
@@ -83,8 +83,8 @@ public final class PojoWithValidatedCollection implements SerializableStruct {
     }
 
     @Override
-    public SdkSchema schema() {
-        return SCHEMA;
+    public void serialize(ShapeSerializer encoder) {
+        encoder.writeStruct(SCHEMA, this);
     }
 
     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
@@ -69,8 +69,8 @@ public final class UnvalidatedPojo implements SerializableStruct {
     }
 
     @Override
-    public SdkSchema schema() {
-        return SCHEMA;
+    public void serialize(ShapeSerializer encoder) {
+        encoder.writeStruct(SCHEMA, this);
     }
 
     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
@@ -73,8 +73,8 @@ public final class ValidatedPojo implements SerializableStruct {
     }
 
     @Override
-    public SdkSchema schema() {
-        return SCHEMA;
+    public void serialize(ShapeSerializer encoder) {
+        encoder.writeStruct(SCHEMA, this);
     }
 
     @Override

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonSerializerTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonSerializerTest.java
@@ -144,10 +144,13 @@ public class JsonSerializerTest {
             var codec = JsonCodec.builder().useJsonName(useJsonName).build(); var output = new ByteArrayOutputStream()
         ) {
             try (var serializer = codec.createSerializer(output)) {
-                serializer.writeStruct(SerializableStruct.create(JsonTestData.BIRD, (schema, ser) -> {
-                    ser.writeString(schema.member("name"), "Toucan");
-                    ser.writeString(schema.member("color"), "red");
-                }));
+                serializer.writeStruct(
+                    JsonTestData.BIRD,
+                    SerializableStruct.create(JsonTestData.BIRD, (schema, ser) -> {
+                        ser.writeString(schema.member("name"), "Toucan");
+                        ser.writeString(schema.member("color"), "red");
+                    })
+                );
             }
             var result = output.toString(StandardCharsets.UTF_8);
             assertThat(result, equalTo(json));
@@ -165,9 +168,12 @@ public class JsonSerializerTest {
     public void writesNestedStructures() throws Exception {
         try (var codec = JsonCodec.builder().build(); var output = new ByteArrayOutputStream()) {
             try (var serializer = codec.createSerializer(output)) {
-                serializer.writeStruct(SerializableStruct.create(JsonTestData.BIRD, (schema, ser) -> {
-                    ser.writeStruct(schema.member("nested"), new NestedStruct());
-                }));
+                serializer.writeStruct(
+                    JsonTestData.BIRD,
+                    SerializableStruct.create(JsonTestData.BIRD, (schema, ser) -> {
+                        ser.writeStruct(schema.member("nested"), new NestedStruct());
+                    })
+                );
             }
             var result = output.toString(StandardCharsets.UTF_8);
             assertThat(result, equalTo("{\"nested\":{\"number\":10}}"));
@@ -187,8 +193,8 @@ public class JsonSerializerTest {
 
     private static final class NestedStruct implements SerializableStruct {
         @Override
-        public SdkSchema schema() {
-            return JsonTestData.NESTED;
+        public void serialize(ShapeSerializer encoder) {
+            encoder.writeStruct(JsonTestData.NESTED, this);
         }
 
         @Override


### PR DESCRIPTION
Schema wasn't being used by anything other than the default impl of SerializableStruct. Removing it for now to encourage using generated classes rather than relying on schemas. We can add it back later if we really need it, but for now it's safer to remove it.

This commit also removes the methods from ShapeSerializer that accept a value without a schema (struct and document methods). This makes it easier to implement the interface, and the only places the methods that didn't provide a schema were being used was in tests.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
