### PR TITLE
Add __type to structure documents

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
@@ -538,7 +538,9 @@ public interface Document extends SerializableShape {
      * @return the Document type.
      */
     static Document createTyped(SerializableShape shape) {
-        return new Documents.LazilyCreatedTypedDocument(shape);
+        var parser = new DocumentParser();
+        shape.serialize(parser);
+        return parser.getResult();
     }
 
     /**

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
@@ -190,6 +190,7 @@ public class DocumentTest {
             .build();
         var doc = Document.createTyped(person);
 
+        assertThat(doc.getMember("__type").asString(), equalTo(Person.ID.toString()));
         assertThat(doc.getMember("name").asString(), equalTo("A"));
         assertThat(doc.getMember("age").asInteger(), equalTo(1));
         assertThat(doc.getMember("binary").asBlob(), equalTo("hi".getBytes(StandardCharsets.UTF_8)));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
@@ -53,9 +53,19 @@ public class ListDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
+            public void writeDocument(SdkSchema schema, Document value) {
+                value.serializeContents(this);
+            }
+
+            @Override
             public <T> void writeList(SdkSchema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
                 assertThat(schema.type(), equalTo(ShapeType.LIST));
                 consumer.accept(listState, new SpecificShapeSerializer() {
+                    @Override
+                    public void writeDocument(SdkSchema schema, Document value) {
+                        value.serializeContents(this);
+                    }
+
                     @Override
                     public void writeString(SdkSchema schema, String value) {
                         assertThat(schema, equalTo(PreludeSchemas.STRING));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
@@ -59,6 +59,11 @@ public class MapDocumentTest {
         var keys = new ArrayList<>();
         map.serializeContents(new SpecificShapeSerializer() {
             @Override
+            public void writeDocument(SdkSchema schema, Document value) {
+                value.serializeContents(this);
+            }
+
+            @Override
             public <T> void writeMap(SdkSchema schema, T state, BiConsumer<T, MapSerializer> consumer) {
                 assertThat(schema.type(), equalTo(ShapeType.MAP));
                 consumer.accept(state, new MapSerializer() {
@@ -71,6 +76,11 @@ public class MapDocumentTest {
                     ) {
                         keys.add(key);
                         valueSerializer.accept(mapState, new SpecificShapeSerializer() {
+                            @Override
+                            public void writeDocument(SdkSchema schema, Document value) {
+                                value.serializeContents(this);
+                            }
+
                             @Override
                             public void writeInteger(SdkSchema schema, int value) {
                                 assertThat(schema, equalTo(PreludeSchemas.INTEGER));

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
@@ -21,10 +21,11 @@ import software.amazon.smithy.java.runtime.core.serde.document.Document;
 class JsonStructSerializer implements ShapeSerializer {
 
     private final JsonSerializer parent;
-    private boolean firstValue = true;
+    private boolean firstValue;
 
-    JsonStructSerializer(JsonSerializer parent) {
+    JsonStructSerializer(JsonSerializer parent, boolean isFirstValue) {
         this.parent = parent;
+        this.firstValue = isFirstValue;
     }
 
     void startMember(SdkSchema member) {


### PR DESCRIPTION
Typed structure documents will return the shape of the captured shape when a synthetic __type member is accessed.

The JSON codec has been updated to serialize the shape ID using __type. Most protocols will follow this same pattern, though it's theoretically possible that a future codec may wish to deviate.

This commit also updates lazy document handling so that only structures are lazily converted to documents. This ensures that shape -> document -> serialized actually is handled without having to create a DOM version of a structure just to serialize it.

When serializing nested document values within a document, Document#serialize is now used rather than Document#serializeContents. This gives codecs the opportunity to add any necessary framing to structure documents, and this method delegates to serializeContents.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
