### PR TITLE
Remove unnecessary indirection to create output

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
@@ -121,18 +121,6 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
     }
 
     /**
-     * Create a builder for the output of the operation.
-     *
-     * @param context Context to pass to the creator.
-     * @param shapeId Nullable ID of the error shape to create, if known.
-     * @return Returns the created output builder.
-     */
-    public ShapeBuilder<O> createOutputBuilder(Context context, String shapeId) {
-        // TODO: Allow customizing this if needed.
-        return operation().outputBuilder();
-    }
-
-    /**
      * Attempts to create a builder for a modeled error.
      *
      * <p>If this method returns null, a protocol must create an appropriate error based on protocol hints.

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
@@ -82,7 +82,7 @@ public class HttpBindingClientProtocol<F extends Frame<?>> extends HttpClientPro
 
         LOGGER.log(System.Logger.Level.TRACE, () -> "Deserializing successful response with " + getClass().getName());
 
-        var outputBuilder = call.createOutputBuilder(call.context(), call.operation().outputSchema().id().toString());
+        var outputBuilder = call.operation().outputBuilder();
         ResponseDeserializer deser = HttpBinding.responseDeserializer()
             .payloadCodec(codec)
             .outputShapeBuilder(outputBuilder)


### PR DESCRIPTION
If an implementation ever needed to customize how an output is created, it can do so in protocol implementations _instead_ of calling the default outputBuilder method. The layer of indirection in ClientCall wasn't actually useful for this purpose anyways because ClientCall is final.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
