### PR TITLE
Update codegen to support missing default types

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/DefaultsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/DefaultsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.smithy.codegen.test.model.DefaultsInput;
+import io.smithy.codegen.test.model.FishOrBird;
+import io.smithy.codegen.test.model.OneOrTwo;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.runtime.core.serde.document.Document;
+
+public class DefaultsTest {
+    @Test
+    void setsCorrectDefault() throws IOException {
+        var defaults = DefaultsInput.builder().build();
+
+        assertTrue(defaults.booleanMember());
+        assertEquals(defaults.bigDecimal(), BigDecimal.valueOf(1.0));
+        assertEquals(defaults.bigInteger(), BigInteger.valueOf(1));
+        assertEquals(defaults.byteMember(), (byte) 1);
+        assertEquals(defaults.doubleMember(), 1.0);
+        assertEquals(defaults.floatMember(), 1f);
+        assertEquals(defaults.integer(), 1);
+        assertEquals(defaults.longMember(), 1);
+        assertEquals(defaults.shortMember(), (short) 1);
+        assertArrayEquals(defaults.blob(), Base64.getDecoder().decode("YmxvYg=="));
+        defaults.streamingBlob()
+            .asBytes()
+            .thenAccept(b -> assertArrayEquals(b, Base64.getDecoder().decode("c3RyZWFtaW5n")));
+        assertEquals(defaults.boolDoc(), Document.createBoolean(true));
+        assertEquals(defaults.stringDoc(), Document.createString("string"));
+        assertEquals(defaults.numberDoc(), Document.createInteger(1));
+        assertEquals(defaults.floatingPointnumberDoc(), Document.createDouble(1.2));
+        assertEquals(defaults.listDoc(), Document.createList(Collections.emptyList()));
+        assertEquals(defaults.mapDoc(), Document.createStringMap(Collections.emptyMap()));
+        assertEquals(defaults.list(), List.of());
+        assertEquals(defaults.map(), Map.of());
+        assertEquals(defaults.timestamp(), Instant.parse("1985-04-12T23:20:50.52Z"));
+        assertEquals(defaults.enumMember(), FishOrBird.FISH);
+        assertEquals(defaults.intEnum(), OneOrTwo.ONE);
+    }
+}

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/SerdeTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/SerdeTest.java
@@ -15,6 +15,7 @@ import io.smithy.codegen.test.model.BigIntegersInput;
 import io.smithy.codegen.test.model.BlobsInput;
 import io.smithy.codegen.test.model.BooleansInput;
 import io.smithy.codegen.test.model.BytesInput;
+import io.smithy.codegen.test.model.DocumentsInput;
 import io.smithy.codegen.test.model.DoublesInput;
 import io.smithy.codegen.test.model.EnumType;
 import io.smithy.codegen.test.model.EnumsInput;
