### PR TITLE
Support for sparse list and map values

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
@@ -16,6 +16,7 @@ import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+import software.amazon.smithy.model.traits.SparseTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -63,6 +64,10 @@ public class MapGenerator
 
                             @Override
                             public void accept(${value:B} values, ${shapeSerializer:T} serializer) {
+                                ${?sparse}if (values == null) {
+                                    serializer.writeNull(${valueSchema:L});
+                                    return;
+                                }${/sparse}
                                 ${memberSerializer:C|};
                             }
                         }
@@ -78,6 +83,10 @@ public class MapGenerator
 
                             @Override
                             public void accept(${shape:B} state, ${key:T} key, ${shapeDeserializer:T} deserializer) {
+                                ${?sparse}if (deserializer.isNull()) {
+                                    state.put(key, deserializer.readNull());
+                                    return;
+                                }${/sparse}
                                 state.put(key, $memberDeserializer:C);
                             }
                         }
@@ -119,6 +128,7 @@ public class MapGenerator
                             valueSchema
                         )
                     );
+                    writer.putContext("sparse", directive.shape().hasTrait(SparseTrait.class));
                     writer.write(template);
                     writer.popState();
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
@@ -149,6 +149,23 @@ public interface ShapeDeserializer extends AutoCloseable {
     <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> consumer);
 
     /**
+     *
+     * Attempt to see if this value is null. Useful for sparse collections.
+     *
+     * @return true if null
+     */
+    boolean isNull();
+
+    /**
+     * Read (skip) the null value. Only makes sense after {@link #isNull()}.
+     *
+     * @return null
+     */
+    default <T> T readNull() {
+        return null;
+    }
+
+    /**
      * Consumer of a structure member.
      *
      * @param <T> Passed in state value to avoid capturing external state.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
@@ -102,4 +102,9 @@ public abstract class SpecificShapeDeserializer implements ShapeDeserializer {
     public <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> consumer) {
         throw throwForInvalidState(schema);
     }
+
+    @Override
+    public boolean isNull() {
+        throw new UnsupportedOperationException("cannot look ahead for null values");
+    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 
 /**
@@ -122,5 +123,18 @@ public class DocumentDeserializer implements ShapeDeserializer {
         for (var entry : map.entrySet()) {
             mapMemberConsumer.accept(state, entry.getKey(), deserializer(entry.getValue()));
         }
+    }
+
+    @Override
+    public boolean isNull() {
+        return value == null;
+    }
+
+    @Override
+    public <T> T readNull() {
+        if (value != null) {
+            throw new SerializationException("Attempted to read non-null value as null");
+        }
+        return null;
     }
 }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderDeserializer.java
@@ -118,4 +118,9 @@ final class HttpHeaderDeserializer implements ShapeDeserializer {
     public <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
         throw new UnsupportedOperationException("List map support not yet implemented");
     }
+
+    @Override
+    public boolean isNull() {
+        return value == null;
+    }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDeserializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonDeserializer.java
@@ -205,4 +205,25 @@ final class JsonDeserializer implements ShapeDeserializer {
             throw new SerializationException(e);
         }
     }
+
+    @Override
+    public boolean isNull() {
+        try {
+            return iter.whatIsNext() == ValueType.NULL;
+        } catch (IOException e) {
+            throw new SerializationException(e);
+        }
+    }
+
+    @Override
+    public <T> T readNull() {
+        try {
+            if (!iter.readNull()) {
+                throw new SerializationException("Attempted to read non-null value as null");
+            }
+        } catch (IOException e) {
+            throw new SerializationException(e);
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Since serde mostly likes to work with primitive types, added isNull and readNull methods so that we can check for nullity only in sparse collections, and assume non-null in other cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
