### PR TITLE
Fix TimestampFormatter to not be locale specific

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,3 +17,14 @@ jmh {
     fork = 1
     //profilers = ['async:output=flamegraph', 'gc']
 }
+
+//Run all tests with a different locale to ensure we are not doing anything locale specific.
+val localeTest = tasks.register<Test>("localeTest") {
+    useJUnitPlatform()
+    systemProperty("user.country", "DE")
+    systemProperty("user.language", "de")
+}
+
+tasks.build {
+    dependsOn(localeTest)
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/TimestampFormatter.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/TimestampFormatter.java
@@ -107,9 +107,9 @@ public interface TimestampFormatter {
                 double v = ((double) value.toEpochMilli()) / 1000;
                 // only write fractional seconds if we wouldn't write ".000"
                 if (v - (long) v >= 0.001d) {
-                    return String.format("%.3f", v);
+                    return String.format(Locale.ROOT, "%.3f", v);
                 }
-                return String.format("%d", (long) v);
+                return Long.toString((long) v);
             }
 
             @Override


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Without this change the `TimestampFormatter` formats it to `1718830549,174` instead of `1718830549.174`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
