### PR TITLE
EventStreaming support

### DIFF
--- a/aws-event-streams/build.gradle.kts
+++ b/aws-event-streams/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("smithy-java.module-conventions")
+}
+
+description = "This module provides AWS event streaming support"
+
+extra["displayName"] = "Smithy :: Java :: AWS Event Streams"
+extra["moduleName"] = "software.amazon.smithy.java.aws-event-streams"
+
+dependencies {
+    api(project(":core"))
+    api("software.amazon.eventstream:eventstream:1.0.1")
+}

--- a/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventDecoderFactory.java
+++ b/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventDecoderFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.events.aws;
+
+import java.util.function.Supplier;
+import software.amazon.smithy.java.runtime.core.schema.InputEventStreamingApiOperation;
+import software.amazon.smithy.java.runtime.core.schema.OutputEventStreamingApiOperation;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.runtime.core.serde.Codec;
+import software.amazon.smithy.java.runtime.core.serde.event.EventDecoder;
+import software.amazon.smithy.java.runtime.core.serde.event.EventDecoderFactory;
+import software.amazon.smithy.java.runtime.core.serde.event.FrameDecoder;
+import software.amazon.smithy.java.runtime.core.serde.event.FrameTransformer;
+
+public class AwsEventDecoderFactory<E extends SerializableStruct> implements EventDecoderFactory<AwsEventFrame> {
+
+    private final Schema schema;
+    private final Codec codec;
+    private final Supplier<ShapeBuilder<E>> eventBuilder;
+    private final FrameTransformer<AwsEventFrame> transformer;
+
+    private AwsEventDecoderFactory(
+        Schema schema,
+        Codec codec,
+        Supplier<ShapeBuilder<E>> eventBuilder,
+        FrameTransformer<AwsEventFrame> transformer
+    ) {
+        this.schema = schema;
+        this.codec = codec;
+        this.eventBuilder = eventBuilder;
+        this.transformer = transformer;
+    }
+
+    public static <IE extends SerializableStruct> AwsEventDecoderFactory<IE> forInputStream(
+        InputEventStreamingApiOperation<?, ?, IE> operation,
+        Codec codec,
+        FrameTransformer<AwsEventFrame> transformer
+    ) {
+        return new AwsEventDecoderFactory<>(
+            operation.inputEventSchema(),
+            codec,
+            operation.inputEventBuilderSupplier(),
+            transformer
+        );
+    }
+
+    public static <OE extends SerializableStruct> AwsEventDecoderFactory<OE> forOutputStream(
+        OutputEventStreamingApiOperation<?, ?, OE> operation,
+        Codec codec,
+        FrameTransformer<AwsEventFrame> transformer
+    ) {
+        return new AwsEventDecoderFactory<>(
+            operation.outputEventSchema(),
+            codec,
+            operation.outputEventBuilderSupplier(),
+            transformer
+        );
+    }
+
+    @Override
+    public EventDecoder<AwsEventFrame> newEventDecoder() {
+        return new AwsEventShapeDecoder<>(eventBuilder, schema, codec);
+    }
+
+    @Override
+    public FrameDecoder<AwsEventFrame> newFrameDecoder() {
+        return new AwsFrameDecoder(transformer);
+    }
+}

--- a/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventDeserializer.java
+++ b/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.events.aws;
+
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.runtime.core.serde.SpecificShapeDeserializer;
+
+public final class AwsEventDeserializer extends SpecificShapeDeserializer {
+
+    private final Schema expectedMember;
+    private final ShapeDeserializer memberDeserializer;
+
+    public AwsEventDeserializer(Schema expectedMember, ShapeDeserializer memberDeserializer) {
+        this.expectedMember = expectedMember;
+        this.memberDeserializer = memberDeserializer;
+    }
+
+    @Override
+    protected RuntimeException throwForInvalidState(Schema schema) {
+        throw new IllegalStateException(
+            "Expected to parse a structure for Json-encoded event stream data,"
+                + " but found " + schema
+        );
+    }
+
+    @Override
+    public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> consumer) {
+        consumer.accept(state, expectedMember, memberDeserializer);
+    }
+}

