### PR TITLE
Remove non existent identity-api sub project

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,6 @@ include(":client-endpoint-api")
 include(":client-http")
 include(":client-auth")
 
-include(":identity-api")
 include(":auth-api")
 include(":sigv4")
 


### PR DESCRIPTION
This was refactored to be combined into `auth-api` a while back. There is no `identity-api` now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
