### PR TITLE
Fix member names in member schema

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaGenerator.java
@@ -189,7 +189,7 @@ public final class SchemaGenerator extends ShapeVisitor.Default<Void> implements
     @Override
     public Void memberShape(MemberShape shape) {
         var target = model.expectShape(shape.getTarget());
-        writer.putContext("member", symbolProvider.toMemberName(shape));
+        writer.putContext("member", shape.getMemberName());
         writer.putContext("schema", CodegenUtils.getSchemaType(writer, symbolProvider, target));
         writer.write("${schemaClass:T}.memberBuilder(${member:S}, ${schema:L})${traitInitializer:C}");
 
@@ -197,13 +197,12 @@ public final class SchemaGenerator extends ShapeVisitor.Default<Void> implements
     }
 
     private void writeNestedMemberSchema(MemberShape member) {
-        var memberName = symbolProvider.toMemberName(member);
         var target = model.expectShape(member.getTarget());
 
         writer.pushState();
         writer.putContext("schema", CodegenUtils.getSchemaType(writer, symbolProvider, target));
-        writer.putContext("memberName", memberName);
-        writer.putContext("name", CodegenUtils.toMemberSchemaName(memberName));
+        writer.putContext("memberName", member.getMemberName());
+        writer.putContext("name", CodegenUtils.toMemberSchemaName(symbolProvider.toMemberName(member)));
         writer.write(
             """
                 private static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.memberBuilder(${memberName:S}, ${schema:L})


### PR DESCRIPTION
*Description of changes:*
A schema's memberName should be the member name in the Smithy model, so
that references to that member name do not also have to be run through
a symbol provider. This is the case in traits like HttpTrait, where the
labels in uri reference member names in the model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
