### PR TITLE
Fix URL

### DIFF
--- a/.github/workflows/update-codgen-branch.yml
+++ b/.github/workflows/update-codgen-branch.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git config --global user.email "github-smithy-automation@amazon.com"
           git config --global user.name "smithy-automation"
-          git remote set-url origin https://x-access-token/:${{ secrets.PR_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ secrets.PR_TOKEN }}@github.com/${{ github.repository }}
 
       - name: Add generated files
         run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation, URL has an extra `/`
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
