### PR TITLE
Ensure docs are added to enum variants

### DIFF
--- a/codegen/client/src/it/java/software/amazon/smithy/java/codegen/client/GenericClientTest.java
+++ b/codegen/client/src/it/java/software/amazon/smithy/java/codegen/client/GenericClientTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client;
+
+
+import java.net.http.HttpClient;
+import org.junit.jupiter.api.Test;
+import smithy.java.codegen.server.test.client.TestService;
+import smithy.java.codegen.server.test.client.TestServiceClient;
+import smithy.java.codegen.server.test.model.EchoInput;
+import software.amazon.smithy.java.runtime.client.aws.restjson1.RestJsonClientProtocol;
+import software.amazon.smithy.java.runtime.client.core.interceptors.ClientInterceptor;
+import software.amazon.smithy.java.runtime.client.http.HttpContext;
+import software.amazon.smithy.java.runtime.client.http.JavaHttpClientTransport;
+import software.amazon.smithy.java.runtime.core.Context;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+
+
+public class GenericClientTest {
+    // TODO: Update tests once issue with body not serializing is resolved.
+    @Test
+    public void echoTest() {
+        var client = TestServiceClient.builder()
+            .transport(new JavaHttpClientTransport(HttpClient.newHttpClient(), new RestJsonClientProtocol()))
+            .endpoint("https://httpbin.org")
+            .build();
+
+        var value = "hello world";
+        var input = EchoInput.builder().string(value).build();
+        var output = client.echo(input);
+    }
+
+    @Test
+    public void supportsInterceptors() {
+        var interceptor = new ClientInterceptor() {
+            @Override
+            public <I extends SerializableStruct, RequestT> void readBeforeTransmit(
+                Context context,
+                I input,
+                Context.Value<RequestT> request
+            ) {
+                System.out.println("Sending request: " + request);
+            }
+
+            @Override
+            public <I extends SerializableStruct, RequestT, ResponseT> void readBeforeDeserialization(
+                Context context,
+                I input,
+                Context.Value<RequestT> request,
+                Context.Value<ResponseT> response
+            ) {
+                System.out.println("GOT: " + response.toString());
+            }
+
+            @Override
+            public <I extends SerializableStruct, RequestT> Context.Value<RequestT> modifyBeforeTransmit(
+                Context context,
+                I input,
+                Context.Value<RequestT> request
+            ) {
+                return request.mapIf(HttpContext.HTTP_REQUEST, r -> r.withAddedHeaders("X-Foo", "Bar"));
+            }
+        };
+
+        TestService client = TestServiceClient.builder()
+            .transport(new JavaHttpClientTransport(HttpClient.newHttpClient(), new RestJsonClientProtocol()))
+            .endpoint("https://httpbin.org")
+            .addInterceptor(interceptor)
+            .build();
+
+        var input = EchoInput.builder().string("hello world").build();
+        var output = client.echo(input);
+    }
+}

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/ClientSymbolProperties.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/ClientSymbolProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client;
+
+import software.amazon.smithy.codegen.core.Property;
+import software.amazon.smithy.codegen.core.Symbol;
+
+public final class ClientSymbolProperties {
+
+    /**
+     * Indicates if a symbol represents an async implementation.
+     */
+    public static final Property<Boolean> ASYNC = Property.named("is-async");
+
+    /**
+     * Symbol representing the async implementation of Symbol.
+     *
+     * <p>This property is expected on all {@code Service} shape symbols.
+     */
+    public static final Property<Symbol> ASYNC_SYMBOL = Property.named("async-symbol");
+
+    /**
+     * Symbol representing the implementation class for a client.
+     *
+     * <p>This property is expected on all {@code Service} shape symbols.
+     */
+    public static final Property<Symbol> CLIENT_IMPL = Property.named("client-symbol");
+
+    private ClientSymbolProperties() {}
+}

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client.generators;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
+import software.amazon.smithy.java.codegen.CodeGenerationContext;
+import software.amazon.smithy.java.codegen.CodegenUtils;
+import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.client.ClientSymbolProperties;
+import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.java.runtime.client.core.Client;
+import software.amazon.smithy.java.runtime.core.Context;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.OperationIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.utils.StringUtils;
+
+@SmithyInternalApi
+public final class ClientImplementationGenerator
+    implements Consumer<GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings>> {
+
+    @Override
+    public void accept(GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
+        // Write Synchronous implementation
+        writeForSymbol(directive.symbol(), directive);
+        // Write Async implementation
+        writeForSymbol(directive.symbol().expectProperty(ClientSymbolProperties.ASYNC_SYMBOL), directive);
+    }
+
+    public static void writeForSymbol(
+        Symbol symbol,
+        GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive
+    ) {
+        var impl = symbol.expectProperty(ClientSymbolProperties.CLIENT_IMPL);
+        directive.context().writerDelegator().useFileWriter(impl.getDeclarationFile(), impl.getNamespace(), writer -> {
+            writer.pushState(new ClassSection(directive.shape()));
+            var template = """
+                public final class ${clientImpl:T} extends ${client:T} implements ${interface:T} {
+
+                    private ${clientImpl:T}(Builder builder) {
+                        super(builder);
+                    }
+
+                    ${operations:C|}
+
+                    public static Builder builder() {
+                        return new Builder();
+                    }
+
+                    public static final class Builder extends ${client:T}.Builder<Builder> {
+
+                        private Builder() {}
+
+                        @Override
+                        public ${clientImpl:T} build() {
+                            return new ${clientImpl:T}(this);
+                        }
+                    }
+                }
+                """;
+            writer.putContext("client", Client.class);
+            writer.putContext("interface", symbol);
+            writer.putContext("clientImpl", impl);
+            writer.putContext("future", CompletableFuture.class);
+            writer.putContext(
+                "operations",
+                new OperationMethodGenerator(
+                    writer,
+                    directive.shape(),
+                    directive.symbolProvider(),
+                    directive.model(),
+                    symbol.expectProperty(ClientSymbolProperties.ASYNC)
+                )
+            );
+            writer.write(template);
+            writer.popState();
+        });
+    }
+
+    private record OperationMethodGenerator(
+        JavaWriter writer, ServiceShape service, SymbolProvider symbolProvider, Model model, boolean async
+    ) implements Runnable {
+
+        @Override
+        public void run() {
+            // TODO: support event streams and streaming blobs
+            writer.pushState();
+            writer.putContext("async", async);
+            writer.putContext("context", Context.class);
+            var opIndex = OperationIndex.of(model);
+            for (var operation : TopDownIndex.of(model).getContainedOperations(service)) {
+                writer.pushState();
+                writer.putContext("name", StringUtils.uncapitalize(CodegenUtils.getDefaultName(operation, service)));
+                writer.putContext("operation", symbolProvider.toSymbol(operation));
+                writer.putContext("input", symbolProvider.toSymbol(opIndex.expectInputShape(operation)));
+                writer.putContext("output", symbolProvider.toSymbol(opIndex.expectOutputShape(operation)));
+                writer.write(
+                    """
+                        @Override
+                        public ${?async}${future:T}<${/async}${output:T}${?async}>${/async} ${name:L}(${input:T} input, ${context:T} context) {
+                            return call(input, null, null, new ${operation:T}(), context)${^async}.join()${/async};
+                        }
+                        """
+                );
+                writer.popState();
+            }
+
+            writer.popState();
+        }
+    }
+}

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client.generators;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
+import software.amazon.smithy.java.codegen.CodeGenerationContext;
+import software.amazon.smithy.java.codegen.CodegenUtils;
+import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.client.ClientSymbolProperties;
+import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.java.runtime.core.Context;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.OperationIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.utils.StringUtils;
+
+@SmithyInternalApi
+public final class ClientInterfaceGenerator
+    implements Consumer<GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings>> {
+
+    @Override
+    public void accept(GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
+        // Write synchronous interface
+        writeForSymbol(directive.symbol(), directive);
+        // Write async interface
+        writeForSymbol(directive.symbol().expectProperty(ClientSymbolProperties.ASYNC_SYMBOL), directive);
+    }
+
+    private static void writeForSymbol(
+        Symbol symbol,
+        GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive
+    ) {
+        directive.context()
+            .writerDelegator()
+            .useFileWriter(symbol.getDeclarationFile(), symbol.getNamespace(), writer -> {
+                writer.pushState(new ClassSection(directive.shape()));
+                var template = """
+                    public interface ${interface:T} {
+
+                        ${operations:C|}
+                    }
+                    """;
+                writer.putContext("interface", symbol);
+                writer.putContext(
+                    "operations",
+                    new OperationMethodGenerator(
+                        writer,
+                        directive.shape(),
+                        directive.symbolProvider(),
+                        symbol,
+                        directive.model()
+                    )
+                );
+                writer.write(template);
+                writer.popState();
+            });
+    }
+
+    private record OperationMethodGenerator(
+        JavaWriter writer, ServiceShape service, SymbolProvider symbolProvider, Symbol symbol, Model model
+    ) implements Runnable {
+
+        @Override
+        public void run() {
+            writer.pushState();
+            var template = """
+                default ${?async}${future:T}<${/async}${output:T}${?async}>${/async} ${name:L}(${input:T} input) {
+                    return ${name:L}(input, ${context:T}.create());
+                }
+
+                ${?async}${future:T}<${/async}${output:T}${?async}>${/async} ${name:L}(${input:T} input, ${context:T} context);
+                """;
+            writer.putContext("async", symbol.expectProperty(ClientSymbolProperties.ASYNC));
+            writer.putContext("context", Context.class);
+            writer.putContext("future", CompletableFuture.class);
+
+            var opIndex = OperationIndex.of(model);
+            for (var operation : TopDownIndex.of(model).getContainedOperations(service)) {
+                writer.pushState();
+                writer.putContext("name", StringUtils.uncapitalize(CodegenUtils.getDefaultName(operation, service)));
+                writer.putContext("input", symbolProvider.toSymbol(opIndex.expectInputShape(operation)));
+                writer.putContext("output", symbolProvider.toSymbol(opIndex.expectOutputShape(operation)));
+                writer.write(template);
+                writer.popState();
+            }
+            writer.popState();
+        }
+    }
+}

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/integration/ClientIntegration.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/integration/ClientIntegration.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client.integration;
+
+import static java.lang.String.format;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.java.codegen.CodegenUtils;
+import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
+import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.SymbolProperties;
+import software.amazon.smithy.java.codegen.client.ClientSymbolProperties;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class ClientIntegration implements JavaCodegenIntegration {
+
+    @Override
+    public String name() {
+        return "client-core";
+    }
+
+    @Override
+    public SymbolProvider decorateSymbolProvider(
+        Model model,
+        JavaCodegenSettings settings,
+        SymbolProvider symbolProvider
+    ) {
+        return new SymbolProvider() {
+            @Override
+            public Symbol toSymbol(Shape shape) {
+                if (shape.isServiceShape()) {
+                    return getServiceSymbol(settings, shape.asServiceShape().get(), symbolProvider.toSymbol(shape));
+                }
+                return symbolProvider.toSymbol(shape);
+            }
+
+            // Explicitly delegate to ensure initial toMemberName is not squashed by decorating
+            @Override
+            public String toMemberName(MemberShape shape) {
+                return symbolProvider.toMemberName(shape);
+            }
+        };
+    }
+
+    private static Symbol getServiceSymbol(JavaCodegenSettings settings, ServiceShape shape, Symbol symbol) {
+        var name = CodegenUtils.getDefaultName(shape, shape);
+        return getSymbolFromName(settings, name, false).toBuilder()
+            .putProperty(ClientSymbolProperties.ASYNC_SYMBOL, getSymbolFromName(settings, name + "Async", true))
+            .build();
+    }
+
+    private static Symbol getSymbolFromName(JavaCodegenSettings settings, String name, boolean async) {
+        var symbol = Symbol.builder()
+            .name(name)
+            .putProperty(SymbolProperties.IS_PRIMITIVE, false)
+            .putProperty(ClientSymbolProperties.ASYNC, async)
+            .namespace(format("%s.client", settings.packageNamespace()), ".")
+            .declarationFile(format("./%s/client/%s.java", settings.packageNamespace().replace(".", "/"), name))
+            .build();
+
+        return symbol.toBuilder()
+            .putProperty(
+                ClientSymbolProperties.CLIENT_IMPL,
+                symbol.toBuilder()
+                    .name(name + "Client")
+                    .declarationFile(symbol.getDefinitionFile().replace(name, name + "Client"))
+                    .build()
+            )
+            .build();
+    }
+}

