### PR TITLE
Remove sdk prefix from common classes

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/CallContext.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/CallContext.java
@@ -10,8 +10,8 @@ import software.amazon.smithy.java.runtime.auth.api.identity.Identity;
 import software.amazon.smithy.java.runtime.client.core.interceptors.ClientInterceptor;
 import software.amazon.smithy.java.runtime.client.endpoint.api.EndpointResolver;
 import software.amazon.smithy.java.runtime.core.Context;
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
@@ -31,12 +31,12 @@ public final class CallContext {
     /**
      * Error encountered by the call that will be thrown.
      */
-    public static final Context.Key<SdkException> ERROR = Context.key("Error");
+    public static final Context.Key<ApiException> ERROR = Context.key("Error");
 
     /**
      * Contains the schema of the operation being sent.
      */
-    public static final Context.Key<SdkSchema> OPERATION_SCHEMA = Context.key("Operation schema");
+    public static final Context.Key<Schema> OPERATION_SCHEMA = Context.key("Operation schema");
 
     /**
      * The total amount of time to wait for an API call to complete, including retries, and serialization.

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
@@ -21,8 +21,8 @@ import software.amazon.smithy.java.runtime.client.core.interceptors.ClientInterc
 import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
 import software.amazon.smithy.java.runtime.client.endpoint.api.EndpointResolver;
 import software.amazon.smithy.java.runtime.core.Context;
-import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
-import software.amazon.smithy.java.runtime.core.schema.SdkOperation;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
+import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.schema.TypeRegistry;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
@@ -76,7 +76,7 @@ public abstract class Client {
         I input,
         DataStream inputStream,
         Object eventStream,
-        SdkOperation<I, O> operation,
+        ApiOperation<I, O> operation,
         Context context
     ) {
         // Create a copy of the type registry that adds the errors this operation can encounter.
@@ -98,7 +98,7 @@ public abstract class Client {
                 .identityResolvers(identityResolvers)
                 .errorCreator((c, id) -> {
                     ShapeId shapeId = ShapeId.from(id);
-                    return operationRegistry.create(shapeId, ModeledSdkException.class);
+                    return operationRegistry.create(shapeId, ModeledApiException.class);
                 })
                 .build()
         );

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
@@ -21,10 +21,10 @@ import software.amazon.smithy.java.runtime.auth.api.scheme.AuthSchemeResolver;
 import software.amazon.smithy.java.runtime.client.core.interceptors.ClientInterceptor;
 import software.amazon.smithy.java.runtime.client.endpoint.api.EndpointResolver;
 import software.amazon.smithy.java.runtime.core.Context;
-import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
-import software.amazon.smithy.java.runtime.core.schema.SdkOperation;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
+import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
 
 /**
@@ -37,9 +37,9 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
 
     private final I input;
     private final EndpointResolver endpointResolver;
-    private final SdkOperation<I, O> operation;
+    private final ApiOperation<I, O> operation;
     private final Context context;
-    private final BiFunction<Context, String, Optional<SdkShapeBuilder<ModeledSdkException>>> errorCreator;
+    private final BiFunction<Context, String, Optional<ShapeBuilder<ModeledApiException>>> errorCreator;
     private final ClientInterceptor interceptor;
     private final DataStream requestDataStream;
     private final AuthSchemeResolver authSchemeResolver;
@@ -95,7 +95,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
      *
      * @return Returns the operation definition.
      */
-    public SdkOperation<I, O> operation() {
+    public ApiOperation<I, O> operation() {
         return operation;
     }
 
@@ -152,7 +152,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
      * @param shapeId Nullable ID of the error shape to create, if known.
      * @return Returns the created output builder.
      */
-    public SdkShapeBuilder<O> createOutputBuilder(Context context, String shapeId) {
+    public ShapeBuilder<O> createOutputBuilder(Context context, String shapeId) {
         // TODO: Allow customizing this if needed.
         return operation().outputBuilder();
     }
@@ -167,7 +167,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
      *                only information we have is just a name.
      * @return Returns the error deserializer if present.
      */
-    public Optional<SdkShapeBuilder<ModeledSdkException>> createExceptionBuilder(Context context, String shapeId) {
+    public Optional<ShapeBuilder<ModeledApiException>> createExceptionBuilder(Context context, String shapeId) {
         return errorCreator.apply(context, shapeId);
     }
 
@@ -217,9 +217,9 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
 
         private I input;
         private EndpointResolver endpointResolver;
-        private SdkOperation<I, O> operation;
+        private ApiOperation<I, O> operation;
         private Context context;
-        private BiFunction<Context, String, Optional<SdkShapeBuilder<ModeledSdkException>>> errorCreator;
+        private BiFunction<Context, String, Optional<ShapeBuilder<ModeledApiException>>> errorCreator;
         private ClientInterceptor interceptor = ClientInterceptor.NOOP;
         private DataStream requestDataStream;
         private AuthSchemeResolver authSchemeResolver;
@@ -247,7 +247,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
          * @param operation Operation to call.
          * @return Returns the builder.
          */
-        public Builder<I, O> operation(SdkOperation<I, O> operation) {
+        public Builder<I, O> operation(ApiOperation<I, O> operation) {
             this.operation = operation;
             return this;
         }
@@ -273,7 +273,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
          * @return Returns the builder.
          */
         public Builder<I, O> errorCreator(
-            BiFunction<Context, String, Optional<SdkShapeBuilder<ModeledSdkException>>> errorCreator
+            BiFunction<Context, String, Optional<ShapeBuilder<ModeledApiException>>> errorCreator
         ) {
             this.errorCreator = errorCreator;
             return this;

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
@@ -9,7 +9,7 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
 import software.amazon.smithy.java.runtime.core.Context;
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 public interface ClientProtocol<RequestT, ResponseT> {
@@ -65,7 +65,7 @@ public interface ClientProtocol<RequestT, ResponseT> {
      * @param request  Request that was sent for this response.
      * @param response Response to deserialize.
      * @return the deserialized output shape.
-     * @throws SdkException if an error occurs, including deserialized modeled errors and protocol errors.
+     * @throws ApiException if an error occurs, including deserialized modeled errors and protocol errors.
      */
     <I extends SerializableStruct, O extends SerializableStruct> CompletableFuture<O> deserializeResponse(
         ClientCall<I, O> call,

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientTransport.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientTransport.java
@@ -6,8 +6,8 @@
 package software.amazon.smithy.java.runtime.client.core;
 
 import java.util.concurrent.CompletableFuture;
-import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
+import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
@@ -21,8 +21,8 @@ public interface ClientTransport {
      * @return a CompletableFuture of the deserialized output.
      * @param <I> Input shape.
      * @param <O> Output shape.
-     * @throws ModeledSdkException if a modeled error occurs.
-     * @throws SdkException if an error occurs.
+     * @throws ModeledApiException if a modeled error occurs.
+     * @throws ApiException if an error occurs.
      */
     <I extends SerializableStruct, O extends SerializableStruct> CompletableFuture<O> send(ClientCall<I, O> call);
 

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/SraPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/SraPipeline.java
@@ -20,7 +20,7 @@ import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
 import software.amazon.smithy.java.runtime.client.endpoint.api.EndpointResolverParams;
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.Either;
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
@@ -149,7 +149,7 @@ public final class SraPipeline<I extends SerializableStruct, O extends Serializa
         }
 
         // TODO: Build more useful error message (to log also) indicating why some schemes were not used.
-        throw new SdkException("No auth scheme could be resolved for " + call.operation().schema().id());
+        throw new ApiException("No auth scheme could be resolved for " + call.operation().schema().id());
     }
 
     private <IdentityT extends Identity> Optional<ResolvedScheme<IdentityT, RequestT>> createResolvedSchema(
@@ -215,7 +215,7 @@ public final class SraPipeline<I extends SerializableStruct, O extends Serializa
         return protocol.deserializeResponse(call, request, modifiedResponse)
             .thenApply(shape -> {
                 context.put(CallContext.OUTPUT, shape);
-                Either<SdkException, O> result = Either.right(shape);
+                Either<ApiException, O> result = Either.right(shape);
 
                 interceptor.readAfterDeserialization(
                     context,

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptor.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptor.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.Either;
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
@@ -452,7 +452,7 @@ public interface ClientInterceptor {
         I input,
         Value<RequestT> request,
         Value<ResponseT> response,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {}
 
     /**
@@ -478,12 +478,12 @@ public interface ClientInterceptor {
      * @param <RequestT> Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<SdkException, O> modifyBeforeAttemptCompletion(
+    default <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<ApiException, O> modifyBeforeAttemptCompletion(
         Context context,
         I input,
         Value<RequestT> request,
         Value<ResponseT> response,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {
         return result;
     }
@@ -517,7 +517,7 @@ public interface ClientInterceptor {
         I input,
         Value<RequestT> request,
         Value<ResponseT> responseIfAvailable,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {}
 
     /**
@@ -544,12 +544,12 @@ public interface ClientInterceptor {
      * @param <RequestT>  Protocol-specific request type.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<SdkException, O> modifyBeforeCompletion(
+    default <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<ApiException, O> modifyBeforeCompletion(
         Context context,
         I input,
         Value<RequestT> requestIfAvailable,
         Value<ResponseT> responseIfAvailable,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {
         return result;
     }
@@ -583,6 +583,6 @@ public interface ClientInterceptor {
         I input,
         Value<RequestT> requestIfAvailable,
         Value<ResponseT> responseIfAvailable,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {}
 }

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptorChain.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptorChain.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.Either;
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 final class ClientInterceptorChain implements ClientInterceptor {
@@ -194,7 +194,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
         I input,
         Value<RequestT> request,
         Value<ResponseT> response,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {
         for (var interceptor : interceptors) {
             interceptor.readAfterDeserialization(context, input, request, response, result);
@@ -202,12 +202,12 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<SdkException, O> modifyBeforeAttemptCompletion(
+    public <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<ApiException, O> modifyBeforeAttemptCompletion(
         Context context,
         I input,
         Value<RequestT> request,
         Value<ResponseT> response,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {
         for (var interceptor : interceptors) {
             result = interceptor.modifyBeforeAttemptCompletion(context, input, request, response, result);
@@ -221,7 +221,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
         I input,
         Value<RequestT> request,
         Value<ResponseT> responseIfAvailable,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {
         applyToEachThrowLastError(
             interceptor -> interceptor.readAfterAttempt(context, input, request, responseIfAvailable, result)
@@ -229,12 +229,12 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<SdkException, O> modifyBeforeCompletion(
+    public <I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> Either<ApiException, O> modifyBeforeCompletion(
         Context context,
         I input,
         Value<RequestT> requestIfAvailable,
         Value<ResponseT> responseIfAvailable,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {
         for (var interceptor : interceptors) {
             result = interceptor.modifyBeforeCompletion(
@@ -254,7 +254,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
         I input,
         Value<RequestT> requestIfAvailable,
         Value<ResponseT> responseIfAvailable,
-        Either<SdkException, O> result
+        Either<ApiException, O> result
     ) {
         applyToEachThrowLastError(
             interceptor -> interceptor.readAfterExecution(

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
@@ -10,10 +10,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.client.core.ClientCall;
-import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
+import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
@@ -92,7 +92,7 @@ public class HttpBindingClientProtocol extends HttpClientProtocol {
      * @param response HTTP response to deserialize.
      * @return Returns the deserialized error.
      */
-    protected CompletableFuture<? extends SdkException> createError(
+    protected CompletableFuture<? extends ApiException> createError(
         ClientCall<?, ?> call,
         SmithyHttpResponse response
     ) {
@@ -107,7 +107,7 @@ public class HttpBindingClientProtocol extends HttpClientProtocol {
             // Attempt to match the extracted error ID to a modeled error type.
             .flatMap(
                 errorId -> call.createExceptionBuilder(call.context(), errorId)
-                    .<CompletableFuture<? extends SdkException>>map(
+                    .<CompletableFuture<? extends ApiException>>map(
                         error -> createModeledException(codec, response, error)
                     )
             )
@@ -118,10 +118,10 @@ public class HttpBindingClientProtocol extends HttpClientProtocol {
             });
     }
 
-    private CompletableFuture<ModeledSdkException> createModeledException(
+    private CompletableFuture<ModeledApiException> createModeledException(
         Codec codec,
         SmithyHttpResponse response,
-        SdkShapeBuilder<ModeledSdkException> error
+        ShapeBuilder<ModeledApiException> error
     ) {
         return HttpBinding.responseDeserializer()
             .payloadCodec(codec)

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpClientProtocol.java
@@ -16,7 +16,7 @@ import java.util.concurrent.Flow;
 import software.amazon.smithy.java.runtime.client.core.ClientProtocol;
 import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
 import software.amazon.smithy.java.runtime.core.Context;
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
 import software.amazon.smithy.java.runtime.core.uri.URIBuilder;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
@@ -88,11 +88,11 @@ public abstract class HttpClientProtocol implements ClientProtocol<SmithyHttpReq
      * @param response    HTTP response that was received.
      * @return the created exception.
      */
-    public static CompletableFuture<SdkException> createErrorFromHints(
+    public static CompletableFuture<ApiException> createErrorFromHints(
         String operationId,
         SmithyHttpResponse response
     ) {
-        SdkException.Fault fault = SdkException.Fault.ofHttpStatusCode(response.statusCode());
+        ApiException.Fault fault = ApiException.Fault.ofHttpStatusCode(response.statusCode());
         StringBuilder message = new StringBuilder();
         message.append(switch (fault) {
             case CLIENT -> "Client error ";
@@ -118,12 +118,12 @@ public abstract class HttpClientProtocol implements ClientProtocol<SmithyHttpReq
             .toLowerCase(Locale.ENGLISH);
 
         if (!isText(contentType)) {
-            return CompletableFuture.completedFuture(new SdkException(message.toString(), fault));
+            return CompletableFuture.completedFuture(new ApiException(message.toString(), fault));
         }
 
         return asString(response).thenApply(string -> {
             message.append(string);
-            return new SdkException(message.toString(), fault);
+            return new ApiException(message.toString(), fault);
         });
     }
 

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/OperationGenerator.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/OperationGenerator.java
@@ -13,9 +13,9 @@ import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.generators.SchemaGenerator;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
-import software.amazon.smithy.java.runtime.core.schema.SdkOperation;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.schema.TypeRegistry;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -72,11 +72,11 @@ public class OperationGenerator
                 }
                 """;
             writer.putContext("shape", directive.symbol());
-            writer.putContext("sdkOperation", SdkOperation.class);
+            writer.putContext("sdkOperation", ApiOperation.class);
             writer.putContext("inputType", input);
             writer.putContext("outputType", output);
-            writer.putContext("sdkSchema", SdkSchema.class);
-            writer.putContext("sdkShapeBuilder", SdkShapeBuilder.class);
+            writer.putContext("sdkSchema", Schema.class);
+            writer.putContext("sdkShapeBuilder", ShapeBuilder.class);
             writer.putContext("typeRegistry", TypeRegistry.class);
             writer.putContext(
                 "schema",

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/PresenceTrackingTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/PresenceTrackingTest.java
@@ -12,12 +12,12 @@ import io.smithy.codegen.test.model.BooleansInput;
 import io.smithy.codegen.test.model.Nested;
 import io.smithy.codegen.test.model.StructuresInput;
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 
 public class PresenceTrackingTest {
     @Test
     void throwsSerdeExceptionOnMissingRequiredForPrimitiveField() {
-        var exc = assertThrows(SdkSerdeException.class, () -> {
+        var exc = assertThrows(SerializationException.class, () -> {
             // Missing requiredBooleanField
             BooleansInput.builder().optionalBoolean(true).build();
         });
@@ -26,7 +26,7 @@ public class PresenceTrackingTest {
 
     @Test
     void throwsSerdeExceptionOnMissingRequiredForNonPrimitiveField() {
-        var exc = assertThrows(SdkSerdeException.class, () -> {
+        var exc = assertThrows(SerializationException.class, () -> {
             // Missing requiredBooleanField
             StructuresInput.builder().optionalStruct(Nested.builder().build()).build();
         });

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/BuilderGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/BuilderGenerator.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.java.codegen.generators;
 import java.util.List;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.*;
 
@@ -64,7 +64,7 @@ abstract class BuilderGenerator implements Runnable {
 
                 ${deserializer:C|}
             }""";
-        writer.putContext("sdkShapeBuilder", SdkShapeBuilder.class);
+        writer.putContext("sdkShapeBuilder", ShapeBuilder.class);
         writer.putContext("builderProperties", writer.consumer(this::generateProperties));
         writer.putContext("builderSetters", writer.consumer(this::generateSetters));
         writer.putContext("buildMethod", writer.consumer(this::generateBuild));

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -12,8 +12,8 @@ import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.SymbolProperties;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.model.traits.UniqueItemsTrait;
@@ -72,12 +72,12 @@ public final class ListGenerator
                         "collectionImpl",
                         directive.symbol().expectProperty(SymbolProperties.COLLECTION_IMPLEMENTATION_CLASS)
                     );
-                    writer.putContext("schema", SdkSchema.class);
+                    writer.putContext("schema", Schema.class);
                     writer.putContext("biConsumer", BiConsumer.class);
                     writer.putContext("shapeSerializer", ShapeSerializer.class);
                     writer.putContext("shapeDeserializer", ShapeDeserializer.class);
                     writer.putContext("unique", directive.shape().hasTrait(UniqueItemsTrait.class));
-                    writer.putContext("serdeException", SdkSerdeException.class);
+                    writer.putContext("serdeException", SerializationException.class);
                     writer.putContext(
                         "memberSerializer",
                         new SerializerMemberGenerator(

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
@@ -12,7 +12,7 @@ import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.SymbolProperties;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -91,7 +91,7 @@ public class MapGenerator
                         "collectionImpl",
                         directive.symbol().expectProperty(SymbolProperties.COLLECTION_IMPLEMENTATION_CLASS)
                     );
-                    writer.putContext("schema", SdkSchema.class);
+                    writer.putContext("schema", Schema.class);
                     writer.putContext("biConsumer", BiConsumer.class);
                     writer.putContext("mapSerializer", MapSerializer.class);
                     writer.putContext("shapeSerializer", ShapeSerializer.class);

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaGenerator.java
@@ -9,7 +9,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.IntEnumShape;
@@ -55,7 +55,7 @@ public final class SchemaGenerator extends ShapeVisitor.Default<Void> implements
     @Override
     public void run() {
         writer.pushState();
-        writer.putContext("schemaClass", SdkSchema.class);
+        writer.putContext("schemaClass", Schema.class);
         writer.putContext("shapeTypeClass", ShapeType.class);
         writer.putContext("shapeId", shape.toShapeId());
         writer.putContext("shapeType", shape.getType().name());

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SharedSchemasGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SharedSchemasGenerator.java
@@ -17,7 +17,7 @@ import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.shapes.MemberShape;
@@ -93,7 +93,7 @@ public final class SharedSchemasGenerator
         public void run() {
             Set<Shape> deferred = deferredShapes(shapes);
             writer.pushState();
-            writer.putContext("schemaClass", SdkSchema.class);
+            writer.putContext("schemaClass", Schema.class);
             for (var shape : shapes) {
                 if (deferred.contains(shape)) {
                     writer.write("static final ${schemaClass:T} $L;", CodegenUtils.toSchemaName(shape));

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.java.codegen.generators;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -40,7 +40,7 @@ record StructureDeserializerGenerator(
             }
             """;
         writer.putContext("shapeDeserializer", ShapeDeserializer.class);
-        writer.putContext("sdkSchema", SdkSchema.class);
+        writer.putContext("sdkSchema", Schema.class);
         writer.putContext("hasMembers", !shape.members().isEmpty());
         writer.putContext("cases", writer.consumer(this::generateMemberSwitchCases));
         writer.write(template);

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -23,7 +23,7 @@ import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.sections.GetterSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
-import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
+import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.PresenceTracker;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
@@ -95,7 +95,7 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
             writer.putContext("isError", shape.hasTrait(ErrorTrait.class));
             writer.putContext("shape", directive.symbol());
             writer.putContext("serializableStruct", SerializableStruct.class);
-            writer.putContext("sdkException", ModeledSdkException.class);
+            writer.putContext("sdkException", ModeledApiException.class);
             writer.putContext("id", new IdStringGenerator(writer, shape));
             writer.putContext(
                 "schemas",

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -18,7 +18,7 @@ import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 import software.amazon.smithy.model.Model;
@@ -287,7 +287,7 @@ public final class UnionGenerator
             }
 
             writer.pushState();
-            writer.putContext("serdeException", SdkSerdeException.class);
+            writer.putContext("serdeException", SerializationException.class);
             writer.write("""
                 private void checkForExistingValue() {
                     if (this.value != null) {

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ApiException.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ApiException.java
@@ -14,7 +14,7 @@ import java.util.Objects;
  * errors, and shape validation errors. It should not be used for illegal arguments, null argument validation,
  * or other kinds of logic errors sufficiently covered by the Java standard library.
  */
-public class SdkException extends RuntimeException {
+public class ApiException extends RuntimeException {
 
     /**
      * The party that is at fault for the error, if any.
@@ -47,31 +47,31 @@ public class SdkException extends RuntimeException {
          */
         public static Fault ofHttpStatusCode(int statusCode) {
             if (statusCode >= 400 && statusCode <= 499) {
-                return SdkException.Fault.CLIENT;
+                return ApiException.Fault.CLIENT;
             } else if (statusCode >= 500 && statusCode <= 599) {
-                return SdkException.Fault.SERVER;
+                return ApiException.Fault.SERVER;
             } else {
-                return SdkException.Fault.OTHER;
+                return ApiException.Fault.OTHER;
             }
         }
     }
 
     private final Fault errorType;
 
-    public SdkException(String message) {
+    public ApiException(String message) {
         this(message, Fault.OTHER);
     }
 
-    public SdkException(String message, Fault errorType) {
+    public ApiException(String message, Fault errorType) {
         super(message);
         this.errorType = Objects.requireNonNull(errorType);
     }
 
-    public SdkException(String message, Throwable cause) {
+    public ApiException(String message, Throwable cause) {
         this(message, cause, Fault.OTHER);
     }
 
-    public SdkException(String message, Throwable cause, Fault errorType) {
+    public ApiException(String message, Throwable cause, Fault errorType) {
         super(message, cause);
         this.errorType = Objects.requireNonNull(errorType);
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ApiOperation.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ApiOperation.java
@@ -11,41 +11,41 @@ package software.amazon.smithy.java.runtime.core.schema;
  * @param <I> Operation input shape type.
  * @param <O> Operation output shape type.
  */
-public interface SdkOperation<I extends SerializableStruct, O extends SerializableStruct> {
+public interface ApiOperation<I extends SerializableStruct, O extends SerializableStruct> {
     /**
      * Create a builder used to create the input of the operation.
      *
      * @return Returns the input builder.
      */
-    SdkShapeBuilder<I> inputBuilder();
+    ShapeBuilder<I> inputBuilder();
 
     /**
      * Create a builder used to create the output of the operation.
      *
      * @return Returns the operation output builder.
      */
-    SdkShapeBuilder<O> outputBuilder();
+    ShapeBuilder<O> outputBuilder();
 
     /**
      * Get the schema of the operation.
      *
      * @return Returns the operation schema, including relevant traits.
      */
-    SdkSchema schema();
+    Schema schema();
 
     /**
      * Get the input structure schema.
      *
      * @return Returns the input schema.
      */
-    SdkSchema inputSchema();
+    Schema inputSchema();
 
     /**
      * Get the output structure schema.
      *
      * @return Returns the output schema.
      */
-    SdkSchema outputSchema();
+    Schema outputSchema();
 
     /**
      * Get a type registry for the operation used to create errors and output types.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/MemberContainers.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/MemberContainers.java
@@ -19,7 +19,7 @@ final class MemberContainers {
 
     private MemberContainers() {}
 
-    static Map<String, SdkSchema> of(ShapeType type, List<SdkSchema> members, Map<String, SdkSchema> targetMembers) {
+    static Map<String, Schema> of(ShapeType type, List<Schema> members, Map<String, Schema> targetMembers) {
         if (members == null || members.isEmpty()) {
             // Use the members of the target shape directly rather than needing to do a recursive resolution.
             return targetMembers != null ? targetMembers : Map.of();
@@ -32,8 +32,8 @@ final class MemberContainers {
             var member = members.get(0);
             return Map.of(member.memberName(), member);
         } else {
-            Map<String, SdkSchema> result = new LinkedHashMap<>(members.size());
-            for (SdkSchema member : members) {
+            Map<String, Schema> result = new LinkedHashMap<>(members.size());
+            for (Schema member : members) {
                 result.put(member.memberName(), member);
             }
             return result;
@@ -43,12 +43,12 @@ final class MemberContainers {
     /**
      * Validates and stores list members that always have a single "member" member.
      */
-    private static final class ListMembers extends AbstractMap<String, SdkSchema> {
+    private static final class ListMembers extends AbstractMap<String, Schema> {
 
-        private final SdkSchema member;
-        private final Set<Entry<String, SdkSchema>> entries;
+        private final Schema member;
+        private final Set<Entry<String, Schema>> entries;
 
-        ListMembers(List<SdkSchema> members) {
+        ListMembers(List<Schema> members) {
             if (members.size() != 1) {
                 throw new IllegalArgumentException("List shapes require exactly one member");
             }
@@ -67,12 +67,12 @@ final class MemberContainers {
         }
 
         @Override
-        public SdkSchema get(Object key) {
+        public Schema get(Object key) {
             return "member".equals(key) ? member : null;
         }
 
         @Override
-        public Set<Entry<String, SdkSchema>> entrySet() {
+        public Set<Entry<String, Schema>> entrySet() {
             return entries;
         }
     }
@@ -80,19 +80,19 @@ final class MemberContainers {
     /**
      * Validates and stores map members that always have a "key" and "value" member, in that order.
      */
-    private static final class MapMembers extends AbstractMap<String, SdkSchema> {
+    private static final class MapMembers extends AbstractMap<String, Schema> {
 
-        private final SdkSchema key;
-        private final SdkSchema value;
-        private final Set<Entry<String, SdkSchema>> entries;
+        private final Schema key;
+        private final Schema value;
+        private final Set<Entry<String, Schema>> entries;
 
-        private MapMembers(SdkSchema key, SdkSchema value) {
+        private MapMembers(Schema key, Schema value) {
             this.key = key;
             this.value = value;
             this.entries = Set.of(new SimpleImmutableEntry<>("key", key), new SimpleImmutableEntry<>("value", value));
         }
 
-        static MapMembers of(List<SdkSchema> members) {
+        static MapMembers of(List<Schema> members) {
             int size = members.size();
             if (size != 2) {
                 throw new IllegalArgumentException("Maps require exactly two members. Found: " + members);
@@ -111,7 +111,7 @@ final class MemberContainers {
         }
 
         @Override
-        public SdkSchema get(Object key) {
+        public Schema get(Object key) {
             if ("key".equals(key)) {
                 return this.key;
             } else if ("value".equals(key)) {
@@ -122,7 +122,7 @@ final class MemberContainers {
         }
 
         @Override
-        public Set<Entry<String, SdkSchema>> entrySet() {
+        public Set<Entry<String, Schema>> entrySet() {
             return entries;
         }
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ModeledApiException.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ModeledApiException.java
@@ -10,26 +10,26 @@ import software.amazon.smithy.model.shapes.ShapeId;
 /**
  * The top-level exception that should be used to throw modeled errors from clients and servers.
  */
-public abstract class ModeledSdkException extends SdkException implements SerializableStruct {
+public abstract class ModeledApiException extends ApiException implements SerializableStruct {
 
     private final ShapeId shapeId;
 
-    public ModeledSdkException(ShapeId shapeId, String message) {
+    public ModeledApiException(ShapeId shapeId, String message) {
         super(message);
         this.shapeId = shapeId;
     }
 
-    public ModeledSdkException(ShapeId shapeId, String message, Fault errorType) {
+    public ModeledApiException(ShapeId shapeId, String message, Fault errorType) {
         super(message, errorType);
         this.shapeId = shapeId;
     }
 
-    public ModeledSdkException(ShapeId shapeId, String message, Throwable cause) {
+    public ModeledApiException(ShapeId shapeId, String message, Throwable cause) {
         super(message, cause);
         this.shapeId = shapeId;
     }
 
-    public ModeledSdkException(ShapeId shapeId, String message, Throwable cause, Fault errorType) {
+    public ModeledApiException(ShapeId shapeId, String message, Throwable cause, Fault errorType) {
         super(message, cause, errorType);
         this.shapeId = shapeId;
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/PreludeSchemas.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/PreludeSchemas.java
@@ -11,78 +11,78 @@ import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 
 /**
- * {@link SdkSchema} definitions for the Smithy prelude
+ * {@link Schema} definitions for the Smithy prelude
  */
 public final class PreludeSchemas {
-    public static final SdkSchema BLOB = SdkSchema.builder().type(ShapeType.BLOB).id("smithy.api#Blob").build();
-    public static final SdkSchema BOOLEAN = SdkSchema.builder()
+    public static final Schema BLOB = Schema.builder().type(ShapeType.BLOB).id("smithy.api#Blob").build();
+    public static final Schema BOOLEAN = Schema.builder()
         .type(ShapeType.BOOLEAN)
         .id("smithy.api#Boolean")
         .build();
-    public static final SdkSchema STRING = SdkSchema.builder().type(ShapeType.STRING).id("smithy.api#String").build();
-    public static final SdkSchema TIMESTAMP = SdkSchema.builder()
+    public static final Schema STRING = Schema.builder().type(ShapeType.STRING).id("smithy.api#String").build();
+    public static final Schema TIMESTAMP = Schema.builder()
         .type(ShapeType.TIMESTAMP)
         .id("smithy.api#Timestamp")
         .build();
-    public static final SdkSchema BYTE = SdkSchema.builder().type(ShapeType.BYTE).id("smithy.api#Byte").build();
-    public static final SdkSchema SHORT = SdkSchema.builder().type(ShapeType.SHORT).id("smithy.api#Short").build();
-    public static final SdkSchema INTEGER = SdkSchema.builder()
+    public static final Schema BYTE = Schema.builder().type(ShapeType.BYTE).id("smithy.api#Byte").build();
+    public static final Schema SHORT = Schema.builder().type(ShapeType.SHORT).id("smithy.api#Short").build();
+    public static final Schema INTEGER = Schema.builder()
         .type(ShapeType.INTEGER)
         .id("smithy.api#Integer")
         .build();
-    public static final SdkSchema LONG = SdkSchema.builder().type(ShapeType.LONG).id("smithy.api#Long").build();
-    public static final SdkSchema FLOAT = SdkSchema.builder().type(ShapeType.FLOAT).id("smithy.api#Float").build();
-    public static final SdkSchema DOUBLE = SdkSchema.builder().type(ShapeType.DOUBLE).id("smithy.api#Double").build();
-    public static final SdkSchema BIG_INTEGER = SdkSchema.builder()
+    public static final Schema LONG = Schema.builder().type(ShapeType.LONG).id("smithy.api#Long").build();
+    public static final Schema FLOAT = Schema.builder().type(ShapeType.FLOAT).id("smithy.api#Float").build();
+    public static final Schema DOUBLE = Schema.builder().type(ShapeType.DOUBLE).id("smithy.api#Double").build();
+    public static final Schema BIG_INTEGER = Schema.builder()
         .type(ShapeType.BIG_INTEGER)
         .id("smithy.api#BigInteger")
         .build();
-    public static final SdkSchema BIG_DECIMAL = SdkSchema.builder()
+    public static final Schema BIG_DECIMAL = Schema.builder()
         .type(ShapeType.BIG_DECIMAL)
         .id("smithy.api#BigDecimal")
         .build();
-    public static final SdkSchema DOCUMENT = SdkSchema.builder()
+    public static final Schema DOCUMENT = Schema.builder()
         .type(ShapeType.DOCUMENT)
         .id("smithy.api#Document")
         .build();
 
     // Primitive types
-    public static final SdkSchema PRIMITIVE_BOOLEAN = SdkSchema.builder()
+    public static final Schema PRIMITIVE_BOOLEAN = Schema.builder()
         .type(ShapeType.BOOLEAN)
         .id("smithy.api#PrimitiveBoolean")
         .traits(new DefaultTrait(Node.from(false)))
         .build();
-    public static final SdkSchema PRIMITIVE_BYTE = SdkSchema.builder()
+    public static final Schema PRIMITIVE_BYTE = Schema.builder()
         .type(ShapeType.BYTE)
         .id("smithy.api#PrimitiveByte")
         .traits(new DefaultTrait(Node.from(0)))
         .build();
-    public static final SdkSchema PRIMITIVE_SHORT = SdkSchema.builder()
+    public static final Schema PRIMITIVE_SHORT = Schema.builder()
         .type(ShapeType.SHORT)
         .id("smithy.api#PrimitiveShort")
         .traits(new DefaultTrait(Node.from(0)))
         .build();
-    public static final SdkSchema PRIMITIVE_INTEGER = SdkSchema.builder()
+    public static final Schema PRIMITIVE_INTEGER = Schema.builder()
         .type(ShapeType.INTEGER)
         .id("smithy.api#PrimitiveInteger")
         .traits(new DefaultTrait(Node.from(0)))
         .build();
-    public static final SdkSchema PRIMITIVE_LONG = SdkSchema.builder()
+    public static final Schema PRIMITIVE_LONG = Schema.builder()
         .type(ShapeType.LONG)
         .id("smithy.api#PrimitiveLong")
         .traits(new DefaultTrait(Node.from(0)))
         .build();
-    public static final SdkSchema PRIMITIVE_FLOAT = SdkSchema.builder()
+    public static final Schema PRIMITIVE_FLOAT = Schema.builder()
         .type(ShapeType.FLOAT)
         .id("smithy.api#PrimitiveFloat")
         .traits(new DefaultTrait(Node.from(0)))
         .build();
-    public static final SdkSchema PRIMITIVE_DOUBLE = SdkSchema.builder()
+    public static final Schema PRIMITIVE_DOUBLE = Schema.builder()
         .type(ShapeType.DOUBLE)
         .id("smithy.api#PrimitiveDouble")
         .traits(new DefaultTrait(Node.from(0)))
         .build();
-    public static final SdkSchema UNIT = SdkSchema.builder()
+    public static final Schema UNIT = Schema.builder()
         .type(ShapeType.STRUCTURE)
         .id("smithy.api#Unit")
         .traits(new UnitTypeTrait())
@@ -104,7 +104,7 @@ public final class PreludeSchemas {
      * @param type Type to compute a schema from.
      * @return the schema type.
      */
-    public static SdkSchema getSchemaForType(ShapeType type) {
+    public static Schema getSchemaForType(ShapeType type) {
         return switch (type) {
             case BOOLEAN -> PreludeSchemas.BOOLEAN;
             case BYTE -> PreludeSchemas.BYTE;

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SerializableStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SerializableStruct.java
@@ -28,7 +28,7 @@ public interface SerializableStruct extends SerializableShape {
      * @param memberWriter BiConsumer that writes members to the given serializer.
      * @return the created SerializableStruct.
      */
-    static SerializableStruct create(SdkSchema schema, BiConsumer<SdkSchema, ShapeSerializer> memberWriter) {
+    static SerializableStruct create(Schema schema, BiConsumer<Schema, ShapeSerializer> memberWriter) {
         return new SerializableStruct() {
             @Override
             public void serialize(ShapeSerializer encoder) {
@@ -51,9 +51,9 @@ public interface SerializableStruct extends SerializableShape {
      * @return the filtered struct.
      */
     static SerializableStruct filteredMembers(
-        SdkSchema schema,
+        Schema schema,
         SerializableStruct struct,
-        Predicate<SdkSchema> memberPredicate
+        Predicate<Schema> memberPredicate
     ) {
         return new SerializableStruct() {
             @Override
@@ -65,7 +65,7 @@ public interface SerializableStruct extends SerializableShape {
             public void serializeMembers(ShapeSerializer serializer) {
                 struct.serializeMembers(new InterceptingSerializer() {
                     @Override
-                    protected ShapeSerializer before(SdkSchema schema) {
+                    protected ShapeSerializer before(Schema schema) {
                         return memberPredicate.test(schema) ? serializer : ShapeSerializer.nullSerializer();
                     }
                 });

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ShapeBuilder.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ShapeBuilder.java
@@ -14,7 +14,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
  *
  * @param <T> Shape to build.
  */
-public interface SdkShapeBuilder<T extends SerializableShape> extends SmithyBuilder<T> {
+public interface ShapeBuilder<T extends SerializableShape> extends SmithyBuilder<T> {
     /**
      * Set a stream of data on the shape, if allowed.
      *
@@ -42,7 +42,7 @@ public interface SdkShapeBuilder<T extends SerializableShape> extends SmithyBuil
      *
      * @param decoder Decoder used to deserialize the shape.
      */
-    SdkShapeBuilder<T> deserialize(ShapeDeserializer decoder);
+    ShapeBuilder<T> deserialize(ShapeDeserializer decoder);
 
     /**
      * Performs any necessary error correction before the shape can be built.
@@ -52,7 +52,7 @@ public interface SdkShapeBuilder<T extends SerializableShape> extends SmithyBuil
      *
      * @return Returns the builder.
      */
-    default SdkShapeBuilder<T> errorCorrection() {
+    default ShapeBuilder<T> errorCorrection() {
         return this;
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidationError.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidationError.java
@@ -33,25 +33,25 @@ public interface ValidationError {
         }
     }
 
-    record UnionValidationFailure(String path, String message, SdkSchema schema) implements ValidationError {}
+    record UnionValidationFailure(String path, String message, Schema schema) implements ValidationError {}
 
-    record TypeValidationFailure(String path, String message, ShapeType actual, SdkSchema schema) implements
+    record TypeValidationFailure(String path, String message, ShapeType actual, Schema schema) implements
         ValidationError {
-        public TypeValidationFailure(String path, ShapeType actual, SdkSchema schema) {
+        public TypeValidationFailure(String path, ShapeType actual, Schema schema) {
             this(path, "Value must be " + schema.type() + ", but found " + actual, actual, schema);
         }
     }
 
-    record RequiredValidationFailure(String path, String message, String missingMember, SdkSchema schema) implements
+    record RequiredValidationFailure(String path, String message, String missingMember, Schema schema) implements
         ValidationError {
-        public RequiredValidationFailure(String path, String missingMember, SdkSchema schema) {
+        public RequiredValidationFailure(String path, String missingMember, Schema schema) {
             this(path, "Value missing required member: " + missingMember, missingMember, schema);
         }
     }
 
-    record PatternValidationFailure(String path, String message, String value, SdkSchema schema) implements
+    record PatternValidationFailure(String path, String message, String value, Schema schema) implements
         ValidationError {
-        public PatternValidationFailure(String path, String value, SdkSchema schema) {
+        public PatternValidationFailure(String path, String value, Schema schema) {
             this(
                 path,
                 "Value must satisfy regular expression pattern: "
@@ -62,33 +62,33 @@ public interface ValidationError {
         }
     }
 
-    record EnumValidationFailure(String path, String message, String value, SdkSchema schema) implements
+    record EnumValidationFailure(String path, String message, String value, Schema schema) implements
         ValidationError {
-        public EnumValidationFailure(String path, String value, SdkSchema schema) {
+        public EnumValidationFailure(String path, String value, Schema schema) {
             this(path, "Value is not an allowed enum string", value, schema);
         }
     }
 
-    record IntEnumValidationFailure(String path, String message, int value, SdkSchema schema) implements
+    record IntEnumValidationFailure(String path, String message, int value, Schema schema) implements
         ValidationError {
-        public IntEnumValidationFailure(String path, int value, SdkSchema schema) {
+        public IntEnumValidationFailure(String path, int value, Schema schema) {
             this(path, "Value is not an allowed integer enum number", value, schema);
         }
     }
 
-    record SparseValidationFailure(String path, String message, SdkSchema schema) implements ValidationError {
-        public SparseValidationFailure(String path, SdkSchema schema) {
+    record SparseValidationFailure(String path, String message, Schema schema) implements ValidationError {
+        public SparseValidationFailure(String path, Schema schema) {
             this(path, "Value is in a " + schema.type() + " that does not allow null values", schema);
         }
     }
 
-    record RangeValidationFailure(String path, String message, Number value, SdkSchema schema) implements
+    record RangeValidationFailure(String path, String message, Number value, Schema schema) implements
         ValidationError {
-        public RangeValidationFailure(String path, Number value, SdkSchema schema) {
+        public RangeValidationFailure(String path, Number value, Schema schema) {
             this(path, createMessage(schema), value, schema);
         }
 
-        private static String createMessage(SdkSchema schema) {
+        private static String createMessage(Schema schema) {
             if (schema.minRangeConstraint == null) {
                 return "Value must be less than or equal to " + formatDecimal(schema.maxRangeConstraint);
             } else if (schema.maxRangeConstraint == null) {
@@ -110,13 +110,13 @@ public interface ValidationError {
         }
     }
 
-    record LengthValidationFailure(String path, String message, long length, SdkSchema schema) implements
+    record LengthValidationFailure(String path, String message, long length, Schema schema) implements
         ValidationError {
-        public LengthValidationFailure(String path, long length, SdkSchema schema) {
+        public LengthValidationFailure(String path, long length, Schema schema) {
             this(path, createMessage(length, schema), length, schema);
         }
 
-        private static String createMessage(long length, SdkSchema schema) {
+        private static String createMessage(long length, Schema schema) {
             var prefix = "Value with length " + length;
             if (schema.minLengthConstraint == Long.MIN_VALUE) {
                 return prefix + " must have length less than or equal to " + schema.maxLengthConstraint;

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfString.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfString.java
@@ -14,7 +14,7 @@ abstract sealed class ValidatorOfString permits ValidatorOfString.NoStringValida
     ValidatorOfString.PatternStringValidator,
     ValidatorOfString.CompositeStringValidator {
 
-    abstract void apply(SdkSchema schema, String value, Validator.ShapeValidator validator);
+    abstract void apply(Schema schema, String value, Validator.ShapeValidator validator);
 
     static ValidatorOfString of(List<ValidatorOfString> validators) {
         if (validators == null || validators.isEmpty()) {
@@ -30,7 +30,7 @@ abstract sealed class ValidatorOfString permits ValidatorOfString.NoStringValida
         static final NoStringValidation INSTANCE = new NoStringValidation();
 
         @Override
-        public void apply(SdkSchema schema, String value, Validator.ShapeValidator validator) {}
+        public void apply(Schema schema, String value, Validator.ShapeValidator validator) {}
     }
 
     static final class CompositeStringValidator extends ValidatorOfString {
@@ -41,7 +41,7 @@ abstract sealed class ValidatorOfString permits ValidatorOfString.NoStringValida
         }
 
         @Override
-        public void apply(SdkSchema schema, String value, Validator.ShapeValidator validator) {
+        public void apply(Schema schema, String value, Validator.ShapeValidator validator) {
             for (var v : validators) {
                 v.apply(schema, value, validator);
             }
@@ -59,7 +59,7 @@ abstract sealed class ValidatorOfString permits ValidatorOfString.NoStringValida
         }
 
         @Override
-        public void apply(SdkSchema schema, String value, Validator.ShapeValidator validator) {
+        public void apply(Schema schema, String value, Validator.ShapeValidator validator) {
             var length = value.codePointCount(0, value.length());
             if (length < min || length > max) {
                 validator.addError(new ValidationError.LengthValidationFailure(validator.createPath(), length, schema));
@@ -76,7 +76,7 @@ abstract sealed class ValidatorOfString permits ValidatorOfString.NoStringValida
         }
 
         @Override
-        public void apply(SdkSchema schema, String value, Validator.ShapeValidator validator) {
+        public void apply(Schema schema, String value, Validator.ShapeValidator validator) {
             try {
                 // Note: using Matcher#find() here and not Matcher#match() because Smithy expects patterns to be rooted
                 // with ^ and $ to get the same behavior as #match().
@@ -101,7 +101,7 @@ abstract sealed class ValidatorOfString permits ValidatorOfString.NoStringValida
         static final EnumStringValidator INSTANCE = new EnumStringValidator();
 
         @Override
-        public void apply(SdkSchema schema, String value, Validator.ShapeValidator validator) {
+        public void apply(Schema schema, String value, Validator.ShapeValidator validator) {
             if (!schema.stringEnumValues().contains(value)) {
                 validator.addError(new ValidationError.EnumValidationFailure(validator.createPath(), value, schema));
             }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
@@ -26,7 +26,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
         this.structValidator = structValidator;
     }
 
-    static void validate(Validator.ShapeValidator validator, SdkSchema schema, SerializableStruct struct) {
+    static void validate(Validator.ShapeValidator validator, Schema schema, SerializableStruct struct) {
         var tracker = PresenceTracker.of(schema);
         struct.serializeMembers(new ValidatorOfStruct(validator, tracker));
         if (!tracker.allSet()) {
@@ -39,7 +39,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeBoolean(SdkSchema member, boolean value) {
+    public void writeBoolean(Schema member, boolean value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeBoolean(member, value);
@@ -47,7 +47,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeByte(SdkSchema member, byte value) {
+    public void writeByte(Schema member, byte value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeByte(member, value);
@@ -55,7 +55,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeShort(SdkSchema member, short value) {
+    public void writeShort(Schema member, short value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeShort(member, value);
@@ -63,7 +63,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeInteger(SdkSchema member, int value) {
+    public void writeInteger(Schema member, int value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeInteger(member, value);
@@ -71,7 +71,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeLong(SdkSchema member, long value) {
+    public void writeLong(Schema member, long value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeLong(member, value);
@@ -79,7 +79,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeFloat(SdkSchema member, float value) {
+    public void writeFloat(Schema member, float value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeFloat(member, value);
@@ -87,7 +87,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeDouble(SdkSchema member, double value) {
+    public void writeDouble(Schema member, double value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeDouble(member, value);
@@ -95,7 +95,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeBigInteger(SdkSchema member, BigInteger value) {
+    public void writeBigInteger(Schema member, BigInteger value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeBigInteger(member, value);
@@ -103,7 +103,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema member, BigDecimal value) {
+    public void writeBigDecimal(Schema member, BigDecimal value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeBigDecimal(member, value);
@@ -111,7 +111,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeBlob(SdkSchema member, byte[] value) {
+    public void writeBlob(Schema member, byte[] value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeBlob(member, value);
@@ -119,7 +119,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeString(SdkSchema member, String value) {
+    public void writeString(Schema member, String value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeString(member, value);
@@ -127,7 +127,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeTimestamp(SdkSchema member, Instant value) {
+    public void writeTimestamp(Schema member, Instant value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeTimestamp(member, value);
@@ -135,7 +135,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeDocument(SdkSchema member, Document value) {
+    public void writeDocument(Schema member, Document value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeDocument(member, value);
@@ -143,7 +143,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(SdkSchema member, T state, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema member, T state, BiConsumer<T, ShapeSerializer> consumer) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeList(member, state, consumer);
@@ -151,7 +151,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(SdkSchema member, T state, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema member, T state, BiConsumer<T, MapSerializer> consumer) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeMap(member, state, consumer);
@@ -159,7 +159,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeStruct(SdkSchema member, SerializableStruct struct) {
+    public void writeStruct(Schema member, SerializableStruct struct) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeStruct(member, struct);
@@ -167,7 +167,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeNull(SdkSchema member) {
+    public void writeNull(Schema member) {
         // A null member does not count as present so don't set the bitfield.
         validator.pushPath(member.memberName());
         validator.writeNull(member);

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
@@ -19,15 +19,15 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
 final class ValidatorOfUnion implements ShapeSerializer {
 
     private final Validator.ShapeValidator validator;
-    private final SdkSchema schema;
+    private final Schema schema;
     private String setMember;
 
-    private ValidatorOfUnion(Validator.ShapeValidator validator, SdkSchema schema) {
+    private ValidatorOfUnion(Validator.ShapeValidator validator, Schema schema) {
         this.validator = validator;
         this.schema = schema;
     }
 
-    static void validate(Validator.ShapeValidator validator, SdkSchema schema, SerializableStruct struct) {
+    static void validate(Validator.ShapeValidator validator, Schema schema, SerializableStruct struct) {
         var unionValidator = new ValidatorOfUnion(validator, schema);
         struct.serializeMembers(unionValidator);
         unionValidator.checkResult();
@@ -44,12 +44,12 @@ final class ValidatorOfUnion implements ShapeSerializer {
         }
     }
 
-    private boolean validateSetValue(SdkSchema schema, Object value) {
+    private boolean validateSetValue(Schema schema, Object value) {
         // Don't further validate the value if it's null.
         return value != null && validateSetValue(schema);
     }
 
-    private boolean validateSetValue(SdkSchema schema) {
+    private boolean validateSetValue(Schema schema) {
         if (setMember != null) {
             String message = "Union member conflicts with '" + setMember + "'";
             validator.addError(new ValidationError.UnionValidationFailure(validator.createPath(), message, schema));
@@ -61,7 +61,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeBoolean(SdkSchema member, boolean value) {
+    public void writeBoolean(Schema member, boolean value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
             validator.writeBoolean(member, value);
@@ -70,7 +70,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeByte(SdkSchema member, byte value) {
+    public void writeByte(Schema member, byte value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
             validator.writeByte(member, value);
@@ -79,7 +79,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeShort(SdkSchema member, short value) {
+    public void writeShort(Schema member, short value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
             validator.writeShort(member, value);
@@ -88,7 +88,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeInteger(SdkSchema member, int value) {
+    public void writeInteger(Schema member, int value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
             validator.writeInteger(member, value);
@@ -97,7 +97,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeLong(SdkSchema member, long value) {
+    public void writeLong(Schema member, long value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
             validator.writeLong(member, value);
@@ -106,7 +106,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeFloat(SdkSchema member, float value) {
+    public void writeFloat(Schema member, float value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
             validator.writeFloat(member, value);
@@ -115,7 +115,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeDouble(SdkSchema member, double value) {
+    public void writeDouble(Schema member, double value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
             validator.writeDouble(member, value);
@@ -124,7 +124,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeBigInteger(SdkSchema member, BigInteger value) {
+    public void writeBigInteger(Schema member, BigInteger value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member, value)) {
             validator.writeBigInteger(member, value);
@@ -133,7 +133,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema member, BigDecimal value) {
+    public void writeBigDecimal(Schema member, BigDecimal value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member, value)) {
             validator.writeBigDecimal(member, value);
@@ -142,7 +142,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeBlob(SdkSchema member, byte[] value) {
+    public void writeBlob(Schema member, byte[] value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member, value)) {
             validator.writeBlob(member, value);
@@ -151,7 +151,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeString(SdkSchema member, String value) {
+    public void writeString(Schema member, String value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member, value)) {
             validator.writeString(member, value);
@@ -160,7 +160,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeTimestamp(SdkSchema member, Instant value) {
+    public void writeTimestamp(Schema member, Instant value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member, value)) {
             validator.writeTimestamp(member, value);
@@ -169,7 +169,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeDocument(SdkSchema member, Document value) {
+    public void writeDocument(Schema member, Document value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member, value)) {
             validator.writeDocument(member, value);
@@ -178,7 +178,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(SdkSchema member, T state, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema member, T state, BiConsumer<T, ShapeSerializer> consumer) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
             validator.writeList(member, state, consumer);
@@ -187,7 +187,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(SdkSchema member, T state, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema member, T state, BiConsumer<T, MapSerializer> consumer) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
             validator.writeMap(member, state, consumer);
@@ -196,7 +196,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeStruct(SdkSchema member, SerializableStruct struct) {
+    public void writeStruct(Schema member, SerializableStruct struct) {
         validator.pushPath(member);
         if (validateSetValue(member)) {
             validator.writeStruct(member, struct);
@@ -205,7 +205,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeNull(SdkSchema schema) {
+    public void writeNull(Schema schema) {
         // null values in unions are ignored.
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/Codec.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/Codec.java
@@ -8,8 +8,8 @@ package software.amazon.smithy.java.runtime.core.serde;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 
 /**
  * Generic shape serialization and deserialization.
@@ -66,7 +66,7 @@ public interface Codec extends AutoCloseable {
      * @return Returns the built and error-corrected shape.
      * @param <T> Shape to build.
      */
-    default <T extends SerializableShape> T deserializeShape(byte[] source, SdkShapeBuilder<T> builder) {
+    default <T extends SerializableShape> T deserializeShape(byte[] source, ShapeBuilder<T> builder) {
         return builder.deserialize(createDeserializer(source)).errorCorrection().build();
     }
 
@@ -78,7 +78,7 @@ public interface Codec extends AutoCloseable {
      * @return Returns the built and error-corrected shape.
      * @param <T> Shape to build.
      */
-    default <T extends SerializableShape> T deserializeShape(String source, SdkShapeBuilder<T> builder) {
+    default <T extends SerializableShape> T deserializeShape(String source, ShapeBuilder<T> builder) {
         return deserializeShape(source.getBytes(StandardCharsets.UTF_8), builder);
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
@@ -9,14 +9,14 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
  * Intercepts serialization before and after each write.
  *
- * <p>{@link #before(SdkSchema)} is responsible for returning the {@link ShapeSerializer} used to actually perform a
+ * <p>{@link #before(Schema)} is responsible for returning the {@link ShapeSerializer} used to actually perform a
  * write, making the method act as a router between serializers, predicated on the given schema.
  */
 public abstract class InterceptingSerializer implements ShapeSerializer {
@@ -27,113 +27,113 @@ public abstract class InterceptingSerializer implements ShapeSerializer {
      * @param schema Schema of the shape about to be written.
      * @return the serializer that is to be used to write this schema.
      */
-    protected abstract ShapeSerializer before(SdkSchema schema);
+    protected abstract ShapeSerializer before(Schema schema);
 
     /**
      * Called after the delegated serializer is called.
      *
      * @param schema Schema that was serialized.
      */
-    protected void after(SdkSchema schema) {}
+    protected void after(Schema schema) {}
 
     @Override
-    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
+    public void writeStruct(Schema schema, SerializableStruct struct) {
         before(schema).writeStruct(schema, struct);
         after(schema);
     }
 
     @Override
-    public final <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+    public final <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
         before(schema).writeList(schema, listState, consumer);
         after(schema);
     }
 
     @Override
-    public final <T> void writeMap(SdkSchema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public final <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
         before(schema).writeMap(schema, mapState, consumer);
         after(schema);
     }
 
     @Override
-    public final void writeBoolean(SdkSchema schema, boolean value) {
+    public final void writeBoolean(Schema schema, boolean value) {
         before(schema).writeBoolean(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeShort(SdkSchema schema, short value) {
+    public final void writeShort(Schema schema, short value) {
         before(schema).writeShort(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeByte(SdkSchema schema, byte value) {
+    public final void writeByte(Schema schema, byte value) {
         before(schema).writeByte(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeInteger(SdkSchema schema, int value) {
+    public final void writeInteger(Schema schema, int value) {
         before(schema).writeInteger(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeLong(SdkSchema schema, long value) {
+    public final void writeLong(Schema schema, long value) {
         before(schema).writeLong(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeFloat(SdkSchema schema, float value) {
+    public final void writeFloat(Schema schema, float value) {
         before(schema).writeFloat(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeDouble(SdkSchema schema, double value) {
+    public final void writeDouble(Schema schema, double value) {
         before(schema).writeDouble(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeBigInteger(SdkSchema schema, BigInteger value) {
+    public final void writeBigInteger(Schema schema, BigInteger value) {
         before(schema).writeBigInteger(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeBigDecimal(SdkSchema schema, BigDecimal value) {
+    public final void writeBigDecimal(Schema schema, BigDecimal value) {
         before(schema).writeBigDecimal(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeString(SdkSchema schema, String value) {
+    public final void writeString(Schema schema, String value) {
         before(schema).writeString(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeBlob(SdkSchema schema, byte[] value) {
+    public final void writeBlob(Schema schema, byte[] value) {
         before(schema).writeBlob(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeTimestamp(SdkSchema schema, Instant value) {
+    public final void writeTimestamp(Schema schema, Instant value) {
         before(schema).writeTimestamp(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeDocument(SdkSchema schema, Document value) {
+    public final void writeDocument(Schema schema, Document value) {
         before(schema).writeDocument(schema, value);
         after(schema);
     }
 
     @Override
-    public final void writeNull(SdkSchema schema) {
+    public final void writeNull(Schema schema) {
         before(schema).writeNull(schema);
         after(schema);
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.IntConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
@@ -49,103 +49,103 @@ public final class ListSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
+    public void writeStruct(Schema schema, SerializableStruct struct) {
         beforeWrite();
         delegate.writeStruct(schema, struct);
     }
 
     @Override
-    public <T> void writeList(SdkSchema schema, T state, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T state, BiConsumer<T, ShapeSerializer> consumer) {
         beforeWrite();
         delegate.writeList(schema, state, consumer);
     }
 
     @Override
-    public <T> void writeMap(SdkSchema schema, T state, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T state, BiConsumer<T, MapSerializer> consumer) {
         beforeWrite();
         delegate.writeMap(schema, state, consumer);
     }
 
     @Override
-    public void writeBoolean(SdkSchema schema, boolean value) {
+    public void writeBoolean(Schema schema, boolean value) {
         beforeWrite();
         delegate.writeBoolean(schema, value);
     }
 
     @Override
-    public void writeShort(SdkSchema schema, short value) {
+    public void writeShort(Schema schema, short value) {
         beforeWrite();
         delegate.writeShort(schema, value);
     }
 
     @Override
-    public void writeByte(SdkSchema schema, byte value) {
+    public void writeByte(Schema schema, byte value) {
         beforeWrite();
         delegate.writeByte(schema, value);
     }
 
     @Override
-    public void writeInteger(SdkSchema schema, int value) {
+    public void writeInteger(Schema schema, int value) {
         beforeWrite();
         delegate.writeInteger(schema, value);
     }
 
     @Override
-    public void writeLong(SdkSchema schema, long value) {
+    public void writeLong(Schema schema, long value) {
         beforeWrite();
         delegate.writeLong(schema, value);
     }
 
     @Override
-    public void writeFloat(SdkSchema schema, float value) {
+    public void writeFloat(Schema schema, float value) {
         beforeWrite();
         delegate.writeFloat(schema, value);
     }
 
     @Override
-    public void writeDouble(SdkSchema schema, double value) {
+    public void writeDouble(Schema schema, double value) {
         beforeWrite();
         delegate.writeDouble(schema, value);
     }
 
     @Override
-    public void writeBigInteger(SdkSchema schema, BigInteger value) {
+    public void writeBigInteger(Schema schema, BigInteger value) {
         beforeWrite();
         delegate.writeBigInteger(schema, value);
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
         beforeWrite();
         delegate.writeBigDecimal(schema, value);
     }
 
     @Override
-    public void writeString(SdkSchema schema, String value) {
+    public void writeString(Schema schema, String value) {
         beforeWrite();
         delegate.writeString(schema, value);
     }
 
     @Override
-    public void writeBlob(SdkSchema schema, byte[] value) {
+    public void writeBlob(Schema schema, byte[] value) {
         beforeWrite();
         delegate.writeBlob(schema, value);
     }
 
     @Override
-    public void writeTimestamp(SdkSchema schema, Instant value) {
+    public void writeTimestamp(Schema schema, Instant value) {
         beforeWrite();
         delegate.writeTimestamp(schema, value);
     }
 
     @Override
-    public void writeDocument(SdkSchema schema, Document value) {
+    public void writeDocument(Schema schema, Document value) {
         beforeWrite();
         delegate.writeDocument(schema, value);
     }
 
     @Override
-    public void writeNull(SdkSchema schema) {
+    public void writeNull(Schema schema) {
         beforeWrite();
         delegate.writeNull(schema);
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/MapSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/MapSerializer.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.runtime.core.serde;
 
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 
 /**
  * Serializes a map shape.
@@ -20,5 +20,5 @@ public interface MapSerializer {
      * @param state           State to pass to {@code valueSerializer}.
      * @param valueSerializer Serializer used to serialize the map value. A value must be serialized.
      */
-    <T> void writeEntry(SdkSchema keySchema, String key, T state, BiConsumer<T, ShapeSerializer> valueSerializer);
+    <T> void writeEntry(Schema keySchema, String key, T state, BiConsumer<T, ShapeSerializer> valueSerializer);
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/NullSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/NullSerializer.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
@@ -23,53 +23,53 @@ final class NullSerializer implements ShapeSerializer {
     static final NullSerializer INSTANCE = new NullSerializer();
 
     @Override
-    public void writeStruct(SdkSchema schema, SerializableStruct struct) {}
+    public void writeStruct(Schema schema, SerializableStruct struct) {}
 
     @Override
-    public <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {}
+    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {}
 
     @Override
-    public <T> void writeMap(SdkSchema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {}
+    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {}
 
     @Override
-    public void writeBoolean(SdkSchema schema, boolean value) {}
+    public void writeBoolean(Schema schema, boolean value) {}
 
     @Override
-    public void writeByte(SdkSchema schema, byte value) {}
+    public void writeByte(Schema schema, byte value) {}
 
     @Override
-    public void writeShort(SdkSchema schema, short value) {}
+    public void writeShort(Schema schema, short value) {}
 
     @Override
-    public void writeInteger(SdkSchema schema, int value) {}
+    public void writeInteger(Schema schema, int value) {}
 
     @Override
-    public void writeLong(SdkSchema schema, long value) {}
+    public void writeLong(Schema schema, long value) {}
 
     @Override
-    public void writeFloat(SdkSchema schema, float value) {}
+    public void writeFloat(Schema schema, float value) {}
 
     @Override
-    public void writeDouble(SdkSchema schema, double value) {}
+    public void writeDouble(Schema schema, double value) {}
 
     @Override
-    public void writeBigInteger(SdkSchema schema, BigInteger value) {}
+    public void writeBigInteger(Schema schema, BigInteger value) {}
 
     @Override
-    public void writeBigDecimal(SdkSchema schema, BigDecimal value) {}
+    public void writeBigDecimal(Schema schema, BigDecimal value) {}
 
     @Override
-    public void writeString(SdkSchema schema, String value) {}
+    public void writeString(Schema schema, String value) {}
 
     @Override
-    public void writeBlob(SdkSchema schema, byte[] value) {}
+    public void writeBlob(Schema schema, byte[] value) {}
 
     @Override
-    public void writeTimestamp(SdkSchema schema, Instant value) {}
+    public void writeTimestamp(Schema schema, Instant value) {}
 
     @Override
-    public void writeDocument(SdkSchema schema, Document value) {}
+    public void writeDocument(Schema schema, Document value) {}
 
     @Override
-    public void writeNull(SdkSchema schema) {}
+    public void writeNull(Schema schema) {}
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SerializationException.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SerializationException.java
@@ -5,18 +5,18 @@
 
 package software.amazon.smithy.java.runtime.core.serde;
 
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
 
-public class SdkSerdeException extends SdkException {
-    public SdkSerdeException(String message) {
+public class SerializationException extends ApiException {
+    public SerializationException(String message) {
         super(message, Fault.OTHER);
     }
 
-    public SdkSerdeException(Throwable cause) {
+    public SerializationException(Throwable cause) {
         this(cause.getMessage(), cause);
     }
 
-    public SdkSerdeException(String message, Throwable cause) {
+    public SerializationException(String message, Throwable cause) {
         super(message, cause, Fault.OTHER);
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
@@ -25,7 +25,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    boolean readBoolean(SdkSchema schema);
+    boolean readBoolean(Schema schema);
 
     /**
      * Attempt to read a blob value.
@@ -33,7 +33,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    byte[] readBlob(SdkSchema schema);
+    byte[] readBlob(Schema schema);
 
     /**
      * Attempt to read a byte value.
@@ -41,7 +41,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    byte readByte(SdkSchema schema);
+    byte readByte(Schema schema);
 
     /**
      * Attempt to read a short value.
@@ -49,7 +49,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    short readShort(SdkSchema schema);
+    short readShort(Schema schema);
 
     /**
      * Attempt to read an integer or intEnum value.
@@ -57,7 +57,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    int readInteger(SdkSchema schema);
+    int readInteger(Schema schema);
 
     /**
      * Attempt to read a long value.
@@ -65,7 +65,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    long readLong(SdkSchema schema);
+    long readLong(Schema schema);
 
     /**
      * Attempt to read a float value.
@@ -73,7 +73,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    float readFloat(SdkSchema schema);
+    float readFloat(Schema schema);
 
     /**
      * Attempt to read a double value.
@@ -81,7 +81,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    double readDouble(SdkSchema schema);
+    double readDouble(Schema schema);
 
     /**
      * Attempt to read a bigInteger value.
@@ -89,7 +89,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    BigInteger readBigInteger(SdkSchema schema);
+    BigInteger readBigInteger(Schema schema);
 
     /**
      * Attempt to read a bigDecimal value.
@@ -97,7 +97,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    BigDecimal readBigDecimal(SdkSchema schema);
+    BigDecimal readBigDecimal(Schema schema);
 
     /**
      * Attempt to read a string or enum value.
@@ -105,7 +105,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    String readString(SdkSchema schema);
+    String readString(Schema schema);
 
     /**
      * Attempt to read a document value.
@@ -119,7 +119,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      *
      * @return the read value.
      */
-    Instant readTimestamp(SdkSchema schema);
+    Instant readTimestamp(Schema schema);
 
     /**
      * Attempt to read a structure or union value.
@@ -128,7 +128,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param state    State to pass to the consumer.
      * @param consumer Consumer that receives the state, member schema, and deserializer.
      */
-    <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> consumer);
+    <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> consumer);
 
     /**
      * Attempt to read a list value.
@@ -137,7 +137,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param state    State to pass to the consumer.
      * @param consumer Consumer that receives the state and deserializer.
      */
-    <T> void readList(SdkSchema schema, T state, ListMemberConsumer<T> consumer);
+    <T> void readList(Schema schema, T state, ListMemberConsumer<T> consumer);
 
     /**
      * Attempt to read a map value.
@@ -146,7 +146,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param state    State to pass to the consumer.
      * @param consumer Consumer that receives the state, map key, and deserializer.
      */
-    <T> void readStringMap(SdkSchema schema, T state, MapMemberConsumer<String, T> consumer);
+    <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> consumer);
 
     /**
      * Consumer of a structure member.
@@ -155,7 +155,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      */
     @FunctionalInterface
     interface StructMemberConsumer<T> {
-        void accept(T state, SdkSchema memberSchema, ShapeDeserializer memberDeserializer);
+        void accept(T state, Schema memberSchema, ShapeDeserializer memberDeserializer);
     }
 
     /**

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -11,14 +11,14 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
  * Serializes a shape by receiving the Smithy data model and writing output to a receiver owned by the serializer.
  *
- * <p>Note: null values should only ever be written using {@link #writeNull(SdkSchema)}. Every other method expects
+ * <p>Note: null values should only ever be written using {@link #writeNull(Schema)}. Every other method expects
  * a non-null value or a value type.
  */
 public interface ShapeSerializer extends Flushable, AutoCloseable {
@@ -44,7 +44,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema A member schema that targets the given struct.
      * @param struct Structure to serialize.
      */
-    void writeStruct(SdkSchema schema, SerializableStruct struct);
+    void writeStruct(Schema schema, SerializableStruct struct);
 
     /**
      * Begin a list and write zero or more values into it using the provided serializer.
@@ -53,7 +53,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param listState State to pass into the consumer.
      * @param consumer  Received in the context of the list and writes zero or more values.
      */
-    <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer);
+    <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer);
 
     /**
      * Begin a map and write zero or more entries into it using the provided serializer.
@@ -62,7 +62,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param mapState State to pass into the consumer.
      * @param consumer Received in the context of the map and writes zero or more entries.
      */
-    <T> void writeMap(SdkSchema schema, T mapState, BiConsumer<T, MapSerializer> consumer);
+    <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer);
 
     /**
      * Serialize a boolean.
@@ -70,7 +70,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Value to serialize.
      */
-    void writeBoolean(SdkSchema schema, boolean value);
+    void writeBoolean(Schema schema, boolean value);
 
     /**
      * Serialize a byte.
@@ -78,7 +78,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Value to serialize.
      */
-    void writeByte(SdkSchema schema, byte value);
+    void writeByte(Schema schema, byte value);
 
     /**
      * Serialize a short.
@@ -86,7 +86,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Value to serialize.
      */
-    void writeShort(SdkSchema schema, short value);
+    void writeShort(Schema schema, short value);
 
     /**
      * Serialize an integer.
@@ -94,7 +94,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Value to serialize.
      */
-    void writeInteger(SdkSchema schema, int value);
+    void writeInteger(Schema schema, int value);
 
     /**
      * Serialize a long.
@@ -102,7 +102,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Value to serialize.
      */
-    void writeLong(SdkSchema schema, long value);
+    void writeLong(Schema schema, long value);
 
     /**
      * Serialize a float.
@@ -110,7 +110,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Value to serialize.
      */
-    void writeFloat(SdkSchema schema, float value);
+    void writeFloat(Schema schema, float value);
 
     /**
      * Serialize a double.
@@ -118,7 +118,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Value to serialize.
      */
-    void writeDouble(SdkSchema schema, double value);
+    void writeDouble(Schema schema, double value);
 
     /**
      * Serialize a big integer.
@@ -126,7 +126,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Value to serialize.
      */
-    void writeBigInteger(SdkSchema schema, BigInteger value);
+    void writeBigInteger(Schema schema, BigInteger value);
 
     /**
      * Serialize a big decimal.
@@ -134,7 +134,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Value to serialize.
      */
-    void writeBigDecimal(SdkSchema schema, BigDecimal value);
+    void writeBigDecimal(Schema schema, BigDecimal value);
 
     /**
      * Serialize a string.
@@ -142,7 +142,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  String value.
      */
-    void writeString(SdkSchema schema, String value);
+    void writeString(Schema schema, String value);
 
     /**
      * Serialize a blob.
@@ -150,7 +150,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Blob value.
      */
-    void writeBlob(SdkSchema schema, byte[] value);
+    void writeBlob(Schema schema, byte[] value);
 
     /**
      * Serialize a timestamp.
@@ -158,7 +158,7 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Timestamp value.
      */
-    void writeTimestamp(SdkSchema schema, Instant value);
+    void writeTimestamp(Schema schema, Instant value);
 
     /**
      * Serialize a document shape.
@@ -169,12 +169,12 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      *               document wraps a modeled shape.
      * @param value  Value to serialize.
      */
-    void writeDocument(SdkSchema schema, Document value);
+    void writeDocument(Schema schema, Document value);
 
     /**
      * Writes a null value.
      *
      * @param schema Schema of the null value.
      */
-    void writeNull(SdkSchema schema);
+    void writeNull(Schema schema);
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 public abstract class SpecificShapeDeserializer implements ShapeDeserializer {
@@ -20,61 +20,61 @@ public abstract class SpecificShapeDeserializer implements ShapeDeserializer {
      * @param schema Unexpected encountered schema.
      * @return Returns an exception to throw.
      */
-    protected abstract RuntimeException throwForInvalidState(SdkSchema schema);
+    protected abstract RuntimeException throwForInvalidState(Schema schema);
 
     @Override
-    public byte[] readBlob(SdkSchema schema) {
+    public byte[] readBlob(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
 
-    public byte readByte(SdkSchema schema) {
+    public byte readByte(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public short readShort(SdkSchema schema) {
+    public short readShort(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public int readInteger(SdkSchema schema) {
+    public int readInteger(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public long readLong(SdkSchema schema) {
+    public long readLong(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public float readFloat(SdkSchema schema) {
+    public float readFloat(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public double readDouble(SdkSchema schema) {
+    public double readDouble(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public BigInteger readBigInteger(SdkSchema schema) {
+    public BigInteger readBigInteger(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public BigDecimal readBigDecimal(SdkSchema schema) {
+    public BigDecimal readBigDecimal(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public String readString(SdkSchema schema) {
+    public String readString(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public boolean readBoolean(SdkSchema schema) {
+    public boolean readBoolean(Schema schema) {
         return false;
     }
 
@@ -84,22 +84,22 @@ public abstract class SpecificShapeDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public Instant readTimestamp(SdkSchema schema) {
+    public Instant readTimestamp(Schema schema) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> consumer) {
+    public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> consumer) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public <T> void readList(SdkSchema schema, T state, ListMemberConsumer<T> consumer) {
+    public <T> void readList(Schema schema, T state, ListMemberConsumer<T> consumer) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public <T> void readStringMap(SdkSchema schema, T state, MapMemberConsumer<String, T> consumer) {
+    public <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> consumer) {
         throw throwForInvalidState(schema);
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
@@ -24,96 +24,96 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
      * @param schema Unexpected encountered schema.
      * @return Returns an exception to throw.
      */
-    protected RuntimeException throwForInvalidState(String message, SdkSchema schema) {
-        throw new SdkSerdeException(message);
+    protected RuntimeException throwForInvalidState(String message, Schema schema) {
+        throw new SerializationException(message);
     }
 
-    private RuntimeException throwForInvalidState(SdkSchema schema) {
+    private RuntimeException throwForInvalidState(Schema schema) {
         return throwForInvalidState("Unexpected schema type: " + schema, schema);
     }
 
     @Override
-    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
+    public void writeStruct(Schema schema, SerializableStruct struct) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public <T> void writeMap(SdkSchema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeBoolean(SdkSchema schema, boolean value) {
+    public void writeBoolean(Schema schema, boolean value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeShort(SdkSchema schema, short value) {
+    public void writeShort(Schema schema, short value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeByte(SdkSchema schema, byte value) {
+    public void writeByte(Schema schema, byte value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeInteger(SdkSchema schema, int value) {
+    public void writeInteger(Schema schema, int value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeLong(SdkSchema schema, long value) {
+    public void writeLong(Schema schema, long value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeFloat(SdkSchema schema, float value) {
+    public void writeFloat(Schema schema, float value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeDouble(SdkSchema schema, double value) {
+    public void writeDouble(Schema schema, double value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeBigInteger(SdkSchema schema, BigInteger value) {
+    public void writeBigInteger(Schema schema, BigInteger value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeString(SdkSchema schema, String value) {
+    public void writeString(Schema schema, String value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeBlob(SdkSchema schema, byte[] value) {
+    public void writeBlob(Schema schema, byte[] value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeTimestamp(SdkSchema schema, Instant value) {
+    public void writeTimestamp(Schema schema, Instant value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeDocument(SdkSchema schema, Document value) {
+    public void writeDocument(Schema schema, Document value) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public void writeNull(SdkSchema schema) {
+    public void writeNull(Schema schema) {
         throw throwForInvalidState("Unexpected null value written for " + schema, schema);
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/TimestampFormatter.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/TimestampFormatter.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 
 /**
@@ -29,14 +29,14 @@ public interface TimestampFormatter {
      *
      * @param trait Trait to create the format from.
      * @return Returns the created formatter.
-     * @throws SdkSerdeException for an unknown format.
+     * @throws SerializationException for an unknown format.
      */
     static TimestampFormatter of(TimestampFormatTrait trait) {
         return switch (trait.getFormat()) {
             case DATE_TIME -> Prelude.DATE_TIME;
             case EPOCH_SECONDS -> Prelude.EPOCH_SECONDS;
             case HTTP_DATE -> Prelude.HTTP_DATE;
-            default -> throw new SdkSerdeException("Unknown timestamp format: " + trait.getFormat());
+            default -> throw new SerializationException("Unknown timestamp format: " + trait.getFormat());
         };
     }
 
@@ -68,7 +68,7 @@ public interface TimestampFormatter {
      * @param value      Timestamp value to serialize.
      * @param serializer Where to serialize the data.
      */
-    void writeToSerializer(SdkSchema schema, Instant value, ShapeSerializer serializer);
+    void writeToSerializer(Schema schema, Instant value, ShapeSerializer serializer);
 
     /**
      * Parse a timestamp from a string.
@@ -140,7 +140,7 @@ public interface TimestampFormatter {
             }
 
             @Override
-            public void writeToSerializer(SdkSchema schema, Instant instant, ShapeSerializer serializer) {
+            public void writeToSerializer(Schema schema, Instant instant, ShapeSerializer serializer) {
                 double value = ((double) instant.toEpochMilli()) / 1000;
                 serializer.writeDouble(schema, value);
             }
@@ -191,7 +191,7 @@ public interface TimestampFormatter {
         }
 
         @Override
-        public void writeToSerializer(SdkSchema schema, Instant value, ShapeSerializer serializer) {
+        public void writeToSerializer(Schema schema, Instant value, ShapeSerializer serializer) {
             serializer.writeString(schema, writeString(value));
         }
 
@@ -214,7 +214,7 @@ public interface TimestampFormatter {
     /**
      * Thrown when a timestamp format cannot be parsed.
      */
-    final class TimestampSyntaxError extends SdkSerdeException {
+    final class TimestampSyntaxError extends SerializationException {
 
         private final TimestampFormatTrait.Format format;
         private final ExpectedType expectedType;

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
@@ -39,7 +39,7 @@ public final class ToStringSerializer implements ShapeSerializer {
         return builder.toString().trim();
     }
 
-    private void append(SdkSchema schema, Object value) {
+    private void append(Schema schema, Object value) {
         if (schema.hasTrait(SensitiveTrait.class)) {
             builder.append("*REDACTED*");
         } else {
@@ -48,7 +48,7 @@ public final class ToStringSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
+    public void writeStruct(Schema schema, SerializableStruct struct) {
         builder.append(schema.id().getName()).append('[');
         struct.serializeMembers(new StructureWriter(this));
         builder.append(']');
@@ -63,7 +63,7 @@ public final class ToStringSerializer implements ShapeSerializer {
         }
 
         @Override
-        protected ShapeSerializer before(SdkSchema schema) {
+        protected ShapeSerializer before(Schema schema) {
             if (!isFirst) {
                 toStringSerializer.builder.append(", ");
             } else {
@@ -75,7 +75,7 @@ public final class ToStringSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(SdkSchema schema, T state, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T state, BiConsumer<T, ShapeSerializer> consumer) {
         builder.append('[');
         consumer.accept(state, new ListSerializer(this, this::writeComma));
         builder.append(']');
@@ -88,7 +88,7 @@ public final class ToStringSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(SdkSchema schema, T state, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T state, BiConsumer<T, MapSerializer> consumer) {
         builder.append('{');
         consumer.accept(state, new ToStringMapSerializer(this));
         builder.append('}');
@@ -104,7 +104,7 @@ public final class ToStringSerializer implements ShapeSerializer {
 
         @Override
         public <T> void writeEntry(
-            SdkSchema keySchema,
+            Schema keySchema,
             String key,
             T state,
             BiConsumer<T, ShapeSerializer> valueSerializer
@@ -121,57 +121,57 @@ public final class ToStringSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void writeBoolean(SdkSchema schema, boolean value) {
+    public void writeBoolean(Schema schema, boolean value) {
         append(schema, value);
     }
 
     @Override
-    public void writeShort(SdkSchema schema, short value) {
+    public void writeShort(Schema schema, short value) {
         append(schema, value);
     }
 
     @Override
-    public void writeByte(SdkSchema schema, byte value) {
+    public void writeByte(Schema schema, byte value) {
         append(schema, value);
     }
 
     @Override
-    public void writeInteger(SdkSchema schema, int value) {
+    public void writeInteger(Schema schema, int value) {
         append(schema, value);
     }
 
     @Override
-    public void writeLong(SdkSchema schema, long value) {
+    public void writeLong(Schema schema, long value) {
         append(schema, value);
     }
 
     @Override
-    public void writeFloat(SdkSchema schema, float value) {
+    public void writeFloat(Schema schema, float value) {
         builder.append(value);
     }
 
     @Override
-    public void writeDouble(SdkSchema schema, double value) {
+    public void writeDouble(Schema schema, double value) {
         append(schema, value);
     }
 
     @Override
-    public void writeBigInteger(SdkSchema schema, BigInteger value) {
+    public void writeBigInteger(Schema schema, BigInteger value) {
         append(schema, value);
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
         append(schema, value);
     }
 
     @Override
-    public void writeString(SdkSchema schema, String value) {
+    public void writeString(Schema schema, String value) {
         append(schema, value);
     }
 
     @Override
-    public void writeBlob(SdkSchema schema, byte[] value) {
+    public void writeBlob(Schema schema, byte[] value) {
         if (schema.hasTrait(SensitiveTrait.class)) {
             append(schema, value);
         } else {
@@ -182,19 +182,19 @@ public final class ToStringSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void writeTimestamp(SdkSchema schema, Instant value) {
+    public void writeTimestamp(Schema schema, Instant value) {
         append(schema, value);
     }
 
     @Override
-    public void writeDocument(SdkSchema schema, Document value) {
+    public void writeDocument(Schema schema, Document value) {
         builder.append(value.type()).append('.').append("Document[");
         value.serializeContents(this);
         builder.append(']');
     }
 
     @Override
-    public void writeNull(SdkSchema schema) {
+    public void writeNull(Schema schema) {
         builder.append("null");
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
@@ -13,12 +13,11 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import javax.xml.validation.Schema;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
 
@@ -87,11 +86,11 @@ public interface Document extends SerializableShape {
      * Serializes the Document as a document value in the Smithy data model.
      *
      * <p>All implementations of a document type are expected to follow the same behavior as this method when writing
-     * to a {@link ShapeSerializer}; the document is always written with {@link ShapeSerializer#writeDocument(SdkSchema, Document)}
+     * to a {@link ShapeSerializer}; the document is always written with {@link ShapeSerializer#writeDocument(Schema, Document)}
      * and receivers are free to query the underlying contents of the document using
      * {@link #serializeContents(ShapeSerializer)}.
      *
-     * @param serializer Where to send the document to {@link ShapeSerializer#writeDocument(SdkSchema, Document)}.
+     * @param serializer Where to send the document to {@link ShapeSerializer#writeDocument(Schema, Document)}.
      */
     @Override
     default void serialize(ShapeSerializer serializer) {
@@ -99,10 +98,10 @@ public interface Document extends SerializableShape {
     }
 
     /**
-     * Serialize the contents of the document using the Smithy data model and an appropriate {@link Schema}.
+     * Serialize the contents of the document using the Smithy data model and an appropriate {@link javax.xml.validation.Schema}.
      *
      * <p>While {@link #serialize(ShapeSerializer)} always emits document values as
-     * {@link ShapeSerializer#writeDocument(SdkSchema, Document)}, this method emits the contents of the document itself.
+     * {@link ShapeSerializer#writeDocument(Schema, Document)}, this method emits the contents of the document itself.
      * {@code ShapeSerializer} implementations that receive a {@link Document} via {@code writeDocument} can get the
      * inner contents of the document using this method.
      *
@@ -118,7 +117,7 @@ public interface Document extends SerializableShape {
      * (e.g., {@code smithy.api#Document$value}). In doing so, receivers of the document's data model do not need to
      * implement special-cased logic to account for synthetic document type members vs. actual modeled members
      *
-     * <p>Implementations must not write the contents of the document as {@link ShapeSerializer#writeDocument(SdkSchema, Document)}
+     * <p>Implementations must not write the contents of the document as {@link ShapeSerializer#writeDocument(Schema, Document)}
      * because that could result in infinite recursion for serializers that want access to the contents of a document.
      *
      * @param serializer Serializer to write the underlying data of the document to.
@@ -129,10 +128,10 @@ public interface Document extends SerializableShape {
      * Get the boolean value of the Document if it is a boolean.
      *
      * @return the boolean value.
-     * @throws SdkSerdeException if the Document is not a boolean.
+     * @throws SerializationException if the Document is not a boolean.
      */
     default boolean asBoolean() {
-        throw new SdkSerdeException("Expected a boolean document, but found " + type());
+        throw new SerializationException("Expected a boolean document, but found " + type());
     }
 
     /**
@@ -141,11 +140,11 @@ public interface Document extends SerializableShape {
      * <p>If the value is a number of a different type, the value is cast, which can result in a loss of precision.
      *
      * @return the byte value.
-     * @throws SdkSerdeException if the Document is not a number.
+     * @throws SerializationException if the Document is not a number.
      * @throws ArithmeticException if the value is out of range for this type.
      */
     default byte asByte() {
-        throw new SdkSerdeException("Expected a byte document, but found " + type());
+        throw new SerializationException("Expected a byte document, but found " + type());
     }
 
     /**
@@ -154,11 +153,11 @@ public interface Document extends SerializableShape {
      * <p>If the value is a number of a different type, the value is cast, which can result in a loss of precision.
      *
      * @return the short value.
-     * @throws SdkSerdeException if the Document is not a number.
+     * @throws SerializationException if the Document is not a number.
      * @throws ArithmeticException if the value is out of range for this type.
      */
     default short asShort() {
-        throw new SdkSerdeException("Expected a short document, but found " + type());
+        throw new SerializationException("Expected a short document, but found " + type());
     }
 
     /**
@@ -167,11 +166,11 @@ public interface Document extends SerializableShape {
      * <p>If the value is a number of a different type, the value is cast, which can result in a loss of precision.
      *
      * @return the integer value.
-     * @throws SdkSerdeException if the Document is not a number.
+     * @throws SerializationException if the Document is not a number.
      * @throws ArithmeticException if the value is out of range for this type.
      */
     default int asInteger() {
-        throw new SdkSerdeException("Expected an integer document, but found " + type());
+        throw new SerializationException("Expected an integer document, but found " + type());
     }
 
     /**
@@ -180,11 +179,11 @@ public interface Document extends SerializableShape {
      * <p>If the value is a number of a different type, the value is cast, which can result in a loss of precision.
      *
      * @return the long value.
-     * @throws SdkSerdeException if the Document is not a number.
+     * @throws SerializationException if the Document is not a number.
      * @throws ArithmeticException if the value is out of range for this type.
      */
     default long asLong() {
-        throw new SdkSerdeException("Expected a long document, but found " + type());
+        throw new SerializationException("Expected a long document, but found " + type());
     }
 
     /**
@@ -193,11 +192,11 @@ public interface Document extends SerializableShape {
      * <p>If the value is a number of a different type, the value is cast, which can result in a loss of precision.
      *
      * @return the float value.
-     * @throws SdkSerdeException if the Document is not a number.
+     * @throws SerializationException if the Document is not a number.
      * @throws ArithmeticException if the value is out of range for this type.
      */
     default float asFloat() {
-        throw new SdkSerdeException("Expected a float document, but found " + type());
+        throw new SerializationException("Expected a float document, but found " + type());
     }
 
     /**
@@ -206,11 +205,11 @@ public interface Document extends SerializableShape {
      * <p>If the value is a number of a different type, the value is cast, which can result in a loss of precision.
      *
      * @return the double value.
-     * @throws SdkSerdeException if the Document is not a number.
+     * @throws SerializationException if the Document is not a number.
      * @throws ArithmeticException if the value is out of range for this type.
      */
     default double asDouble() {
-        throw new SdkSerdeException("Expected a double document, but found " + type());
+        throw new SerializationException("Expected a double document, but found " + type());
     }
 
     /**
@@ -219,10 +218,10 @@ public interface Document extends SerializableShape {
      * <p>If the value is a number of a different type, the value is cast, which can result in a loss of precision.
      *
      * @return the BigInteger value.
-     * @throws SdkSerdeException if the Document is not a number.
+     * @throws SerializationException if the Document is not a number.
      */
     default BigInteger asBigInteger() {
-        throw new SdkSerdeException("Expected a bigInteger document, but found " + type());
+        throw new SerializationException("Expected a bigInteger document, but found " + type());
     }
 
     /**
@@ -231,17 +230,17 @@ public interface Document extends SerializableShape {
      * <p>If the value is a number of a different type, the value is cast, which can result in a loss of precision.
      *
      * @return the BigDecimal value.
-     * @throws SdkSerdeException if the Document is not a number.
+     * @throws SerializationException if the Document is not a number.
      */
     default BigDecimal asBigDecimal() {
-        throw new SdkSerdeException("Expected a bigDecimal document, but found " + type());
+        throw new SerializationException("Expected a bigDecimal document, but found " + type());
     }
 
     /**
      * Get the value of the builder as a Number.
      *
      * @return the Number value.
-     * @throws SdkSerdeException if the Document is not a numeric type.
+     * @throws SerializationException if the Document is not a numeric type.
      */
     default Number asNumber() {
         return switch (type()) {
@@ -253,7 +252,7 @@ public interface Document extends SerializableShape {
             case DOUBLE -> asDouble();
             case BIG_INTEGER -> asBigInteger();
             case BIG_DECIMAL -> asBigDecimal();
-            default -> throw new SdkSerdeException("Expected a number document, but found " + type());
+            default -> throw new SerializationException("Expected a number document, but found " + type());
         };
     }
 
@@ -261,40 +260,40 @@ public interface Document extends SerializableShape {
      * Get the string value of the Document if it is a string.
      *
      * @return the string value.
-     * @throws SdkSerdeException if the Document is not a string.
+     * @throws SerializationException if the Document is not a string.
      */
     default String asString() {
-        throw new SdkSerdeException("Expected a string document, but found " + type());
+        throw new SerializationException("Expected a string document, but found " + type());
     }
 
     /**
      * Get the Document as a blob if the Document is a blob.
      *
      * @return the bytes of the blob.
-     * @throws SdkSerdeException if the Document is not a blob.
+     * @throws SerializationException if the Document is not a blob.
      */
     default byte[] asBlob() {
-        throw new SdkSerdeException("Expected a blob document, but found " + type());
+        throw new SerializationException("Expected a blob document, but found " + type());
     }
 
     /**
      * Get the Document as an Instant if the Document is a timestamp.
      *
      * @return the Instant value of the timestamp.
-     * @throws SdkSerdeException if the Document is not a timestamp.
+     * @throws SerializationException if the Document is not a timestamp.
      */
     default Instant asTimestamp() {
-        throw new SdkSerdeException("Expected a timestamp document, but found " + type());
+        throw new SerializationException("Expected a timestamp document, but found " + type());
     }
 
     /**
      * Get the list contents of the Document if it is a list.
      *
      * @return the list contents.
-     * @throws SdkSerdeException if the Document is not a list.
+     * @throws SerializationException if the Document is not a list.
      */
     default List<Document> asList() {
-        throw new SdkSerdeException("Expected a list document, but found " + type());
+        throw new SerializationException("Expected a list document, but found " + type());
     }
 
     /**
@@ -305,10 +304,10 @@ public interface Document extends SerializableShape {
      * member names of each present member.
      *
      * @return the map contents.
-     * @throws SdkSerdeException if the Document is not a map, structure, or union or the keys are numbers.
+     * @throws SerializationException if the Document is not a map, structure, or union or the keys are numbers.
      */
     default Map<String, Document> asStringMap() {
-        throw new SdkSerdeException("Expected a map of strings to documents, but found " + type());
+        throw new SerializationException("Expected a map of strings to documents, but found " + type());
     }
 
     /**
@@ -320,7 +319,7 @@ public interface Document extends SerializableShape {
      * @throws IllegalStateException if the Document is not a string map, structure, or union shape.
      */
     default Document getMember(String memberName) {
-        throw new SdkSerdeException("Expected a map, structure, or union document, but found " + type());
+        throw new SerializationException("Expected a map, structure, or union document, but found " + type());
     }
 
     /**
@@ -372,7 +371,7 @@ public interface Document extends SerializableShape {
      * @param builder Builder to populate from the Document.
      * @param <T> Shape type to build.
      */
-    default <T extends SerializableShape> void deserializeInto(SdkShapeBuilder<T> builder) {
+    default <T extends SerializableShape> void deserializeInto(ShapeBuilder<T> builder) {
         builder.deserialize(new DocumentDeserializer(this));
     }
 
@@ -383,7 +382,7 @@ public interface Document extends SerializableShape {
      * @return the built and error-corrected shape.
      * @param <T> Shape type to build.
      */
-    default <T extends SerializableShape> T asShape(SdkShapeBuilder<T> builder) {
+    default <T extends SerializableShape> T asShape(ShapeBuilder<T> builder) {
         deserializeInto(builder);
         return builder.errorCorrection().build();
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 
 /**
@@ -35,62 +35,62 @@ public class DocumentDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public String readString(SdkSchema schema) {
+    public String readString(Schema schema) {
         return value.asString();
     }
 
     @Override
-    public boolean readBoolean(SdkSchema schema) {
+    public boolean readBoolean(Schema schema) {
         return value.asBoolean();
     }
 
     @Override
-    public byte[] readBlob(SdkSchema schema) {
+    public byte[] readBlob(Schema schema) {
         return value.asBlob();
     }
 
     @Override
-    public byte readByte(SdkSchema schema) {
+    public byte readByte(Schema schema) {
         return value.asByte();
     }
 
     @Override
-    public short readShort(SdkSchema schema) {
+    public short readShort(Schema schema) {
         return value.asShort();
     }
 
     @Override
-    public int readInteger(SdkSchema schema) {
+    public int readInteger(Schema schema) {
         return value.asInteger();
     }
 
     @Override
-    public long readLong(SdkSchema schema) {
+    public long readLong(Schema schema) {
         return value.asLong();
     }
 
     @Override
-    public float readFloat(SdkSchema schema) {
+    public float readFloat(Schema schema) {
         return value.asFloat();
     }
 
     @Override
-    public double readDouble(SdkSchema schema) {
+    public double readDouble(Schema schema) {
         return value.asDouble();
     }
 
     @Override
-    public BigInteger readBigInteger(SdkSchema schema) {
+    public BigInteger readBigInteger(Schema schema) {
         return value.asBigInteger();
     }
 
     @Override
-    public BigDecimal readBigDecimal(SdkSchema schema) {
+    public BigDecimal readBigDecimal(Schema schema) {
         return value.asBigDecimal();
     }
 
     @Override
-    public Instant readTimestamp(SdkSchema schema) {
+    public Instant readTimestamp(Schema schema) {
         return value.asTimestamp();
     }
 
@@ -100,7 +100,7 @@ public class DocumentDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
+    public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
         for (var memberSchema : schema.members()) {
             var memberValue = value.getMember(memberSchema.memberName());
             if (memberValue != null) {
@@ -110,14 +110,14 @@ public class DocumentDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public <T> void readList(SdkSchema schema, T state, ListMemberConsumer<T> listMemberConsumer) {
+    public <T> void readList(Schema schema, T state, ListMemberConsumer<T> listMemberConsumer) {
         for (var element : value.asList()) {
             listMemberConsumer.accept(state, deserializer(element));
         }
     }
 
     @Override
-    public <T> void readStringMap(SdkSchema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
+    public <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
         var map = value.asStringMap();
         for (var entry : map.entrySet()) {
             mapMemberConsumer.accept(state, entry.getKey(), deserializer(entry.getValue()));

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -12,31 +12,31 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
 
 final class Documents {
 
-    static final SdkSchema LIST_SCHEMA = SdkSchema.builder()
+    static final Schema LIST_SCHEMA = Schema.builder()
         .id(PreludeSchemas.DOCUMENT.id())
         .type(ShapeType.LIST)
-        .members(SdkSchema.memberBuilder("member", PreludeSchemas.DOCUMENT))
+        .members(Schema.memberBuilder("member", PreludeSchemas.DOCUMENT))
         .build();
 
-    static final SdkSchema STR_MAP_SCHEMA = SdkSchema.builder()
+    static final Schema STR_MAP_SCHEMA = Schema.builder()
         .id(PreludeSchemas.DOCUMENT.id())
         .type(ShapeType.MAP)
         .members(
-            SdkSchema.memberBuilder("key", PreludeSchemas.STRING).id(PreludeSchemas.DOCUMENT.id()).build(),
-            SdkSchema.memberBuilder("value", PreludeSchemas.DOCUMENT).id(PreludeSchemas.DOCUMENT.id()).build()
+            Schema.memberBuilder("key", PreludeSchemas.STRING).id(PreludeSchemas.DOCUMENT.id()).build(),
+            Schema.memberBuilder("value", PreludeSchemas.DOCUMENT).id(PreludeSchemas.DOCUMENT.id()).build()
         )
         .build();
 
     private Documents() {}
 
-    record BooleanDocument(SdkSchema schema, boolean value) implements Document {
+    record BooleanDocument(Schema schema, boolean value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.BOOLEAN;
@@ -82,7 +82,7 @@ final class Documents {
         return converted;
     }
 
-    record ByteDocument(SdkSchema schema, byte value) implements Document {
+    record ByteDocument(Schema schema, byte value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.BYTE;
@@ -139,7 +139,7 @@ final class Documents {
         }
     }
 
-    record ShortDocument(SdkSchema schema, short value) implements Document {
+    record ShortDocument(Schema schema, short value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.SHORT;
@@ -196,7 +196,7 @@ final class Documents {
         }
     }
 
-    record IntegerDocument(SdkSchema schema, int value) implements Document {
+    record IntegerDocument(Schema schema, int value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.INTEGER;
@@ -253,7 +253,7 @@ final class Documents {
         }
     }
 
-    record LongDocument(SdkSchema schema, long value) implements Document {
+    record LongDocument(Schema schema, long value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.LONG;
@@ -310,7 +310,7 @@ final class Documents {
         }
     }
 
-    record FloatDocument(SdkSchema schema, float value) implements Document {
+    record FloatDocument(Schema schema, float value) implements Document {
 
         private static long convertFloatToLong(ShapeType dest, float value) {
             if (!Float.isFinite(value)) {
@@ -375,7 +375,7 @@ final class Documents {
         }
     }
 
-    record DoubleDocument(SdkSchema schema, double value) implements Document {
+    record DoubleDocument(Schema schema, double value) implements Document {
 
         private static long convertDoubleToLong(ShapeType dest, double value) {
             if (!Double.isFinite(value)) {
@@ -452,7 +452,7 @@ final class Documents {
         }
     }
 
-    record BigIntegerDocument(SdkSchema schema, BigInteger value) implements Document {
+    record BigIntegerDocument(Schema schema, BigInteger value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.BIG_INTEGER;
@@ -509,7 +509,7 @@ final class Documents {
         }
     }
 
-    record BigDecimalDocument(SdkSchema schema, BigDecimal value) implements Document {
+    record BigDecimalDocument(Schema schema, BigDecimal value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.BIG_DECIMAL;
@@ -566,7 +566,7 @@ final class Documents {
         }
     }
 
-    record StringDocument(SdkSchema schema, String value) implements Document {
+    record StringDocument(Schema schema, String value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.STRING;
@@ -588,7 +588,7 @@ final class Documents {
         }
     }
 
-    record BlobDocument(SdkSchema schema, byte[] value) implements Document {
+    record BlobDocument(Schema schema, byte[] value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.BLOB;
@@ -628,7 +628,7 @@ final class Documents {
         }
     }
 
-    record TimestampDocument(SdkSchema schema, Instant value) implements Document {
+    record TimestampDocument(Schema schema, Instant value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.TIMESTAMP;
@@ -650,7 +650,7 @@ final class Documents {
         }
     }
 
-    record ListDocument(SdkSchema schema, List<Document> values) implements Document {
+    record ListDocument(Schema schema, List<Document> values) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.LIST;
@@ -671,7 +671,7 @@ final class Documents {
         }
     }
 
-    record StringMapDocument(SdkSchema schema, Map<String, Document> members) implements Document {
+    record StringMapDocument(Schema schema, Map<String, Document> members) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.MAP;
@@ -698,7 +698,7 @@ final class Documents {
         }
     }
 
-    record StructureDocument(SdkSchema schema, Map<String, Document> members) implements Document, SerializableStruct {
+    record StructureDocument(Schema schema, Map<String, Document> members) implements Document, SerializableStruct {
         @Override
         public ShapeType type() {
             return ShapeType.STRUCTURE;
@@ -739,11 +739,11 @@ final class Documents {
      */
     static final class LazyStructure implements Document {
 
-        private final SdkSchema schema;
+        private final Schema schema;
         private final SerializableStruct struct;
         private volatile transient Document createdDocument;
 
-        LazyStructure(SdkSchema schema, SerializableStruct struct) {
+        LazyStructure(Schema schema, SerializableStruct struct) {
             this.schema = schema;
             this.struct = struct;
         }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/MemberContainersTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/MemberContainersTest.java
@@ -24,8 +24,8 @@ public class MemberContainersTest {
     @Test
     public void listShapesRequireOneMember() {
         var members = List.of(
-            SdkSchema.memberBuilder("member", PreludeSchemas.STRING).id(id).build(),
-            SdkSchema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build()
+            Schema.memberBuilder("member", PreludeSchemas.STRING).id(id).build(),
+            Schema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build()
         );
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
@@ -35,7 +35,7 @@ public class MemberContainersTest {
 
     @Test
     public void listShapesRequireOneMemberNamedMember() {
-        var members = List.of(SdkSchema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build());
+        var members = List.of(Schema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build());
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             MemberContainers.of(ShapeType.LIST, members, Map.of());
@@ -44,7 +44,7 @@ public class MemberContainersTest {
 
     @Test
     public void listContainerReturnsValues() {
-        var members = List.of(SdkSchema.memberBuilder("member", PreludeSchemas.STRING).id(id).build());
+        var members = List.of(Schema.memberBuilder("member", PreludeSchemas.STRING).id(id).build());
         var listMembers = MemberContainers.of(ShapeType.LIST, members, Map.of());
 
         assertThat(listMembers.values(), hasSize(1));
@@ -56,7 +56,7 @@ public class MemberContainersTest {
 
     @Test
     public void mapShapesRequireTwoMembers() {
-        var members = List.of(SdkSchema.memberBuilder("key", PreludeSchemas.STRING).id(id).build());
+        var members = List.of(Schema.memberBuilder("key", PreludeSchemas.STRING).id(id).build());
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             MemberContainers.of(ShapeType.MAP, members, Map.of());
@@ -66,8 +66,8 @@ public class MemberContainersTest {
     @Test
     public void mapShapesRequireKeyAndValue() {
         var members = List.of(
-            SdkSchema.memberBuilder("key", PreludeSchemas.STRING).id(id).build(),
-            SdkSchema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build()
+            Schema.memberBuilder("key", PreludeSchemas.STRING).id(id).build(),
+            Schema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build()
         );
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
@@ -78,8 +78,8 @@ public class MemberContainersTest {
     @Test
     public void mapShapesRequireKeyAndValueOtherOrder() {
         var members = List.of(
-            SdkSchema.memberBuilder("value", PreludeSchemas.STRING).id(id).build(),
-            SdkSchema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build()
+            Schema.memberBuilder("value", PreludeSchemas.STRING).id(id).build(),
+            Schema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build()
         );
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
@@ -90,8 +90,8 @@ public class MemberContainersTest {
     @Test
     public void mapShapesRequireKeyAndValueBothWrong() {
         var members = List.of(
-            SdkSchema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build(),
-            SdkSchema.memberBuilder("bar", PreludeSchemas.STRING).id(id).build()
+            Schema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build(),
+            Schema.memberBuilder("bar", PreludeSchemas.STRING).id(id).build()
         );
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
@@ -102,8 +102,8 @@ public class MemberContainersTest {
     @Test
     public void mapContainerReturnsKeysAndValues() {
         var members = List.of(
-            SdkSchema.memberBuilder("key", PreludeSchemas.STRING).id(id).build(),
-            SdkSchema.memberBuilder("value", PreludeSchemas.STRING).id(id).build()
+            Schema.memberBuilder("key", PreludeSchemas.STRING).id(id).build(),
+            Schema.memberBuilder("value", PreludeSchemas.STRING).id(id).build()
         );
 
         var mapMembers = MemberContainers.of(ShapeType.MAP, members, Map.of());
@@ -119,7 +119,7 @@ public class MemberContainersTest {
 
     @Test
     public void returnsSingleItemContainer() {
-        var members = List.of(SdkSchema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build());
+        var members = List.of(Schema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build());
 
         var memberMap = MemberContainers.of(ShapeType.STRUCTURE, members, Map.of());
 
@@ -130,8 +130,8 @@ public class MemberContainersTest {
     @Test
     public void createsOtherKindsOfMemberMaps() {
         var members = List.of(
-            SdkSchema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build(),
-            SdkSchema.memberBuilder("bar", PreludeSchemas.STRING).id(id).build()
+            Schema.memberBuilder("foo", PreludeSchemas.STRING).id(id).build(),
+            Schema.memberBuilder("bar", PreludeSchemas.STRING).id(id).build()
         );
 
         var memberMap = MemberContainers.of(ShapeType.STRUCTURE, members, Map.of());

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/PresenceTrackerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/PresenceTrackerTest.java
@@ -12,7 +12,7 @@ import static software.amazon.smithy.java.runtime.core.schema.ValidatorTest.crea
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 
 public class PresenceTrackerTest {
 
@@ -20,7 +20,7 @@ public class PresenceTrackerTest {
     @ValueSource(ints = {1, 63, 64, 65, 128})
     void throwsUnsetMembers(int requiredFields) {
         var exc = assertThrows(
-            SdkSerdeException.class,
+            SerializationException.class,
             () -> PresenceTracker.of(createBigRequiredSchema(requiredFields, requiredFields, 0)).validate()
         );
         for (var i = 0; i < requiredFields; i++) {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/SchemaTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/SchemaTest.java
@@ -12,11 +12,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.shapes.ShapeType;
 
-public class SdkSchemaTest {
+public class SchemaTest {
     @Test
     public void intEnumRequiresIntEnumSchema() {
-        Assertions.assertThrows(SdkException.class, () -> {
-            SdkSchema.builder()
+        Assertions.assertThrows(ApiException.class, () -> {
+            Schema.builder()
                 .type(ShapeType.STRING)
                 .id("smithy.example#Foo")
                 .intEnumValues(1, 2, 3)
@@ -26,8 +26,8 @@ public class SdkSchemaTest {
 
     @Test
     public void enumRequiresStringSchema() {
-        Assertions.assertThrows(SdkException.class, () -> {
-            SdkSchema.builder()
+        Assertions.assertThrows(ApiException.class, () -> {
+            Schema.builder()
                 .type(ShapeType.INTEGER)
                 .id("smithy.example#Foo")
                 .stringEnumValues("a", "b")
@@ -37,7 +37,7 @@ public class SdkSchemaTest {
 
     @Test
     public void enumWorksWithEnumSchema() {
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .id("smithy.example#Foo")
             .type(ShapeType.ENUM)
             .stringEnumValues("a", "b")
@@ -48,7 +48,7 @@ public class SdkSchemaTest {
 
     @Test
     public void intEnumWorksWithIntEnumSchema() {
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .id("smithy.example#Foo")
             .type(ShapeType.INT_ENUM)
             .intEnumValues(1, 2, 3)

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/SerializableStructTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/SerializableStructTest.java
@@ -23,7 +23,7 @@ public class SerializableStructTest {
             private boolean wroteStruct;
 
             @Override
-            public void writeStruct(SdkSchema schema, SerializableStruct struct) {
+            public void writeStruct(Schema schema, SerializableStruct struct) {
                 wroteStruct = true;
                 struct.serializeMembers(this);
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/TypeRegistryTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/TypeRegistryTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.testmodels.Bird;
 import software.amazon.smithy.java.runtime.core.testmodels.Person;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -43,7 +43,7 @@ public class TypeRegistryTest {
             .build();
 
         Assertions.assertThrows(
-            SdkSerdeException.class,
+            SerializationException.class,
             () -> registry.create(ShapeId.from("smithy.example#Person"), Bird.class)
         );
     }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
@@ -52,7 +52,7 @@ public class ValidatorTest {
 
     @Test
     public void storesErrors() {
-        SdkSchema schema = SdkSchema.builder()
+        Schema schema = Schema.builder()
             .type(ShapeType.STRING)
             .id("smithy.example#Str")
             .traits(
@@ -68,7 +68,7 @@ public class ValidatorTest {
 
     @Test
     public void stopsWhenTooManyErrors() {
-        SdkSchema schema = SdkSchema.builder()
+        Schema schema = Schema.builder()
             .type(ShapeType.STRING)
             .id("smithy.example#Str")
             .traits(
@@ -86,7 +86,7 @@ public class ValidatorTest {
     @Test
     public void stopsValidatingWhenMaxErrorsReached() {
         Validator validator = Validator.builder().maxAllowedErrors(2).build();
-        SdkSchema schema = SdkSchema.builder()
+        Schema schema = Schema.builder()
             .type(ShapeType.BYTE)
             .id("smithy.example#E")
             .traits(RangeTrait.builder().min(BigDecimal.valueOf(2)).build())
@@ -127,7 +127,7 @@ public class ValidatorTest {
         assertThat(errors.get(0).message(), equalTo("Value is too deeply nested"));
 
         // Now ensure that the path is back to normal.
-        SdkSchema schema = SdkSchema.builder()
+        Schema schema = Schema.builder()
             .type(ShapeType.INT_ENUM)
             .intEnumValues(1, 2, 3)
             .id("smithy.example#E")
@@ -138,23 +138,23 @@ public class ValidatorTest {
         assertThat(errors.get(0).path(), equalTo("/"));
     }
 
-    private List<SdkSchema> createListSchemas(int depth) {
-        List<SdkSchema> schemas = new ArrayList<>(depth);
+    private List<Schema> createListSchemas(int depth) {
+        List<Schema> schemas = new ArrayList<>(depth);
         for (int i = depth; i > 0; i--) {
             if (i == depth) {
                 schemas.add(
-                    SdkSchema.builder()
+                    Schema.builder()
                         .type(ShapeType.LIST)
                         .id("s#L" + depth)
-                        .members(SdkSchema.memberBuilder("member", PreludeSchemas.STRING))
+                        .members(Schema.memberBuilder("member", PreludeSchemas.STRING))
                         .build()
                 );
             } else {
                 schemas.add(
-                    SdkSchema.builder()
+                    Schema.builder()
                         .type(ShapeType.LIST)
                         .id("s#L3")
-                        .members(SdkSchema.memberBuilder("member", schemas.get(schemas.size() - 1)))
+                        .members(Schema.memberBuilder("member", schemas.get(schemas.size() - 1)))
                         .build()
                 );
             }
@@ -199,7 +199,7 @@ public class ValidatorTest {
         Validator validator = Validator.builder().build();
         var errors = validator.validate(encoder -> {
             encoder.writeString(
-                SdkSchema.builder()
+                Schema.builder()
                     .type(ShapeType.STRING)
                     .id("smithy.example#Foo")
                     .traits(new PatternTrait("^[a-z]+$"))
@@ -221,20 +221,20 @@ public class ValidatorTest {
     @Test
     public void validatesRequiredMembersMissingMultiple() {
         var string = PreludeSchemas.STRING;
-        SdkSchema struct = SdkSchema.builder()
+        Schema struct = Schema.builder()
             .type(ShapeType.STRUCTURE)
             .id("smithy.example#Foo")
             .members(
-                SdkSchema.memberBuilder("a", string).traits(new RequiredTrait()),
-                SdkSchema.memberBuilder("b", string).traits(new RequiredTrait()),
-                SdkSchema.memberBuilder("c", string).traits(new RequiredTrait()),
-                SdkSchema.memberBuilder("d", string)
+                Schema.memberBuilder("a", string).traits(new RequiredTrait()),
+                Schema.memberBuilder("b", string).traits(new RequiredTrait()),
+                Schema.memberBuilder("c", string).traits(new RequiredTrait()),
+                Schema.memberBuilder("d", string)
                     .traits(
                         new RequiredTrait(),
                         new DefaultTrait(Node.from("default"))
                     ),
-                SdkSchema.memberBuilder("e", string).traits(new DefaultTrait(Node.from("default"))),
-                SdkSchema.memberBuilder("f", string)
+                Schema.memberBuilder("e", string).traits(new DefaultTrait(Node.from("default"))),
+                Schema.memberBuilder("f", string)
             )
             .build();
 
@@ -257,10 +257,10 @@ public class ValidatorTest {
     @Test
     public void validatesRequiredMembersMissingSingle() {
         var string = PreludeSchemas.STRING;
-        SdkSchema struct = SdkSchema.builder()
+        Schema struct = Schema.builder()
             .type(ShapeType.STRUCTURE)
             .id("smithy.example#Foo")
-            .members(SdkSchema.memberBuilder("a", string).traits(new RequiredTrait()))
+            .members(Schema.memberBuilder("a", string).traits(new RequiredTrait()))
             .build();
 
         Validator validator = Validator.builder().build();
@@ -278,7 +278,7 @@ public class ValidatorTest {
     @Test
     public void validatesStringEnums() {
         Validator validator = Validator.builder().build();
-        SdkSchema schema = SdkSchema.builder()
+        Schema schema = Schema.builder()
             .type(ShapeType.ENUM)
             .stringEnumValues("a", "b", "c")
             .id("smithy.example#E")
@@ -296,7 +296,7 @@ public class ValidatorTest {
     @Test
     public void validatesIntEnums() {
         Validator validator = Validator.builder().build();
-        SdkSchema schema = SdkSchema.builder()
+        Schema schema = Schema.builder()
             .type(ShapeType.INT_ENUM)
             .intEnumValues(1, 2, 3)
             .id("smithy.example#E")
@@ -327,15 +327,15 @@ public class ValidatorTest {
     public void validatesLists() {
         Validator validator = Validator.builder().build();
 
-        var memberTarget = SdkSchema.builder()
+        var memberTarget = Schema.builder()
             .id("s#S")
             .type(ShapeType.STRING)
             .traits(LengthTrait.builder().min(3L).build())
             .build();
-        var list = SdkSchema.builder()
+        var list = Schema.builder()
             .id("s#L")
             .type(ShapeType.LIST)
-            .members(SdkSchema.memberBuilder("member", memberTarget))
+            .members(Schema.memberBuilder("member", memberTarget))
             .build();
 
         var errors = validator.validate(s -> {
@@ -363,17 +363,17 @@ public class ValidatorTest {
     public void validatesMapKeysAndValues() {
         Validator validator = Validator.builder().build();
 
-        var keySchema = SdkSchema.builder()
+        var keySchema = Schema.builder()
             .type(ShapeType.STRING)
             .id("s#K")
             .traits(LengthTrait.builder().min(3L).build())
             .build();
-        var map = SdkSchema.builder()
+        var map = Schema.builder()
             .type(ShapeType.MAP)
             .id("s#M")
             .members(
-                SdkSchema.memberBuilder("key", keySchema),
-                SdkSchema.memberBuilder("value", PreludeSchemas.STRING).traits(LengthTrait.builder().min(2L).build())
+                Schema.memberBuilder("key", keySchema),
+                Schema.memberBuilder("value", PreludeSchemas.STRING).traits(LengthTrait.builder().min(2L).build())
             )
             .build();
 
@@ -478,14 +478,14 @@ public class ValidatorTest {
 
     // Union validation
 
-    private SdkSchema getTestUnionSchema() {
-        return SdkSchema.builder()
+    private Schema getTestUnionSchema() {
+        return Schema.builder()
             .type(ShapeType.UNION)
             .id("s#U")
             .members(
-                SdkSchema.memberBuilder("a", PreludeSchemas.STRING).traits(LengthTrait.builder().max(3L).build()),
-                SdkSchema.memberBuilder("b", PreludeSchemas.STRING),
-                SdkSchema.memberBuilder("c", PreludeSchemas.STRING)
+                Schema.memberBuilder("a", PreludeSchemas.STRING).traits(LengthTrait.builder().max(3L).build()),
+                Schema.memberBuilder("b", PreludeSchemas.STRING),
+                Schema.memberBuilder("c", PreludeSchemas.STRING)
             )
             .build();
     }
@@ -585,11 +585,11 @@ public class ValidatorTest {
     @Test
     public void allowsNullInSparseList() {
         Validator validator = Validator.builder().build();
-        var listSchema = SdkSchema.builder()
+        var listSchema = Schema.builder()
             .type(ShapeType.LIST)
             .id("smithy.api#Test")
             .traits(new SparseTrait())
-            .members(SdkSchema.memberBuilder("member", PreludeSchemas.STRING))
+            .members(Schema.memberBuilder("member", PreludeSchemas.STRING))
             .build();
 
         var errors = validator.validate(s -> {
@@ -606,10 +606,10 @@ public class ValidatorTest {
     public void allowsNullInStructures() {
         // Required structure member is validated elsewhere.
         Validator validator = Validator.builder().build();
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .type(ShapeType.STRUCTURE)
             .id("smithy.api#Test")
-            .members(SdkSchema.memberBuilder("foo", PreludeSchemas.STRING))
+            .members(Schema.memberBuilder("foo", PreludeSchemas.STRING))
             .build();
 
         var errors = validator.validate(s -> {
@@ -625,10 +625,10 @@ public class ValidatorTest {
     @Test
     public void doesNotAllowNullValuesInListByDefault() {
         Validator validator = Validator.builder().build();
-        var listSchema = SdkSchema.builder()
+        var listSchema = Schema.builder()
             .type(ShapeType.LIST)
             .id("smithy.api#Test")
-            .members(SdkSchema.memberBuilder("member", PreludeSchemas.STRING))
+            .members(Schema.memberBuilder("member", PreludeSchemas.STRING))
             .build();
 
         var errors = validator.validate(s -> {
@@ -650,12 +650,12 @@ public class ValidatorTest {
     @Test
     public void doesNotAllowNullValuesInMapsByDefault() {
         Validator validator = Validator.builder().build();
-        var mapSchema = SdkSchema.builder()
+        var mapSchema = Schema.builder()
             .type(ShapeType.MAP)
             .id("smithy.api#Test")
             .members(
-                SdkSchema.memberBuilder("key", PreludeSchemas.STRING),
-                SdkSchema.memberBuilder("value", PreludeSchemas.STRING)
+                Schema.memberBuilder("key", PreludeSchemas.STRING),
+                Schema.memberBuilder("value", PreludeSchemas.STRING)
             )
             .build();
 
@@ -792,9 +792,9 @@ public class ValidatorTest {
     public void validatesRanges(
         Class<? extends ValidationError> error,
         ShapeType type,
-        BiConsumer<SdkSchema, ShapeSerializer> consumer
+        BiConsumer<Schema, ShapeSerializer> consumer
     ) {
-        SdkSchema schema = SdkSchema.builder()
+        Schema schema = Schema.builder()
             .type(type)
             .id("smithy.example#Number")
             .traits(
@@ -831,12 +831,12 @@ public class ValidatorTest {
             Arguments.of(
                 null,
                 ShapeType.BYTE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeByte(schema, (byte) 1)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeByte(schema, (byte) 1)
             ),
             Arguments.of(
                 null,
                 ShapeType.SHORT,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeShort(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeShort(
                     schema,
                     (short) 1
                 )
@@ -844,27 +844,27 @@ public class ValidatorTest {
             Arguments.of(
                 null,
                 ShapeType.INTEGER,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeInteger(schema, 1)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeInteger(schema, 1)
             ),
             Arguments.of(
                 null,
                 ShapeType.LONG,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeLong(schema, 1L)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeLong(schema, 1L)
             ),
             Arguments.of(
                 null,
                 ShapeType.FLOAT,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeFloat(schema, 1f)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeFloat(schema, 1f)
             ),
             Arguments.of(
                 null,
                 ShapeType.DOUBLE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeDouble(schema, 1.0)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeDouble(schema, 1.0)
             ),
             Arguments.of(
                 null,
                 ShapeType.BIG_INTEGER,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigInteger(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigInteger(
                     schema,
                     BigInteger.ONE
                 )
@@ -872,7 +872,7 @@ public class ValidatorTest {
             Arguments.of(
                 null,
                 ShapeType.BIG_DECIMAL,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigDecimal(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigDecimal(
                     schema,
                     BigDecimal.ONE
                 )
@@ -881,12 +881,12 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.BYTE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeByte(schema, (byte) 0)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeByte(schema, (byte) 0)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.SHORT,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeShort(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeShort(
                     schema,
                     (short) 0
                 )
@@ -894,27 +894,27 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.INTEGER,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeInteger(schema, 0)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeInteger(schema, 0)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.LONG,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeLong(schema, 0L)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeLong(schema, 0L)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.FLOAT,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeFloat(schema, 0f)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeFloat(schema, 0f)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.DOUBLE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeDouble(schema, 0.0)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeDouble(schema, 0.0)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.BIG_INTEGER,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigInteger(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigInteger(
                     schema,
                     BigInteger.ZERO
                 )
@@ -922,7 +922,7 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.BIG_DECIMAL,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigDecimal(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigDecimal(
                     schema,
                     BigDecimal.ZERO
                 )
@@ -931,12 +931,12 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.BYTE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeByte(schema, (byte) 11)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeByte(schema, (byte) 11)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.SHORT,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeShort(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeShort(
                     schema,
                     (short) 11
                 )
@@ -944,27 +944,27 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.INTEGER,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeInteger(schema, 11)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeInteger(schema, 11)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.LONG,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeLong(schema, 11L)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeLong(schema, 11L)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.FLOAT,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeFloat(schema, 11f)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeFloat(schema, 11f)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.DOUBLE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeDouble(schema, 11.0)
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeDouble(schema, 11.0)
             ),
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.BIG_INTEGER,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigInteger(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigInteger(
                     schema,
                     BigInteger.valueOf(11)
                 )
@@ -972,7 +972,7 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.RangeValidationFailure.class,
                 ShapeType.BIG_DECIMAL,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigDecimal(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBigDecimal(
                     schema,
                     BigDecimal.valueOf(11)
                 )
@@ -981,7 +981,7 @@ public class ValidatorTest {
             Arguments.of(
                 null,
                 ShapeType.BLOB,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeBlob(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBlob(
                     schema,
                     "a".getBytes(StandardCharsets.UTF_8)
                 )
@@ -989,12 +989,12 @@ public class ValidatorTest {
             Arguments.of(
                 null,
                 ShapeType.STRING,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeString(schema, "a")
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeString(schema, "a")
             ),
             Arguments.of(
                 null,
                 ShapeType.LIST,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeList(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeList(
                     schema,
                     null,
                     (v, ls) -> ls.writeString(PreludeSchemas.STRING, "a")
@@ -1003,7 +1003,7 @@ public class ValidatorTest {
             Arguments.of(
                 null,
                 ShapeType.MAP,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeMap(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeMap(
                     schema,
                     null,
                     (mapStateValue, mapSerializer) -> mapSerializer.writeEntry(
@@ -1020,7 +1020,7 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.LengthValidationFailure.class,
                 ShapeType.BLOB,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeBlob(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBlob(
                     schema,
                     "".getBytes(StandardCharsets.UTF_8)
                 )
@@ -1028,12 +1028,12 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.LengthValidationFailure.class,
                 ShapeType.STRING,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeString(schema, "")
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeString(schema, "")
             ),
             Arguments.of(
                 ValidationError.LengthValidationFailure.class,
                 ShapeType.LIST,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeList(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeList(
                     schema,
                     null,
                     (v, ls) -> {}
@@ -1042,7 +1042,7 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.LengthValidationFailure.class,
                 ShapeType.MAP,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> {
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> {
                     serializer.writeMap(schema, null, (mapStateValue, mapSerializer) -> {});
                 }
             ),
@@ -1050,7 +1050,7 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.LengthValidationFailure.class,
                 ShapeType.BLOB,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeBlob(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBlob(
                     schema,
                     "abcdefghijklmnop".getBytes(StandardCharsets.UTF_8)
                 )
@@ -1058,7 +1058,7 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.LengthValidationFailure.class,
                 ShapeType.STRING,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeString(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeString(
                     schema,
                     "abcdefghijklmnop"
                 )
@@ -1066,7 +1066,7 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.LengthValidationFailure.class,
                 ShapeType.LIST,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> serializer.writeList(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeList(
                     schema,
                     null,
                     (v, ls) -> {
@@ -1079,7 +1079,7 @@ public class ValidatorTest {
             Arguments.of(
                 ValidationError.LengthValidationFailure.class,
                 ShapeType.MAP,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, serializer) -> {
+                (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> {
                     serializer.writeMap(schema, null, (mapState, mapSerializer) -> {
                         for (int i = 0; i < 11; i++) {
                             mapSerializer.writeEntry(
@@ -1099,7 +1099,7 @@ public class ValidatorTest {
 
     @Test
     public void rangeErrorTooSmall() {
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .type(ShapeType.FLOAT)
             .id("smithy.example#Number")
             .traits(RangeTrait.builder().min(new BigDecimal("1.2")).build())
@@ -1114,7 +1114,7 @@ public class ValidatorTest {
 
     @Test
     public void rangeErrorTooBig() {
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .type(ShapeType.FLOAT)
             .id("smithy.example#Number")
             .traits(RangeTrait.builder().max(new BigDecimal("1.2")).build())
@@ -1129,7 +1129,7 @@ public class ValidatorTest {
 
     @Test
     public void rangeErrorNotBetween() {
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .type(ShapeType.FLOAT)
             .id("smithy.example#Number")
             .traits(RangeTrait.builder().min(new BigDecimal("1.1")).max(new BigDecimal("1.2")).build())
@@ -1151,11 +1151,11 @@ public class ValidatorTest {
 
     @Test
     public void lengthTooShort() {
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .type(ShapeType.LIST)
             .id("smithy.api#Test")
             .traits(LengthTrait.builder().min(2L).build())
-            .members(SdkSchema.memberBuilder("member", PreludeSchemas.STRING))
+            .members(Schema.memberBuilder("member", PreludeSchemas.STRING))
             .build();
         var validator = Validator.builder().build();
         var errors = validator.validate(e -> e.writeList(schema, null, (v, ser) -> {}));
@@ -1170,11 +1170,11 @@ public class ValidatorTest {
 
     @Test
     public void lengthTooLong() {
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .type(ShapeType.LIST)
             .id("smithy.api#Test")
             .traits(LengthTrait.builder().max(1L).build())
-            .members(SdkSchema.memberBuilder("member", PreludeSchemas.STRING))
+            .members(Schema.memberBuilder("member", PreludeSchemas.STRING))
             .build();
         var validator = Validator.builder().build();
         var errors = validator.validate(e -> e.writeList(schema, schema.member("member"), (member, ser) -> {
@@ -1192,11 +1192,11 @@ public class ValidatorTest {
 
     @Test
     public void lengthNotBetween() {
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .type(ShapeType.LIST)
             .id("smithy.api#Test")
             .traits(LengthTrait.builder().min(1L).max(2L).build())
-            .members(SdkSchema.memberBuilder("member", PreludeSchemas.STRING))
+            .members(Schema.memberBuilder("member", PreludeSchemas.STRING))
             .build();
         var validator = Validator.builder().build();
         var errors = validator.validate(e -> e.writeList(schema, schema.member("member"), (member, ser) -> {
@@ -1281,12 +1281,12 @@ public class ValidatorTest {
         );
     }
 
-    static SdkSchema createBigRequiredSchema(int totalMembers, int requiredCount, int defaultedCount) {
+    static Schema createBigRequiredSchema(int totalMembers, int requiredCount, int defaultedCount) {
         var string = PreludeSchemas.STRING;
 
-        SdkSchema.Builder[] members = new SdkSchema.Builder[totalMembers];
+        Schema.Builder[] members = new Schema.Builder[totalMembers];
         for (var i = 0; i < totalMembers; i++) {
-            SdkSchema.Builder member = SdkSchema.memberBuilder("member" + i, string);
+            Schema.Builder member = Schema.memberBuilder("member" + i, string);
             if (i < requiredCount) {
                 member.traits(new RequiredTrait());
             }
@@ -1296,7 +1296,7 @@ public class ValidatorTest {
             members[i] = member;
         }
 
-        return SdkSchema.builder()
+        return Schema.builder()
             .type(ShapeType.STRUCTURE)
             .id("smithy.example#Foo")
             .members(members)

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ListSerializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ListSerializerTest.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 
 public class ListSerializerTest {
     @Test
@@ -23,7 +23,7 @@ public class ListSerializerTest {
 
         var delegate = new SpecificShapeSerializer() {
             @Override
-            public void writeString(SdkSchema schema, String value) {
+            public void writeString(Schema schema, String value) {
                 strings.add(value);
             }
         };

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
@@ -14,7 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.testmodels.Bird;
 import software.amazon.smithy.java.runtime.core.testmodels.Person;
@@ -52,23 +52,23 @@ public class ToStringSerializerTest {
 
     @Test
     public void redactsSensitiveKeys() {
-        var mapMemberSchema = SdkSchema.builder()
+        var mapMemberSchema = Schema.builder()
             .type(ShapeType.STRING)
             .id("smithy.example#Str")
             .traits(new SensitiveTrait())
             .build();
-        var mapSchema = SdkSchema.builder()
+        var mapSchema = Schema.builder()
             .type(ShapeType.MAP)
             .id("smithy.example#Map")
             .members(
-                SdkSchema.memberBuilder("key", mapMemberSchema),
-                SdkSchema.memberBuilder("value", mapMemberSchema)
+                Schema.memberBuilder("key", mapMemberSchema),
+                Schema.memberBuilder("value", mapMemberSchema)
             )
             .build();
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .id("smithy.example#Struct")
             .type(ShapeType.STRUCTURE)
-            .members(SdkSchema.memberBuilder("foo", mapSchema))
+            .members(Schema.memberBuilder("foo", mapSchema))
             .build();
 
         var str = ToStringSerializer.serialize(e -> {
@@ -89,15 +89,15 @@ public class ToStringSerializerTest {
 
     @Test
     public void redactsSensitiveBlobs() {
-        var blobSchema = SdkSchema.builder()
+        var blobSchema = Schema.builder()
             .type(ShapeType.BLOB)
             .id("smithy.example#Blob")
             .traits(new SensitiveTrait())
             .build();
-        var schema = SdkSchema.builder()
+        var schema = Schema.builder()
             .id("smithy.example#Struct")
             .type(ShapeType.STRUCTURE)
-            .members(SdkSchema.memberBuilder("foo", blobSchema))
+            .members(Schema.memberBuilder("foo", blobSchema))
             .build();
 
         var str = ToStringSerializer.serialize(e -> {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BigDecimalDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BigDecimalDocumentTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -34,7 +34,7 @@ public class BigDecimalDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -46,7 +46,7 @@ public class BigDecimalDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
+            public void writeBigDecimal(Schema schema, BigDecimal value) {
                 assertThat(schema, equalTo(PreludeSchemas.BIG_DECIMAL));
                 assertThat(value, equalTo(new BigDecimal(10)));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BigIntegerDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BigIntegerDocumentTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -34,7 +34,7 @@ public class BigIntegerDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -46,7 +46,7 @@ public class BigIntegerDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeBigInteger(SdkSchema schema, BigInteger value) {
+            public void writeBigInteger(Schema schema, BigInteger value) {
                 assertThat(schema, equalTo(PreludeSchemas.BIG_INTEGER));
                 assertThat(value, equalTo(BigInteger.valueOf(10)));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -34,7 +34,7 @@ public class BlobDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -46,7 +46,7 @@ public class BlobDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeBlob(SdkSchema schema, byte[] value) {
+            public void writeBlob(Schema schema, byte[] value) {
                 assertThat(schema, equalTo(PreludeSchemas.BLOB));
                 assertThat(value, equalTo("hi".getBytes(StandardCharsets.UTF_8)));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BooleanDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BooleanDocumentTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -32,7 +32,7 @@ public class BooleanDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -44,7 +44,7 @@ public class BooleanDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeBoolean(SdkSchema schema, boolean value) {
+            public void writeBoolean(Schema schema, boolean value) {
                 assertThat(schema, equalTo(PreludeSchemas.BOOLEAN));
                 assertThat(value, equalTo(true));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ByteDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ByteDocumentTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -33,7 +33,7 @@ public class ByteDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -45,7 +45,7 @@ public class ByteDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeByte(SdkSchema schema, byte value) {
+            public void writeByte(Schema schema, byte value) {
                 assertThat(schema, equalTo(PreludeSchemas.BYTE));
                 assertThat(value, equalTo((byte) 1));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ToStringSerializer;
@@ -105,7 +105,7 @@ public class DocumentTest {
     @ParameterizedTest
     @MethodSource("invalidConversionSupplier")
     public void throwsOnInvalidConversion(Document value, Consumer<Document> call) {
-        Assertions.assertThrows(SdkSerdeException.class, () -> call.accept(value));
+        Assertions.assertThrows(SerializationException.class, () -> call.accept(value));
     }
 
     public static List<Arguments> invalidConversionSupplier() {
@@ -308,7 +308,7 @@ public class DocumentTest {
 
     @Test
     public void throwsWhenDocumentWritesNothing() {
-        var e = Assertions.assertThrows(SdkSerdeException.class, () -> {
+        var e = Assertions.assertThrows(SerializationException.class, () -> {
             var document = Document.createTyped(encoder -> {});
             // Trigger the lazy document to create the underlying document.
             document.getMember("hello!");

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DoubleDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DoubleDocumentTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -38,7 +38,7 @@ public class DoubleDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -50,7 +50,7 @@ public class DoubleDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeDouble(SdkSchema schema, double value) {
+            public void writeDouble(Schema schema, double value) {
                 assertThat(schema, equalTo(PreludeSchemas.DOUBLE));
                 assertThat(value, equalTo(1.0));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/FloatDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/FloatDocumentTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -34,7 +34,7 @@ public class FloatDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -46,7 +46,7 @@ public class FloatDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeFloat(SdkSchema schema, float value) {
+            public void writeFloat(Schema schema, float value) {
                 assertThat(schema, equalTo(PreludeSchemas.FLOAT));
                 assertThat(value, equalTo(1.0f));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/IntegerDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/IntegerDocumentTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -34,7 +34,7 @@ public class IntegerDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -46,7 +46,7 @@ public class IntegerDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeInteger(SdkSchema schema, int value) {
+            public void writeInteger(Schema schema, int value) {
                 assertThat(schema, equalTo(PreludeSchemas.INTEGER));
                 assertThat(value, equalTo(10));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -38,7 +38,7 @@ public class ListDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -53,21 +53,21 @@ public class ListDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 value.serializeContents(this);
             }
 
             @Override
-            public <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+            public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
                 assertThat(schema.type(), equalTo(ShapeType.LIST));
                 consumer.accept(listState, new SpecificShapeSerializer() {
                     @Override
-                    public void writeDocument(SdkSchema schema, Document value) {
+                    public void writeDocument(Schema schema, Document value) {
                         value.serializeContents(this);
                     }
 
                     @Override
-                    public void writeString(SdkSchema schema, String value) {
+                    public void writeString(Schema schema, String value) {
                         assertThat(schema, equalTo(PreludeSchemas.STRING));
                         writtenStrings.add(value);
                     }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/LongDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/LongDocumentTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -34,7 +34,7 @@ public class LongDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -46,7 +46,7 @@ public class LongDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeLong(SdkSchema schema, long value) {
+            public void writeLong(Schema schema, long value) {
                 assertThat(schema, equalTo(PreludeSchemas.LONG));
                 assertThat(value, equalTo(10L));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
@@ -45,7 +45,7 @@ public class MapDocumentTest {
 
         map.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(map));
             }
         });
@@ -59,17 +59,17 @@ public class MapDocumentTest {
         var keys = new ArrayList<>();
         map.serializeContents(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 value.serializeContents(this);
             }
 
             @Override
-            public <T> void writeMap(SdkSchema schema, T state, BiConsumer<T, MapSerializer> consumer) {
+            public <T> void writeMap(Schema schema, T state, BiConsumer<T, MapSerializer> consumer) {
                 assertThat(schema.type(), equalTo(ShapeType.MAP));
                 consumer.accept(state, new MapSerializer() {
                     @Override
                     public <K> void writeEntry(
-                        SdkSchema keySchema,
+                        Schema keySchema,
                         String key,
                         K mapState,
                         BiConsumer<K, ShapeSerializer> valueSerializer
@@ -77,12 +77,12 @@ public class MapDocumentTest {
                         keys.add(key);
                         valueSerializer.accept(mapState, new SpecificShapeSerializer() {
                             @Override
-                            public void writeDocument(SdkSchema schema, Document value) {
+                            public void writeDocument(Schema schema, Document value) {
                                 value.serializeContents(this);
                             }
 
                             @Override
-                            public void writeInteger(SdkSchema schema, int value) {
+                            public void writeInteger(Schema schema, int value) {
                                 assertThat(schema, equalTo(PreludeSchemas.INTEGER));
                                 if (key.equals("a")) {
                                     assertThat(value, is(1));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ShortDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ShortDocumentTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -34,7 +34,7 @@ public class ShortDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -46,7 +46,7 @@ public class ShortDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeShort(SdkSchema schema, short value) {
+            public void writeShort(Schema schema, short value) {
                 assertThat(schema, equalTo(PreludeSchemas.SHORT));
                 assertThat(value, equalTo((short) 10));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/StringDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/StringDocumentTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -33,7 +33,7 @@ public class StringDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -45,7 +45,7 @@ public class StringDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeString(SdkSchema schema, String value) {
+            public void writeString(Schema schema, String value) {
                 assertThat(schema, equalTo(PreludeSchemas.STRING));
                 assertThat(value, equalTo("hi"));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TimestampDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TimestampDocumentTest.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -42,7 +42,7 @@ public class TimestampDocumentTest {
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(document));
             }
         });
@@ -55,7 +55,7 @@ public class TimestampDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeTimestamp(SdkSchema schema, Instant value) {
+            public void writeTimestamp(Schema schema, Instant value) {
                 assertThat(schema, equalTo(PreludeSchemas.TIMESTAMP));
                 assertThat(value, equalTo(time));
             }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -32,10 +32,10 @@ public class TypedDocumentMemberTest {
     // There's special handling for equality to account for the schema and normalized value.
     @Test
     public void equalityAndHashTest() {
-        var structSchema = SdkSchema.builder()
+        var structSchema = Schema.builder()
             .id("smithy.example#Struct1")
             .type(ShapeType.STRUCTURE)
-            .members(SdkSchema.memberBuilder("foo", PreludeSchemas.STRING))
+            .members(Schema.memberBuilder("foo", PreludeSchemas.STRING))
             .build();
 
         SerializableShape serializableShape = encoder -> {
@@ -60,15 +60,15 @@ public class TypedDocumentMemberTest {
 
     @Test
     public void inequalityAndHashTest() {
-        var structSchema1 = SdkSchema.builder()
+        var structSchema1 = Schema.builder()
             .id("smithy.example#Struct1")
             .type(ShapeType.STRUCTURE)
-            .members(SdkSchema.memberBuilder("foo", PreludeSchemas.STRING))
+            .members(Schema.memberBuilder("foo", PreludeSchemas.STRING))
             .build();
-        var structSchema2 = SdkSchema.builder()
+        var structSchema2 = Schema.builder()
             .id("smithy.example#Struct2")
             .type(ShapeType.STRUCTURE)
-            .members(SdkSchema.memberBuilder("foo", PreludeSchemas.INTEGER))
+            .members(Schema.memberBuilder("foo", PreludeSchemas.INTEGER))
             .build();
 
         var document1 = Document.createTyped(encoder -> {
@@ -95,13 +95,13 @@ public class TypedDocumentMemberTest {
     public void convertsMember(
         Object targetTypeOrSchema,
         Object value,
-        BiConsumer<SdkSchema, ShapeSerializer> writer,
+        BiConsumer<Schema, ShapeSerializer> writer,
         Function<Document, Object> extractor
     ) {
-        SdkSchema targetSchema;
+        Schema targetSchema;
         if (targetTypeOrSchema instanceof ShapeType t) {
             targetSchema = PreludeSchemas.getSchemaForType(t);
-        } else if (targetTypeOrSchema instanceof SdkSchema s) {
+        } else if (targetTypeOrSchema instanceof Schema s) {
             targetSchema = s;
         } else {
             throw new IllegalArgumentException(
@@ -110,10 +110,10 @@ public class TypedDocumentMemberTest {
             );
         }
 
-        SdkSchema structSchema = SdkSchema.builder()
+        Schema structSchema = Schema.builder()
             .type(ShapeType.STRUCTURE)
             .id("smithy.example#Foo")
-            .members(SdkSchema.memberBuilder("a", targetSchema))
+            .members(Schema.memberBuilder("a", targetSchema))
             .build();
         var document = Document.createTyped(encoder -> {
             encoder.writeStruct(structSchema, SerializableStruct.create(structSchema, (schema, serializer) -> {
@@ -129,19 +129,19 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 ShapeType.BOOLEAN,
                 true,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBoolean(schema, true),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBoolean(schema, true),
                 (Function<Document, Object>) Document::asBoolean
             ),
             Arguments.of(
                 ShapeType.STRING,
                 "a",
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeString(schema, "a"),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeString(schema, "a"),
                 (Function<Document, Object>) Document::asString
             ),
             Arguments.of(
                 ShapeType.BLOB,
                 "a".getBytes(StandardCharsets.UTF_8),
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBlob(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBlob(
                     schema,
                     "a".getBytes(StandardCharsets.UTF_8)
                 ),
@@ -150,7 +150,7 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 ShapeType.TIMESTAMP,
                 Instant.EPOCH,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeTimestamp(schema, Instant.EPOCH),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeTimestamp(schema, Instant.EPOCH),
                 (Function<Document, Object>) Document::asTimestamp
             ),
 
@@ -158,392 +158,392 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 ShapeType.BYTE,
                 (byte) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
                 (Function<Document, Object>) Document::asByte
             ),
             Arguments.of(
                 ShapeType.BYTE,
                 (short) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
                 (Function<Document, Object>) Document::asShort
             ),
             Arguments.of(
                 ShapeType.BYTE,
                 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
                 (Function<Document, Object>) Document::asInteger
             ),
             Arguments.of(
                 ShapeType.BYTE,
                 1L,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
                 (Function<Document, Object>) Document::asLong
             ),
             Arguments.of(
                 ShapeType.BYTE,
                 1f,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
                 (Function<Document, Object>) Document::asFloat
             ),
             Arguments.of(
                 ShapeType.BYTE,
                 1.0,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
                 (Function<Document, Object>) Document::asDouble
             ),
             Arguments.of(
                 ShapeType.BYTE,
                 BigInteger.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.of(
                 ShapeType.BYTE,
                 BigDecimal.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeByte(schema, (byte) 1),
                 (Function<Document, Object>) Document::asBigDecimal
             ),
 
             Arguments.of(
                 ShapeType.SHORT,
                 (byte) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
                 (Function<Document, Object>) Document::asByte
             ),
             Arguments.of(
                 ShapeType.SHORT,
                 (short) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
                 (Function<Document, Object>) Document::asShort
             ),
             Arguments.of(
                 ShapeType.SHORT,
                 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
                 (Function<Document, Object>) Document::asInteger
             ),
             Arguments.of(
                 ShapeType.SHORT,
                 1L,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
                 (Function<Document, Object>) Document::asLong
             ),
             Arguments.of(
                 ShapeType.SHORT,
                 1f,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
                 (Function<Document, Object>) Document::asFloat
             ),
             Arguments.of(
                 ShapeType.SHORT,
                 1.0,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
                 (Function<Document, Object>) Document::asDouble
             ),
             Arguments.of(
                 ShapeType.SHORT,
                 BigInteger.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.of(
                 ShapeType.SHORT,
                 BigDecimal.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeShort(schema, (short) 1),
                 (Function<Document, Object>) Document::asBigDecimal
             ),
 
             Arguments.of(
                 ShapeType.INTEGER,
                 (byte) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
                 (Function<Document, Object>) Document::asByte
             ),
             Arguments.of(
                 ShapeType.INTEGER,
                 (short) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
                 (Function<Document, Object>) Document::asShort
             ),
             Arguments.of(
                 ShapeType.INTEGER,
                 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
                 (Function<Document, Object>) Document::asInteger
             ),
             Arguments.of(
                 ShapeType.INTEGER,
                 1L,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
                 (Function<Document, Object>) Document::asLong
             ),
             Arguments.of(
                 ShapeType.INTEGER,
                 1f,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
                 (Function<Document, Object>) Document::asFloat
             ),
             Arguments.of(
                 ShapeType.INTEGER,
                 1.0,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
                 (Function<Document, Object>) Document::asDouble
             ),
             Arguments.of(
                 ShapeType.INTEGER,
                 BigInteger.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.of(
                 ShapeType.INTEGER,
                 BigDecimal.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeInteger(schema, 1),
                 (Function<Document, Object>) Document::asBigDecimal
             ),
 
             Arguments.of(
                 ShapeType.LONG,
                 (byte) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
                 (Function<Document, Object>) Document::asByte
             ),
             Arguments.of(
                 ShapeType.LONG,
                 (short) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
                 (Function<Document, Object>) Document::asShort
             ),
             Arguments.of(
                 ShapeType.LONG,
                 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
                 (Function<Document, Object>) Document::asInteger
             ),
             Arguments.of(
                 ShapeType.LONG,
                 1L,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
                 (Function<Document, Object>) Document::asLong
             ),
             Arguments.of(
                 ShapeType.LONG,
                 1f,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
                 (Function<Document, Object>) Document::asFloat
             ),
             Arguments.of(
                 ShapeType.LONG,
                 1.0,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
                 (Function<Document, Object>) Document::asDouble
             ),
             Arguments.of(
                 ShapeType.LONG,
                 BigInteger.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.of(
                 ShapeType.LONG,
                 BigDecimal.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeLong(schema, 1),
                 (Function<Document, Object>) Document::asBigDecimal
             ),
 
             Arguments.of(
                 ShapeType.FLOAT,
                 (byte) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
                 (Function<Document, Object>) Document::asByte
             ),
             Arguments.of(
                 ShapeType.FLOAT,
                 (short) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
                 (Function<Document, Object>) Document::asShort
             ),
             Arguments.of(
                 ShapeType.FLOAT,
                 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
                 (Function<Document, Object>) Document::asInteger
             ),
             Arguments.of(
                 ShapeType.FLOAT,
                 1L,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
                 (Function<Document, Object>) Document::asLong
             ),
             Arguments.of(
                 ShapeType.FLOAT,
                 1f,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
                 (Function<Document, Object>) Document::asFloat
             ),
             Arguments.of(
                 ShapeType.FLOAT,
                 1.0,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
                 (Function<Document, Object>) Document::asDouble
             ),
             Arguments.of(
                 ShapeType.FLOAT,
                 BigInteger.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.of(
                 ShapeType.FLOAT,
                 BigDecimal.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeFloat(schema, 1),
                 (Function<Document, Object>) Document::asBigDecimal
             ),
 
             Arguments.of(
                 ShapeType.DOUBLE,
                 (byte) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
                 (Function<Document, Object>) Document::asByte
             ),
             Arguments.of(
                 ShapeType.DOUBLE,
                 (short) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
                 (Function<Document, Object>) Document::asShort
             ),
             Arguments.of(
                 ShapeType.DOUBLE,
                 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
                 (Function<Document, Object>) Document::asInteger
             ),
             Arguments.of(
                 ShapeType.DOUBLE,
                 1L,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
                 (Function<Document, Object>) Document::asLong
             ),
             Arguments.of(
                 ShapeType.DOUBLE,
                 1f,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
                 (Function<Document, Object>) Document::asFloat
             ),
             Arguments.of(
                 ShapeType.DOUBLE,
                 1.0,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
                 (Function<Document, Object>) Document::asDouble
             ),
             Arguments.of(
                 ShapeType.DOUBLE,
                 BigInteger.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.of(
                 ShapeType.DOUBLE,
                 BigDecimal.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeDouble(schema, 1),
                 (Function<Document, Object>) Document::asBigDecimal
             ),
 
             Arguments.of(
                 ShapeType.BIG_INTEGER,
                 (byte) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
                 (Function<Document, Object>) Document::asByte
             ),
             Arguments.of(
                 ShapeType.BIG_INTEGER,
                 (short) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
                 (Function<Document, Object>) Document::asShort
             ),
             Arguments.of(
                 ShapeType.BIG_INTEGER,
                 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
                 (Function<Document, Object>) Document::asInteger
             ),
             Arguments.of(
                 ShapeType.BIG_INTEGER,
                 1L,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
                 (Function<Document, Object>) Document::asLong
             ),
             Arguments.of(
                 ShapeType.BIG_INTEGER,
                 1f,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
                 (Function<Document, Object>) Document::asFloat
             ),
             Arguments.of(
                 ShapeType.BIG_INTEGER,
                 1.0,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
                 (Function<Document, Object>) Document::asDouble
             ),
             Arguments.of(
                 ShapeType.BIG_INTEGER,
                 BigInteger.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.of(
                 ShapeType.BIG_INTEGER,
                 BigDecimal.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigInteger(schema, BigInteger.ONE),
                 (Function<Document, Object>) Document::asBigDecimal
             ),
 
             Arguments.of(
                 ShapeType.BIG_DECIMAL,
                 (byte) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
                 (Function<Document, Object>) Document::asByte
             ),
             Arguments.of(
                 ShapeType.BIG_DECIMAL,
                 (short) 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
                 (Function<Document, Object>) Document::asShort
             ),
             Arguments.of(
                 ShapeType.BIG_DECIMAL,
                 1,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
                 (Function<Document, Object>) Document::asInteger
             ),
             Arguments.of(
                 ShapeType.BIG_DECIMAL,
                 1L,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
                 (Function<Document, Object>) Document::asLong
             ),
             Arguments.of(
                 ShapeType.BIG_DECIMAL,
                 1f,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
                 (Function<Document, Object>) Document::asFloat
             ),
             Arguments.of(
                 ShapeType.BIG_DECIMAL,
                 1.0,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
                 (Function<Document, Object>) Document::asDouble
             ),
             Arguments.of(
                 ShapeType.BIG_DECIMAL,
                 BigInteger.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.of(
                 ShapeType.BIG_DECIMAL,
                 BigDecimal.ONE,
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBigDecimal(schema, BigDecimal.ONE),
                 (Function<Document, Object>) Document::asBigDecimal
             ),
 
@@ -551,7 +551,7 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 ShapeType.DOCUMENT,
                 List.of(Document.createInteger(1)),
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeList(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeList(
                     schema,
                     null,
                     (v, c) -> c.writeInteger(PreludeSchemas.INTEGER, 1)
@@ -563,7 +563,7 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 Documents.STR_MAP_SCHEMA,
                 Map.of("a", Document.createInteger(1)),
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeMap(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
                     null,
                     (mapValue, mapSerializer) -> mapSerializer.writeEntry(
@@ -580,7 +580,7 @@ public class TypedDocumentMemberTest {
             Arguments.of(
                 Documents.STR_MAP_SCHEMA,
                 Document.createInteger(1),
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> s.writeMap(
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
                     null,
                     (mapState, m) -> m.writeEntry(
@@ -595,16 +595,16 @@ public class TypedDocumentMemberTest {
 
             // Get a member from a struct by name.
             Arguments.of(
-                SdkSchema.builder()
+                Schema.builder()
                     .type(ShapeType.STRUCTURE)
                     .id("smithy.example#Foo")
                     .members(
-                        SdkSchema.memberBuilder("foo", PreludeSchemas.STRING),
-                        SdkSchema.memberBuilder("bar", PreludeSchemas.STRING)
+                        Schema.memberBuilder("foo", PreludeSchemas.STRING),
+                        Schema.memberBuilder("bar", PreludeSchemas.STRING)
                     )
                     .build(),
                 "b",
-                (BiConsumer<SdkSchema, ShapeSerializer>) (schema, s) -> {
+                (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> {
                     s.writeStruct(schema, SerializableStruct.create(schema, (passedSchema, ser) -> {
                         ser.writeString(passedSchema.member("foo"), "a");
                         ser.writeString(passedSchema.member("bar"), "b");

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.sameInstance;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
@@ -23,12 +23,12 @@ import software.amazon.smithy.model.shapes.ShapeType;
 public class TypedDocumentTest {
 
     private SerializableShape createSerializableShape() {
-        var structSchema = SdkSchema.builder()
+        var structSchema = Schema.builder()
             .id("smithy.example#Struct")
             .type(ShapeType.STRUCTURE)
             .members(
-                SdkSchema.memberBuilder("a", PreludeSchemas.STRING),
-                SdkSchema.memberBuilder("b", PreludeSchemas.STRING)
+                Schema.memberBuilder("a", PreludeSchemas.STRING),
+                Schema.memberBuilder("b", PreludeSchemas.STRING)
             )
             .build();
 
@@ -71,7 +71,7 @@ public class TypedDocumentTest {
         // Writes as document unless getting contents.
         result.serialize(new SpecificShapeSerializer() {
             @Override
-            public void writeDocument(SdkSchema schema, Document value) {
+            public void writeDocument(Schema schema, Document value) {
                 assertThat(value, is(result));
             }
         });

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
@@ -6,9 +6,9 @@
 package software.amazon.smithy.java.runtime.core.testmodels;
 
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ToStringSerializer;
@@ -18,10 +18,10 @@ import software.amazon.smithy.model.shapes.ShapeType;
 public final class Bird implements SerializableStruct {
 
     public static final ShapeId ID = ShapeId.from("smithy.example#Bird");
-    public static final SdkSchema SCHEMA_NAME = SdkSchema.memberBuilder("name", PreludeSchemas.STRING)
+    public static final Schema SCHEMA_NAME = Schema.memberBuilder("name", PreludeSchemas.STRING)
         .id(ID)
         .build();
-    public static final SdkSchema SCHEMA = SdkSchema.builder()
+    public static final Schema SCHEMA = Schema.builder()
         .id(ID)
         .type(ShapeType.STRUCTURE)
         .members(SCHEMA_NAME)
@@ -56,7 +56,7 @@ public final class Bird implements SerializableStruct {
         serializer.writeString(SCHEMA_NAME, name);
     }
 
-    public static final class Builder implements SdkShapeBuilder<Bird> {
+    public static final class Builder implements ShapeBuilder<Bird> {
 
         private String name;
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
@@ -13,9 +13,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -30,29 +30,29 @@ import software.amazon.smithy.model.traits.RequiredTrait;
 public final class Person implements SerializableStruct {
 
     public static final ShapeId ID = ShapeId.from("smithy.example#Person");
-    private static final SdkSchema SCHEMA_NAME = SdkSchema.memberBuilder("name", PreludeSchemas.STRING)
+    private static final Schema SCHEMA_NAME = Schema.memberBuilder("name", PreludeSchemas.STRING)
         .id(ID)
         .traits(new HttpLabelTrait(), new RequiredTrait(), LengthTrait.builder().max(7L).build())
         .build();
-    private static final SdkSchema SCHEMA_FAVORITE_COLOR = SdkSchema
+    private static final Schema SCHEMA_FAVORITE_COLOR = Schema
         .memberBuilder("favoriteColor", PreludeSchemas.STRING)
         .id(ID)
         .build();
-    private static final SdkSchema SCHEMA_AGE = SdkSchema.memberBuilder("age", PreludeSchemas.INTEGER)
+    private static final Schema SCHEMA_AGE = Schema.memberBuilder("age", PreludeSchemas.INTEGER)
         .id(ID)
         .traits(RangeTrait.builder().max(BigDecimal.valueOf(150)).build())
         .build();
-    private static final SdkSchema SCHEMA_BIRTHDAY = SdkSchema.memberBuilder("birthday", SharedSchemas.BIRTHDAY)
+    private static final Schema SCHEMA_BIRTHDAY = Schema.memberBuilder("birthday", SharedSchemas.BIRTHDAY)
         .id(ID)
         .build();
-    private static final SdkSchema SCHEMA_BINARY = SdkSchema.memberBuilder("binary", PreludeSchemas.BLOB)
+    private static final Schema SCHEMA_BINARY = Schema.memberBuilder("binary", PreludeSchemas.BLOB)
         .id(ID)
         .build();
-    private static final SdkSchema SCHEMA_QUERY_PARAMS = SdkSchema
+    private static final Schema SCHEMA_QUERY_PARAMS = Schema
         .memberBuilder("queryParams", SharedSchemas.MAP_LIST_STRING)
         .id(ID)
         .build();
-    static final SdkSchema SCHEMA = SdkSchema.builder()
+    static final Schema SCHEMA = Schema.builder()
         .id(ID)
         .type(ShapeType.STRUCTURE)
         .members(
@@ -64,9 +64,9 @@ public final class Person implements SerializableStruct {
             SCHEMA_QUERY_PARAMS
         )
         .build();
-    private static final SdkSchema SCHEMA_QUERY_PARAMS_KEY = SharedSchemas.MAP_LIST_STRING.member("key");
-    private static final SdkSchema SCHEMA_QUERY_PARAMS_VALUE = SharedSchemas.MAP_LIST_STRING.member("value");
-    private static final SdkSchema LIST_OF_STRING_MEMBER = SharedSchemas.LIST_OF_STRING.member("member");
+    private static final Schema SCHEMA_QUERY_PARAMS_KEY = SharedSchemas.MAP_LIST_STRING.member("key");
+    private static final Schema SCHEMA_QUERY_PARAMS_VALUE = SharedSchemas.MAP_LIST_STRING.member("value");
+    private static final Schema LIST_OF_STRING_MEMBER = SharedSchemas.LIST_OF_STRING.member("member");
 
     private final String name;
     private final int age;
@@ -157,7 +157,7 @@ public final class Person implements SerializableStruct {
         }
     }
 
-    public static final class Builder implements SdkShapeBuilder<Person> {
+    public static final class Builder implements ShapeBuilder<Person> {
 
         private String name;
         private int age = 0;

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
@@ -10,9 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -26,32 +26,32 @@ public final class PojoWithValidatedCollection implements SerializableStruct {
     public static final ShapeId ID = ShapeId.from("smithy.example#PojoWithValidatedCollection");
 
     private static final ShapeId MAP_OF_VALIDATED_POJO_ID = ShapeId.from("smithy.example#MapOfValidatedPojo");
-    private static final SdkSchema MAP_OF_VALIDATED_POJO_KEY = SdkSchema.memberBuilder("key", PreludeSchemas.STRING)
+    private static final Schema MAP_OF_VALIDATED_POJO_KEY = Schema.memberBuilder("key", PreludeSchemas.STRING)
         .id(MAP_OF_VALIDATED_POJO_ID)
         .build();
-    private static final SdkSchema MAP_OF_VALIDATED_POJO_VALUE = SdkSchema.memberBuilder("value", ValidatedPojo.SCHEMA)
+    private static final Schema MAP_OF_VALIDATED_POJO_VALUE = Schema.memberBuilder("value", ValidatedPojo.SCHEMA)
         .id(MAP_OF_VALIDATED_POJO_ID)
         .build();
-    private static final SdkSchema MAP_OF_VALIDATED_POJO = SdkSchema.builder()
+    private static final Schema MAP_OF_VALIDATED_POJO = Schema.builder()
         .type(ShapeType.MAP)
         .id(MAP_OF_VALIDATED_POJO_ID)
         .members(MAP_OF_VALIDATED_POJO_KEY, MAP_OF_VALIDATED_POJO_VALUE)
         .build();
-    private static final SdkSchema LIST_OF_VALIDATED_POJO = SdkSchema.builder()
+    private static final Schema LIST_OF_VALIDATED_POJO = Schema.builder()
         .type(ShapeType.LIST)
         .id("smithy.example#ListOfValidatedPojo")
-        .members(SdkSchema.memberBuilder("member", ValidatedPojo.SCHEMA))
+        .members(Schema.memberBuilder("member", ValidatedPojo.SCHEMA))
         .build();
-    private static final SdkSchema SCHEMA_MAP = SdkSchema.memberBuilder("map", MAP_OF_VALIDATED_POJO)
+    private static final Schema SCHEMA_MAP = Schema.memberBuilder("map", MAP_OF_VALIDATED_POJO)
         .id(ID)
         .traits(new RequiredTrait())
         .build();
-    private static final SdkSchema SCHEMA_LIST = SdkSchema
+    private static final Schema SCHEMA_LIST = Schema
         .memberBuilder("list", LIST_OF_VALIDATED_POJO)
         .id(ID)
         .traits(new RequiredTrait())
         .build();
-    static final SdkSchema SCHEMA = SdkSchema.builder()
+    static final Schema SCHEMA = Schema.builder()
         .id(ID)
         .type(ShapeType.STRUCTURE)
         .members(SCHEMA_MAP, SCHEMA_LIST)
@@ -115,7 +115,7 @@ public final class PojoWithValidatedCollection implements SerializableStruct {
         }
     }
 
-    public static final class Builder implements SdkShapeBuilder<PojoWithValidatedCollection> {
+    public static final class Builder implements ShapeBuilder<PojoWithValidatedCollection> {
 
         private Map<String, ValidatedPojo> map = Collections.emptyMap();
         private List<ValidatedPojo> list = Collections.emptyList();

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/SharedSchemas.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/SharedSchemas.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.runtime.core.testmodels;
 
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 
@@ -15,24 +15,24 @@ import software.amazon.smithy.model.traits.SensitiveTrait;
  */
 public final class SharedSchemas {
 
-    public static final SdkSchema BIRTHDAY = SdkSchema.builder()
+    public static final Schema BIRTHDAY = Schema.builder()
         .type(ShapeType.TIMESTAMP)
         .id("smithy.example#Birthday")
         .traits(new SensitiveTrait())
         .build();
 
-    public static final SdkSchema LIST_OF_STRING = SdkSchema.builder()
+    public static final Schema LIST_OF_STRING = Schema.builder()
         .type(ShapeType.LIST)
         .id("smithy.example#ListOfString")
-        .members(SdkSchema.memberBuilder("member", PreludeSchemas.STRING))
+        .members(Schema.memberBuilder("member", PreludeSchemas.STRING))
         .build();
 
-    public static final SdkSchema MAP_LIST_STRING = SdkSchema.builder()
+    public static final Schema MAP_LIST_STRING = Schema.builder()
         .type(ShapeType.MAP)
         .id("smithy.example#StringsMap")
         .members(
-            SdkSchema.memberBuilder("key", PreludeSchemas.STRING),
-            SdkSchema.memberBuilder("value", SharedSchemas.LIST_OF_STRING)
+            Schema.memberBuilder("key", PreludeSchemas.STRING),
+            Schema.memberBuilder("value", SharedSchemas.LIST_OF_STRING)
         )
         .build();
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
@@ -6,9 +6,9 @@
 package software.amazon.smithy.java.runtime.core.testmodels;
 
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ToStringSerializer;
@@ -21,17 +21,17 @@ import software.amazon.smithy.model.shapes.ShapeType;
 public final class UnvalidatedPojo implements SerializableStruct {
 
     public static final ShapeId ID = ShapeId.from("smithy.example#UnvalidatedPojo");
-    private static final SdkSchema SCHEMA_STRING = SdkSchema.memberBuilder("string", PreludeSchemas.STRING)
+    private static final Schema SCHEMA_STRING = Schema.memberBuilder("string", PreludeSchemas.STRING)
         .id(ID)
         .build();
-    private static final SdkSchema SCHEMA_BOXED_INTEGER = SdkSchema
+    private static final Schema SCHEMA_BOXED_INTEGER = Schema
         .memberBuilder("boxedInteger", PreludeSchemas.INTEGER)
         .id(ID)
         .build();
-    private static final SdkSchema SCHEMA_INTEGER = SdkSchema.memberBuilder("integer", PreludeSchemas.PRIMITIVE_INTEGER)
+    private static final Schema SCHEMA_INTEGER = Schema.memberBuilder("integer", PreludeSchemas.PRIMITIVE_INTEGER)
         .id(ID)
         .build();
-    static final SdkSchema SCHEMA = SdkSchema.builder()
+    static final Schema SCHEMA = Schema.builder()
         .id(ID)
         .type(ShapeType.STRUCTURE)
         .members(SCHEMA_STRING, SCHEMA_BOXED_INTEGER, SCHEMA_INTEGER)
@@ -81,7 +81,7 @@ public final class UnvalidatedPojo implements SerializableStruct {
         serializer.writeInteger(SCHEMA_INTEGER, integer);
     }
 
-    public static final class Builder implements SdkShapeBuilder<UnvalidatedPojo> {
+    public static final class Builder implements ShapeBuilder<UnvalidatedPojo> {
 
         private String string;
         private int integer;

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
@@ -7,9 +7,9 @@ package software.amazon.smithy.java.runtime.core.testmodels;
 
 import java.math.BigDecimal;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ToStringSerializer;
@@ -22,20 +22,20 @@ import software.amazon.smithy.model.traits.RequiredTrait;
 public final class ValidatedPojo implements SerializableStruct {
 
     public static final ShapeId ID = ShapeId.from("smithy.example#ValidatedPojo");
-    private static final SdkSchema SCHEMA_STRING = SdkSchema.memberBuilder("string", PreludeSchemas.STRING)
+    private static final Schema SCHEMA_STRING = Schema.memberBuilder("string", PreludeSchemas.STRING)
         .id(ID)
         .traits(new RequiredTrait(), LengthTrait.builder().min(1L).max(100L).build())
         .build();
-    private static final SdkSchema SCHEMA_BOXED_INTEGER = SdkSchema
+    private static final Schema SCHEMA_BOXED_INTEGER = Schema
         .memberBuilder("boxedInteger", PreludeSchemas.INTEGER)
         .id(ID)
         .traits(new RequiredTrait())
         .build();
-    private static final SdkSchema SCHEMA_INTEGER = SdkSchema.memberBuilder("integer", PreludeSchemas.PRIMITIVE_INTEGER)
+    private static final Schema SCHEMA_INTEGER = Schema.memberBuilder("integer", PreludeSchemas.PRIMITIVE_INTEGER)
         .id(ID)
         .traits(new RequiredTrait(), RangeTrait.builder().min(BigDecimal.valueOf(0)).build())
         .build();
-    static final SdkSchema SCHEMA = SdkSchema.builder()
+    static final Schema SCHEMA = Schema.builder()
         .id(ID)
         .type(ShapeType.STRUCTURE)
         .members(SCHEMA_STRING, SCHEMA_BOXED_INTEGER, SCHEMA_INTEGER)
@@ -88,7 +88,7 @@ public final class ValidatedPojo implements SerializableStruct {
         st.writeInteger(SCHEMA_INTEGER, integer);
     }
 
-    public static final class Builder implements SdkShapeBuilder<ValidatedPojo> {
+    public static final class Builder implements ShapeBuilder<ValidatedPojo> {
 
         private String string;
         private int integer;

--- a/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
+++ b/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
@@ -15,9 +15,9 @@ import software.amazon.smithy.java.runtime.client.core.interceptors.ClientInterc
 import software.amazon.smithy.java.runtime.client.http.HttpContext;
 import software.amazon.smithy.java.runtime.client.http.JavaHttpClientTransport;
 import software.amazon.smithy.java.runtime.core.Context;
-import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.schema.TypeRegistry;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
@@ -114,8 +114,8 @@ public class GenericTest {
             .putType(ValidationError.ID, ValidationError.class, ValidationError::builder)
             .build();
 
-        registry.create(ValidationError.ID, ModeledSdkException.class)
-            .map(SdkShapeBuilder::build)
+        registry.create(ValidationError.ID, ModeledApiException.class)
+            .map(ShapeBuilder::build)
             .ifPresent(System.out::println);
     }
 

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/BindingMatcher.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/BindingMatcher.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.runtime.http.binding;
 
 import java.util.Objects;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.model.traits.HttpHeaderTrait;
 import software.amazon.smithy.model.traits.HttpLabelTrait;
 import software.amazon.smithy.model.traits.HttpPayloadTrait;
@@ -49,7 +49,7 @@ final class BindingMatcher {
         return new BindingMatcher(false);
     }
 
-    Binding match(SdkSchema member) {
+    Binding match(Schema member) {
         if (isRequest) {
             label = member.getTrait(HttpLabelTrait.class);
             if (label != null) {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderDeserializer.java
@@ -10,7 +10,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
@@ -25,7 +25,7 @@ final class HttpHeaderDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public boolean readBoolean(SdkSchema schema) {
+    public boolean readBoolean(Schema schema) {
         return switch (value) {
             case "true" -> true;
             case "false" -> false;
@@ -34,7 +34,7 @@ final class HttpHeaderDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public byte[] readBlob(SdkSchema schema) {
+    public byte[] readBlob(Schema schema) {
         try {
             return Base64.getDecoder().decode(value.getBytes(StandardCharsets.UTF_8));
         } catch (IllegalArgumentException e) {
@@ -46,47 +46,47 @@ final class HttpHeaderDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public byte readByte(SdkSchema schema) {
+    public byte readByte(Schema schema) {
         return Byte.parseByte(value);
     }
 
     @Override
-    public short readShort(SdkSchema schema) {
+    public short readShort(Schema schema) {
         return Short.parseShort(value);
     }
 
     @Override
-    public int readInteger(SdkSchema schema) {
+    public int readInteger(Schema schema) {
         return Integer.parseInt(value);
     }
 
     @Override
-    public long readLong(SdkSchema schema) {
+    public long readLong(Schema schema) {
         return Long.parseLong(value);
     }
 
     @Override
-    public float readFloat(SdkSchema schema) {
+    public float readFloat(Schema schema) {
         return Float.parseFloat(value);
     }
 
     @Override
-    public double readDouble(SdkSchema schema) {
+    public double readDouble(Schema schema) {
         return Double.parseDouble(value);
     }
 
     @Override
-    public BigInteger readBigInteger(SdkSchema schema) {
+    public BigInteger readBigInteger(Schema schema) {
         return new BigInteger(value);
     }
 
     @Override
-    public BigDecimal readBigDecimal(SdkSchema schema) {
+    public BigDecimal readBigDecimal(Schema schema) {
         return new BigDecimal(value);
     }
 
     @Override
-    public String readString(SdkSchema schema) {
+    public String readString(Schema schema) {
         return value;
     }
 
@@ -96,7 +96,7 @@ final class HttpHeaderDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public Instant readTimestamp(SdkSchema schema) {
+    public Instant readTimestamp(Schema schema) {
         var trait = schema.getTrait(TimestampFormatTrait.class);
         TimestampFormatter formatter = trait != null
             ? TimestampFormatter.of(trait)
@@ -105,17 +105,17 @@ final class HttpHeaderDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
+    public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
         throw new UnsupportedOperationException("Structures are not supported in HTTP header bindings");
     }
 
     @Override
-    public <T> void readList(SdkSchema schema, T state, ListMemberConsumer<T> listMemberConsumer) {
+    public <T> void readList(Schema schema, T state, ListMemberConsumer<T> listMemberConsumer) {
         throw new UnsupportedOperationException("List header support not yet implemented");
     }
 
     @Override
-    public <T> void readStringMap(SdkSchema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
+    public <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
         throw new UnsupportedOperationException("List map support not yet implemented");
     }
 }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ListSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
@@ -28,73 +28,73 @@ final class HttpHeaderSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
         consumer.accept(listState, new ListSerializer(this, position -> {}));
     }
 
-    void writeHeader(SdkSchema schema, Supplier<String> supplier) {
+    void writeHeader(Schema schema, Supplier<String> supplier) {
         var headerTrait = schema.getTrait(HttpHeaderTrait.class);
         var field = headerTrait != null ? headerTrait.getValue() : schema.memberName();
         headerWriter.accept(field, supplier.get());
     }
 
     @Override
-    public void writeBoolean(SdkSchema schema, boolean value) {
+    public void writeBoolean(Schema schema, boolean value) {
         writeHeader(schema, () -> value ? "true" : "false");
     }
 
     @Override
-    public void writeShort(SdkSchema schema, short value) {
+    public void writeShort(Schema schema, short value) {
         writeHeader(schema, () -> Short.toString(value));
     }
 
     @Override
-    public void writeByte(SdkSchema schema, byte value) {
+    public void writeByte(Schema schema, byte value) {
         writeHeader(schema, () -> Byte.toString(value));
     }
 
     @Override
-    public void writeInteger(SdkSchema schema, int value) {
+    public void writeInteger(Schema schema, int value) {
         writeHeader(schema, () -> Integer.toString(value));
     }
 
     @Override
-    public void writeLong(SdkSchema schema, long value) {
+    public void writeLong(Schema schema, long value) {
         writeHeader(schema, () -> Long.toString(value));
     }
 
     @Override
-    public void writeFloat(SdkSchema schema, float value) {
+    public void writeFloat(Schema schema, float value) {
         writeHeader(schema, () -> Float.toString(value));
     }
 
     @Override
-    public void writeDouble(SdkSchema schema, double value) {
+    public void writeDouble(Schema schema, double value) {
         writeHeader(schema, () -> Double.toString(value));
     }
 
     @Override
-    public void writeBigInteger(SdkSchema schema, BigInteger value) {
+    public void writeBigInteger(Schema schema, BigInteger value) {
         writeHeader(schema, value::toString);
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
         writeHeader(schema, value::toString);
     }
 
     @Override
-    public void writeString(SdkSchema schema, String value) {
+    public void writeString(Schema schema, String value) {
         writeHeader(schema, () -> value);
     }
 
     @Override
-    public void writeBlob(SdkSchema schema, byte[] value) {
+    public void writeBlob(Schema schema, byte[] value) {
         writeHeader(schema, () -> Base64.getEncoder().encodeToString(value));
     }
 
     @Override
-    public void writeTimestamp(SdkSchema schema, Instant value) {
+    public void writeTimestamp(Schema schema, Instant value) {
         writeHeader(
             schema,
             () -> {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpLabelSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpLabelSerializer.java
@@ -10,7 +10,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
@@ -24,57 +24,57 @@ final class HttpLabelSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void writeBoolean(SdkSchema schema, boolean value) {
+    public void writeBoolean(Schema schema, boolean value) {
         labelReceiver.accept(schema.memberName(), Boolean.toString(value));
     }
 
     @Override
-    public void writeByte(SdkSchema schema, byte value) {
+    public void writeByte(Schema schema, byte value) {
         labelReceiver.accept(schema.memberName(), Byte.toString(value));
     }
 
     @Override
-    public void writeShort(SdkSchema schema, short value) {
+    public void writeShort(Schema schema, short value) {
         labelReceiver.accept(schema.memberName(), Short.toString(value));
     }
 
     @Override
-    public void writeInteger(SdkSchema schema, int value) {
+    public void writeInteger(Schema schema, int value) {
         labelReceiver.accept(schema.memberName(), Integer.toString(value));
     }
 
     @Override
-    public void writeLong(SdkSchema schema, long value) {
+    public void writeLong(Schema schema, long value) {
         labelReceiver.accept(schema.memberName(), Long.toString(value));
     }
 
     @Override
-    public void writeFloat(SdkSchema schema, float value) {
+    public void writeFloat(Schema schema, float value) {
         labelReceiver.accept(schema.memberName(), Float.toString(value));
     }
 
     @Override
-    public void writeDouble(SdkSchema schema, double value) {
+    public void writeDouble(Schema schema, double value) {
         labelReceiver.accept(schema.memberName(), Double.toString(value));
     }
 
     @Override
-    public void writeBigInteger(SdkSchema schema, BigInteger value) {
+    public void writeBigInteger(Schema schema, BigInteger value) {
         labelReceiver.accept(schema.memberName(), value.toString());
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
         labelReceiver.accept(schema.memberName(), value.toString());
     }
 
     @Override
-    public void writeString(SdkSchema schema, String value) {
+    public void writeString(Schema schema, String value) {
         labelReceiver.accept(schema.memberName(), value);
     }
 
     @Override
-    public void writeTimestamp(SdkSchema schema, Instant value) {
+    public void writeTimestamp(Schema schema, Instant value) {
         var trait = schema.getTrait(TimestampFormatTrait.class);
         TimestampFormatter formatter = trait != null
             ? TimestampFormatter.of(trait)

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpPrefixHeadersSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpPrefixHeadersSerializer.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.runtime.http.binding;
 
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
@@ -26,7 +26,7 @@ final class HttpPrefixHeadersSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(SdkSchema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
         consumer.accept(mapState, prefixHeadersMapSerializer);
     }
 
@@ -34,14 +34,14 @@ final class HttpPrefixHeadersSerializer extends SpecificShapeSerializer {
         MapSerializer {
         @Override
         public <K> void writeEntry(
-            SdkSchema keySchema,
+            Schema keySchema,
             String key,
             K keyState,
             BiConsumer<K, ShapeSerializer> valueSerializer
         ) {
             valueSerializer.accept(keyState, new SpecificShapeSerializer() {
                 @Override
-                public void writeString(SdkSchema schema, String value) {
+                public void writeString(Schema schema, String value) {
                     headerConsumer.accept(prefix + key, value);
                 }
             });

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsSerializer.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.runtime.http.binding;
 
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
@@ -23,29 +23,29 @@ final class HttpQueryParamsSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(SdkSchema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
         consumer.accept(mapState, mapEntrySerializer);
     }
 
     private record MapEntrySerializer(BiConsumer<String, String> queryWriter) implements MapSerializer {
         @Override
         public <K> void writeEntry(
-            SdkSchema keySchema,
+            Schema keySchema,
             String key,
             K keyState,
             BiConsumer<K, ShapeSerializer> valueSerializer
         ) {
             valueSerializer.accept(keyState, new SpecificShapeSerializer() {
                 @Override
-                public void writeString(SdkSchema schema, String value) {
+                public void writeString(Schema schema, String value) {
                     queryWriter.accept(key, value);
                 }
 
                 @Override
-                public <L> void writeList(SdkSchema schema, L listState, BiConsumer<L, ShapeSerializer> consumer) {
+                public <L> void writeList(Schema schema, L listState, BiConsumer<L, ShapeSerializer> consumer) {
                     consumer.accept(listState, new SpecificShapeSerializer() {
                         @Override
-                        public void writeString(SdkSchema schema, String value) {
+                        public void writeString(Schema schema, String value) {
                             queryWriter.accept(key, value);
                         }
                     });

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ListSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
@@ -28,11 +28,11 @@ final class HttpQuerySerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
         consumer.accept(listState, new ListSerializer(this, position -> {}));
     }
 
-    void writeQuery(SdkSchema schema, Supplier<String> supplier) {
+    void writeQuery(Schema schema, Supplier<String> supplier) {
         var queryTrait = schema.getTrait(HttpQueryTrait.class);
         if (queryTrait != null) {
             queryWriter.accept(queryTrait.getValue(), supplier.get());
@@ -40,62 +40,62 @@ final class HttpQuerySerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void writeBoolean(SdkSchema schema, boolean value) {
+    public void writeBoolean(Schema schema, boolean value) {
         writeQuery(schema, () -> value ? "true" : "false");
     }
 
     @Override
-    public void writeShort(SdkSchema schema, short value) {
+    public void writeShort(Schema schema, short value) {
         writeQuery(schema, () -> Short.toString(value));
     }
 
     @Override
-    public void writeByte(SdkSchema schema, byte value) {
+    public void writeByte(Schema schema, byte value) {
         writeQuery(schema, () -> Byte.toString(value));
     }
 
     @Override
-    public void writeInteger(SdkSchema schema, int value) {
+    public void writeInteger(Schema schema, int value) {
         writeQuery(schema, () -> Integer.toString(value));
     }
 
     @Override
-    public void writeLong(SdkSchema schema, long value) {
+    public void writeLong(Schema schema, long value) {
         writeQuery(schema, () -> Long.toString(value));
     }
 
     @Override
-    public void writeFloat(SdkSchema schema, float value) {
+    public void writeFloat(Schema schema, float value) {
         writeQuery(schema, () -> Float.toString(value));
     }
 
     @Override
-    public void writeDouble(SdkSchema schema, double value) {
+    public void writeDouble(Schema schema, double value) {
         writeQuery(schema, () -> Double.toString(value));
     }
 
     @Override
-    public void writeBigInteger(SdkSchema schema, BigInteger value) {
+    public void writeBigInteger(Schema schema, BigInteger value) {
         writeQuery(schema, value::toString);
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
         writeQuery(schema, value::toString);
     }
 
     @Override
-    public void writeString(SdkSchema schema, String value) {
+    public void writeString(Schema schema, String value) {
         writeQuery(schema, () -> value);
     }
 
     @Override
-    public void writeBlob(SdkSchema schema, byte[] value) {
+    public void writeBlob(Schema schema, byte[] value) {
         writeQuery(schema, () -> Base64.getEncoder().encodeToString(value));
     }
 
     @Override
-    public void writeTimestamp(SdkSchema schema, Instant value) {
+    public void writeTimestamp(Schema schema, Instant value) {
         var trait = schema.getTrait(TimestampFormatTrait.class);
         TimestampFormatter formatter = trait != null
             ? TimestampFormatter.of(trait)

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestSerializer.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.java.runtime.http.binding;
 
 import java.net.URI;
 import java.util.Objects;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
@@ -22,7 +22,7 @@ import software.amazon.smithy.model.traits.HttpTrait;
 public final class RequestSerializer {
 
     private Codec payloadCodec;
-    private SdkSchema operation;
+    private Schema operation;
     private URI endpoint;
     private SerializableShape shapeValue;
     private DataStream payload;
@@ -36,7 +36,7 @@ public final class RequestSerializer {
      * @param operation Operation schema.
      * @return Returns the serializer.
      */
-    public RequestSerializer operation(SdkSchema operation) {
+    public RequestSerializer operation(Schema operation) {
         if (operation.type() != ShapeType.OPERATION) {
             throw new IllegalArgumentException("operation must be an operation, but found " + operation);
         }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
@@ -6,8 +6,8 @@
 package software.amazon.smithy.java.runtime.http.binding;
 
 import java.util.concurrent.CompletableFuture;
-import software.amazon.smithy.java.runtime.core.schema.ModeledSdkException;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
@@ -18,8 +18,8 @@ import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 public final class ResponseDeserializer {
 
     private final HttpBindingDeserializer.Builder deserBuilder = HttpBindingDeserializer.builder();
-    private SdkShapeBuilder<?> outputShapeBuilder;
-    private SdkShapeBuilder<? extends ModeledSdkException> errorShapeBuilder;
+    private ShapeBuilder<?> outputShapeBuilder;
+    private ShapeBuilder<? extends ModeledApiException> errorShapeBuilder;
 
     ResponseDeserializer() {}
 
@@ -61,7 +61,7 @@ public final class ResponseDeserializer {
      * @param outputShapeBuilder Output shape builder.
      * @return Returns the deserializer.
      */
-    public ResponseDeserializer outputShapeBuilder(SdkShapeBuilder<?> outputShapeBuilder) {
+    public ResponseDeserializer outputShapeBuilder(ShapeBuilder<?> outputShapeBuilder) {
         this.outputShapeBuilder = outputShapeBuilder;
         errorShapeBuilder = null;
         return this;
@@ -73,7 +73,7 @@ public final class ResponseDeserializer {
      * @param errorShapeBuilder Error shape builder.
      * @return Returns the deserializer.
      */
-    public ResponseDeserializer errorShapeBuilder(SdkShapeBuilder<? extends ModeledSdkException> errorShapeBuilder) {
+    public ResponseDeserializer errorShapeBuilder(ShapeBuilder<? extends ModeledApiException> errorShapeBuilder) {
         this.errorShapeBuilder = errorShapeBuilder;
         outputShapeBuilder = null;
         return this;

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseSerializer.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.runtime.http.binding;
 
 import java.util.Objects;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
@@ -19,7 +19,7 @@ import software.amazon.smithy.model.traits.HttpTrait;
  */
 public final class ResponseSerializer {
     private Codec payloadCodec;
-    private SdkSchema operation;
+    private Schema operation;
     private SerializableShape shapeValue;
     private final BindingMatcher bindingMatcher = BindingMatcher.responseMatcher();
     private DataStream payload;
@@ -32,7 +32,7 @@ public final class ResponseSerializer {
      * @param operation Operation schema.
      * @return Returns the serializer.
      */
-    public ResponseSerializer operation(SdkSchema operation) {
+    public ResponseSerializer operation(Schema operation) {
         if (operation.type() != ShapeType.OPERATION) {
             throw new IllegalArgumentException("operation must be an operation, but found " + operation);
         }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseStatusSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseStatusSerializer.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.runtime.http.binding;
 
 import java.util.function.IntConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 
 final class ResponseStatusSerializer extends SpecificShapeSerializer {
@@ -18,7 +18,7 @@ final class ResponseStatusSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void writeInteger(SdkSchema schema, int value) {
+    public void writeInteger(Schema schema, int value) {
         consumer.accept(value);
     }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDeserializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDeserializer.java
@@ -14,8 +14,8 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.function.Consumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 
 final class JsonDeserializer implements ShapeDeserializer {
@@ -44,102 +44,102 @@ final class JsonDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public byte[] readBlob(SdkSchema schema) {
+    public byte[] readBlob(Schema schema) {
         try {
             String content = iter.readString();
             return Base64.getDecoder().decode(content);
         } catch (JsonException | IOException | IllegalArgumentException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public byte readByte(SdkSchema schema) {
+    public byte readByte(Schema schema) {
         try {
             return (byte) iter.readShort();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public short readShort(SdkSchema schema) {
+    public short readShort(Schema schema) {
         try {
             return iter.readShort();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public int readInteger(SdkSchema schema) {
+    public int readInteger(Schema schema) {
         try {
             return iter.readInt();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public long readLong(SdkSchema schema) {
+    public long readLong(Schema schema) {
         try {
             return iter.readLong();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public float readFloat(SdkSchema schema) {
+    public float readFloat(Schema schema) {
         try {
             return iter.readFloat();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public double readDouble(SdkSchema schema) {
+    public double readDouble(Schema schema) {
         try {
             return iter.readDouble();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public BigInteger readBigInteger(SdkSchema schema) {
+    public BigInteger readBigInteger(Schema schema) {
         try {
             return iter.readBigInteger();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public BigDecimal readBigDecimal(SdkSchema schema) {
+    public BigDecimal readBigDecimal(Schema schema) {
         try {
             return iter.readBigDecimal();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public String readString(SdkSchema schema) {
+    public String readString(Schema schema) {
         try {
             return iter.readString();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public boolean readBoolean(SdkSchema schema) {
+    public boolean readBoolean(Schema schema) {
         try {
             return iter.readBoolean();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
@@ -154,22 +154,22 @@ final class JsonDeserializer implements ShapeDeserializer {
                 return new JsonDocument(any, fieldMapper, timestampResolver);
             }
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public Instant readTimestamp(SdkSchema schema) {
+    public Instant readTimestamp(Schema schema) {
         try {
             var format = timestampResolver.resolve(schema);
             return TimestampResolver.readTimestamp(iter.readAny(), format);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public <T> void readStruct(SdkSchema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
+    public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
         try {
             for (var field = iter.readObject(); field != null; field = iter.readObject()) {
                 var member = fieldMapper.fieldToMember(schema, field);
@@ -180,29 +180,29 @@ final class JsonDeserializer implements ShapeDeserializer {
                 }
             }
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public <T> void readList(SdkSchema schema, T state, ListMemberConsumer<T> listMemberConsumer) {
+    public <T> void readList(Schema schema, T state, ListMemberConsumer<T> listMemberConsumer) {
         try {
             while (iter.readArray()) {
                 listMemberConsumer.accept(state, this);
             }
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public <T> void readStringMap(SdkSchema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
+    public <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
         try {
             for (var field = iter.readObject(); field != null; field = iter.readObject()) {
                 mapMemberConsumer.accept(state, field, this);
             }
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonFieldMapper.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonFieldMapper.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.java.runtime.json;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 
 /**
@@ -22,7 +22,7 @@ sealed interface JsonFieldMapper {
      * @param field     JSON object field name.
      * @return the resolved member schema or null if not found.
      */
-    SdkSchema fieldToMember(SdkSchema container, String field);
+    Schema fieldToMember(Schema container, String field);
 
     /**
      * Converts a member schema a JSON object field name.
@@ -30,7 +30,7 @@ sealed interface JsonFieldMapper {
      * @param member Member to convert to a field.
      * @return the resolved object field name.
      */
-    String memberToField(SdkSchema member);
+    String memberToField(Schema member);
 
     /**
      * Uses the member name and ignores the jsonName trait.
@@ -39,12 +39,12 @@ sealed interface JsonFieldMapper {
         static final UseMemberName INSTANCE = new UseMemberName();
 
         @Override
-        public SdkSchema fieldToMember(SdkSchema container, String field) {
+        public Schema fieldToMember(Schema container, String field) {
             return container.member(field);
         }
 
         @Override
-        public String memberToField(SdkSchema member) {
+        public String memberToField(Schema member) {
             return member.memberName();
         }
 
@@ -59,13 +59,13 @@ sealed interface JsonFieldMapper {
      */
     final class UseJsonNameTrait implements JsonFieldMapper {
 
-        private final Map<SdkSchema, Map<String, SdkSchema>> jsonNameCache = new ConcurrentHashMap<>();
+        private final Map<Schema, Map<String, Schema>> jsonNameCache = new ConcurrentHashMap<>();
 
         @Override
-        public SdkSchema fieldToMember(SdkSchema container, String field) {
+        public Schema fieldToMember(Schema container, String field) {
             return jsonNameCache.computeIfAbsent(container, schema -> {
-                Map<String, SdkSchema> map = new HashMap<>(schema.members().size());
-                for (SdkSchema m : schema.members()) {
+                Map<String, Schema> map = new HashMap<>(schema.members().size());
+                for (Schema m : schema.members()) {
                     var jsonName = m.getTrait(JsonNameTrait.class);
                     if (jsonName != null) {
                         map.put(jsonName.getValue(), m);
@@ -78,7 +78,7 @@ sealed interface JsonFieldMapper {
         }
 
         @Override
-        public String memberToField(SdkSchema member) {
+        public String memberToField(Schema member) {
             var jsonName = member.getTrait(JsonNameTrait.class);
             return jsonName == null ? member.memberName() : jsonName.getValue();
         }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonMapSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonMapSerializer.java
@@ -9,9 +9,9 @@ import com.jsoniter.output.JsonStream;
 import com.jsoniter.spi.JsonException;
 import java.io.IOException;
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 
 final class JsonMapSerializer implements MapSerializer {
@@ -27,7 +27,7 @@ final class JsonMapSerializer implements MapSerializer {
 
     @Override
     public <T> void writeEntry(
-        SdkSchema keySchema,
+        Schema keySchema,
         String key,
         T state,
         BiConsumer<T, ShapeSerializer> valueSerializer
@@ -37,7 +37,7 @@ final class JsonMapSerializer implements MapSerializer {
             stream.writeObjectField(key);
             valueSerializer.accept(state, parent);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
@@ -14,11 +14,11 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ListSerializer;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
@@ -48,7 +48,7 @@ final class JsonSerializer implements ShapeSerializer {
         try {
             stream.flush();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
@@ -59,133 +59,133 @@ final class JsonSerializer implements ShapeSerializer {
             returnHandle.accept(stream);
             stream = null;
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeBoolean(SdkSchema schema, boolean value) {
+    public void writeBoolean(Schema schema, boolean value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeByte(SdkSchema schema, byte value) {
+    public void writeByte(Schema schema, byte value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeShort(SdkSchema schema, short value) {
+    public void writeShort(Schema schema, short value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeBlob(SdkSchema schema, byte[] value) {
+    public void writeBlob(Schema schema, byte[] value) {
         try {
             stream.writeVal(Base64.getEncoder().encodeToString(value));
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeInteger(SdkSchema schema, int value) {
+    public void writeInteger(Schema schema, int value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeLong(SdkSchema schema, long value) {
+    public void writeLong(Schema schema, long value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeFloat(SdkSchema schema, float value) {
+    public void writeFloat(Schema schema, float value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeDouble(SdkSchema schema, double value) {
+    public void writeDouble(Schema schema, double value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeBigInteger(SdkSchema schema, BigInteger value) {
+    public void writeBigInteger(Schema schema, BigInteger value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema schema, BigDecimal value) {
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeString(SdkSchema schema, String value) {
+    public void writeString(Schema schema, String value) {
         try {
             stream.writeVal(value);
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeTimestamp(SdkSchema schema, Instant value) {
+    public void writeTimestamp(Schema schema, Instant value) {
         timestampResolver.resolve(schema).writeToSerializer(schema, value, this);
     }
 
     @Override
-    public void writeStruct(SdkSchema schema, SerializableStruct struct) {
+    public void writeStruct(Schema schema, SerializableStruct struct) {
         try {
             stream.writeObjectStart();
             struct.serializeMembers(new JsonStructSerializer(this, true));
             stream.writeObjectEnd();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
         try {
             stream.writeArrayStart();
             consumer.accept(listState, new ListSerializer(this, this::writeComma));
             stream.writeArrayEnd();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
@@ -200,25 +200,25 @@ final class JsonSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(SdkSchema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
         try {
             stream.writeObjectStart();
             consumer.accept(mapState, new JsonMapSerializer(this, stream));
             stream.writeObjectEnd();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeDocument(SdkSchema schema, Document value) {
+    public void writeDocument(Schema schema, Document value) {
         // Document values in JSON are serialized inline by receiving the data model contents of the document.
         if (value.type() != ShapeType.STRUCTURE) {
             value.serializeContents(this);
         } else {
             value.serializeContents(new SpecificShapeSerializer() {
                 @Override
-                public void writeStruct(SdkSchema schema, SerializableStruct struct) {
+                public void writeStruct(Schema schema, SerializableStruct struct) {
                     try {
                         stream.writeObjectStart();
                         stream.writeObjectField("__type");
@@ -226,7 +226,7 @@ final class JsonSerializer implements ShapeSerializer {
                         struct.serializeMembers(new JsonStructSerializer(JsonSerializer.this, false));
                         stream.writeObjectEnd();
                     } catch (IOException | JsonException e) {
-                        throw new SdkSerdeException(e);
+                        throw new SerializationException(e);
                     }
                 }
             });
@@ -234,11 +234,11 @@ final class JsonSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void writeNull(SdkSchema schema) {
+    public void writeNull(Schema schema) {
         try {
             stream.writeNull();
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
@@ -11,10 +11,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
@@ -28,7 +28,7 @@ class JsonStructSerializer implements ShapeSerializer {
         this.firstValue = isFirstValue;
     }
 
-    void startMember(SdkSchema member) {
+    void startMember(Schema member) {
         try {
             // Write commas when needed.
             if (!firstValue) {
@@ -38,108 +38,108 @@ class JsonStructSerializer implements ShapeSerializer {
             }
             parent.stream.writeObjectField(parent.fieldMapper.memberToField(member));
         } catch (JsonException | IOException e) {
-            throw new SdkSerdeException(e);
+            throw new SerializationException(e);
         }
     }
 
     @Override
-    public void writeStruct(SdkSchema member, SerializableStruct struct) {
+    public void writeStruct(Schema member, SerializableStruct struct) {
         startMember(member);
         parent.writeStruct(member, struct);
     }
 
     @Override
-    public <T> void writeList(SdkSchema member, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema member, T listState, BiConsumer<T, ShapeSerializer> consumer) {
         startMember(member);
         parent.writeList(member, listState, consumer);
     }
 
     @Override
-    public <T> void writeMap(SdkSchema member, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema member, T mapState, BiConsumer<T, MapSerializer> consumer) {
         startMember(member);
         parent.writeMap(member, mapState, consumer);
     }
 
     @Override
-    public void writeBoolean(SdkSchema member, boolean value) {
+    public void writeBoolean(Schema member, boolean value) {
         startMember(member);
         parent.writeBoolean(member, value);
     }
 
     @Override
-    public void writeByte(SdkSchema member, byte value) {
+    public void writeByte(Schema member, byte value) {
         startMember(member);
         parent.writeByte(member, value);
     }
 
     @Override
-    public void writeShort(SdkSchema member, short value) {
+    public void writeShort(Schema member, short value) {
         startMember(member);
         parent.writeShort(member, value);
     }
 
     @Override
-    public void writeInteger(SdkSchema member, int value) {
+    public void writeInteger(Schema member, int value) {
         startMember(member);
         parent.writeInteger(member, value);
     }
 
     @Override
-    public void writeLong(SdkSchema member, long value) {
+    public void writeLong(Schema member, long value) {
         startMember(member);
         parent.writeLong(member, value);
     }
 
     @Override
-    public void writeFloat(SdkSchema member, float value) {
+    public void writeFloat(Schema member, float value) {
         startMember(member);
         parent.writeFloat(member, value);
     }
 
     @Override
-    public void writeDouble(SdkSchema member, double value) {
+    public void writeDouble(Schema member, double value) {
         startMember(member);
         parent.writeDouble(member, value);
     }
 
     @Override
-    public void writeBigInteger(SdkSchema member, BigInteger value) {
+    public void writeBigInteger(Schema member, BigInteger value) {
         startMember(member);
         parent.writeBigInteger(member, value);
     }
 
     @Override
-    public void writeBigDecimal(SdkSchema member, BigDecimal value) {
+    public void writeBigDecimal(Schema member, BigDecimal value) {
         startMember(member);
         parent.writeBigDecimal(member, value);
     }
 
     @Override
-    public void writeString(SdkSchema member, String value) {
+    public void writeString(Schema member, String value) {
         startMember(member);
         parent.writeString(member, value);
     }
 
     @Override
-    public void writeBlob(SdkSchema member, byte[] value) {
+    public void writeBlob(Schema member, byte[] value) {
         startMember(member);
         parent.writeBlob(member, value);
     }
 
     @Override
-    public void writeTimestamp(SdkSchema member, Instant value) {
+    public void writeTimestamp(Schema member, Instant value) {
         startMember(member);
         parent.writeTimestamp(member, value);
     }
 
     @Override
-    public void writeDocument(SdkSchema member, Document value) {
+    public void writeDocument(Schema member, Document value) {
         startMember(member);
         parent.writeDocument(member, value);
     }
 
     @Override
-    public void writeNull(SdkSchema member) {
+    public void writeNull(Schema member) {
         startMember(member);
         parent.writeNull(member);
     }

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDeserializerTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDeserializerTest.java
@@ -30,8 +30,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
@@ -97,7 +97,7 @@ public class JsonDeserializerTest {
     public void deserializesBigIntegerOnlyFromRawNumbersByDefault() {
         try (var codec = JsonCodec.builder().build()) {
             var de = codec.createDeserializer("\"1\"".getBytes(StandardCharsets.UTF_8));
-            Assertions.assertThrows(SdkSerdeException.class, () -> de.readBigInteger(PreludeSchemas.BIG_INTEGER));
+            Assertions.assertThrows(SerializationException.class, () -> de.readBigInteger(PreludeSchemas.BIG_INTEGER));
         }
     }
 
@@ -113,7 +113,7 @@ public class JsonDeserializerTest {
     public void deserializesBigDecimalOnlyFromRawNumbersByDefault() {
         try (var codec = JsonCodec.builder().build()) {
             var de = codec.createDeserializer("\"1\"".getBytes(StandardCharsets.UTF_8));
-            Assertions.assertThrows(SdkSerdeException.class, () -> de.readBigDecimal(PreludeSchemas.BIG_DECIMAL));
+            Assertions.assertThrows(SerializationException.class, () -> de.readBigDecimal(PreludeSchemas.BIG_DECIMAL));
         }
     }
 
@@ -277,7 +277,7 @@ public class JsonDeserializerTest {
         TimestampFormatter defaultFormat,
         String json
     ) {
-        SdkSchema.Builder schemaBuilder = SdkSchema.builder()
+        Schema.Builder schemaBuilder = Schema.builder()
             .type(ShapeType.TIMESTAMP)
             .id("smithy.foo#Time");
 
@@ -340,14 +340,14 @@ public class JsonDeserializerTest {
 
     @Test
     public void throwsWhenTimestampIsWrongType() {
-        SdkSchema schema = SdkSchema.builder()
+        Schema schema = Schema.builder()
             .type(ShapeType.TIMESTAMP)
             .id("smithy.foo#Time")
             .build();
 
         try (var codec = JsonCodec.builder().build()) {
             var de = codec.createDeserializer("true".getBytes(StandardCharsets.UTF_8));
-            var e = Assertions.assertThrows(SdkSerdeException.class, () -> de.readTimestamp(schema));
+            var e = Assertions.assertThrows(SerializationException.class, () -> de.readTimestamp(schema));
             assertThat(e.getMessage(), equalTo("Expected a timestamp, but found boolean"));
         }
     }

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
-import software.amazon.smithy.java.runtime.core.schema.SdkShapeBuilder;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
-import software.amazon.smithy.java.runtime.core.serde.SdkSerdeException;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
@@ -109,7 +109,7 @@ public class JsonDocumentTest {
         var de = codec.createDeserializer("true".getBytes(StandardCharsets.UTF_8));
         var document = de.readDocument();
 
-        var e = Assertions.assertThrows(SdkSerdeException.class, document::asTimestamp);
+        var e = Assertions.assertThrows(SerializationException.class, document::asTimestamp);
         assertThat(e.getMessage(), containsString("Expected a timestamp, but found boolean"));
     }
 
@@ -177,7 +177,7 @@ public class JsonDocumentTest {
         var de = codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8));
         var document = de.readDocument();
 
-        Assertions.assertThrows(SdkSerdeException.class, () -> consumer.accept(document));
+        Assertions.assertThrows(SerializationException.class, () -> consumer.accept(document));
     }
 
     public static List<Arguments> failToConvertSource() {
@@ -283,31 +283,31 @@ public class JsonDocumentTest {
 
         private static final ShapeId ID = ShapeId.from("smithy.example#Foo");
 
-        private static final SdkSchema NAME = SdkSchema.memberBuilder("name", PreludeSchemas.STRING)
+        private static final Schema NAME = Schema.memberBuilder("name", PreludeSchemas.STRING)
             .id(ID)
             .build();
 
-        private static final SdkSchema BINARY = SdkSchema.memberBuilder("binary", PreludeSchemas.BLOB)
+        private static final Schema BINARY = Schema.memberBuilder("binary", PreludeSchemas.BLOB)
             .id(ID)
             .traits(new JsonNameTrait("BINARY"))
             .build();
 
-        private static final SdkSchema DATE = SdkSchema.memberBuilder("date", PreludeSchemas.TIMESTAMP)
+        private static final Schema DATE = Schema.memberBuilder("date", PreludeSchemas.TIMESTAMP)
             .id(ID)
             .traits(new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME))
             .build();
 
-        private static final SdkSchema NUMBERS_LIST = SdkSchema.builder()
+        private static final Schema NUMBERS_LIST = Schema.builder()
             .type(ShapeType.LIST)
             .id("smithy.example#Numbers")
-            .members(SdkSchema.memberBuilder("member", PreludeSchemas.INTEGER))
+            .members(Schema.memberBuilder("member", PreludeSchemas.INTEGER))
             .build();
 
-        private static final SdkSchema NUMBERS = SdkSchema.memberBuilder("numbers", NUMBERS_LIST)
+        private static final Schema NUMBERS = Schema.memberBuilder("numbers", NUMBERS_LIST)
             .id(ID)
             .build();
 
-        private static final SdkSchema SCHEMA = SdkSchema.builder()
+        private static final Schema SCHEMA = Schema.builder()
             .id(ID)
             .type(ShapeType.STRUCTURE)
             .members(NAME, BINARY, DATE, NUMBERS)
@@ -330,7 +330,7 @@ public class JsonDocumentTest {
             throw new UnsupportedOperationException();
         }
 
-        private static final class Builder implements SdkShapeBuilder<TestPojo> {
+        private static final class Builder implements ShapeBuilder<TestPojo> {
 
             private String name;
             private byte[] binary;

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonSerializerTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonSerializerTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
@@ -112,7 +112,7 @@ public class JsonSerializerTest {
     @ParameterizedTest
     @MethodSource("configurableTimestampFormatProvider")
     public void configurableTimestampFormat(boolean useTimestampFormat, String json) throws Exception {
-        SdkSchema schema = SdkSchema.builder()
+        Schema schema = Schema.builder()
             .type(ShapeType.TIMESTAMP)
             .id("smithy.example#foo")
             .traits(new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME))

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonTestData.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonTestData.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.runtime.json;
 
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
-import software.amazon.smithy.java.runtime.core.schema.SdkSchema;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.JsonNameTrait;
@@ -14,25 +14,25 @@ import software.amazon.smithy.model.traits.JsonNameTrait;
 public final class JsonTestData {
 
     static final ShapeId BIRD_ID = ShapeId.from("smithy.example#Bird");
-    static final SdkSchema BIRD_NAME = SdkSchema.memberBuilder("name", PreludeSchemas.STRING)
+    static final Schema BIRD_NAME = Schema.memberBuilder("name", PreludeSchemas.STRING)
         .id(BIRD_ID)
         .build();
-    static final SdkSchema BIRD_COLOR = SdkSchema.memberBuilder("color", PreludeSchemas.STRING)
+    static final Schema BIRD_COLOR = Schema.memberBuilder("color", PreludeSchemas.STRING)
         .id(BIRD_ID)
         .traits(new JsonNameTrait("Color"))
         .build();
-    static final SdkSchema BIRD_NESTED = SdkSchema.memberBuilder("nested", PreludeSchemas.STRING).id(BIRD_ID).build();
-    static final SdkSchema BIRD = SdkSchema.builder()
+    static final Schema BIRD_NESTED = Schema.memberBuilder("nested", PreludeSchemas.STRING).id(BIRD_ID).build();
+    static final Schema BIRD = Schema.builder()
         .id(BIRD_ID)
         .type(ShapeType.STRUCTURE)
         .members(BIRD_NAME, BIRD_COLOR, BIRD_NESTED)
         .build();
 
     static final ShapeId NESTED_ID = ShapeId.from("smithy.example#Nested");
-    static final SdkSchema NESTED_NUMBER = SdkSchema.memberBuilder("number", PreludeSchemas.INTEGER)
+    static final Schema NESTED_NUMBER = Schema.memberBuilder("number", PreludeSchemas.INTEGER)
         .id(NESTED_ID)
         .build();
-    static final SdkSchema NESTED = SdkSchema.builder()
+    static final Schema NESTED = Schema.builder()
         .id(NESTED_ID)
         .type(ShapeType.STRUCTURE)
         .members(NESTED_NUMBER)

--- a/server-core/src/main/java/software/amazon/smithy/java/server/core/exceptions/UnknownOperationException.java
+++ b/server-core/src/main/java/software/amazon/smithy/java/server/core/exceptions/UnknownOperationException.java
@@ -5,9 +5,9 @@
 
 package software.amazon.smithy.java.server.core.exceptions;
 
-import software.amazon.smithy.java.runtime.core.schema.SdkException;
+import software.amazon.smithy.java.runtime.core.schema.ApiException;
 
-public final class UnknownOperationException extends SdkException {
+public final class UnknownOperationException extends ApiException {
     public UnknownOperationException(String s) {
         super(s);
     }


### PR DESCRIPTION
### Description of changes
Proposes a refactor to remove the `sdk` prefix from classes that are not SDK specific.

Changes: 
* `SdkSchema` -> `Schema`
* `SdkShapeBuilder` -> `ShapeBuilder`
* `SdkSerdeException ` -> `SerializationException`
* `ModeledSdkException` -> `ModeledApiException`
* `SdkException` -> `ApiException`
* `SdkOperation` -> `ApiOperation`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