--- a/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventEncoderFactory.java
+++ b/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventEncoderFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.events.aws;
+
+import java.util.function.Function;
+import software.amazon.smithy.java.runtime.core.schema.InputEventStreamingApiOperation;
+import software.amazon.smithy.java.runtime.core.schema.OutputEventStreamingApiOperation;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.serde.Codec;
+import software.amazon.smithy.java.runtime.core.serde.event.EventEncoder;
+import software.amazon.smithy.java.runtime.core.serde.event.EventEncoderFactory;
+import software.amazon.smithy.java.runtime.core.serde.event.EventStreamingException;
+import software.amazon.smithy.java.runtime.core.serde.event.FrameEncoder;
+
+public class AwsEventEncoderFactory implements EventEncoderFactory<AwsEventFrame> {
+
+    private final Schema schema;
+    private final Codec codec;
+    private final Function<Throwable, EventStreamingException> exceptionHandler;
+
+    private AwsEventEncoderFactory(
+        Schema schema,
+        Codec codec,
+        Function<Throwable, EventStreamingException> exceptionHandler
+    ) {
+        this.schema = schema;
+        this.codec = codec;
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    public static AwsEventEncoderFactory forInputStream(
+        InputEventStreamingApiOperation<?, ?, ?> operation,
+        Codec codec,
+        Function<Throwable, EventStreamingException> exceptionHandler
+    ) {
+        return new AwsEventEncoderFactory(operation.inputEventSchema(), codec, exceptionHandler);
+    }
+
+    public static AwsEventEncoderFactory forOutputStream(
+        OutputEventStreamingApiOperation<?, ?, ?> operation,
+        Codec codec,
+        Function<Throwable, EventStreamingException> exceptionHandler
+    ) {
+        return new AwsEventEncoderFactory(operation.outputEventSchema(), codec, exceptionHandler);
+    }
+
+
+    @Override
+    public EventEncoder<AwsEventFrame> newEventEncoder() {
+        return new AwsEventShapeEncoder(schema, codec, exceptionHandler);
+    }
+
+    @Override
+    public FrameEncoder<AwsEventFrame> newFrameEncoder() {
+        return new AwsFrameEncoder();
+    }
+
+    @Override
+    public String contentType() {
+        return "application/vnd.amazon.eventstream";
+    }
+
+}

--- a/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventFrame.java
+++ b/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventFrame.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.events.aws;
+
+import software.amazon.eventstream.Message;
+import software.amazon.smithy.java.runtime.core.serde.event.Frame;
+
+public final class AwsEventFrame implements Frame<Message> {
+
+    private final Message message;
+
+    AwsEventFrame(Message message) {
+        this.message = message;
+    }
+
+    @Override
+    public Message unwrap() {
+        return message;
+    }
+}

--- a/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventShapeDecoder.java
+++ b/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventShapeDecoder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.events.aws;
+
+import java.util.function.Supplier;
+import software.amazon.eventstream.Message;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.runtime.core.serde.Codec;
+import software.amazon.smithy.java.runtime.core.serde.event.EventDecoder;
+
+public final class AwsEventShapeDecoder<E extends SerializableStruct> implements EventDecoder<AwsEventFrame> {
+
+    private final Supplier<ShapeBuilder<E>> eventBuilder;
+    private final Schema eventSchema;
+    private final Codec codec;
+
+    public AwsEventShapeDecoder(
+        Supplier<ShapeBuilder<E>> eventBuilder,
+        Schema eventSchema,
+        Codec codec
+    ) {
+        this.eventBuilder = eventBuilder;
+        this.eventSchema = eventSchema;
+        this.codec = codec;
+    }
+
+    @Override
+    public E decode(AwsEventFrame frame) {
+        Message message = frame.unwrap();
+        String messageType = getMessageType(message);
+        if (!messageType.equals("event")) {
+            throw new UnsupportedOperationException("Unsupported frame type: " + messageType);
+        }
+        String eventType = getEventType(message);
+        Schema memberSchema = eventSchema.member(eventType);
+        if (memberSchema == null) {
+            throw new IllegalArgumentException("Unsupported event type: " + eventType);
+        }
+
+        return eventBuilder.get()
+            .deserialize(
+                new AwsEventDeserializer(
+                    memberSchema,
+                    codec.createDeserializer(message.getPayload())
+                )
+            )
+            .build();
+    }
+
+    private String getEventType(Message message) {
+        return message.getHeaders().get(":event-type").getString();
+    }
+
+    private String getMessageType(Message message) {
+        return message.getHeaders().get(":message-type").getString();
+    }
+}

--- a/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventShapeEncoder.java
+++ b/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventShapeEncoder.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.events.aws;
+
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import software.amazon.eventstream.HeaderValue;
+import software.amazon.eventstream.Message;
+import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.serde.Codec;
+import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
+import software.amazon.smithy.java.runtime.core.serde.event.EventEncoder;
+import software.amazon.smithy.java.runtime.core.serde.event.EventStreamingException;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.ErrorTrait;
+
+public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
+
+    private final Schema eventSchema;
+    private final Codec codec;
+    private final Set<String> possibleTypes;
+    private final Map<ShapeId, Schema> possibleExceptions;
+    private final Function<Throwable, EventStreamingException> exceptionHandler;
+
+    public AwsEventShapeEncoder(
+        Schema eventSchema,
+        Codec codec,
+        Function<Throwable, EventStreamingException> exceptionHandler
+    ) {
+        this.eventSchema = eventSchema;
+        this.codec = codec;
+        this.possibleTypes = eventSchema.members().stream().map(Schema::memberName).collect(Collectors.toSet());
+        this.possibleExceptions = eventSchema.members()
+            .stream()
+            .filter(s -> s.hasTrait(ErrorTrait.class))
+            .collect(Collectors.toMap(s -> s.memberTarget().id(), Function.identity()));
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    @Override
+    public AwsEventFrame encode(SerializableStruct item) {
+        var os = new ByteArrayOutputStream();
+        var typeHolder = new AtomicReference<String>();
+        try (var baseSerializer = codec.createSerializer(os)) {
+
+            item.serializeMembers(new SpecificShapeSerializer() {
+                @Override
+                public void writeStruct(Schema schema, SerializableStruct struct) {
+                    if (possibleTypes.contains(schema.memberName())) {
+                        typeHolder.compareAndSet(null, schema.memberName());
+                    }
+                    baseSerializer.writeStruct(schema, struct);
+                }
+            });
+        }
+
+        var headers = new HashMap<String, HeaderValue>();
+        headers.put(":event-type", HeaderValue.fromString(typeHolder.get()));
+        headers.put(":message-type", HeaderValue.fromString("event"));
+        headers.put(":content-type", HeaderValue.fromString(codec.getMediaType()));
+
+        return new AwsEventFrame(new Message(headers, os.toByteArray()));
+    }
+
+    @Override
+    public AwsEventFrame encodeFailure(Throwable exception) {
+        AwsEventFrame frame;
+        Schema exceptionSchema;
+        if (exception instanceof ModeledApiException me && (exceptionSchema = possibleExceptions.get(
+            me.getShapeId()
+        )) != null) {
+            var headers = new HashMap<String, HeaderValue>();
+            headers.put(":message-type", HeaderValue.fromString("exception"));
+            headers.put(
+                ":exception-type",
+                HeaderValue.fromString(exceptionSchema.memberName())
+            );
+            headers.put(":content-type", HeaderValue.fromString(codec.getMediaType()));
+            var os = new ByteArrayOutputStream();
+            try (var serializer = codec.createSerializer(os)) {
+                me.serialize(serializer);
+            }
+            frame = new AwsEventFrame(new Message(headers, os.toByteArray()));
+        } else {
+            EventStreamingException es = exceptionHandler.apply(exception);
+            var headers = new HashMap<String, HeaderValue>();
+            headers.put(":message-type", HeaderValue.fromString("error"));
+            headers.put(":error-code", HeaderValue.fromString(es.getErrorCode()));
+            headers.put(":error-message", HeaderValue.fromString(es.getMessage()));
+
+            frame = new AwsEventFrame(new Message(headers, new byte[0]));
+        }
+        return frame;
+
+    }
+}

--- a/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsFrameDecoder.java
+++ b/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsFrameDecoder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.events.aws;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+import software.amazon.eventstream.MessageDecoder;
+import software.amazon.smithy.java.runtime.core.serde.event.FrameDecoder;
+import software.amazon.smithy.java.runtime.core.serde.event.FrameTransformer;
+
+public final class AwsFrameDecoder implements FrameDecoder<AwsEventFrame> {
+    private final MessageDecoder decoder = new MessageDecoder();
+    private final FrameTransformer<AwsEventFrame> transformer;
+
+    public AwsFrameDecoder(FrameTransformer<AwsEventFrame> transformer) {
+        this.transformer = transformer;
+    }
+
+    @Override
+    public List<AwsEventFrame> decode(ByteBuffer buffer) {
+        decoder.feed(buffer);
+        return decoder.getDecodedMessages()
+            .stream()
+            .map(AwsEventFrame::new)
+            .map(transformer)
+            .filter(Objects::nonNull)
+            .toList();
+    }
+}

--- a/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsFrameEncoder.java
+++ b/aws-event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsFrameEncoder.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.events.aws;
+
+import java.nio.ByteBuffer;
+import software.amazon.smithy.java.runtime.core.serde.event.FrameEncoder;
+
+public final class AwsFrameEncoder implements FrameEncoder<AwsEventFrame> {
+
+    @Override
+    public ByteBuffer encode(AwsEventFrame frame) {
+        return frame.unwrap().toByteBuffer();
+    }
+}

--- a/client-aws-rest-json1/build.gradle.kts
+++ b/client-aws-rest-json1/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     api(project(":client-http"))
     api(project(":http-binding"))
     api(project(":json-codec"))
+    api(project(":aws-event-streams"))
 }