--- a/codegen/client/src/main/resources/META-INF/services/software.amazon.smithy.java.codegen.JavaCodegenIntegration
+++ b/codegen/client/src/main/resources/META-INF/services/software.amazon.smithy.java.codegen.JavaCodegenIntegration
@@ -1,0 +1,1 @@
+software.amazon.smithy.java.codegen.client.integration.ClientIntegration

--- a/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestServerJavaCodegenRunner.java
+++ b/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestServerJavaCodegenRunner.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client;
+
+
+import java.nio.file.Paths;
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ObjectNode;
+
+
+/**
+ * Simple wrapper class used to execute the test Java codegen plugin for integration tests.
+ */
+public final class TestServerJavaCodegenRunner {
+    private TestServerJavaCodegenRunner() {
+        // Utility class does not have constructor
+    }
+
+    public static void main(String[] args) {
+        JavaClientCodegenPlugin plugin = new JavaClientCodegenPlugin();
+        Model model = Model.assembler(TestServerJavaCodegenRunner.class.getClassLoader())
+            .discoverModels(TestServerJavaCodegenRunner.class.getClassLoader())
+            .assemble()
+            .unwrap();
+        PluginContext context = PluginContext.builder()
+            .fileManifest(FileManifest.create(Paths.get(System.getenv("output"))))
+            .settings(
+                ObjectNode.builder()
+                    .withMember("service", System.getenv("service"))
+                    .withMember("namespace", System.getenv("namespace"))
+                    .build()
+            )
+            .model(model)
+            .build();
+        plugin.execute(context);
+    }
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
@@ -17,6 +17,7 @@ import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.codegen.sections.EnumVariantSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
@@ -113,10 +114,11 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
         public void run() {
             writer.pushState();
             writer.putContext("string", shape.isEnumShape());
-            for (var entry : getEnumValues(shape).entrySet()) {
-                writer.pushState();
-                writer.putContext("var", CodegenUtils.toUpperSnakeCase(entry.getKey()));
-                writer.putContext("val", entry.getValue());
+            var enumValues = getEnumValues(shape);
+            for (var member : shape.members()) {
+                writer.pushState(new EnumVariantSection(member));
+                writer.putContext("var", CodegenUtils.toUpperSnakeCase(member.getMemberName()));
+                writer.putContext("val", enumValues.get(member.getMemberName()));
                 writer.write(
                     "public static final ${shape:T} ${var:L} = new ${shape:T}(Type.${var:L}, ${?string}${val:S}${/string}${^string}${val:L}${/string});"
                 );

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocInjectorInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocInjectorInterceptor.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.codegen.integrations.javadoc;
 
 import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.codegen.sections.EnumVariantSection;
 import software.amazon.smithy.java.codegen.sections.GetterSection;
 import software.amazon.smithy.java.codegen.sections.JavadocSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
@@ -31,8 +32,9 @@ final class JavadocInjectorInterceptor implements CodeInterceptor.Prepender<Code
     @Override
     public boolean isIntercepted(CodeSection section) {
         // Javadocs are generated for Classes, on member Getters, and on enum variants
-        // TODO: Add enum variant section
-        return section instanceof ClassSection || section instanceof GetterSection;
+        return section instanceof ClassSection
+            || section instanceof GetterSection
+            || section instanceof EnumVariantSection;
     }
 
     @Override
@@ -42,6 +44,8 @@ final class JavadocInjectorInterceptor implements CodeInterceptor.Prepender<Code
             shape = cs.shape();
         } else if (section instanceof GetterSection gs) {
             shape = gs.memberShape();
+        } else if (section instanceof EnumVariantSection es) {
+            shape = es.memberShape();
         } else {
             throw new IllegalArgumentException("Javadocs cannot be injected for section: " + section);
         }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/EnumVariantSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/EnumVariantSection.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.sections;
+
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.utils.CodeSection;
+
+/**
+ * Used to add documentation to an Enum Variant member shape.
+ *
+ * @param shape Member shape for enum variant
+ */
+public record EnumVariantSection(MemberShape memberShape) implements CodeSection {}

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -219,6 +219,29 @@ public class JavadocIntegrationTest {
             """));
     }
 
+    @Test
+    void addsToEnumVariants() {
+        var fileContents = getFileStringForClass("EnumWithDocs");
+        assertThat(
+            fileContents,
+            containsString(
+                """
+                        public static final ShapeId ID = ShapeId.from("smithy.java.codegen.integrations.javadoc#EnumWithDocs");
+                        /**
+                         * @deprecated As of the past.
+                         */
+                        @Deprecated(since = "the past")
+                        public static final EnumWithDocs DOCUMENTED = new EnumWithDocs(Type.DOCUMENTED, "DOCUMENTED");
+                        /**
+                         * General Docs
+                         */
+                        @SmithyUnstableApi
+                        public static final EnumWithDocs ALSO_DOCUMENTED = new EnumWithDocs(Type.ALSO_DOCUMENTED, "ALSO_DOCUMENTED");
+                    """
+            )
+        );
+    }
+
     private String getFileStringForClass(String className) {
         var fileStringOptional = manifest.getFileString(
             Paths.get(String.format("/test/smithy/codegen/model/%s.java", className))

--- a/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
+++ b/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
@@ -12,6 +12,7 @@ service TestService {
         ExternalDocumentation
         Unstable
         Rollup
+        EnumVariants
     ]
 }
 
@@ -110,4 +111,21 @@ structure RollupInput {
     )
     @since("4.5")
     rollupMember: String
+}
+
+/// Checks that docs are correctly added to enum variants
+operation EnumVariants {
+    input := {
+        enum: EnumWithDocs
+    }
+}
+
+/// Generic Documentation
+@since("4.5")
+enum EnumWithDocs {
+    @deprecated(since: "the past")
+    DOCUMENTED
+    /// General Docs
+    @unstable
+    ALSO_DOCUMENTED
 }


### PR DESCRIPTION
### Description of changes
Codegen update to add docs to any enum variants with documentation traits added.
The added test shows an example of added documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
