### PR TITLE
Remove Document#normalize

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
@@ -362,49 +362,6 @@ public interface Document extends SerializableShape {
     }
 
     /**
-     * Create a normalized version of the document using normalized document types that aren't tied to any specific
-     * protocol or schema.
-     *
-     * <p>A structure and union document are converted to a map of string to normalized documents. An intEnum is
-     * converted to an integer. An enum is converted to a string.
-     *
-     * @return the normalized document.
-     */
-    default Document normalize() {
-        return switch (type()) {
-            case BOOLEAN -> createBoolean(asBoolean());
-            case BYTE -> createByte(asByte());
-            case SHORT -> createShort(asShort());
-            case INTEGER, INT_ENUM -> createInteger(asInteger());
-            case LONG -> createLong(asLong());
-            case FLOAT -> createFloat(asFloat());
-            case DOUBLE -> createDouble(asDouble());
-            case BIG_INTEGER -> createBigInteger(asBigInteger());
-            case BIG_DECIMAL -> createBigDecimal(asBigDecimal());
-            case STRING, ENUM -> createString(asString());
-            case BLOB -> createBlob(asBlob());
-            case TIMESTAMP -> createTimestamp(asTimestamp());
-            case STRUCTURE, UNION, MAP -> {
-                var map = asStringMap();
-                Map<String, Document> result = new LinkedHashMap<>(map.size());
-                for (var entry : map.entrySet()) {
-                    result.put(entry.getKey(), entry.getValue().normalize());
-                }
-                yield createStringMap(result);
-            }
-            case LIST -> {
-                var list = asList();
-                List<Document> result = new ArrayList<>(list.size());
-                for (var element : list) {
-                    result.add(element.normalize());
-                }
-                yield createList(result);
-            }
-            default -> throw new UnsupportedOperationException("Unable to normalize document: " + this);
-        };
-    }
-
-    /**
      * Attempt to deserialize the Document into a builder.
      *
      * @param builder Builder to populate from the Document.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -51,11 +51,6 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBoolean(schema, value);
         }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.BOOLEAN ? this : Document.super.normalize();
-        }
     }
 
     private static byte toByteExact(ShapeType source, long value) {
@@ -132,11 +127,6 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeByte(schema, value);
         }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.BYTE ? this : Document.super.normalize();
-        }
     }
 
     record ShortDocument(Schema schema, short value) implements Document {
@@ -188,11 +178,6 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeShort(schema, value);
-        }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.SHORT ? this : Document.super.normalize();
         }
     }
 
@@ -246,11 +231,6 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeInteger(schema, value);
         }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.INTEGER ? this : Document.super.normalize();
-        }
     }
 
     record LongDocument(Schema schema, long value) implements Document {
@@ -302,11 +282,6 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeLong(schema, value);
-        }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.LONG ? this : Document.super.normalize();
         }
     }
 
@@ -367,11 +342,6 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeFloat(schema, value);
-        }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.FLOAT ? this : Document.super.normalize();
         }
     }
 
@@ -445,11 +415,6 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeDouble(schema, value);
         }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.DOUBLE ? this : Document.super.normalize();
-        }
     }
 
     record BigIntegerDocument(Schema schema, BigInteger value) implements Document {
@@ -501,11 +466,6 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBigInteger(schema, value);
-        }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.BIG_INTEGER ? this : Document.super.normalize();
         }
     }
 
@@ -559,11 +519,6 @@ final class Documents {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeBigDecimal(schema, value);
         }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.BIG_DECIMAL ? this : Document.super.normalize();
-        }
     }
 
     record StringDocument(Schema schema, String value) implements Document {
@@ -580,11 +535,6 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeString(schema, value);
-        }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.STRING ? this : Document.super.normalize();
         }
     }
 
@@ -621,11 +571,6 @@ final class Documents {
         public int hashCode() {
             return Arrays.hashCode(value);
         }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.BLOB ? this : Document.super.normalize();
-        }
     }
 
     record TimestampDocument(Schema schema, Instant value) implements Document {
@@ -642,11 +587,6 @@ final class Documents {
         @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeTimestamp(schema, value);
-        }
-
-        @Override
-        public Document normalize() {
-            return schema == PreludeSchemas.TIMESTAMP ? this : Document.super.normalize();
         }
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
@@ -56,9 +56,10 @@ public class BlobDocumentTest {
     }
 
     @Test
-    public void normalizeReturnsSelf() {
-        var doc = Document.createBlob("a".getBytes(StandardCharsets.UTF_8));
+    public void toObjectReturnsSelf() {
+        var bytes = "a".getBytes(StandardCharsets.UTF_8);
+        var doc = Document.createBlob(bytes);
 
-        assertThat(doc.normalize(), is(doc));
+        assertThat(doc.asObject(), is(bytes));
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -87,13 +86,5 @@ public class TypedDocumentTest {
         var copy1 = result.asStringMap();
         assertThat(copy1.get("a").asString(), equalTo("1"));
         assertThat(copy1.get("b").asString(), equalTo("2"));
-    }
-
-    @Test
-    public void normalizesWithoutSchema() {
-        var serializableShape = createSerializableShape();
-        var result = Document.createTyped(serializableShape);
-
-        assertThat(result.normalize(), not(sameInstance(result)));
     }
 }

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
@@ -431,6 +431,6 @@ public class JsonDocumentTest {
         var de = codec.createDeserializer("true".getBytes(StandardCharsets.UTF_8));
         var json = de.readDocument();
 
-        assertThat(json.normalize(), equalTo(Document.createBoolean(true)));
+        assertThat(Document.equals(json, Document.createBoolean(true)), is(true));
     }
 }


### PR DESCRIPTION
Now that documents have Document#equals to compare across protocols and implementations and Document#asObject, the #normalize method doesn't add as much value. If a normalized document is necessary still, an end user can call `Document.createFromObject(document.asObject())``.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