--- a/client-aws-rest-json1/src/main/java/software/amazon/smithy/java/runtime/client/aws/restjson1/RestJsonClientProtocol.java
+++ b/client-aws-rest-json1/src/main/java/software/amazon/smithy/java/runtime/client/aws/restjson1/RestJsonClientProtocol.java
@@ -6,13 +6,44 @@
 package software.amazon.smithy.java.runtime.client.aws.restjson1;
 
 import software.amazon.smithy.java.runtime.client.http.HttpBindingClientProtocol;
+import software.amazon.smithy.java.runtime.core.schema.InputEventStreamingApiOperation;
+import software.amazon.smithy.java.runtime.core.schema.OutputEventStreamingApiOperation;
+import software.amazon.smithy.java.runtime.core.serde.event.EventDecoderFactory;
+import software.amazon.smithy.java.runtime.core.serde.event.EventEncoderFactory;
+import software.amazon.smithy.java.runtime.core.serde.event.EventStreamingException;
+import software.amazon.smithy.java.runtime.events.aws.AwsEventDecoderFactory;
+import software.amazon.smithy.java.runtime.events.aws.AwsEventEncoderFactory;
+import software.amazon.smithy.java.runtime.events.aws.AwsEventFrame;
 import software.amazon.smithy.java.runtime.json.JsonCodec;
 
 /**
  * Implements aws.protocols#restJson1.
  */
