### PR TITLE
Minor fixes found in protocol testing

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -60,7 +60,7 @@ public final class ListGenerator
 
                             @Override
                             public void accept(${shape:B} state, ${shapeDeserializer:T} deserializer) {
-                                ${?unique}if (${/unique}state.add($memberDeserializer:C)${^unique};${/unique}${?unique}) {
+                                ${?unique}if (!${/unique}state.add($memberDeserializer:C)${^unique};${/unique}${?unique}) {
                                     throw new ${serdeException:T}("Member must have unique values");
                                 }${/unique}
                             }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -244,7 +244,8 @@ public final class UnionGenerator
 
         private void writePropertyEqualityCheck(JavaWriter writer) {
             var memberSymbol = symbolProvider.toSymbol(shape);
-            if (memberSymbol.expectProperty(SymbolProperties.IS_PRIMITIVE)) {
+            if (memberSymbol.expectProperty(SymbolProperties.IS_PRIMITIVE)
+                && !memberSymbol.getProperty(SymbolProperties.IS_JAVA_ARRAY).orElse(false)) {
                 writer.writeInlineWithNoFormatting("value == that.value");
             } else {
                 Class<?> comparator = CodegenUtils.isJavaArray(memberSymbol) ? Arrays.class : Objects.class;

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpBindingDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpBindingDeserializer.java
@@ -78,7 +78,7 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
                         structMemberConsumer.accept(state, member, new HttpHeaderDeserializer(headerValue));
                     }
                 }
-                case BODY -> bodyMembers.add(member.id().getName());
+                case BODY -> bodyMembers.add(member.memberName());
                 case PAYLOAD -> {
                     if (member.memberTarget().type() == ShapeType.STRUCTURE) {
                         // Read the payload into a byte buffer to deserialize a shape in the body.
@@ -114,7 +114,7 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
                     () -> "Deserializing the structured body of " + schema + " via " + payloadCodec.getMediaType()
                 );
                 payloadCodec.createDeserializer(bytes).readStruct(schema, bodyMembers, (body, m, de) -> {
-                    if (!body.contains(m.id().getName())) {
+                    if (body.contains(m.memberName())) {
                         body.structMemberConsumer.accept(body.state, m, de);
                     }
                 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Union equals generation would use == for byte[] equality
- Lists with unique members had the incorrect check during deserialization, and would always fail when non-empty
- HttpBinding body deserialization was using the enclosing shape name, instead of the member name, when looking up members bound to the body, and thus would always fail the lookup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
