### PR TITLE
Ensure tests generate operations with dedicated IO

### DIFF
--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegen.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegen.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.codegen.core.directed.GenerateErrorDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateIntEnumDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateListDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateMapDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateOperationDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateStructureDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateUnionDirective;
@@ -25,6 +26,7 @@ import software.amazon.smithy.java.codegen.JavaSymbolProvider;
 import software.amazon.smithy.java.codegen.generators.EnumGenerator;
 import software.amazon.smithy.java.codegen.generators.ListGenerator;
 import software.amazon.smithy.java.codegen.generators.MapGenerator;
+import software.amazon.smithy.java.codegen.generators.OperationGenerator;
 import software.amazon.smithy.java.codegen.generators.SharedSchemasGenerator;
 import software.amazon.smithy.java.codegen.generators.SharedSerdeGenerator;
 import software.amazon.smithy.java.codegen.generators.StructureGenerator;
@@ -67,6 +69,11 @@ public class TestJavaCodegen implements
     @Override
     public void generateService(GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
         // No service generated for tests.
+    }
+
+    @Override
+    public void generateOperation(GenerateOperationDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
+        new OperationGenerator().accept(directive);
     }
 
     @Override

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenPlugin.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenPlugin.java
@@ -31,6 +31,7 @@ public class TestJavaCodegenPlugin implements SmithyBuildPlugin {
         runner.model(context.getModel());
         runner.integrationClass(JavaCodegenIntegration.class);
         runner.performDefaultCodegenTransforms();
+        runner.createDedicatedInputsAndOutputs();
         runner.run();
     }
 }


### PR DESCRIPTION
### Description of changes
Updates integration test runner for codegen:core to use dedicated inputs and outputs for operations and to generate operation now that the operation generator is in the core package.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
