### PR TITLE
Use different character for second pass

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
@@ -19,6 +19,14 @@ java {
     }
 }
 
+tasks.withType<JavaCompile>() {
+    options.encoding = "UTF-8"
+}
+
+tasks.withType<Javadoc>() {
+    options.encoding = "UTF-8"
+}
+
 /*
  * Common test configuration
  * ===============================

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
@@ -168,7 +168,7 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
             }
 
             public static ${shape:T} unknown(${value:T} value) {
-                return new ${shape:T}(Type.$$$$UNKNOWN, value);
+                return new ${shape:T}(Type.$$UNKNOWN, value);
             }
             """);
     }
@@ -311,7 +311,7 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
                 public ${shape:T} build() {
                     return switch (value) {
                         ${C|}
-                        default -> new ${shape:T}(Type.$$$$UNKNOWN, value);
+                        default -> new ${shape:T}(Type.$$UNKNOWN, value);
                     };
                 }
                 """, writer.consumer(w -> generateSwitchCases(w, shape)));

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/TypeEnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/TypeEnumGenerator.java
@@ -18,7 +18,7 @@ record TypeEnumGenerator(JavaWriter writer, Shape shape, SymbolProvider symbolPr
     @Override
     public void run() {
         List<String> enumList = new ArrayList<>();
-        enumList.add("$$UNKNOWN");
+        enumList.add("$UNKNOWN");
         for (var member : shape.members()) {
             enumList.add(CodegenUtils.getEnumVariantName(symbolProvider, member));
         }


### PR DESCRIPTION
### Description of changes
Updates writer to use second character other than dollar sign for second pass.

Also factors out some common formatter code into a separate method.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
