### PR TITLE
Use the correct default for StreamingBlob

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
@@ -98,10 +98,8 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
 
     @Override
     public Symbol blobShape(BlobShape blobShape) {
-        if (blobShape.hasTrait(StreamingTrait.class)) {
-            return CodegenUtils.fromClass(DataStream.class);
-        }
-        return CodegenUtils.fromClass(ByteBuffer.class)
+        var type = blobShape.hasTrait(StreamingTrait.class) ? DataStream.class : ByteBuffer.class;
+        return CodegenUtils.fromClass(type)
             .toBuilder()
             .putProperty(SymbolProperties.IS_PRIMITIVE, false)
             .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -658,15 +658,6 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
             // Add non-static builder properties
             for (var member : shape.members()) {
                 var memberName = symbolProvider.toMemberName(member);
-                if (CodegenUtils.isStreamingBlob(model.expectShape(member.getTarget()))) {
-                    // Streaming blobs need a custom initializer
-                    writer.write(
-                        "private $1T $2L = $1T.ofEmpty();",
-                        DataStream.class,
-                        memberName
-                    );
-                    continue;
-                }
                 writer.pushState();
                 writer.putContext("nullable", CodegenUtils.isNullableMember(member));
                 writer.putContext("default", member.hasNonNullDefault());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

See [this](https://github.com/smithy-lang/smithy-java/blob/c1757ea9b6264a5fa9ace8dc5dbea3f7db78003b/codegen/core/build/generated-src/software/amazon/smithy/java/codegen/test/model/DefaultsInput.java#L511), the default is always `DataStream.ofBytes()`.

After this change,

```
private DataStream streamingBlob = DataStream.ofBytes(Base64.getDecoder().decode("c3RyZWFtaW5n"));
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
