### PR TITLE
Rely on ShapeSerializer for stream bindings

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
@@ -25,7 +25,6 @@ import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.schema.TypeRegistry;
-import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public abstract class Client {
@@ -64,8 +63,6 @@ public abstract class Client {
      * Performs the actual RPC call.
      *
      * @param input       Input to send.
-     * @param inputStream Any kind of data stream extracted from the input, or null.
-     * @param eventStream The event stream extracted from the input, or null. TODO: Implement.
      * @param operation   The operation shape.
      * @param context     Context of the call.
      * @param <I>         Input shape.
@@ -74,8 +71,6 @@ public abstract class Client {
      */
     protected <I extends SerializableStruct, O extends SerializableStruct> CompletableFuture<O> call(
         I input,
-        DataStream inputStream,
-        Object eventStream,
         ApiOperation<I, O> operation,
         Context context
     ) {
@@ -90,8 +85,6 @@ public abstract class Client {
                 .operation(operation)
                 .endpointResolver(endpointResolver)
                 .context(context)
-                .requestDataStream(inputStream)
-                .requestEventStream(eventStream)
                 .interceptor(interceptor)
                 .supportedAuthSchemes(supportedAuthSchemes)
                 .authSchemeResolver(authSchemeResolver)

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
@@ -40,7 +40,6 @@ public class HttpBindingClientProtocol extends HttpClientProtocol {
     public SmithyHttpRequest createRequest(ClientCall<?, ?> call, URI endpoint) {
         return HttpBinding.requestSerializer()
             .operation(call.operation().schema())
-            .payload(call.requestDataStream().orElse(null))
             .payloadCodec(codec)
             .shapeValue(call.input())
             .endpoint(endpoint)

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
@@ -79,7 +79,6 @@ public final class ClientImplementationGenerator
 
         @Override
         public void run() {
-            // TODO: support event streams and streaming blobs
             writer.pushState();
             writer.putContext("async", async);
             writer.putContext("context", Context.class);
@@ -94,7 +93,7 @@ public final class ClientImplementationGenerator
                     """
                         @Override
                         public ${?async}${future:T}<${/async}${output:T}${?async}>${/async} ${name:L}(${input:T} input, ${context:T} context) {
-                            return call(input, null, null, new ${operation:T}(), context)${^async}.join()${/async};
+                            return call(input, new ${operation:T}(), context)${^async}.join()${/async};
                         }
                         """
                 );

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/PersonDirectoryAsyncClientImpl.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/PersonDirectoryAsyncClientImpl.java
@@ -26,16 +26,16 @@ final class PersonDirectoryAsyncClientImpl extends Client implements PersonDirec
 
     @Override
     public CompletableFuture<PutPersonOutput> putPerson(PutPersonInput input, Context context) {
-        return call(input, null, null, new PutPerson(), context);
+        return call(input, new PutPerson(), context);
     }
 
     @Override
     public CompletableFuture<PutPersonImageOutput> putPersonImage(PutPersonImageInput input, Context context) {
-        return call(input, input.image(), null, new PutPersonImage(), context);
+        return call(input, new PutPersonImage(), context);
     }
 
     @Override
     public CompletableFuture<GetPersonImageOutput> getPersonImage(GetPersonImageInput input, Context context) {
-        return call(input, null, null, new GetPersonImage(), context);
+        return call(input, new GetPersonImage(), context);
     }
 }

--- a/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/PersonDirectoryClientImpl.java
+++ b/examples/restjson-example/src/main/java/software/amazon/smithy/java/runtime/example/PersonDirectoryClientImpl.java
@@ -25,16 +25,16 @@ final class PersonDirectoryClientImpl extends Client implements PersonDirectoryC
 
     @Override
     public PutPersonOutput putPerson(PutPersonInput input, Context context) {
-        return call(input, null, null, new PutPerson(), context).join();
+        return call(input, new PutPerson(), context).join();
     }
 
     @Override
     public PutPersonImageOutput putPersonImage(PutPersonImageInput input, Context context) {
-        return call(input, input.image(), null, new PutPersonImage(), context).join();
+        return call(input, new PutPersonImage(), context).join();
     }
 
     @Override
     public GetPersonImageOutput getPersonImage(GetPersonImageInput input, Context context) {
-        return call(input, null, null, new GetPersonImage(), context).join();
+        return call(input, new GetPersonImage(), context).join();
     }
 }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpBindingSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpBindingSerializer.java
@@ -61,12 +61,7 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
         headers.computeIfAbsent(field, f -> new ArrayList<>()).add(value);
     };
 
-    HttpBindingSerializer(
-        HttpTrait httpTrait,
-        Codec payloadCodec,
-        BindingMatcher bindingMatcher,
-        DataStream httpPayload
-    ) {
+    HttpBindingSerializer(HttpTrait httpTrait, Codec payloadCodec, BindingMatcher bindingMatcher) {
         uriPattern = httpTrait.getUri();
         responseStatus = httpTrait.getCode();
         this.payloadCodec = payloadCodec;
@@ -74,7 +69,6 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
         headerSerializer = new HttpHeaderSerializer(headerConsumer);
         querySerializer = new HttpQuerySerializer(queryStringParams::put);
         labelSerializer = new HttpLabelSerializer(labels::put);
-        this.httpPayload = httpPayload;
     }
 
     @Override

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestSerializer.java
@@ -10,7 +10,6 @@ import java.util.Objects;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
-import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.core.uri.URIBuilder;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -25,7 +24,6 @@ public final class RequestSerializer {
     private Schema operation;
     private URI endpoint;
     private SerializableShape shapeValue;
-    private DataStream payload;
     private final BindingMatcher bindingMatcher = BindingMatcher.requestMatcher();
 
     RequestSerializer() {}
@@ -78,17 +76,6 @@ public final class RequestSerializer {
     }
 
     /**
-     * Set the streaming payload of the request, if any.
-     *
-     * @param payload Payload to associate to the request.
-     * @return Returns the serializer.
-     */
-    public RequestSerializer payload(DataStream payload) {
-        this.payload = payload;
-        return this;
-    }
-
-    /**
      * Finishes setting up the serializer and creates an HTTP request.
      *
      * @return Returns the created request.
@@ -101,7 +88,7 @@ public final class RequestSerializer {
         Objects.requireNonNull(payloadCodec, "value is not set");
 
         var httpTrait = operation.expectTrait(HttpTrait.class);
-        var serializer = new HttpBindingSerializer(httpTrait, payloadCodec, bindingMatcher, payload);
+        var serializer = new HttpBindingSerializer(httpTrait, payloadCodec, bindingMatcher);
         shapeValue.serialize(serializer);
         serializer.flush();
 

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseSerializer.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableShape;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
-import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.HttpTrait;
@@ -22,7 +21,6 @@ public final class ResponseSerializer {
     private Schema operation;
     private SerializableShape shapeValue;
     private final BindingMatcher bindingMatcher = BindingMatcher.responseMatcher();
-    private DataStream payload;
 
     ResponseSerializer() {}
 
@@ -63,17 +61,6 @@ public final class ResponseSerializer {
     }
 
     /**
-     * Set the streaming payload of the response, if any.
-     *
-     * @param payload Payload to associate to the response.
-     * @return Returns the serializer.
-     */
-    public ResponseSerializer payload(DataStream payload) {
-        this.payload = payload;
-        return this;
-    }
-
-    /**
      * Finishes setting up the serializer and creates an HTTP response.
      *
      * @return Returns the created response.
@@ -86,7 +73,7 @@ public final class ResponseSerializer {
         Objects.requireNonNull(payloadCodec, "value is not set");
 
         var httpTrait = operation.expectTrait(HttpTrait.class);
-        var serializer = new HttpBindingSerializer(httpTrait, payloadCodec, bindingMatcher, payload);
+        var serializer = new HttpBindingSerializer(httpTrait, payloadCodec, bindingMatcher);
         shapeValue.serialize(serializer);
         serializer.flush();
 


### PR DESCRIPTION
We previously relied on externalized support for serializing event/ data streams by extracting them from inputs and explicitly passing them to call and clientCall. Now that this is handled in ShapeSerializer, this is no longer necessary. We don't need to allow them to be set in HttpBinding classes either and can just rely on the shape serialization.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
