### PR TITLE
Add gradle task to automatically add git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,9 @@
 ## Development
 
 ### Pre-commit hooks
-Provided pre-commit hooks make it easier to pass automated linting when opening a pull request.
-To set up these hooks run:
-```shell 
-ln -s -f ../../git-hooks/pre-commit .git/hooks/pre-commit
-```
+Pre-commit hooks are automatically added for unix users via the `addPreCommitHooks` gradle task.
 **Note**: In order to successfully execute the pre-defined hooks you must have the `smithy` CLI installed. 
-See [installation instructions](https://smithy.io/2.0/guides/smithy-cli/cli_installation.html) if you do not already 
-have the CLI installed.
+See [installation instructions](https://smithy.io/2.0/guides/smithy-cli/cli_installation.html) if you do not already have the CLI installed.
 
 ## Security
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,12 @@
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
+task("addPreCommitHooks") {
+    onlyIf("unix") {
+        !Os.isFamily(Os.FAMILY_WINDOWS)
+    }
+    exec {
+        commandLine("ln", "-s", "-f", "../../git-hooks/pre-commit", ".git/hooks/pre-commit")
+    }
+    println("Pre-commit hooks added")
+}


### PR DESCRIPTION
### Description of changes
Adds a gradle task to automatically set up git pre-commit hooks for unix users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
