### PR TITLE
Simplify protocols and transports further

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.runtime.client.core;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
-import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.schema.ApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
@@ -27,18 +26,18 @@ public interface ClientProtocol<RequestT, ResponseT> {
     String id();
 
     /**
-     * The request type and context key used by the client protocol.
+     * The request class used by protocol.
      *
-     * @return the context key.
+     * @return the request class.
      */
-    Context.Key<RequestT> requestKey();
+    Class<RequestT> requestClass();
 
     /**
-     * The response type and context key used by the client protocol.
+     * The response class used by the protocol.
      *
-     * @return the context key.
+     * @return the response class.
      */
-    Context.Key<ResponseT> responseKey();
+    Class<ResponseT> responseClass();
 
     /**
      * Creates the underlying transport request.

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientTransport.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientTransport.java
@@ -7,45 +7,31 @@ package software.amazon.smithy.java.runtime.client.core;
 
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.core.Context;
-import software.amazon.smithy.java.runtime.core.schema.ApiException;
-import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
-import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
- * Serializes inputs, sends requests on the wire, and deserializes responses.
+ * Sends a serialized request and returns a response.
  */
-public interface ClientTransport {
+public interface ClientTransport<RequestT, ResponseT> {
     /**
-     * Send a call using the transport and protocol.
+     * Send a prepared request.
      *
-     * <p>The request to send can be retrieved by grabbing it from the call context using
-     * {@link #requestKey()}.
-     *
-     * <p>The transport is required to set the appropriate response in the context using
-     * {@link #responseKey()} before completing the returned future.
-     *
-     * @param call Call associated with the request.
-     * @return a CompletableFuture that is completed when the response is set on the context.
-     * @throws ModeledApiException if a modeled error occurs.
-     * @throws ApiException if an error occurs.
+     * @param context Call context.
+     * @param request Request to send.
+     * @return a CompletableFuture that is completed with the response.
      */
-    <I extends SerializableStruct, O extends SerializableStruct> CompletableFuture<Void> send(ClientCall<I, O> call);
+    CompletableFuture<ResponseT> send(Context context, RequestT request);
 
     /**
-     * The request type and context key used by transport.
+     * The request class used by transport.
      *
-     * <p>The transport expects that this key is present in the context of a call to send.
-     *
-     * @return the context key.
+     * @return the request class.
      */
-    Context.Key<?> requestKey();
+    Class<RequestT> requestClass();
 
     /**
-     * The response type and context key used by the transport.
+     * The response class used by the transport.
      *
-     * <p>The transport is required to set this context key in the context of the call before returning.
-     *
-     * @return the context key.
+     * @return the response class.
      */
-    Context.Key<?> responseKey();
+    Class<ResponseT> responseClass();
 }

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptor.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptor.java
@@ -20,7 +20,7 @@ import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
  *     <li>Output: The modeled output of an operation.</li>
  *     <li>Request: A protocol specific request to send.</li>
  *     <li>Response: A protocol specific response from a service.</li>
- *     <li>Error: Modeled or unmodeled errors that can be returned by a client.</li>
+ *     <li>Error: An error encountered while sending or receiving data.</li>
  *     <li>Result: Either a successful output or error.</li>
  *     <li>Execution: is one end-to-end invocation against a client.</li>
  *     <li>Attempt: attempt at performing an execution. By default, executions are retried multiple times based on the
@@ -157,7 +157,7 @@ public interface ClientInterceptor {
      * {@code #readBeforeAttempt} invoked. Other hooks will then be skipped, and execution will jump to
      * {@link #modifyBeforeAttemptCompletion} with the raised error as the result. If multiple {@code beforeAttempt}
      * methods raise errors, the latest is used, and earlier errors are logged and dropped.
-     * 
+     *
      * @param hook Hook data.
      */
     default void readBeforeAttempt(RequestHook<?, ?> hook) {}

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpClientProtocol.java
@@ -15,7 +15,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import software.amazon.smithy.java.runtime.client.core.ClientProtocol;
 import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
-import software.amazon.smithy.java.runtime.core.Context;
 import software.amazon.smithy.java.runtime.core.schema.ApiException;
 import software.amazon.smithy.java.runtime.core.uri.URIBuilder;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
@@ -40,13 +39,13 @@ public abstract class HttpClientProtocol implements ClientProtocol<SmithyHttpReq
     }
 
     @Override
-    public final Context.Key<SmithyHttpRequest> requestKey() {
-        return HttpContext.HTTP_REQUEST;
+    public final Class<SmithyHttpRequest> requestClass() {
+        return SmithyHttpRequest.class;
     }
 
     @Override
-    public final Context.Key<SmithyHttpResponse> responseKey() {
-        return HttpContext.HTTP_RESPONSE;
+    public final Class<SmithyHttpResponse> responseClass() {
+        return SmithyHttpResponse.class;
     }
 
     @Override

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpContext.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpContext.java
@@ -7,23 +7,11 @@ package software.amazon.smithy.java.runtime.client.http;
 
 import java.time.Duration;
 import software.amazon.smithy.java.runtime.core.Context;
-import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
-import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 
 /**
  * {@link Context} keys used with HTTP-based clients.
  */
 public final class HttpContext {
-    /**
-     * HTTP request to send.
-     */
-    public static final Context.Key<SmithyHttpRequest> HTTP_REQUEST = Context.key("HTTP Request");
-
-    /**
-     * HTTP response received.
-     */
-    public static final Context.Key<SmithyHttpResponse> HTTP_RESPONSE = Context.key("HTTP Response");
-
     /**
      * The time from when an HTTP request is sent, and when the response is received. If the response is not
      * received in time, then the request is considered timed out. This setting does not apply to streaming


### PR DESCRIPTION
Protocol and transport now return their request class and response class rather than a Context.Key. Transport now is generic over the request and response types and is no longer passed the entire ClientCall. It is now instead passed the RequestT and Context and returns CompletableFuture<ResponseT>.

HTTP_REQUEST and HTTP_RESPONSE context keys were removed since they weren't really useful.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
