### PR TITLE
Remove deletion of branch in workflow

### DIFF
--- a/.github/workflows/update-codgen-branch.yml
+++ b/.github/workflows/update-codgen-branch.yml
@@ -27,9 +27,6 @@ jobs:
           git config --global user.email "github-aws-smithy-automation@amazon.com"
           git config --global user.name "Smithy Automation"
 
-      - name: Delete local main-codegen branch
-        run: git branch --delete main-codegen
-
       - name: Add generated files
         run: |
           git checkout -b main-codegen


### PR DESCRIPTION
### Description of changes
Apparently the github checkout task does not clone the full repo so there is no main-codegen branch to delete.
```
Run git branch --delete main-codegen
error: branch 'main-codegen' not found
Error: Process completed with exit code 1.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