@@ -68,6 +69,8 @@ public class SerdeTest {
         return Stream.of(
             // Booleans
             BooleansInput.builder().requiredBoolean(true).build(),
+            // Documents
+            DocumentsInput.builder().requiredDoc(Document.createString("str")).build(),
             // Lists
             ListsInput.builder().requiredList(List.of("a", "b", "c")).build(),
             NestedListsInput.builder()

--- a/codegen/core/src/it/resources/META-INF/smithy/manifest
+++ b/codegen/core/src/it/resources/META-INF/smithy/manifest
@@ -2,6 +2,8 @@ main.smithy
 structures/structures.smithy
 structures/blob-members/blobs.smithy
 structures/boolean-members/booleans.smithy
+structures/document-members/documents.smithy
+structures/default-values/defaults.smithy
 structures/list-members/list-of-structs.smithy
 structures/list-members/lists.smithy
 structures/list-members/nested-lists.smithy

--- a/codegen/core/src/it/resources/META-INF/smithy/structures/boolean-members/booleans.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/structures/boolean-members/booleans.smithy
@@ -6,6 +6,10 @@ operation Booleans {
     input := {
         @required
         requiredBoolean: Boolean
+
+        @default(true)
+        defaultBoolean: Boolean
+
         optionalBoolean: Boolean
     }
 }

--- a/codegen/core/src/it/resources/META-INF/smithy/structures/default-values/defaults.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/structures/default-values/defaults.smithy
@@ -1,0 +1,107 @@
+$version: "2"
+
+namespace smithy.java.codegen.test.structures.defaults
+
+use smithy.java.codegen.test.structures.members#Documents
+
+operation Defaults {
+    input := {
+        @default(true)
+        boolean: Boolean
+
+        @default(1)
+        bigDecimal: BigDecimal
+
+        @default(1)
+        bigInteger: BigInteger
+
+        @default(1)
+        byte: Byte
+
+        @default(1.0)
+        double: Double
+
+        @default(1.0)
+        float: Float
+
+        @default(1)
+        integer: Integer
+
+        @default(1)
+        long: Long
+
+        @default(1)
+        short: Short
+
+        @default("default")
+        string: String
+
+        @default("YmxvYg==")
+        blob: Blob
+
+        @default("c3RyZWFtaW5n")
+        streamingBlob: Streaming
+
+        // Documents can be bool, string, numbers, an empty list, or an empty map.
+        // see: https://smithy.io/2.0/spec/type-refinement-traits.html#default-value-constraints
+        @default(true)
+        boolDoc: Document
+
+        @default("string")
+        stringDoc: Document
+
+        @default(1)
+        numberDoc: Document
+
+        @default(1.2)
+        floatingPointnumberDoc: Document
+
+        @default([])
+        listDoc: Document
+
+        @default({})
+        mapDoc: Document
+
+        @default([])
+        list: DefaultList
+
+        @default({})
+        map: DefaultMap
+
+        @default("1985-04-12T23:20:50.52Z")
+        timestamp: Timestamp
+
+        @default("fish")
+        enum: FishOrBird
+
+        @default(1)
+        intEnum: OneOrTwo
+    }
+}
+
+@private
+list DefaultList {
+    member: String
+}
+
+@private
+map DefaultMap {
+    key: String
+    value: String
+}
+
+@private
+enum FishOrBird {
+    BIRD = "bird"
+    FISH = "fish"
+}
+
+@private
+intEnum OneOrTwo {
+    ONE = 1
+    TWO = 2
+}
+
+@private
+@streaming
+blob Streaming

--- a/codegen/core/src/it/resources/META-INF/smithy/structures/document-members/documents.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/structures/document-members/documents.smithy
@@ -1,0 +1,12 @@
+$version: "2"
+
+namespace smithy.java.codegen.test.structures.members
+
+operation Documents {
+    input := {
+        @required
+        requiredDoc: Document
+
+        optionalDocument: Document
+    }
+}

--- a/codegen/core/src/it/resources/META-INF/smithy/structures/enum-members/enums.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/structures/enum-members/enums.smithy
@@ -2,16 +2,20 @@ $version: "2"
 
 namespace smithy.java.codegen.test.structures.members
 
-operation IntEnums {
+operation Enums {
     input := {
         @required
-        requiredEnum: IntEnumType
-        optionalEnum: IntEnumType
+        requiredEnum: EnumType
+
+        @default("option-one")
+        defaultEnum: EnumType
+
+        optionalEnum: EnumType
     }
 }
 
 @private
-intEnum IntEnumType {
-    OPTION_ONE = 1
-    OPTION_TWO = 10
+enum EnumType {
+    OPTION_ONE = "option-one"
+    OPTION_TWO = "option-two"
 }

--- a/codegen/core/src/it/resources/META-INF/smithy/structures/int-enum-members/int-enums.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/structures/int-enum-members/int-enums.smithy
@@ -2,16 +2,18 @@ $version: "2"
 
 namespace smithy.java.codegen.test.structures.members
 
-operation Enums {
-    input := {
+operation IntEnums {
+input := {
         @required
-        requiredEnum: EnumType
-        optionalEnum: EnumType
+        requiredEnum: IntEnumType
+        @default(1)
+        defaultEnum: IntEnumType
+        optionalEnum: IntEnumType
     }
 }
 
 @private
-enum EnumType {
-    OPTION_ONE = "option-one"
-    OPTION_TWO = "option-two"
+intEnum IntEnumType {
+    OPTION_ONE = 1
+    OPTION_TWO = 10
 }

--- a/codegen/core/src/it/resources/META-INF/smithy/structures/structures.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/structures/structures.smithy
@@ -3,12 +3,14 @@ $version: "2"
 namespace smithy.java.codegen.test.structures
 
 use smithy.java.codegen.test.exceptions#ExceptionOperation
+use smithy.java.codegen.test.structures.defaults#Defaults
 use smithy.java.codegen.test.structures.members#BigDecimals
 use smithy.java.codegen.test.structures.members#BigIntegers
 use smithy.java.codegen.test.structures.members#Blobs
 use smithy.java.codegen.test.structures.members#Booleans
 use smithy.java.codegen.test.structures.members#Bytes
 use smithy.java.codegen.test.structures.members#ClientErrorCorrection
+use smithy.java.codegen.test.structures.members#Documents
 use smithy.java.codegen.test.structures.members#Doubles
 use smithy.java.codegen.test.structures.members#Enums
 use smithy.java.codegen.test.structures.members#Floats
@@ -36,6 +38,8 @@ resource StructureShapes {
         Blobs,
         // Boolean members
         Booleans,
+        // Document Members
+        Documents,
         // List members
         Lists,
         Sets,
@@ -72,5 +76,7 @@ resource StructureShapes {
         ExceptionOperation,
         // Error correction
         ClientErrorCorrection
+        // Default values
+        Defaults
     ]
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
@@ -165,6 +165,7 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
     @Override
     public Symbol intEnumShape(IntEnumShape shape) {
         return getJavaClassSymbol(shape).toBuilder()
+            .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)
             .putProperty(SymbolProperties.ENUM_VALUE_TYPE, integerShape(shape))
             .build();
     }
@@ -242,6 +243,7 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
     @Override
     public Symbol enumShape(EnumShape shape) {
         return getJavaClassSymbol(shape).toBuilder()
+            .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)
             .putProperty(SymbolProperties.ENUM_VALUE_TYPE, stringShape(shape))
             .build();
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -38,11 +38,11 @@ public final class ListGenerator
                     var target = directive.model().expectShape(directive.shape().getMember().getTarget());
                     writer.pushState();
                     var template = """
-                        static final class ${name:U}Serializer implements ${biConsumer:T}<${shape:T}, ${shapeSerializer:T}> {
+                        static final class ${name:U}Serializer implements ${biConsumer:T}<${shape:B}, ${shapeSerializer:T}> {
                             static final ${name:U}Serializer INSTANCE = new ${name:U}Serializer();
 
                             @Override
-                            public void accept(${shape:T} values, ${shapeSerializer:T} serializer) {
+                            public void accept(${shape:B} values, ${shapeSerializer:T} serializer) {
                                 for (var value : values) {
                                     ${memberSerializer:C|};
                                 }
@@ -55,11 +55,11 @@ public final class ListGenerator
                             return result;
                         }
 
-                        private static final class ${name:U}MemberDeserializer implements ${shapeDeserializer:T}.ListMemberConsumer<${shape:T}> {
+                        private static final class ${name:U}MemberDeserializer implements ${shapeDeserializer:T}.ListMemberConsumer<${shape:B}> {
                             static final ${name:U}MemberDeserializer INSTANCE = new ${name:U}MemberDeserializer();
 
                             @Override
-                            public void accept(${shape:T} state, ${shapeDeserializer:T} deserializer) {
+                            public void accept(${shape:B} state, ${shapeDeserializer:T} deserializer) {
                                 ${?unique}if (${/unique}state.add($memberDeserializer:C)${^unique};${/unique}${?unique}) {
                                     throw new ${serdeException:T}("Member must have unique values");
                                 }${/unique}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/EnumVariantSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/EnumVariantSection.java
@@ -11,6 +11,6 @@ import software.amazon.smithy.utils.CodeSection;
 /**
  * Used to add documentation to an Enum Variant member shape.
  *
- * @param shape Member shape for enum variant
+ * @param memberShape Member shape for enum variant
  */
 public record EnumVariantSection(MemberShape memberShape) implements CodeSection {}


### PR DESCRIPTION
### Description of changes
Updates codegen to create defaults for `IntEnum`, `Enum`, and `Document` types that were previously unsupported. 

Also adds in a serde test for Document members that was previously missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
