### PR TITLE
Handle unknown unions

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
@@ -37,12 +37,20 @@ record StructureDeserializerGenerator(
                         ${cases:C|}
                     }${/hasMembers}
                 }
+
+                ${?union}
+                @Override
+                public void unknownMember(Builder builder, String memberName) {
+                    builder.$$unknownMember(memberName);
+                }
+                ${/union}
             }
             """;
         writer.putContext("shapeDeserializer", ShapeDeserializer.class);
         writer.putContext("sdkSchema", Schema.class);
         writer.putContext("hasMembers", !shape.members().isEmpty());
         writer.putContext("cases", writer.consumer(this::generateMemberSwitchCases));
+        writer.putContext("union", shape.isUnionShape());
         writer.write(template);
         writer.popState();
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
@@ -173,6 +173,8 @@ public interface ShapeDeserializer extends AutoCloseable {
     @FunctionalInterface
     interface StructMemberConsumer<T> {
         void accept(T state, Schema memberSchema, ShapeDeserializer memberDeserializer);
+
+        default void unknownMember(T state, String memberName) {}
     }
 
     /**

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
@@ -358,6 +359,13 @@ public interface Document extends SerializableShape {
      * @throws IllegalStateException if the Document is not a string map, structure, or union shape.
      */
     default Document getMember(String memberName) {
+        throw new SerializationException("Expected a map, structure, or union document, but found " + type());
+    }
+
+    /**
+     * List all the available members.
+     */
+    default Set<String> getMemberNames() {
         throw new SerializationException("Expected a map, structure, or union document, but found " + type());
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
@@ -102,10 +102,15 @@ public class DocumentDeserializer implements ShapeDeserializer {
 
     @Override
     public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
-        for (var memberSchema : schema.members()) {
-            var memberValue = value.getMember(memberSchema.memberName());
-            if (memberValue != null) {
-                structMemberConsumer.accept(state, memberSchema, deserializer(memberValue));
+        for (var member : value.getMemberNames()) {
+            var memberSchema = schema.member(member);
+            if (memberSchema != null) {
+                var memberValue = value.getMember(member);
+                if (memberValue != null) {
+                    structMemberConsumer.accept(state, memberSchema, deserializer(memberValue));
+                }
+            } else {
+                structMemberConsumer.unknownMember(state, member);
             }
         }
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -9,8 +9,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
@@ -628,6 +630,11 @@ final class Documents {
         }
 
         @Override
+        public Set<String> getMemberNames() {
+            return Set.copyOf(members.keySet());
+        }
+
+        @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeMap(schema, members, (members, s) -> {
                 var key = schema.member("key");
@@ -647,6 +654,11 @@ final class Documents {
         @Override
         public Document getMember(String memberName) {
             return members.get(memberName);
+        }
+
+        @Override
+        public Set<String> getMemberNames() {
+            return Set.copyOf(members.keySet());
         }
 
         @Override
@@ -716,6 +728,13 @@ final class Documents {
             } else {
                 return getDocument().getMember(memberName);
             }
+        }
+
+        @Override
+        public Set<String> getMemberNames() {
+            var result = new HashSet<>(getDocument().getMemberNames());
+            result.add("__type");
+            return result;
         }
 
         @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.junit.jupiter.api.Assertions;
@@ -475,6 +476,11 @@ public class DocumentTest {
         @Override
         public Document getMember(String memberName) {
             return getDocument().getMember(memberName);
+        }
+
+        @Override
+        public Set<String> getMemberNames() {
+            return getDocument().getMemberNames();
         }
 
         @Override

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerializer.java
@@ -27,19 +27,16 @@ import software.amazon.smithy.model.shapes.ShapeType;
 final class JsonSerializer implements ShapeSerializer {
 
     JsonStream stream;
-    final JsonFieldMapper fieldMapper;
-    final TimestampResolver timestampResolver;
+    final JsonCodec.Settings settings;
     private final Consumer<JsonStream> returnHandle;
 
     JsonSerializer(
         JsonStream stream,
-        JsonFieldMapper fieldMapper,
-        TimestampResolver timestampResolver,
+        JsonCodec.Settings settings,
         Consumer<JsonStream> returnHandle
     ) {
         this.stream = stream;
-        this.timestampResolver = timestampResolver;
-        this.fieldMapper = fieldMapper;
+        this.settings = settings;
         this.returnHandle = returnHandle;
     }
 
@@ -184,7 +181,7 @@ final class JsonSerializer implements ShapeSerializer {
 
     @Override
     public void writeTimestamp(Schema schema, Instant value) {
-        timestampResolver.resolve(schema).writeToSerializer(schema, value, this);
+        settings.timestampResolver().resolve(schema).writeToSerializer(schema, value, this);
     }
 
     @Override

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonStructSerializer.java
@@ -36,7 +36,7 @@ class JsonStructSerializer implements ShapeSerializer {
             } else {
                 firstValue = false;
             }
-            parent.stream.writeObjectField(parent.fieldMapper.memberToField(member));
+            parent.stream.writeObjectField(parent.settings.fieldMapper().memberToField(member));
         } catch (JsonException | IOException e) {
             throw new SerializationException(e);
         }

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonTestData.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonTestData.java
@@ -37,4 +37,18 @@ public final class JsonTestData {
         .type(ShapeType.STRUCTURE)
         .members(NESTED_NUMBER)
         .build();
+
+    static final ShapeId UNION_ID = ShapeId.from("smithy.example#Union");
+    static final Schema UNION_BOOLEAN_VALUE = Schema.memberBuilder("booleanValue", PreludeSchemas.BOOLEAN)
+        .id(UNION_ID)
+        .build();
+    static final Schema UNION_INTEGER_VALUE = Schema.memberBuilder("intValue", PreludeSchemas.INTEGER)
+        .id(UNION_ID)
+        .build();
+    static final Schema UNION = Schema.builder()
+        .id(UNION_ID)
+        .type(ShapeType.UNION)
+        .members(UNION_BOOLEAN_VALUE, UNION_INTEGER_VALUE)
+        .build();
+
 }


### PR DESCRIPTION
*Description of changes:*
- Unions now generate a subclass called $UnknownMember and have a method named $unknown() that returns true if the value is unknown. Builder can set the unknown value but cannot switch between known and unknown.
- StructMemberConsumer now has a default "unknownMember" method that is only called when the type is a union and the codec allows unknown variants. We could make it do more in the future for non-union types, but these sorts of features are brittle and potentially dangerous, so I restricted its capabilities and usage to the bare minimum to start.
- JsonCodec can be configured to allow or reject deserialization of unknown values; it seems likely to me that servers will want to reject unknown values but clients will not.
- All unknown variants eagerly reject serialization of unknown variants, as we have no way to communicate them on the wire.

Here's what code generation looks like for a simple union now (I manually redacted all the members except `blobValue` for brevity):

```
package io.smithy.codegen.test.model;

import java.math.BigDecimal;
import java.math.BigInteger;
import java.time.Instant;
import java.util.Arrays;
import java.util.List;
import java.util.Map;
import java.util.Objects;
import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
import software.amazon.smithy.java.runtime.core.schema.Schema;
import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
import software.amazon.smithy.java.runtime.core.serde.SerializationException;
import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
import software.amazon.smithy.java.runtime.core.serde.ToStringSerializer;
import software.amazon.smithy.model.shapes.ShapeId;
import software.amazon.smithy.model.shapes.ShapeType;
import software.amazon.smithy.utils.SmithyGenerated;

@SmithyGenerated
public abstract class UnionType implements SerializableStruct {
    public static final ShapeId ID = ShapeId.from("smithy.java.codegen.test.unions#UnionType");

    private static final Schema SCHEMA_BLOB_VALUE = Schema.memberBuilder("blobValue", PreludeSchemas.BLOB)
        .id(ID)
        .build();

    static final Schema SCHEMA = Schema.builder()
        .id(ID)
        .type(ShapeType.UNION)
        .members(
            SCHEMA_BLOB_VALUE
        )
        .build();

    private final Type type;

    private UnionType(Type type) {
        this.type = type;
    }

    public Type type() {
        return type;
    }

    public enum Type {
        $UNKNOWN,
        BLOB_VALUE
    }

    @Override
    public String toString() {
        return ToStringSerializer.serialize(this);
    }

    public byte[] blobValue() {
        return null;
    }

    public String $unknownMember() {
        return null;
    }

    @SmithyGenerated
    public static final class BlobValueMember extends UnionType {
        private final transient byte[] value;

        public BlobValueMember(byte[] value) {
            super(Type.BLOB_VALUE);
            this.value = value;
        }

        @Override
        public void serialize(ShapeSerializer serializer) {
            serializer.writeStruct(SCHEMA, this);
        }

        @Override
        public void serializeMembers(ShapeSerializer serializer) {
            serializer.writeBlob(SCHEMA_BLOB_VALUE, value);
        }

        @Override
        public byte[] blobValue() {
            return value;
        }

        @Override
        public boolean equals(Object other) {
            if (other == this) {
                return true;
            }
            if (other == null || getClass() != other.getClass()) {
                return false;
            }
            BlobValueMember that = (BlobValueMember) other;
            return Arrays.equals(value, that.value);
        }

        @Override
        public int hashCode() {
            return Arrays.hashCode(value);
        }
    }

    public static final class $UnknownMember extends UnionType {
        private final String memberName;

        public $UnknownMember(String memberName) {
            super(Type.$UNKNOWN);
            this.memberName = memberName;
        }

        @Override
        public String $unknownMember() {
            return memberName;
        }

        @Override
        public void serialize(ShapeSerializer serializer) {
            throw new SerializationException("Cannot serialize union with unknown member " + this.memberName);
        }

        @Override
        public void serializeMembers(ShapeSerializer serializer) {}

        @Override
        public boolean equals(Object other) {
            if (other == this) {
                return true;
            }
            if (other == null || getClass() != other.getClass()) {
                return false;
            }
            return memberName.equals((($UnknownMember) other).memberName);
        }

        @Override
        public int hashCode() {
            return memberName.hashCode();
        }
    }

    public static interface BuildStage {
        UnionType build();
    }

    public static Builder builder() {
        return new Builder();
    }

    /**
     * Builder for {@link UnionType}.
     */
    public static final class Builder implements ShapeBuilder<UnionType>, BuildStage {
        private UnionType value;

        private Builder() {}

        public BuildStage blobValue(byte[] value) {
            checkForExistingValue();
            this.value = new BlobValueMember(value);
            return this;
        }

        public BuildStage $unknownMember(String memberName) {
            checkForExistingValue();
            this.value = new $UnknownMember(memberName);
            return this;
        }

        private void checkForExistingValue() {
            if (this.value != null) {
                if (this.value.type() == Type.$UNKNOWN) {
                    throw new SerializationException("Cannot change union from unknown to known variant");
                }
                throw new SerializationException("Only one value may be set for unions");
            }
        }

        @Override
        public UnionType build() {
            return Objects.requireNonNull(value, "no union value set");
        }

        @Override
        public Builder deserialize(ShapeDeserializer decoder) {
            decoder.readStruct(SCHEMA, this, InnerDeserializer.INSTANCE);
            return this;
        }

        private static final class InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
            private static final InnerDeserializer INSTANCE = new InnerDeserializer();

            @Override
            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
                switch (member.memberIndex()) {
                    case 0 -> builder.blobValue(de.readBlob(member));
                }
            }

            @Override
            public void unknownMember(Builder builder, String memberName) {
                builder.$unknownMember(memberName);
            }
        }

    }
}
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
