### PR TITLE
[Draft] Idea for addressing Unit type handling

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/UnionTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/UnionTest.java
@@ -51,7 +51,8 @@ public class UnionTest {
             new UnionType.TimestampValueMember(Instant.EPOCH),
             new UnionType.UnionValueMember(new NestedUnion.BMember(1)),
             new UnionType.EnumValueMember(NestedEnum.A),
-            new UnionType.IntEnumValueMember(NestedIntEnum.A)
+            new UnionType.IntEnumValueMember(NestedIntEnum.A),
+            new UnionType.UnitValueMember()
         );
     }
 

--- a/codegen/core/src/it/resources/META-INF/smithy/unions/unions-all-types.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/unions/unions-all-types.smithy
@@ -34,4 +34,5 @@ union UnionType {
     unionValue: NestedUnion
     enumValue: NestedEnum
     intEnumValue: NestedIntEnum
+    unitValue: Unit
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -178,9 +178,8 @@ public final class CodegenUtils {
      * @param shape shape to write Schema type for.
      */
     public static String getSchemaType(JavaWriter writer, SymbolProvider provider, Shape shape) {
-        if (Prelude.isPreludeShape(shape)) {
-            var shapeName = shape.hasTrait(UnitTypeTrait.class) ? "UNIT" : shape.getType().name();
-            return writer.format("$T.$L", PreludeSchemas.class, shapeName);
+        if (Prelude.isPreludeShape(shape) && !shape.hasTrait(UnitTypeTrait.class)) {
+            return writer.format("$T.$L", PreludeSchemas.class, shape.getType().name());
         } else if (shape.isStructureShape() || shape.isUnionShape() || shape.isIntEnumShape() || shape.isEnumShape()) {
             // Shapes that generate a class have their schemas as static properties on that class
             return writer.format("$T.SCHEMA", provider.toSymbol(shape));

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.java.runtime.core.schema.Unit;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 import software.amazon.smithy.model.Model;
@@ -50,6 +51,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.UniqueItemsTrait;
+import software.amazon.smithy.model.traits.UnitTypeTrait;
 import software.amazon.smithy.utils.CaseUtils;
 
 /**
@@ -58,6 +60,7 @@ import software.amazon.smithy.utils.CaseUtils;
 public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider {
 
     private static final System.Logger LOGGER = System.getLogger(JavaSymbolProvider.class.getName());
+    private static final Symbol UNIT_SYMBOL = CodegenUtils.fromClass(Unit.class);
 
     private final Model model;
     private final ServiceShape service;
@@ -249,6 +252,9 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
 
     @Override
     public Symbol structureShape(StructureShape structureShape) {
+        if (structureShape.hasTrait(UnitTypeTrait.class)) {
+            return UNIT_SYMBOL;
+        }
         return getJavaClassSymbol(structureShape);
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.codegen.generators;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.java.runtime.core.schema.Unit;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
@@ -33,6 +34,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.UnitTypeTrait;
 
 final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void> implements
     Runnable {
@@ -176,7 +178,11 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
 
     @Override
     public Void structureShape(StructureShape structureShape) {
-        writer.write("serializer.writeStruct(${schema:L}, ${state:L})");
+        if (structureShape.hasTrait(UnitTypeTrait.class)) {
+            writer.write("serializer.writeStruct(${schema:L}, $T.INSTANCE)", Unit.class);
+        } else {
+            writer.write("serializer.writeStruct(${schema:L}, ${state:L})");
+        }
         return null;
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -65,6 +65,7 @@ import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
+import software.amazon.smithy.model.traits.UnitTypeTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -74,6 +75,10 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
     @Override
     public void accept(T directive) {
         var shape = directive.shape();
+        if (shape.hasTrait(UnitTypeTrait.class)) {
+            // Do not generate Unit structures
+            return;
+        }
         directive.context().writerDelegator().useShapeWriter(shape, writer -> {
             writer.pushState(new ClassSection(shape));
             var template = """

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.UnitTypeTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -81,7 +82,10 @@ public final class UnionGenerator
             );
             writer.putContext("memberEnum", new TypeEnumGenerator(writer, shape, directive.symbolProvider()));
             writer.putContext("toString", new ToStringGenerator(writer));
-            writer.putContext("valueCasters", new ValueCasterGenerator(writer, shape, directive.symbolProvider()));
+            writer.putContext(
+                "valueCasters",
+                new ValueCasterGenerator(writer, shape, directive.symbolProvider(), directive.model())
+            );
             writer.putContext(
                 "valueClasses",
                 new ValueClassGenerator(
@@ -108,8 +112,9 @@ public final class UnionGenerator
     }
 
 
-    private record ValueCasterGenerator(JavaWriter writer, UnionShape shape, SymbolProvider symbolProvider) implements
-        Runnable {
+    private record ValueCasterGenerator(
+        JavaWriter writer, UnionShape shape, SymbolProvider symbolProvider, Model model
+    ) implements Runnable {
 
         @Override
         public void run() {
@@ -150,11 +155,11 @@ public final class UnionGenerator
                 writer.injectSection(new ClassSection(member));
                 var template = """
                     public static final class ${memberName:U}Member extends ${shape:T} {
-                        private final transient ${member:T} value;
+                        ${^unit}private final transient ${member:T} value;${/unit}
 
-                        public ${memberName:U}Member(${member:T} value) {
-                            super(Type.${enumValue:L});
-                            this.value = ${?col}${collections:T}.${wrap:L}(${/col}${^primitive}${objects:T}.requireNonNull(${/primitive}value${^primitive}, "Union value cannot be null")${/primitive}${?col})${/col};
+                        public ${memberName:U}Member(${^unit}${member:T} value${/unit}) {
+                            super(Type.${enumValue:L});${^unit}
+                            this.value = ${?col}${collections:T}.${wrap:L}(${/col}${^primitive}${objects:T}.requireNonNull(${/primitive}value${^primitive}, "Union value cannot be null")${/primitive}${?col})${/col};${/unit}
                         }
 
                         @Override
@@ -165,12 +170,12 @@ public final class UnionGenerator
                         @Override
                         public void serializeMembers(${shapeSerializer:T} serializer) {
                             ${serializeMember:C};
-                        }
+                        }${^unit}
 
                         @Override
                         public ${member:B} ${memberName:L}() {
                             return value;
-                        }
+                        }${/unit}
 
                         ${equals:C|}
 
@@ -193,6 +198,7 @@ public final class UnionGenerator
                     memberSymbol.getProperty(SymbolProperties.COLLECTION_IMMUTABLE_WRAPPER).orElse(null)
                 );
                 var target = model.expectShape(member.getTarget());
+                writer.putContext("unit", target.hasTrait(UnitTypeTrait.class));
                 writer.putContext("col", target.isMapShape() || target.isListShape());
                 writer.write(template);
                 writer.popState();
@@ -257,7 +263,7 @@ public final class UnionGenerator
                 """
                     @Override
                     public int hashCode() {
-                        ${C|}
+                        return ${^unit}${C|}${/unit}${?unit}${memberName:U}Member.class.hashCode();${/unit}
                     }""",
                 writer.consumer(this::generate)
             );
@@ -267,10 +273,10 @@ public final class UnionGenerator
             writer.pushState();
             if (CodegenUtils.isJavaArray(symbolProvider.toSymbol(shape))) {
                 writer.putContext("arrays", Arrays.class);
-                writer.write("return ${arrays:T}.hashCode(value);");
+                writer.write("${arrays:T}.hashCode(value);");
             } else {
                 writer.putContext("objects", Objects.class);
-                writer.write("return ${objects:T}.hash(value);");
+                writer.write("${objects:T}.hash(value);");
             }
             writer.popState();
         }
@@ -294,8 +300,8 @@ public final class UnionGenerator
                         if (other == null || getClass() != other.getClass()) {
                             return false;
                         }
-                        ${memberName:U}Member that = (${memberName:U}Member) other;
-                        return ${C};
+                        ${^unit}${memberName:U}Member that = (${memberName:U}Member) other;${/unit}
+                        return ${^unit}${C}${/unit}${?unit}true${/unit};
                     }""",
                 writer.consumer(this::writePropertyEqualityCheck)
             );
@@ -337,10 +343,12 @@ public final class UnionGenerator
                 writer.pushState();
                 writer.putContext("memberName", symbolProvider.toMemberName(member));
                 writer.putContext("member", symbolProvider.toSymbol(member));
+                var target = model.expectShape(member.getTarget());
+                writer.putContext("unit", target.hasTrait(UnitTypeTrait.class));
                 writer.write("""
                     public BuildStage ${memberName:L}(${member:T} value) {
                         checkForExistingValue();
-                        this.value = new ${memberName:U}Member(value);
+                        this.value = new ${memberName:U}Member(${^unit}value${/unit});
                         return this;
                     }
                     """);

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegen.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegen.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.codegen.core.directed.GenerateErrorDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateIntEnumDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateListDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateMapDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateOperationDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateStructureDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateUnionDirective;
@@ -25,6 +26,7 @@ import software.amazon.smithy.java.codegen.JavaSymbolProvider;
 import software.amazon.smithy.java.codegen.generators.EnumGenerator;
 import software.amazon.smithy.java.codegen.generators.ListGenerator;
 import software.amazon.smithy.java.codegen.generators.MapGenerator;
+import software.amazon.smithy.java.codegen.generators.OperationGenerator;
 import software.amazon.smithy.java.codegen.generators.SharedSchemasGenerator;
 import software.amazon.smithy.java.codegen.generators.SharedSerdeGenerator;
 import software.amazon.smithy.java.codegen.generators.StructureGenerator;
@@ -67,6 +69,11 @@ public class TestJavaCodegen implements
     @Override
     public void generateService(GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
         // No service generated for tests.
+    }
+
+    @Override
+    public void generateOperation(GenerateOperationDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
+        new OperationGenerator().accept(directive);
     }
 
     @Override

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/PreludeSchemas.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/PreludeSchemas.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.runtime.core.schema;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.DefaultTrait;
-import software.amazon.smithy.model.traits.UnitTypeTrait;
 
 /**
  * {@link Schema} definitions for the Smithy prelude
@@ -81,11 +80,6 @@ public final class PreludeSchemas {
         .type(ShapeType.DOUBLE)
         .id("smithy.api#PrimitiveDouble")
         .traits(new DefaultTrait(Node.from(0)))
-        .build();
-    public static final Schema UNIT = Schema.builder()
-        .type(ShapeType.STRUCTURE)
-        .id("smithy.api#Unit")
-        .traits(new UnitTypeTrait())
         .build();
 
     private PreludeSchemas() {

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Unit.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Unit.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.schema;
+
+import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.UnitTypeTrait;
+
+/**
+ * TODO: Docs
+ */
+public final class Unit implements SerializableStruct {
+    public static final ShapeId ID = ShapeId.from("smithy.api#Unit");
+
+    public static final Schema SCHEMA = Schema.builder()
+        .type(ShapeType.STRUCTURE)
+        .id(ID)
+        .traits(new UnitTypeTrait())
+        .build();
+
+    public static final Unit INSTANCE = new Unit();
+
+    private Unit() {}
+
+    @Override
+    public void serialize(ShapeSerializer encoder) {
+        encoder.writeStruct(SCHEMA, this);
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        // Unit types have no members
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder implements ShapeBuilder<Unit> {
+
+        @Override
+        public ShapeBuilder<Unit> deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct(SCHEMA, this, (b, m, d) -> {});
+            return this;
+        }
+
+        @Override
+        public Unit build() {
+            return INSTANCE;
+        }
+
+        private Builder() {}
+    }
+}


### PR DESCRIPTION
### Description of changes
Adds a `Unit` type to the `core.*.schema` package and updates how unions generate Unit variants. 

Previously we were actually generating a `Unit` structure shape which is why my guess as to why the union protocol tests were able to pass. I dont think we want to generate this type as part of code gen. However, because unit types seem to be encoded as an empty struct (i.e. `"myUnit": {}`) we still need to call the `writeStruct` and `readStruct` method for serde which this new object will allow. Having a non-generated type for `Unit` allows us to re-use the empty definition and to restrict the behavior of the unit type and use a static instance of the class.

This also has the side effect of supporting Unit types for operations.

Example Generated code: [see]()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
