### PR TITLE
Remove static from BuildStage declaration

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -308,7 +308,7 @@ public final class UnionGenerator
         @Override
         protected void generateStages(JavaWriter writer) {
             writer.write("""
-                public static interface BuildStage {
+                public interface BuildStage {
                     ${shape:T} build();
                 }
                 """);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Static modifier is redundant for inner interfaces.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
