### PR TITLE
Uncomment use of header list in test

### DIFF
--- a/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
+++ b/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
@@ -73,7 +73,7 @@ public class GenericTest {
 
         PutPersonImageInput input = PutPersonImageInput.builder()
             .name("Michael")
-            //.tags(List.of("Foo", "Bar")) // TODO: temporarily commenting as this serialization is broken right now
+            .tags(List.of("Foo", "Bar"))
             .moreTags(List.of("Abc", "one two"))
             .image(DataStream.ofString("image..."))
             .build();


### PR DESCRIPTION
This was fixed in https://github.com/smithy-lang/smithy-java/pull/155.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
