### PR TITLE
Apply fixes for naming collisions

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/UnionTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/UnionTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
-import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 public class UnionTest {
@@ -53,7 +52,7 @@ public class UnionTest {
 
     @ParameterizedTest
     @MethodSource("unionTypes")
-    void pojoToDocumentRoundTrip(SerializableStruct pojo) {
+    void pojoToDocumentRoundTrip(UnionType pojo) {
         var document = Document.createTyped(pojo);
         var builder = UnionType.builder();
         document.deserializeInto(builder);

--- a/codegen/core/src/it/resources/META-INF/smithy/main.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/main.smithy
@@ -6,6 +6,7 @@ use smithy.java.codegen.test.enums#EnumTests
 use smithy.java.codegen.test.exceptions#ExceptionTests
 use smithy.java.codegen.test.lists#ListTests
 use smithy.java.codegen.test.maps#MapTests
+use smithy.java.codegen.test.naming#Naming
 use smithy.java.codegen.test.structures#StructureTests
 use smithy.java.codegen.test.unions#UnionTests
 
@@ -19,5 +20,8 @@ service TestService {
         // TODO: Add recursion tests
         StructureTests
         UnionTests
+    ]
+    operations: [
+        Naming
     ]
 }

--- a/codegen/core/src/it/resources/META-INF/smithy/manifest
+++ b/codegen/core/src/it/resources/META-INF/smithy/manifest
@@ -11,6 +11,7 @@ maps/map-all-types.smithy
 maps/map-tests.smithy
 maps/nested-maps.smithy
 maps/sparse-maps.smithy
+naming/naming-collision.smithy
 recursion/mutual-recursion-list.smithy
 recursion/mutual-recursion-map.smithy
 recursion/recursion-tests.smithy

--- a/codegen/core/src/it/resources/META-INF/smithy/naming/naming-collision.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/naming/naming-collision.smithy
@@ -1,0 +1,28 @@
+$version: "2"
+
+namespace smithy.java.codegen.test.naming
+
+
+/// Compile-only checks that naming collisions are handled correctly and
+/// generate valid code.
+operation Naming {
+    input := {
+        // Collides with `other` in equals
+        other: String
+        builder: Builder
+        inner: InnerDeserializer
+        type: Type
+    }
+}
+
+@private
+structure Builder {
+}
+
+@private
+structure InnerDeserializer {
+}
+
+@private
+structure Type {
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -36,13 +36,14 @@ public final class CodegenUtils {
         CodegenUtils.class.getResource("reserved-words.txt")
     );
 
-    private static final String SCHEMA_STATIC_NAME = "SCHEMA";
     public static final ReservedWords SHAPE_ESCAPER = new ReservedWordsBuilder()
         .loadCaseInsensitiveWords(RESERVED_WORDS_FILE, word -> word + "Shape")
         .build();
     public static final ReservedWords MEMBER_ESCAPER = new ReservedWordsBuilder()
         .loadCaseInsensitiveWords(RESERVED_WORDS_FILE, word -> word + "Member")
         .build();
+
+    private static final String SCHEMA_STATIC_NAME = "SCHEMA";
 
     private CodegenUtils() {
         // Utility class should not be instantiated

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -352,10 +352,10 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
                 if (memberSymbol.expectProperty(SymbolProperties.IS_PRIMITIVE) && !CodegenUtils.isNullableMember(
                     member
                 )) {
-                    writer.writeInline("${memberName:L} == that.${memberName:L}");
+                    writer.writeInline("this.${memberName:L} == that.${memberName:L}");
                 } else {
                     Class<?> comparator = CodegenUtils.isJavaArray(memberSymbol) ? Arrays.class : Objects.class;
-                    writer.writeInline("$T.equals(${memberName:L}, that.${memberName:L})", comparator);
+                    writer.writeInline("$T.equals(this.${memberName:L}, that.${memberName:L})", comparator);
                 }
                 if (iter.hasNext()) {
                     writer.writeInlineWithNoFormatting(writer.getNewline() + "&& ");

--- a/codegen/core/src/main/resources/software/amazon/smithy/java/codegen/reserved-words.txt
+++ b/codegen/core/src/main/resources/software/amazon/smithy/java/codegen/reserved-words.txt
@@ -33,6 +33,8 @@ goto
 if
 implements
 import
+innerDeserializer
+type
 instanceof
 int
 interface


### PR DESCRIPTION
## Description of changes
Corrects the handling of a number of naming collisions: 
- `Type` and `InnerDeserializer` inner classes
- `other` member was colliding with `other` assignment in equals method


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
