### PR TITLE
Add a pre-commit hook for spotless formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-## My Project
+# <img alt="Smithy" src="https://github.com/smithy-lang/smithy/blob/main/docs/_static/favicon.png?raw=true" width="28"> Smithy Java
 
-TODO: Fill this README out!
+[Smithy](https://smithy.io/2.0/index.html) code generators for [Java](https://java.com/).
 
-Be sure to:
+## Development
 
-* Change the title in this README
-* Edit your repository description on GitHub
+### Pre-commit hooks
+Provided pre-commit hooks make it easier to pass automated linting when opening a pull request.
+To set up these hooks run:
+```shell 
+ln -s -f ../../git-hooks/pre-commit .git/hooks/pre-commit
+```
 
 ## Security
 

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Execute formatter if any java files are staged
+changedJavaFiles=$(git diff --staged --name-only | grep .java | xargs -I {} basename {} | tr '\n' '.*' | paste -sd ',' -) 
+if [ -n "$changedJavaFiles" ]; then
+  echo "[git hook] Executing spotless formatter on staged files before commit" 
+  ./gradlew spotlessApply -DspotlessFiles=$changedJavaFiles
+  # Stage updates
+  git add -u
+fi 
+


### PR DESCRIPTION
### Description of changes
Adds a pre-commit hook to execute the spotless formatter automatically.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
