### PR TITLE
Fix RequestHook used by later interceptors

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
@@ -137,9 +137,10 @@ public final class ClientPipeline<RequestT, ResponseT> {
             .thenApply(endpoint -> protocol.setServiceEndpoint(reqBeforeEndpointResolution, endpoint))
             .thenCompose(resolvedAuthScheme::sign)
             .thenApply(req -> {
-                interceptor.readAfterSigning(finalRequestHook);
-                req = interceptor.modifyBeforeTransmit(finalRequestHook);
-                interceptor.readBeforeTransmit(finalRequestHook.withRequest(req));
+                var reqHook = finalRequestHook.withRequest(req);
+                interceptor.readAfterSigning(reqHook);
+                req = interceptor.modifyBeforeTransmit(reqHook);
+                interceptor.readBeforeTransmit(reqHook.withRequest(req));
                 return req;
             })
             .thenCompose(finalRequest -> transport.send(context, finalRequest).thenCompose(response -> {


### PR DESCRIPTION
The `finalRequestHook` was using an earlier `request` not the one that is updating after resolving endpoint and signing - `req`. This would cause the request given to the transport to have URI="/" and not the specified endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
