### PR TITLE
Use ByteBuffers instead of byte[] in generated POJOs

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ClientErrorCorrectionTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ClientErrorCorrectionTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +37,7 @@ public class ClientErrorCorrectionTest {
         assertEquals(corrected.integer(), 0);
         assertEquals(corrected.longMember(), 0);
         assertEquals(corrected.shortMember(), (short) 0);
-        assertArrayEquals(corrected.blob(), new byte[0]);
+        assertEquals(corrected.blob(), ByteBuffer.allocate(0));
         assertEquals(corrected.streamingBlob().contentLength(), 0);
         corrected.streamingBlob().asBytes().thenAccept(bytes -> assertArrayEquals(bytes, new byte[0]));
         assertNull(corrected.document());

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Collections;
@@ -36,7 +37,7 @@ public class DefaultsTest {
         assertEquals(defaults.integer(), 1);
         assertEquals(defaults.longMember(), 1);
         assertEquals(defaults.shortMember(), (short) 1);
-        assertArrayEquals(defaults.blob(), Base64.getDecoder().decode("YmxvYg=="));
+        assertEquals(defaults.blob(), ByteBuffer.wrap(Base64.getDecoder().decode("YmxvYg==")));
         defaults.streamingBlob()
             .asBytes()
             .thenAccept(b -> assertArrayEquals(b, Base64.getDecoder().decode("c3RyZWFtaW5n")));

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ListsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ListsTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.codegen.test;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -15,11 +16,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -95,7 +94,9 @@ public class ListsTest {
                 .build(),
             ListAllTypesInput.builder()
                 .listOfBlobs(
-                    List.of(Base64.getDecoder().decode("YmxvYg=="), Base64.getDecoder().decode("YmlyZHM="))
+                    Stream.of(Base64.getDecoder().decode("YmxvYg=="), Base64.getDecoder().decode("YmlyZHM="))
+                        .map(ByteBuffer::wrap)
+                        .toList()
                 )
                 .build(),
             ListAllTypesInput.builder()
@@ -205,7 +206,11 @@ public class ListsTest {
                 .build(),
             SparseListsInput.builder()
                 .listOfBlobs(
-                    ListUtils.of(Base64.getDecoder().decode("YmxvYg=="), null, Base64.getDecoder().decode("YmlyZHM="))
+                    ListUtils.of(
+                        wrap(Base64.getDecoder().decode("YmxvYg==")),
+                        null,
+                        wrap(Base64.getDecoder().decode("YmlyZHM="))
+                    )
                 )
                 .build(),
             SparseListsInput.builder()

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/MapsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/MapsTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.codegen.test;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -91,7 +92,12 @@ public class MapsTest {
                 .build(),
             MapAllTypesInput.builder()
                 .stringBlobMap(
-                    Map.of("a", Base64.getDecoder().decode("YmxvYg=="), "b", Base64.getDecoder().decode("YmlyZHM="))
+                    Map.of(
+                        "a",
+                        wrap(Base64.getDecoder().decode("YmxvYg==")),
+                        "b",
+                        wrap(Base64.getDecoder().decode("YmlyZHM="))
+                    )
                 )
                 .build(),
             MapAllTypesInput.builder()
@@ -203,11 +209,11 @@ public class MapsTest {
                 .stringBlobMap(
                     MapUtils.of(
                         "a",
-                        Base64.getDecoder().decode("YmxvYg=="),
+                        wrap(Base64.getDecoder().decode("YmxvYg==")),
                         "null",
                         null,
                         "b",
-                        Base64.getDecoder().decode("YmlyZHM=")
+                        wrap(Base64.getDecoder().decode("YmlyZHM="))
                     )
                 )
                 .build(),

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/StructuresTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/StructuresTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.codegen.test;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
@@ -81,7 +82,7 @@ public class StructuresTest {
     @Test
     void blobSerialization() {
         var datastream = DataStream.ofBytes("data streeeeeeeeeeam".getBytes());
-        var builder = BlobMembersInput.builder().requiredBlob("data".getBytes());
+        var builder = BlobMembersInput.builder().requiredBlob(wrap("data".getBytes()));
         builder.setDataStream(datastream);
         var input = builder.build();
         var document = Document.createTyped(builder.build());

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/UnionTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/UnionTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
@@ -46,7 +47,7 @@ public class UnionTest {
             new UnionType.LongValueMember(1L),
             new UnionType.ShortValueMember((short) 1),
             new UnionType.StringValueMember("string"),
-            new UnionType.BlobValueMember(Base64.getDecoder().decode("c3RyZWFtaW5n")),
+            new UnionType.BlobValueMember(ByteBuffer.wrap(Base64.getDecoder().decode("c3RyZWFtaW5n"))),
             new UnionType.StructureValueMember(NestedStruct.builder().build()),
             new UnionType.TimestampValueMember(Instant.EPOCH),
             new UnionType.UnionValueMember(new NestedUnion.BMember(1)),

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -118,7 +118,7 @@ public final class CodegenUtils {
      * @return true if symbol resolves to a Java Array
      */
     public static boolean isJavaArray(Symbol symbol) {
-        return symbol.getProperty(SymbolProperties.IS_JAVA_ARRAY).isPresent();
+        return symbol.getProperty(SymbolProperties.IS_JAVA_ARRAY).orElse(false);
     }
 
     /**

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
@@ -9,6 +9,7 @@ import static java.lang.String.format;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -100,10 +101,9 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
         if (blobShape.hasTrait(StreamingTrait.class)) {
             return CodegenUtils.fromClass(DataStream.class);
         }
-        return CodegenUtils.fromClass(byte[].class)
+        return CodegenUtils.fromClass(ByteBuffer.class)
             .toBuilder()
-            .putProperty(SymbolProperties.IS_JAVA_ARRAY, true)
-            .putProperty(SymbolProperties.IS_PRIMITIVE, true)
+            .putProperty(SymbolProperties.IS_PRIMITIVE, false)
             .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)
             .build();
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/ByteBufferUtils.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/ByteBufferUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public final class ByteBufferUtils {
+
+    private ByteBufferUtils() {
+    }
+
+    public static String base64Encode(ByteBuffer buffer) {
+        if (isExact(buffer)) {
+            return Base64.getEncoder().encodeToString(buffer.array());
+        }
+        return StandardCharsets.UTF_8.decode(Base64.getEncoder().encode(buffer.asReadOnlyBuffer())).toString();
+    }
+
+    public static byte[] getBytes(ByteBuffer buffer) {
+        if (isExact(buffer)) {
+            return buffer.array();
+        }
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.asReadOnlyBuffer().get(bytes);
+        return bytes;
+    }
+
+    private static boolean isExact(ByteBuffer buffer) {
+        return buffer.hasArray() && buffer.arrayOffset() == 0 && buffer.remaining() == buffer.array().length;
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Validator.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Validator.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.schema;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -392,10 +393,11 @@ public final class Validator {
         }
 
         @Override
-        public void writeBlob(Schema schema, byte[] value) {
+        public void writeBlob(Schema schema, ByteBuffer value) {
             checkType(schema, ShapeType.BLOB);
-            if (value.length < schema.minLengthConstraint || value.length > schema.maxLengthConstraint) {
-                addError(new ValidationError.LengthValidationFailure(createPath(), value.length, schema));
+            int length = value.remaining();
+            if (length < schema.minLengthConstraint || length > schema.maxLengthConstraint) {
+                addError(new ValidationError.LengthValidationFailure(createPath(), length, schema));
             }
         }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.schema;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
@@ -111,7 +112,7 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public void writeBlob(Schema member, byte[] value) {
+    public void writeBlob(Schema member, ByteBuffer value) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
         validator.writeBlob(member, value);

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.schema;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
@@ -142,7 +143,7 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public void writeBlob(Schema member, byte[] value) {
+    public void writeBlob(Schema member, ByteBuffer value) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member, value)) {
             validator.writeBlob(member, value);

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/Codec.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/Codec.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
@@ -41,6 +42,14 @@ public interface Codec extends AutoCloseable {
      * @return Returns the created deserializer.
      */
     ShapeDeserializer createDeserializer(byte[] source);
+
+    /**
+     * Create a deserializer from this Codec that deserializes a shape from the source.
+     *
+     * @param source Source to parse.
+     * @return Returns the created deserializer.
+     */
+    ShapeDeserializer createDeserializer(ByteBuffer source);
 
     /**
      * Helper method to serialize a shape a string.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -115,7 +116,7 @@ public abstract class InterceptingSerializer implements ShapeSerializer {
     }
 
     @Override
-    public final void writeBlob(Schema schema, byte[] value) {
+    public final void writeBlob(Schema schema, ByteBuffer value) {
         before(schema).writeBlob(schema, value);
         after(schema);
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -127,7 +128,7 @@ public final class ListSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void writeBlob(Schema schema, byte[] value) {
+    public void writeBlob(Schema schema, ByteBuffer value) {
         beforeWrite();
         delegate.writeBlob(schema, value);
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/NullSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/NullSerializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -62,7 +63,7 @@ final class NullSerializer implements ShapeSerializer {
     public void writeString(Schema schema, String value) {}
 
     @Override
-    public void writeBlob(Schema schema, byte[] value) {}
+    public void writeBlob(Schema schema, ByteBuffer value) {}
 
     @Override
     public void writeTimestamp(Schema schema, Instant value) {}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
@@ -33,7 +34,7 @@ public interface ShapeDeserializer extends AutoCloseable {
      * @param schema Schema of the shape.
      * @return the read value.
      */
-    byte[] readBlob(Schema schema);
+    ByteBuffer readBlob(Schema schema);
 
     /**
      * Attempt to read a byte value.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 import java.io.Flushable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -150,7 +151,11 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param schema Schema of the shape.
      * @param value  Blob value.
      */
-    void writeBlob(Schema schema, byte[] value);
+    void writeBlob(Schema schema, ByteBuffer value);
+
+    default void writeBlob(Schema schema, byte[] value) {
+        writeBlob(schema, ByteBuffer.wrap(value));
+    }
 
     /**
      * Serialize a data stream.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -23,7 +24,7 @@ public abstract class SpecificShapeDeserializer implements ShapeDeserializer {
     protected abstract RuntimeException throwForInvalidState(Schema schema);
 
     @Override
-    public byte[] readBlob(Schema schema) {
+    public ByteBuffer readBlob(Schema schema) {
         throw throwForInvalidState(schema);
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -98,7 +99,7 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void writeBlob(Schema schema, byte[] value) {
+    public void writeBlob(Schema schema, ByteBuffer value) {
         throw throwForInvalidState(schema);
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -171,13 +172,15 @@ public final class ToStringSerializer implements ShapeSerializer {
     }
 
     @Override
-    public void writeBlob(Schema schema, byte[] value) {
+    public void writeBlob(Schema schema, ByteBuffer value) {
         if (schema.hasTrait(SensitiveTrait.class)) {
             append(schema, value);
         } else {
-            for (var b : value) {
-                builder.append(Integer.toHexString(b));
+            value.mark();
+            while (value.hasRemaining()) {
+                builder.append(Integer.toHexString(value.get()));
             }
+            value.reset();
         }
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
@@ -7,9 +7,9 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -273,7 +273,7 @@ public interface Document extends SerializableShape {
      * @return the bytes of the blob.
      * @throws SerializationException if the Document is not a blob.
      */
-    default byte[] asBlob() {
+    default ByteBuffer asBlob() {
         throw new SerializationException("Expected a blob document, but found " + type());
     }
 
@@ -497,8 +497,12 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createBlob(byte[] value) {
+    static Document createBlob(ByteBuffer value) {
         return new Documents.BlobDocument(PreludeSchemas.BLOB, value);
+    }
+
+    static Document createBlob(byte[] value) {
+        return createBlob(ByteBuffer.wrap(value));
     }
 
     /**
@@ -584,6 +588,8 @@ public interface Document extends SerializableShape {
             return createBigInteger(b);
         } else if (o instanceof BigDecimal b) {
             return createBigDecimal(b);
+        } else if (o instanceof ByteBuffer b) {
+            return createBlob(b);
         } else if (o instanceof byte[] b) {
             return createBlob(b);
         } else if (o instanceof Instant i) {
@@ -640,7 +646,7 @@ public interface Document extends SerializableShape {
                     return false;
                 }
                 return switch (l.type()) {
-                    case BLOB -> Arrays.equals(l.asBlob(), r.asBlob());
+                    case BLOB -> l.asBlob().equals(r.asBlob());
                     case BOOLEAN -> l.asBoolean() == r.asBoolean();
                     case STRING, ENUM -> l.asString().equals(r.asString());
                     case TIMESTAMP -> l.asTimestamp().equals(r.asTimestamp());

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.SerializationException;
@@ -46,7 +47,7 @@ public class DocumentDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public byte[] readBlob(Schema schema) {
+    public ByteBuffer readBlob(Schema schema) {
         return value.asBlob();
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentParser.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentParser.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -177,7 +178,7 @@ final class DocumentParser implements ShapeSerializer {
     }
 
     @Override
-    public void writeBlob(Schema schema, byte[] value) {
+    public void writeBlob(Schema schema, ByteBuffer value) {
         setResult(new Documents.BlobDocument(schema, value));
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -7,8 +7,8 @@ package software.amazon.smithy.java.runtime.core.serde.document;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -540,14 +540,14 @@ final class Documents {
         }
     }
 
-    record BlobDocument(Schema schema, byte[] value) implements Document {
+    record BlobDocument(Schema schema, ByteBuffer value) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.BLOB;
         }
 
         @Override
-        public byte[] asBlob() {
+        public ByteBuffer asBlob() {
             return value;
         }
 
@@ -565,13 +565,13 @@ final class Documents {
                 return false;
             } else {
                 BlobDocument that = (BlobDocument) o;
-                return Arrays.equals(value, that.value);
+                return value.equals(that.value);
             }
         }
 
         @Override
         public int hashCode() {
-            return Arrays.hashCode(value);
+            return value.hashCode();
         }
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.core.schema;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.empty;
@@ -702,7 +703,7 @@ public class ValidatorTest {
                 ShapeType.BLOB,
                 (Consumer<ShapeSerializer>) serializer -> serializer.writeBlob(
                     PreludeSchemas.INTEGER,
-                    "a".getBytes(StandardCharsets.UTF_8)
+                    wrap("a".getBytes(StandardCharsets.UTF_8))
                 )
             ),
             Arguments.of(
@@ -983,7 +984,7 @@ public class ValidatorTest {
                 ShapeType.BLOB,
                 (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBlob(
                     schema,
-                    "a".getBytes(StandardCharsets.UTF_8)
+                    wrap("a".getBytes(StandardCharsets.UTF_8))
                 )
             ),
             Arguments.of(
@@ -1022,7 +1023,7 @@ public class ValidatorTest {
                 ShapeType.BLOB,
                 (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBlob(
                     schema,
-                    "".getBytes(StandardCharsets.UTF_8)
+                    wrap("".getBytes(StandardCharsets.UTF_8))
                 )
             ),
             Arguments.of(
@@ -1052,7 +1053,7 @@ public class ValidatorTest {
                 ShapeType.BLOB,
                 (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeBlob(
                     schema,
-                    "abcdefghijklmnop".getBytes(StandardCharsets.UTF_8)
+                    wrap("abcdefghijklmnop".getBytes(StandardCharsets.UTF_8))
                 )
             ),
             Arguments.of(

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.core.serde;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -40,7 +41,7 @@ public class ToStringSerializerTest {
             .name("Mike")
             .age(102)
             .birthday(Instant.EPOCH)
-            .binary("hello".getBytes(StandardCharsets.UTF_8))
+            .binary(wrap("hello".getBytes(StandardCharsets.UTF_8)))
             .queryParams(Map.of("a", List.of("1", "2")))
             .build();
 
@@ -102,7 +103,7 @@ public class ToStringSerializerTest {
 
         var str = ToStringSerializer.serialize(e -> {
             e.writeStruct(schema, SerializableStruct.create(schema, (s, ser) -> {
-                ser.writeBlob(s.member("foo"), "abc".getBytes(StandardCharsets.UTF_8));
+                ser.writeBlob(s.member("foo"), wrap("abc".getBytes(StandardCharsets.UTF_8)));
             }));
         });
 

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/BlobDocumentTest.java
@@ -5,10 +5,12 @@
 
 package software.amazon.smithy.java.runtime.core.serde.document;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
@@ -21,16 +23,16 @@ public class BlobDocumentTest {
 
     @Test
     public void createsDocument() {
-        var document = Document.createBlob("hi".getBytes(StandardCharsets.UTF_8));
+        var document = Document.createBlob(wrap("hi".getBytes(StandardCharsets.UTF_8)));
 
         assertThat(document.type(), equalTo(ShapeType.BLOB));
-        assertThat(document.asBlob(), equalTo("hi".getBytes(StandardCharsets.UTF_8)));
-        assertThat(document, equalTo(Document.createBlob("hi".getBytes(StandardCharsets.UTF_8))));
+        assertThat(document.asBlob(), equalTo(wrap("hi".getBytes(StandardCharsets.UTF_8))));
+        assertThat(document, equalTo(Document.createBlob(wrap("hi".getBytes(StandardCharsets.UTF_8)))));
     }
 
     @Test
     public void serializesShape() {
-        var document = Document.createBlob("hi".getBytes(StandardCharsets.UTF_8));
+        var document = Document.createBlob(wrap("hi".getBytes(StandardCharsets.UTF_8)));
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
@@ -46,9 +48,9 @@ public class BlobDocumentTest {
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
-            public void writeBlob(Schema schema, byte[] value) {
+            public void writeBlob(Schema schema, ByteBuffer value) {
                 assertThat(schema, equalTo(PreludeSchemas.BLOB));
-                assertThat(value, equalTo("hi".getBytes(StandardCharsets.UTF_8)));
+                assertThat(value, equalTo(wrap("hi".getBytes(StandardCharsets.UTF_8))));
             }
         };
 
@@ -60,6 +62,6 @@ public class BlobDocumentTest {
         var bytes = "a".getBytes(StandardCharsets.UTF_8);
         var doc = Document.createBlob(bytes);
 
-        assertThat(doc.asObject(), is(bytes));
+        assertThat(doc.asObject(), is(wrap(bytes)));
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializerTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.core.serde.document;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -28,7 +29,7 @@ public class DocumentDeserializerTest {
                 "birthday",
                 Document.createTimestamp(Instant.EPOCH),
                 "binary",
-                Document.createBlob("hi".getBytes(StandardCharsets.UTF_8))
+                Document.createBlob(wrap("hi".getBytes(StandardCharsets.UTF_8)))
             )
         );
 
@@ -37,7 +38,7 @@ public class DocumentDeserializerTest {
         assertThat(person.name(), is("Savage Bob"));
         assertThat(person.age(), is(100));
         assertThat(person.birthday(), is(Instant.EPOCH));
-        assertThat(person.binary(), is("hi".getBytes(StandardCharsets.UTF_8)));
+        assertThat(person.binary(), is(wrap("hi".getBytes(StandardCharsets.UTF_8))));
     }
 
     @Test
@@ -46,7 +47,7 @@ public class DocumentDeserializerTest {
             .name("Savage Bob")
             .age(100)
             .birthday(Instant.EPOCH)
-            .binary("hi".getBytes(StandardCharsets.UTF_8))
+            .binary(wrap("hi".getBytes(StandardCharsets.UTF_8)))
             .build();
 
         var bobDocument = Document.createTyped(person);
@@ -55,6 +56,6 @@ public class DocumentDeserializerTest {
         assertThat(personCopy.name(), is("Savage Bob"));
         assertThat(personCopy.age(), is(100));
         assertThat(personCopy.birthday(), is(Instant.EPOCH));
-        assertThat(personCopy.binary(), is("hi".getBytes(StandardCharsets.UTF_8)));
+        assertThat(personCopy.binary(), is(wrap("hi".getBytes(StandardCharsets.UTF_8))));
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.core.serde.document;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -15,6 +16,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -162,7 +164,7 @@ public class DocumentTest {
             Arguments.of(Document.createBoolean(true), true, (Function<Document, Object>) Document::asBoolean),
             Arguments.of(
                 Document.createBlob("a".getBytes(StandardCharsets.UTF_8)),
-                "a".getBytes(StandardCharsets.UTF_8),
+                wrap("a".getBytes(StandardCharsets.UTF_8)),
                 (Function<Document, Object>) Document::asBlob
             ),
             Arguments.of(
@@ -188,7 +190,7 @@ public class DocumentTest {
         var person = Person.builder()
             .name("A")
             .age(1)
-            .binary("hi".getBytes(StandardCharsets.UTF_8))
+            .binary(wrap("hi".getBytes(StandardCharsets.UTF_8)))
             .birthday(Instant.EPOCH)
             .build();
         var doc = Document.createTyped(person);
@@ -196,7 +198,7 @@ public class DocumentTest {
         assertThat(doc.getMember("__type").asString(), equalTo(Person.ID.toString()));
         assertThat(doc.getMember("name").asString(), equalTo("A"));
         assertThat(doc.getMember("age").asInteger(), equalTo(1));
-        assertThat(doc.getMember("binary").asBlob(), equalTo("hi".getBytes(StandardCharsets.UTF_8)));
+        assertThat(doc.getMember("binary").asBlob(), equalTo(wrap("hi".getBytes(StandardCharsets.UTF_8))));
         assertThat(doc.getMember("birthday").asTimestamp(), equalTo(Instant.EPOCH));
     }
 
@@ -220,7 +222,7 @@ public class DocumentTest {
             ),
             Arguments.of(
                 Document.createBlob("a".getBytes(StandardCharsets.UTF_8)),
-                "a".getBytes(StandardCharsets.UTF_8),
+                wrap("a".getBytes(StandardCharsets.UTF_8)),
                 (Function<ShapeDeserializer, Object>) s -> s.readBlob(PreludeSchemas.BLOB)
             ),
             Arguments.of(
@@ -454,7 +456,7 @@ public class DocumentTest {
         }
 
         @Override
-        public byte[] asBlob() {
+        public ByteBuffer asBlob() {
             return getDocument().asBlob();
         }
 
@@ -514,7 +516,7 @@ public class DocumentTest {
     public static List<Arguments> documentToObjectProvider() {
         return List.of(
             Arguments.of("hi", ShapeType.STRING),
-            Arguments.of("hi".getBytes(StandardCharsets.UTF_8), ShapeType.BLOB),
+            Arguments.of(wrap("hi".getBytes(StandardCharsets.UTF_8)), ShapeType.BLOB),
             Arguments.of(true, ShapeType.BOOLEAN),
             Arguments.of(Instant.EPOCH, ShapeType.TIMESTAMP),
             Arguments.of((byte) 1, ShapeType.BYTE),

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.core.serde.document;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -140,7 +141,7 @@ public class TypedDocumentMemberTest {
             ),
             Arguments.of(
                 ShapeType.BLOB,
-                "a".getBytes(StandardCharsets.UTF_8),
+                wrap("a".getBytes(StandardCharsets.UTF_8)),
                 (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeBlob(
                     schema,
                     "a".getBytes(StandardCharsets.UTF_8)

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.runtime.core.testmodels;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,7 +73,7 @@ public final class Person implements SerializableStruct {
     private final int age;
     private final Instant birthday;
     private final String favoriteColor;
-    private final byte[] binary;
+    private final ByteBuffer binary;
     private final Map<String, List<String>> queryParams;
 
     private Person(Builder builder) {
@@ -100,7 +101,7 @@ public final class Person implements SerializableStruct {
         return birthday;
     }
 
-    public byte[] binary() {
+    public ByteBuffer binary() {
         return binary;
     }
 
@@ -163,7 +164,7 @@ public final class Person implements SerializableStruct {
         private int age = 0;
         private Instant birthday;
         private String favoriteColor;
-        private byte[] binary;
+        private ByteBuffer binary;
         private Map<String, List<String>> queryParams = Collections.emptyMap();
 
         private Builder() {}
@@ -193,7 +194,7 @@ public final class Person implements SerializableStruct {
             return this;
         }
 
-        public Builder binary(byte[] binary) {
+        public Builder binary(ByteBuffer binary) {
             this.binary = binary;
             return this;
         }

--- a/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
+++ b/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.java.runtime.example;
 
+import static java.nio.ByteBuffer.wrap;
+
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -92,7 +94,7 @@ public class GenericTest {
             .age(999)
             .favoriteColor("Green")
             .birthday(Instant.now())
-            .binary("Hello".getBytes(StandardCharsets.UTF_8))
+            .binary(wrap("Hello".getBytes(StandardCharsets.UTF_8)))
             .build();
 
         // Serialize directly to JSON.

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/BasicStringValueDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/BasicStringValueDeserializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.http.binding;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
@@ -38,9 +39,9 @@ abstract class BasicStringValueDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public byte[] readBlob(Schema schema) {
+    public ByteBuffer readBlob(Schema schema) {
         try {
-            return Base64.getDecoder().decode(value.getBytes(StandardCharsets.UTF_8));
+            return ByteBuffer.wrap(Base64.getDecoder().decode(value.getBytes(StandardCharsets.UTF_8)));
         } catch (IllegalArgumentException e) {
             throw new SerializationException("invalid base64", e);
         }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
@@ -5,10 +5,12 @@
 
 package software.amazon.smithy.java.runtime.http.binding;
 
+import static software.amazon.smithy.java.runtime.core.ByteBufferUtils.base64Encode;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -95,8 +97,8 @@ final class HttpHeaderSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void writeBlob(Schema schema, byte[] value) {
-        writeHeader(schema, () -> Base64.getEncoder().encodeToString(value));
+    public void writeBlob(Schema schema, ByteBuffer value) {
+        writeHeader(schema, () -> base64Encode(value));
     }
 
     @Override

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
@@ -5,10 +5,12 @@
 
 package software.amazon.smithy.java.runtime.http.binding;
 
+import static software.amazon.smithy.java.runtime.core.ByteBufferUtils.base64Encode;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -90,8 +92,8 @@ final class HttpQuerySerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void writeBlob(Schema schema, byte[] value) {
-        writeQuery(schema, () -> Base64.getEncoder().encodeToString(value));
+    public void writeBlob(Schema schema, ByteBuffer value) {
+        writeQuery(schema, () -> base64Encode(value));
     }
 
     @Override

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/PayloadDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/PayloadDeserializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.http.binding;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -25,9 +26,9 @@ final class PayloadDeserializer implements ShapeDeserializer {
         this.body = body;
     }
 
-    private byte[] resolveBodyBytes() {
+    private ByteBuffer resolveBodyBytes() {
         try {
-            return body.asBytes().toCompletableFuture().get();
+            return body.asByteBuffer().toCompletableFuture().get();
         } catch (InterruptedException | ExecutionException e) {
             throw new SerializationException("Failed to get payload bytes", e);
         }
@@ -45,7 +46,7 @@ final class PayloadDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public byte[] readBlob(Schema schema) {
+    public ByteBuffer readBlob(Schema schema) {
         if (isNull()) {
             return null;
         }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/PayloadSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/PayloadSerializer.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.function.BiConsumer;
@@ -144,6 +145,12 @@ final class PayloadSerializer implements ShapeSerializer {
     public void writeBlob(Schema schema, byte[] value) {
         payloadWritten = true;
         serializer.setHttpPayload(schema, DataStream.ofBytes(value));
+    }
+
+    @Override
+    public void writeBlob(Schema schema, ByteBuffer value) {
+        payloadWritten = true;
+        serializer.setHttpPayload(schema, DataStream.ofByteBuffer(value));
     }
 
     @Override

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/SpecificHttpHeaderSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/SpecificHttpHeaderSerializer.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.http.binding;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
@@ -72,7 +73,7 @@ final class SpecificHttpHeaderSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public void writeBlob(Schema schema, byte[] value) {
+    public void writeBlob(Schema schema, ByteBuffer value) {
         delegate.writeBlob(headerSchema, value);
     }
 

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.runtime.json;
 
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
@@ -81,6 +82,11 @@ public final class JsonCodec implements Codec {
 
     @Override
     public ShapeDeserializer createDeserializer(byte[] source) {
+        return provider.newDeserializer(source, settings);
+    }
+
+    @Override
+    public ShapeDeserializer createDeserializer(ByteBuffer source) {
         return provider.newDeserializer(source, settings);
     }
 

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerdeProvider.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonSerdeProvider.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.runtime.json;
 
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 
@@ -16,6 +17,8 @@ public interface JsonSerdeProvider {
     String getName();
 
     ShapeDeserializer newDeserializer(byte[] source, JsonCodec.Settings settings);
+
+    ShapeDeserializer newDeserializer(ByteBuffer source, JsonCodec.Settings settings);
 
     ShapeSerializer newSerializer(OutputStream sink, JsonCodec.Settings settings);
 

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonDocument.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonDocument.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -126,10 +127,10 @@ final class JacksonDocument implements Document {
     }
 
     @Override
-    public byte[] asBlob() {
+    public ByteBuffer asBlob() {
         if (root.isBinary()) {
             try {
-                return root.binaryValue();
+                return ByteBuffer.wrap(root.binaryValue());
             } catch (IOException e) {
                 throw new SerializationException(e);
             }
@@ -137,7 +138,7 @@ final class JacksonDocument implements Document {
         if (root.isTextual()) {
             // Base64 decode JSON blobs.
             try {
-                return Base64.getDecoder().decode(root.textValue());
+                return ByteBuffer.wrap(Base64.getDecoder().decode(root.textValue()));
             } catch (IllegalArgumentException e) {
                 throw new SerializationException("Invalid base64", e);
             }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonDeserializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonDeserializer.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Locale;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -55,9 +56,9 @@ final class JacksonJsonDeserializer implements ShapeDeserializer {
     }
 
     @Override
-    public byte[] readBlob(Schema schema) {
+    public ByteBuffer readBlob(Schema schema) {
         try {
-            return parser.getBinaryValue(Base64Variants.MIME_NO_LINEFEEDS);
+            return ByteBuffer.wrap(parser.getBinaryValue(Base64Variants.MIME_NO_LINEFEEDS));
         } catch (Exception e) {
             throw new SerializationException(e);
         }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonSerdeProvider.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonSerdeProvider.java
@@ -7,8 +7,10 @@ package software.amazon.smithy.java.runtime.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -36,6 +38,15 @@ public class JacksonJsonSerdeProvider implements JsonSerdeProvider {
     ) {
         try {
             return new JacksonJsonDeserializer(FACTORY.createParser(source), settings);
+        } catch (IOException e) {
+            throw new SerializationException(e);
+        }
+    }
+
+    @Override
+    public ShapeDeserializer newDeserializer(ByteBuffer source, JsonCodec.Settings settings) {
+        try {
+            return new JacksonJsonDeserializer(FACTORY.createParser(new ByteBufferBackedInputStream(source)), settings);
         } catch (IOException e) {
             throw new SerializationException(e);
         }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonSerializer.java
@@ -6,8 +6,10 @@
 package software.amazon.smithy.java.runtime.json.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.function.BiConsumer;
@@ -85,6 +87,15 @@ final class JacksonJsonSerializer implements ShapeSerializer {
     public void writeBlob(Schema schema, byte[] value) {
         try {
             generator.writeString(Base64.getEncoder().encodeToString(value));
+        } catch (Exception e) {
+            throw new SerializationException(e);
+        }
+    }
+
+    @Override
+    public void writeBlob(Schema schema, ByteBuffer value) {
+        try {
+            generator.writeBinary(new ByteBufferBackedInputStream(value), value.remaining());
         } catch (Exception e) {
             throw new SerializationException(e);
         }

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDeserializerTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDeserializerTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.json;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -151,7 +152,7 @@ public class JsonDeserializerTest {
             var str = "foo";
             var expected = Base64.getEncoder().encodeToString(str.getBytes());
             var de = codec.createDeserializer(("\"" + expected + "\"").getBytes(StandardCharsets.UTF_8));
-            assertThat(de.readBlob(PreludeSchemas.BLOB), equalTo(str.getBytes(StandardCharsets.UTF_8)));
+            assertThat(de.readBlob(PreludeSchemas.BLOB), equalTo(wrap(str.getBytes(StandardCharsets.UTF_8))));
         }
     }
 

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.json;
 
+import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.containsString;
@@ -17,6 +18,7 @@ import static org.hamcrest.Matchers.nullValue;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -123,7 +125,7 @@ public class JsonDocumentTest {
         assertThat(document.type(), is(ShapeType.STRING));
 
         // Reading here as a blob will base64 decode the value.
-        assertThat(document.asBlob(), equalTo("foo".getBytes(StandardCharsets.UTF_8)));
+        assertThat(document.asBlob(), equalTo(wrap("foo".getBytes(StandardCharsets.UTF_8))));
     }
 
     @Test
@@ -258,7 +260,7 @@ public class JsonDocumentTest {
         var pojo = builder.build();
 
         assertThat(pojo.name, equalTo("Hank"));
-        assertThat(pojo.binary, equalTo("foo".getBytes(StandardCharsets.UTF_8)));
+        assertThat(pojo.binary, equalTo(wrap("foo".getBytes(StandardCharsets.UTF_8))));
         assertThat(pojo.date, equalTo(Instant.EPOCH));
         assertThat(pojo.numbers, equalTo(List.of(1, 2, 3)));
     }
@@ -275,7 +277,7 @@ public class JsonDocumentTest {
         var pojo = builder.build();
 
         assertThat(pojo.name, equalTo("Hank"));
-        assertThat(pojo.binary, equalTo("foo".getBytes(StandardCharsets.UTF_8)));
+        assertThat(pojo.binary, equalTo(wrap("foo".getBytes(StandardCharsets.UTF_8))));
         assertThat(pojo.date, equalTo(Instant.EPOCH));
         assertThat(pojo.numbers, equalTo(List.of(1, 2, 3)));
     }
@@ -315,7 +317,7 @@ public class JsonDocumentTest {
             .build();
 
         private final String name;
-        private final byte[] binary;
+        private final ByteBuffer binary;
         private final Instant date;
         private final List<Integer> numbers;
 
@@ -334,7 +336,7 @@ public class JsonDocumentTest {
         private static final class Builder implements ShapeBuilder<TestPojo> {
 
             private String name;
-            private byte[] binary;
+            private ByteBuffer binary;
             private Instant date;
             private final List<Integer> numbers = new ArrayList<>();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use ByteBuffers instead of byte[] in generated POJOs.  In the getters we return a readOnly view of the Buffer, which aligns with what we do for Collections.

Generated diff can be viewed [here](https://github.com/smithy-lang/smithy-java/pull/183).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