-public final class RestJsonClientProtocol extends HttpBindingClientProtocol {
+public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsEventFrame> {
     public RestJsonClientProtocol() {
         super("aws.protocols#restJson1", JsonCodec.builder().useJsonName(true).useTimestampFormat(true).build());
+    }
+
+    @Override
+    protected EventEncoderFactory<AwsEventFrame> getEventEncoderFactory(
+        InputEventStreamingApiOperation<?, ?, ?> inputOperation
+    ) {
+        // TODO: this is where you'd plumb through Sigv4 support, another frame transformer?
+        return AwsEventEncoderFactory.forInputStream(
+            inputOperation,
+            codec,
+            (e) -> new EventStreamingException("InternalServerException", "Internal Server Error")
+        );
+    }
+
+    @Override
+    protected EventDecoderFactory<AwsEventFrame> getEventDecoderFactory(
+        OutputEventStreamingApiOperation<?, ?, ?> outputOperation
+    ) {
+        return AwsEventDecoderFactory.forOutputStream(
+            outputOperation,
+            codec,
+            f -> f
+        );
     }
 }

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
@@ -11,39 +11,61 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.client.core.ClientCall;
 import software.amazon.smithy.java.runtime.core.schema.ApiException;
+import software.amazon.smithy.java.runtime.core.schema.InputEventStreamingApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
+import software.amazon.smithy.java.runtime.core.schema.OutputEventStreamingApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
+import software.amazon.smithy.java.runtime.core.serde.event.EventDecoderFactory;
+import software.amazon.smithy.java.runtime.core.serde.event.EventEncoderFactory;
+import software.amazon.smithy.java.runtime.core.serde.event.Frame;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.http.binding.HttpBinding;
+import software.amazon.smithy.java.runtime.http.binding.RequestSerializer;
+import software.amazon.smithy.java.runtime.http.binding.ResponseDeserializer;
 
 /**
  * An HTTP-based protocol that uses HTTP binding traits.
  *
  * <p>TODO: Allow for a custom matcher to identity errors beyond X-Amzn-Errortype.
+ *
+ * @param <F> the framing type for event streams.
  */
-public class HttpBindingClientProtocol extends HttpClientProtocol {
+public class HttpBindingClientProtocol<F extends Frame<?>> extends HttpClientProtocol {
 
     private static final System.Logger LOGGER = System.getLogger(HttpBindingClientProtocol.class.getName());
     private static final String X_AMZN_ERROR_TYPE = "X-Amzn-Errortype";
 
-    private final Codec codec;
+    protected final Codec codec;
 
     public HttpBindingClientProtocol(String id, Codec codec) {
         super(id);
         this.codec = Objects.requireNonNull(codec, "codec is null");
     }
 
+    protected EventEncoderFactory<F> getEventEncoderFactory(InputEventStreamingApiOperation<?, ?, ?> inputOperation) {
+        throw new UnsupportedOperationException("This protocol does not support event streaming");
+    }
+
+    protected EventDecoderFactory<F> getEventDecoderFactory(OutputEventStreamingApiOperation<?, ?, ?> outputOperation) {
+        throw new UnsupportedOperationException("This protocol does not support event streaming");
+    }
+
     @Override
     public SmithyHttpRequest createRequest(ClientCall<?, ?> call, URI endpoint) {
-        return HttpBinding.requestSerializer()
-            .operation(call.operation().schema())
+        RequestSerializer serializer = HttpBinding.requestSerializer()
+            .operation(call.operation())
             .payloadCodec(codec)
             .shapeValue(call.input())
-            .endpoint(endpoint)
-            .serializeRequest();
+            .endpoint(endpoint);
+
+        if (call.operation() instanceof InputEventStreamingApiOperation<?, ?, ?> i) {
+            serializer.eventEncoderFactory(getEventEncoderFactory(i));
+        }
+
+        return serializer.serializeRequest();
     }
 
     @Override
@@ -61,10 +83,16 @@ public class HttpBindingClientProtocol extends HttpClientProtocol {
         LOGGER.log(System.Logger.Level.TRACE, () -> "Deserializing successful response with " + getClass().getName());
 
         var outputBuilder = call.createOutputBuilder(call.context(), call.operation().outputSchema().id().toString());
-        return HttpBinding.responseDeserializer()
+        ResponseDeserializer deser = HttpBinding.responseDeserializer()
             .payloadCodec(codec)
             .outputShapeBuilder(outputBuilder)
-            .response(response)
+            .response(response);
+
+        if (call.operation() instanceof OutputEventStreamingApiOperation<?, ?, ?> o) {
+            deser.eventDecoderFactory(getEventDecoderFactory(o));
+        }
+
+        return deser
             .deserialize()
             .thenApply(ignore -> {
                 O output = outputBuilder.errorCorrection().build();

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/InputEventStreamingApiOperation.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/InputEventStreamingApiOperation.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.schema;
+
+import java.util.function.Supplier;
+
+/**
+ * Represents a modeled Smithy operation.
+ *
+ * @param <I> Operation input shape type.
+ * @param <O> Operation output shape type.
+ * @param <IE> Operation input event shape type.
+ */
+public interface InputEventStreamingApiOperation<I extends SerializableStruct, O extends SerializableStruct, IE extends SerializableStruct>
+    extends ApiOperation<I, O> {
+    /**
+     * Retrieves a supplier of builders for input events.
+     *
+     * @return Returns a supplier of input event shape builders.
+     */
+    Supplier<ShapeBuilder<IE>> inputEventBuilderSupplier();
+
+    /**
+     * Get the schema of the input events.
+     *
+     * @return Returns the input event schema, including relevant traits.
+     */
+    Schema inputEventSchema();
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/OutputEventStreamingApiOperation.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/OutputEventStreamingApiOperation.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.schema;
+
+import java.util.function.Supplier;
+
+/**
+ * Represents a modeled Smithy operation.
+ *
+ * @param <I> Operation input shape type.
+ * @param <O> Operation output shape type.
+ * @param <OE> Operation output event shape type.
+ */
+public interface OutputEventStreamingApiOperation<I extends SerializableStruct, O extends SerializableStruct, OE extends SerializableStruct>
+    extends ApiOperation<I, O> {
+    /**
+     * Retrieves a supplier of builders for output events.
+     *
+     * @return Returns a supplier of output event shape builders.
+     */
+    Supplier<ShapeBuilder<OE>> outputEventBuilderSupplier();
+
+    /**
+     * Get the schema of the output events.
+     *
+     * @return Returns the output event schema, including relevant traits.
+     */
+    Schema outputEventSchema();
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ShapeBuilder.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ShapeBuilder.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.core.schema;
 
+import java.util.concurrent.Flow;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -28,12 +29,10 @@ public interface ShapeBuilder<T extends SerializableShape> extends SmithyBuilder
     /**
      * Set an event stream on the shape, if allowed.
      *
-     * <p>TODO: Implement event streams.
-     *
      * @param eventStream Event stream to set.
      * @throws UnsupportedOperationException if the shape has not event stream.
      */
-    default void setEventStream(Object eventStream) {
+    default void setEventStream(Flow.Publisher<? extends SerializableStruct> eventStream) {
         throw new UnsupportedOperationException("This shape does not have an event stream: " + getClass().getName());
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/BufferingFlatMapProcessor.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/BufferingFlatMapProcessor.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Flow;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+/**
+ * A processor abstraction that maps inputs of type I from an upstream publisher to 0-n items of type O
+ * that are buffered without limit and published to a subscriber. This prevents the subscriber from receiving
+ * more items than requested when one I maps to multiple Os.
+ * <p>
+ * Note that this does not perform event publication on a different thread; both receipt of items and requests
+ * for more items can trigger publication of items on the calling thread.
+ *
+ * @param <I> the type published by the upstream publisher.
+ * @param <O> the type published to the downstream subscriber.
+ */
+public abstract class BufferingFlatMapProcessor<I, O> implements
+    Flow.Processor<I, O>,
+    Flow.Subscription {
+    private static final Throwable COMPLETE_SENTINEL = new RuntimeException();
+
+    private final AtomicReference<Throwable> terminalEvent = new AtomicReference<>();
+    private final AtomicLong pendingRequests = new AtomicLong();
+    private final AtomicInteger pendingFlushes = new AtomicInteger();
+    private final Flow.Publisher<I> publisher;
+    private final BlockingQueue<O> queue = new LinkedBlockingQueue<>();
+
+    private volatile Flow.Subscription upstreamSubscription;
+    private volatile Flow.Subscriber<? super O> downstream;
+    private boolean terminated = false;
+
+    public BufferingFlatMapProcessor(
+        Flow.Publisher<I> publisher
+    ) {
+        this.publisher = publisher;
+        publisher.subscribe(this);
+    }
+
+    protected abstract Stream<O> map(I item);
+
+    @Override
+    public final void onSubscribe(Flow.Subscription subscription) {
+        upstreamSubscription = subscription;
+        if (pendingRequests.get() > 0 && pendingFlushes.get() == 0) {
+            flush();
+        }
+    }
+
+    @Override
+    public final void subscribe(Flow.Subscriber<? super O> subscriber) {
+        downstream = subscriber;
+        subscriber.onSubscribe(this);
+    }
+
+    @Override
+    public final void onNext(I item) {
+        try {
+            map(item).forEach(queue::add);
+        } catch (Exception e) {
+            onError(new SerializationException("Malformed input", e));
+            return;
+        }
+
+        flush();
+    }
+
+    @Override
+    public final void onError(Throwable t) {
+        upstreamSubscription.cancel();
+        terminalEvent.compareAndSet(null, t);
+        flush();
+    }
+
+    @Override
+    public final void onComplete() {
+        terminalEvent.compareAndSet(null, COMPLETE_SENTINEL);
+        flush();
+    }
+
+    @Override
+    public final void request(long n) {
+        if (n <= 0) {
+            onError(new IllegalArgumentException("got a request for " + n + " items"));
+            return;
+        }
+
+        accumulate(pendingRequests, n);
+        flush();
+    }
+
+    private void flush() {
+        if (upstreamSubscription == null || downstream == null) {
+            onError(new IllegalStateException("flush() requested before upstream and downstream fully wired."));
+            return;
+        }
+
+        if (pendingFlushes.getAndIncrement() > 0) {
+            return;
+        }
+
+        if (terminated) {
+            return;
+        }
+
+        int loop = 1;
+        while (loop > 0) {
+            long pending = pendingRequests.get();
+
+            Flow.Subscriber<? super O> subscriber = downstream;
+            long delivered = sendMessages(subscriber, pending);
+            boolean empty = queue.isEmpty();
+            Throwable term = terminalEvent.get();
+            if (term != null && attemptTermination(subscriber, term, empty)) {
+                terminated = true;
+                return;
+            }
+
+            if (delivered > 0) {
+                /*
+                 * We still need to re-read at the start of the loop because additions to pendingRequest happen-before
+                 * additions to pendingFlushes. If we reused this value in the next loop, there is a race condition:
+                 * 1. Thread A is in `flush()`.
+                 * 2. Thread B enters `request`.
+                 * 3. Thread A decrements pendingRequests here.
+                 * 4. Thread B increments pendingFlushes and returns because A is still flushing.
+                 * 5. Thread A decrements pendingFlushes and noticed that something requested a flush. It loops around
+                 *    but _doesn't_ read the new value of pendingRequests, so it does nothing.
+                 *
+                 * In short, reload _all_ state on _every_Loop. You are only guaranteed to see updates to shared state
+                 * after reading a value from pendingFlushes.
+                 */
+                accumulate(pendingRequests, -delivered);
+
+                /*
+                 * We need to accumulate our local `pending` value separately from the atomic `pendingRequests`.
+                 * Consider this scenario with two buffers available for flush and one outstanding request:
+                 * 1. Thread A is in `flush()`. It observes 1 pending request and flushes 1 buffer.
+                 * 2. Thread B calls `request` and increments `pendingRequests` from 1 to 2.
+                 * 3. Thread A enters this if statement. It delivered one message, subtracts 1 from `pendingRequests`,
+                 *    and stores the new sum of 1 in `pending`.
+                 * 4. Thread A enters the next if statement and requests one buffer from the upstream subscription,
+                 *    even though it fulfilled the 1 request that was present in this loop and we have 1 more buffer
+                 *    that can be flushed.
+                 *
+                 * To avoid over-requesting buffers, we must only consider how much demand we successfully fulfilled
+                 * verses how much we were willing to fulfill on this loop. To do this, we must only read a value from
+                 * `pendingRequests` a single time, at the top of each loop. The rest of the loop must only work with
+                 * the value read at the start.
+                 */
+                pending = accumulate(pending, -delivered);
+            }
+
+            if (pending > 0) {
+                // do this inside the flush loop so a recursive flush -> request -> onNext -> flush
+                // call will be aborted by the `pendingFlushes` check.
+                upstreamSubscription.request(1);
+            }
+
+            loop = pendingFlushes.addAndGet(-loop);
+        }
+    }
+
+    protected void handleError(Throwable error, Flow.Subscriber<? super O> subscriber) {
+        subscriber.onError(error);
+    }
+
+    /**
+     * @return true if this decoder is in a terminal state
+     */
+    private boolean attemptTermination(Flow.Subscriber<? super O> subscriber, Throwable term, boolean done) {
+        if (done && subscriber != null) {
+            if (term == COMPLETE_SENTINEL) {
+                subscriber.onComplete();
+            } else {
+                handleError(term, subscriber);
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Tries to flush up to the given demand and signals if we need data from
+     * upstream if there is unfulfilled demand.
+     *
+     * @param outstanding outstanding message demand to fulfill
+     * @return number of fulfilled requests
+     */
+    private long sendMessages(Flow.Subscriber<? super O> subscriber, long outstanding) {
+        long served = 0;
+
+        if (subscriber != null) {
+            while (served < outstanding) {
+                O m = queue.poll();
+                if (m == null) {
+                    break;
+                }
+                served++;
+                subscriber.onNext(m);
+            }
+        }
+
+        return served;
+    }
+
+    @Override
+    public final void cancel() {
+        upstreamSubscription.cancel();
+    }
+
+    private static long accumulate(long current, long n) {
+        if (current == Long.MAX_VALUE || n == Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+
+        try {
+            return Math.addExact(current, n);
+        } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    private static long accumulate(AtomicLong l, long n) {
+        return l.accumulateAndGet(n, BufferingFlatMapProcessor::accumulate);
+    }
+
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -9,6 +9,7 @@ import java.io.Flushable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.concurrent.Flow;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
@@ -159,6 +160,16 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      * @param value  Streaming value.
      */
     default void writeDataStream(Schema schema, DataStream value) {
+        // by default, do nothing
+    }
+
+    /**
+     * Serialize an event stream.
+     *
+     * @param schema Schema of the shape.
+     * @param value  Event Stream value.
+     */
+    default void writeEventStream(Schema schema, Flow.Publisher<? extends SerializableStruct> value) {
         // by default, do nothing
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventDecoder.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventDecoder.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+
+public interface EventDecoder<F extends Frame<?>> {
+
+    SerializableStruct decode(F frame);
+
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventDecoderFactory.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventDecoderFactory.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+public interface EventDecoderFactory<F extends Frame<?>> {
+
+    EventDecoder<F> newEventDecoder();
+
+    FrameDecoder<F> newFrameDecoder();
+
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventEncoder.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventEncoder.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+
+public interface EventEncoder<F extends Frame<?>> {
+
+    F encode(SerializableStruct item);
+
+    F encodeFailure(Throwable exception);
+
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventEncoderFactory.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventEncoderFactory.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+public interface EventEncoderFactory<F extends Frame<?>> {
+
+    EventEncoder<F> newEventEncoder();
+
+    FrameEncoder<F> newFrameEncoder();
+
+    /**
+     * Get the content type for this frame type.
+     * @return a content-type.
+     */
+    String contentType();
+
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventStreamFrameDecodingProcessor.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventStreamFrameDecodingProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.Flow;
+import java.util.stream.Stream;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.serde.BufferingFlatMapProcessor;
+
+public final class EventStreamFrameDecodingProcessor<F extends Frame<?>>
+    extends BufferingFlatMapProcessor<ByteBuffer, SerializableStruct> {
+    private final FrameDecoder<F> decoder;
+    private final EventDecoder<F> eventDecoder;
+
+    public EventStreamFrameDecodingProcessor(
+        Flow.Publisher<ByteBuffer> publisher,
+        FrameDecoder<F> decoder,
+        EventDecoder<F> eventDecoder
+    ) {
+        super(publisher);
+        this.decoder = decoder;
+        this.eventDecoder = eventDecoder;
+    }
+
+    public static <F extends Frame<?>> EventStreamFrameDecodingProcessor<F> create(
+        Flow.Publisher<ByteBuffer> publisher,
+        EventDecoderFactory<F> eventDecoderFactory
+    ) {
+        return new EventStreamFrameDecodingProcessor<>(
+            publisher,
+            eventDecoderFactory.newFrameDecoder(),
+            eventDecoderFactory.newEventDecoder()
+        );
+    }
+
+    @Override
+    protected Stream<SerializableStruct> map(ByteBuffer item) {
+        return decoder.decode(item).stream().map(eventDecoder::decode);
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventStreamFrameEncodingProcessor.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventStreamFrameEncodingProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.Flow;
+import java.util.stream.Stream;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.serde.BufferingFlatMapProcessor;
+
+public final class EventStreamFrameEncodingProcessor<F extends Frame<?>, T extends SerializableStruct>
+    extends BufferingFlatMapProcessor<T, ByteBuffer> {
+    private final EventEncoder<F> eventEncoder;
+    private final FrameEncoder<F> encoder;
+
+    public EventStreamFrameEncodingProcessor(
+        Flow.Publisher<T> publisher,
+        EventEncoder<F> eventEncoder,
+        FrameEncoder<F> encoder
+    ) {
+        super(publisher);
+        this.eventEncoder = eventEncoder;
+        this.encoder = encoder;
+    }
+
+    public static <F extends Frame<?>> EventStreamFrameEncodingProcessor<F, ?> create(
+        Flow.Publisher<? extends SerializableStruct> publisher,
+        EventEncoderFactory<F> encoderFactory
+    ) {
+        return new EventStreamFrameEncodingProcessor<>(
+            publisher,
+            encoderFactory.newEventEncoder(),
+            encoderFactory.newFrameEncoder()
+        );
+    }
+
+    @Override
+    protected Stream<ByteBuffer> map(T item) {
+        return Stream.of(encoder.encode(eventEncoder.encode(item)));
+    }
+
+    @Override
+    protected void handleError(Throwable error, Flow.Subscriber<? super ByteBuffer> subscriber) {
+        subscriber.onNext(encoder.encode(eventEncoder.encodeFailure(error)));
+        subscriber.onComplete();
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventStreamingException.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/EventStreamingException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+public class EventStreamingException extends RuntimeException {
+
+    private final String errorCode;
+
+    public EventStreamingException(String errorCode, String errorMessage) {
+        super(errorMessage);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/Frame.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/Frame.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+/**
+ * A frame wraps the data for one event streaming event with metadata for signing and validation.
+ */
+public interface Frame<T> {
+    T unwrap();
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/FrameDecoder.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/FrameDecoder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * Decodes frames from bytes.
+ */
+public interface FrameDecoder<F extends Frame<?>> {
+    /**
+     * Decode 0 or more frames from a buffer, holding on to excess data
+     * that can be prepended to the next `decode` call.
+     * @param buffer the buffer to attempt to read frames from
+     * @return all the frames readable from this pass
+     */
+    List<F> decode(ByteBuffer buffer);
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/FrameEncoder.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/FrameEncoder.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Encodes frames to bytes
+ */
+public interface FrameEncoder<F extends Frame<?>> {
+    /**
+     * Encode a frame into a buffer
+     * @param frame the frame to encode.
+     * @return a bytebuffer with the encoded frame's bytes
+     */
+    ByteBuffer encode(F frame);
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/FrameTransformer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/event/FrameTransformer.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.serde.event;
+
+import java.util.function.Function;
+
+/**
+ * Apply a transformation to a frame, such as validating the signature of a frame
+ * and unwrapping the embedded frame within.
+ * <p>
+ * Null transformation results indicate that the frame should be dropped
+ *
+ * @param <F> the frame type
+ */
+@FunctionalInterface
+public interface FrameTransformer<F extends Frame<?>> extends Function<F, F> {}

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/PayloadSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/PayloadSerializer.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.concurrent.Flow;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
@@ -43,6 +44,16 @@ final class PayloadSerializer implements ShapeSerializer {
         payloadWritten = true;
         serializer.setHttpPayload(schema, value);
     }
+
+    @Override
+    public void writeEventStream(
+        Schema schema,
+        Flow.Publisher<? extends SerializableStruct> value
+    ) {
+        payloadWritten = true;
+        serializer.setEventStream(value);
+    }
+
 
     private void write(byte[] bytes) {
         try {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestDeserializer.java
@@ -11,6 +11,8 @@ import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
+import software.amazon.smithy.java.runtime.core.serde.event.EventDecoderFactory;
+import software.amazon.smithy.java.runtime.core.serde.event.Frame;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 
 /**
@@ -70,6 +72,18 @@ public final class RequestDeserializer {
         errorShapeBuilder = null;
         return this;
     }
+
+    /**
+     * Enables input event decoding.
+     *
+     * @param eventDecoderFactory event decoding support
+     * @return Returns the deserializer.
+     */
+    public <F extends Frame<?>> RequestDeserializer eventDecoderFactory(EventDecoderFactory<F> eventDecoderFactory) {
+        deserBuilder.eventDecoderFactory(eventDecoderFactory);
+        return this;
+    }
+
 
     public RequestDeserializer pathLabelValues(Map<String, String> labelValues) {
         deserBuilder.requestPathLabels(labelValues);

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
@@ -10,6 +10,8 @@ import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
+import software.amazon.smithy.java.runtime.core.serde.event.EventDecoderFactory;
+import software.amazon.smithy.java.runtime.core.serde.event.Frame;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 
 /**
@@ -64,6 +66,17 @@ public final class ResponseDeserializer {
     public ResponseDeserializer outputShapeBuilder(ShapeBuilder<?> outputShapeBuilder) {
         this.outputShapeBuilder = outputShapeBuilder;
         errorShapeBuilder = null;
+        return this;
+    }
+
+    /**
+     * Enables output event decoding.
+     *
+     * @param eventDecoderFactory event decoding support
+     * @return Returns the deserializer.
+     */
+    public <F extends Frame<?>> ResponseDeserializer eventDecoderFactory(EventDecoderFactory<F> eventDecoderFactory) {
+        deserBuilder.eventDecoderFactory(eventDecoderFactory);
         return this;
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ include("tracing-api")
 
 include(":http-api")
 include(":http-binding")
+include(":aws-event-streams")
 
 include(":json-codec")
 


### PR DESCRIPTION
*Description of changes:*
This adds foundational support for event streams and in particular event streams using the published AWS event streaming specification over HTTP bindings.

Request deserialization and response serialization are speculatively hooked up based on work in the server-impl branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
