### PR TITLE
Prefer whole epoch-seconds

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/TimestampFormatter.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/TimestampFormatter.java
@@ -104,7 +104,12 @@ public interface TimestampFormatter {
 
             @Override
             public String writeString(Instant value) {
-                return String.format("%.3f", ((double) value.toEpochMilli()) / 1000);
+                double v = ((double) value.toEpochMilli()) / 1000;
+                // only write fractional seconds if we wouldn't write ".000"
+                if (v - (long) v >= 0.001d) {
+                    return String.format("%.3f", v);
+                }
+                return String.format("%d", (long) v);
             }
 
             @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/TimestampFormatterTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/TimestampFormatterTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+public class TimestampFormatterTest {
+    @Test
+    public void testEpochSecondsRounding() {
+        Instant wholeTime = Instant.ofEpochSecond(7234);
+        assertEquals("7234", TimestampFormatter.Prelude.EPOCH_SECONDS.writeString(wholeTime));
+
+        Instant fractionalTime = Instant.ofEpochMilli(1718830549174L);
+        assertEquals("1718830549.174", TimestampFormatter.Prelude.EPOCH_SECONDS.writeString(fractionalTime));
+
+        fractionalTime = Instant.ofEpochMilli(1718830549002L);
+        assertEquals("1718830549.002", TimestampFormatter.Prelude.EPOCH_SECONDS.writeString(fractionalTime));
+    }
+}


### PR DESCRIPTION
*Description of changes:*
If the EPOCH_SECONDS formatter would write <somenumber>.000, the fractional portion is just costing us bytes on the wire without any actual precision gain. "%.3f" rounds up, so we only use the floating point formatter if we have one millisecond or more. Existing protocol tests enforce this behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
