### PR TITLE
Ensure docs are added to enum variants

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
@@ -17,6 +17,7 @@ import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.codegen.sections.EnumVariantSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
@@ -113,10 +114,11 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
         public void run() {
             writer.pushState();
             writer.putContext("string", shape.isEnumShape());
-            for (var entry : getEnumValues(shape).entrySet()) {
-                writer.pushState();
-                writer.putContext("var", CodegenUtils.toUpperSnakeCase(entry.getKey()));
-                writer.putContext("val", entry.getValue());
+            var enumValues = getEnumValues(shape);
+            for (var member : shape.members()) {
+                writer.pushState(new EnumVariantSection(member));
+                writer.putContext("var", CodegenUtils.toUpperSnakeCase(member.getMemberName()));
+                writer.putContext("val", enumValues.get(member.getMemberName()));
                 writer.write(
                     "public static final ${shape:T} ${var:L} = new ${shape:T}(Type.${var:L}, ${?string}${val:S}${/string}${^string}${val:L}${/string});"
                 );

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocInjectorInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocInjectorInterceptor.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.codegen.integrations.javadoc;
 
 import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.codegen.sections.EnumVariantSection;
 import software.amazon.smithy.java.codegen.sections.GetterSection;
 import software.amazon.smithy.java.codegen.sections.JavadocSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
@@ -31,8 +32,9 @@ final class JavadocInjectorInterceptor implements CodeInterceptor.Prepender<Code
     @Override
     public boolean isIntercepted(CodeSection section) {
         // Javadocs are generated for Classes, on member Getters, and on enum variants
-        // TODO: Add enum variant section
-        return section instanceof ClassSection || section instanceof GetterSection;
+        return section instanceof ClassSection
+            || section instanceof GetterSection
+            || section instanceof EnumVariantSection;
     }
 
     @Override
@@ -42,6 +44,8 @@ final class JavadocInjectorInterceptor implements CodeInterceptor.Prepender<Code
             shape = cs.shape();
         } else if (section instanceof GetterSection gs) {
             shape = gs.memberShape();
+        } else if (section instanceof EnumVariantSection es) {
+            shape = es.memberShape();
         } else {
             throw new IllegalArgumentException("Javadocs cannot be injected for section: " + section);
         }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/EnumVariantSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/EnumVariantSection.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.sections;
+
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.utils.CodeSection;
+
+/**
+ * Used to add documentation to an Enum Variant member shape.
+ *
+ * @param shape Member shape for enum variant
+ */
+public record EnumVariantSection(MemberShape memberShape) implements CodeSection {}

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -219,6 +219,29 @@ public class JavadocIntegrationTest {
             """));
     }
 
+    @Test
+    void addsToEnumVariants() {
+        var fileContents = getFileStringForClass("EnumWithDocs");
+        assertThat(
+            fileContents,
+            containsString(
+                """
+                        public static final ShapeId ID = ShapeId.from("smithy.java.codegen.integrations.javadoc#EnumWithDocs");
+                        /**
+                         * @deprecated As of the past.
+                         */
+                        @Deprecated(since = "the past")
+                        public static final EnumWithDocs DOCUMENTED = new EnumWithDocs(Type.DOCUMENTED, "DOCUMENTED");
+                        /**
+                         * General Docs
+                         */
+                        @SmithyUnstableApi
+                        public static final EnumWithDocs ALSO_DOCUMENTED = new EnumWithDocs(Type.ALSO_DOCUMENTED, "ALSO_DOCUMENTED");
+                    """
+            )
+        );
+    }
+
     private String getFileStringForClass(String className) {
         var fileStringOptional = manifest.getFileString(
             Paths.get(String.format("/test/smithy/codegen/model/%s.java", className))

--- a/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
+++ b/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
@@ -12,6 +12,7 @@ service TestService {
         ExternalDocumentation
         Unstable
         Rollup
+        EnumVariants
     ]
 }
 
@@ -110,4 +111,21 @@ structure RollupInput {
     )
     @since("4.5")
     rollupMember: String
+}
+
+/// Checks that docs are correctly added to enum variants
+operation EnumVariants {
+    input := {
+        enum: EnumWithDocs
+    }
+}
+
+/// Generic Documentation
+@since("4.5")
+enum EnumWithDocs {
+    @deprecated(since: "the past")
+    DOCUMENTED
+    /// General Docs
+    @unstable
+    ALSO_DOCUMENTED
 }


### PR DESCRIPTION
### Description of changes
Add docs to enum variants with documentation traits. 

Added test shows example of what the generated documentation looks like.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
