### PR TITLE
Make deser like ser by adding streaming methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,9 @@ build
 #Ignore mac files
 .DS_Store
 
+# Intellij stuff
+.classpath
+.project
+.settings
+
 smithy-java-core/out

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/StructuresTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/StructuresTest.java
@@ -82,14 +82,17 @@ public class StructuresTest {
     @Test
     void blobSerialization() {
         var datastream = DataStream.ofBytes("data streeeeeeeeeeam".getBytes());
-        var builder = BlobMembersInput.builder().requiredBlob(wrap("data".getBytes()));
-        builder.setDataStream(datastream);
+        var builder = BlobMembersInput
+            .builder()
+            .requiredBlob(wrap("data".getBytes()))
+            .streamingBlob(datastream);
+
         var input = builder.build();
         var document = Document.createTyped(builder.build());
         var outputBuilder = BlobMembersInput.builder();
         document.deserializeInto(outputBuilder);
-        outputBuilder.setDataStream(input.streamingBlob());
         var output = builder.build();
+
         assertEquals(input.hashCode(), output.hashCode());
         assertEquals(input, output);
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/DeserializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/DeserializerGenerator.java
@@ -32,6 +32,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.StreamingTrait;
 
 final class DeserializerGenerator extends ShapeVisitor.DataShapeVisitor<Void> implements Runnable {
 
@@ -72,7 +73,11 @@ final class DeserializerGenerator extends ShapeVisitor.DataShapeVisitor<Void> im
 
     @Override
     public Void blobShape(BlobShape blobShape) {
-        writer.write("${deserializer:L}.readBlob(${schemaName:L})");
+        if (blobShape.hasTrait(StreamingTrait.class)) {
+            writer.write("${deserializer:L}.readDataStream(${schemaName:L})");
+        } else {
+            writer.write("${deserializer:L}.readBlob(${schemaName:L})");
+        }
         return null;
     }
 
@@ -162,7 +167,11 @@ final class DeserializerGenerator extends ShapeVisitor.DataShapeVisitor<Void> im
 
     @Override
     public Void stringShape(StringShape stringShape) {
-        writer.write("${deserializer:L}.readString(${schemaName:L})");
+        if (stringShape.hasTrait(StreamingTrait.class)) {
+            writer.write("${deserializer:L}.readDataStream(${schemaName:L})");
+        } else {
+            writer.write("${deserializer:L}.readString(${schemaName:L})");
+        }
         return null;
     }
 
@@ -180,7 +189,11 @@ final class DeserializerGenerator extends ShapeVisitor.DataShapeVisitor<Void> im
 
     @Override
     public Void unionShape(UnionShape unionShape) {
-        delegateDeser();
+        if (unionShape.hasTrait(StreamingTrait.class)) {
+            writer.write("${deserializer:L}.readEventStream(${schemaName:L})");
+        } else {
+            delegateDeser();
+        }
         return null;
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
@@ -57,12 +57,6 @@ record StructureDeserializerGenerator(
         int idx = 0;
         for (var iter = CodegenUtils.getSortedMembers(shape).iterator(); iter.hasNext(); idx++) {
             var member = iter.next();
-            var target = model.expectShape(member.getTarget());
-            if (CodegenUtils.isStreamingBlob(target)) {
-                // Streaming blobs are not deserialized by the builder class.
-                continue;
-            }
-
             writer.pushState();
             writer.putContext("memberName", symbolProvider.toMemberName(member));
             writer.write(

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -690,17 +690,6 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
                 writer.putContext("check", CodegenUtils.requiresSetterNullCheck(symbolProvider, member));
                 writer.putContext("schemaName", CodegenUtils.toMemberSchemaName(symbolProvider.toMemberName(member)));
 
-                // If streaming blob then a setter must be added to allow
-                // operation to set on builder.
-                if (CodegenUtils.isStreamingBlob(model.expectShape(member.getTarget()))) {
-                    writer.putContext("dataStream", DataStream.class);
-                    writer.write("""
-                        @Override
-                        public void setDataStream(${dataStream:T} stream) {
-                            ${memberName:L}(stream);
-                        }
-                        """);
-                }
                 writer.write(
                     """
                         public Builder ${memberName:L}(${memberSymbol:T} ${memberName:L}) {

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
@@ -51,11 +51,6 @@ record StructureSerializerGenerator(
         boolean isError = shape.hasTrait(ErrorTrait.class);
 
         for (var member : shape.members()) {
-            var target = model.expectShape(member.getTarget());
-            // Streaming blobs are not handled by deserialize method
-            if (CodegenUtils.isStreamingBlob(target)) {
-                continue;
-            }
             var memberName = symbolProvider.toMemberName(member);
             // if the shape is an error we need to use the `getMessage()` method for message field.
             var state = isError && memberName.equals("message") ? "getMessage()" : memberName;

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ShapeBuilder.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ShapeBuilder.java
@@ -5,36 +5,20 @@
 
 package software.amazon.smithy.java.runtime.core.schema;
 
-import java.util.concurrent.Flow;
-import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
-import software.amazon.smithy.utils.SmithyBuilder;
 
 /**
  * Builds deserializable shapes.
  *
  * @param <T> Shape to build.
  */
-public interface ShapeBuilder<T extends SerializableShape> extends SmithyBuilder<T> {
+public interface ShapeBuilder<T extends SerializableShape> {
     /**
-     * Set a stream of data on the shape, if allowed.
+     * Build the shape.
      *
-     * @param stream Stream to set.
-     * @throws UnsupportedOperationException if the shape has no stream.
+     * @return the built shape.
      */
-    default void setDataStream(DataStream stream) {
-        throw new UnsupportedOperationException("This shape does not have a stream: " + getClass().getName());
-    }
-
-    /**
-     * Set an event stream on the shape, if allowed.
-     *
-     * @param eventStream Event stream to set.
-     * @throws UnsupportedOperationException if the shape has not event stream.
-     */
-    default void setEventStream(Flow.Publisher<? extends SerializableStruct> eventStream) {
-        throw new UnsupportedOperationException("This shape does not have an event stream: " + getClass().getName());
-    }
+    T build();
 
     /**
      * Deserializes data from the given decoder into the state of the builder.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
@@ -9,7 +9,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.concurrent.Flow;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 /**
@@ -164,6 +166,26 @@ public interface ShapeDeserializer extends AutoCloseable {
      */
     default <T> T readNull() {
         return null;
+    }
+
+    /**
+     * Read a data stream from the deserializer.
+     *
+     * @param schema Schema of the data stream to read.
+     * @return the data stream.
+     */
+    default DataStream readDataStream(Schema schema) {
+        throw new UnsupportedOperationException("Cannot read data stream from this deserializer");
+    }
+
+    /**
+     * Read an event stream from the deserializer.
+     *
+     * @param schema Schema of the event stream to read.
+     * @return the event stream.
+     */
+    default Flow.Publisher<? extends SerializableStruct> readEventStream(Schema schema) {
+        throw new UnsupportedOperationException("Cannot read event stream from this deserializer");
     }
 
     /**

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeDeserializer.java
@@ -9,8 +9,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.concurrent.Flow;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
 
 public abstract class SpecificShapeDeserializer implements ShapeDeserializer {
@@ -21,7 +23,9 @@ public abstract class SpecificShapeDeserializer implements ShapeDeserializer {
      * @param schema Unexpected encountered schema.
      * @return Returns an exception to throw.
      */
-    protected abstract RuntimeException throwForInvalidState(Schema schema);
+    protected RuntimeException throwForInvalidState(Schema schema) {
+        return new IllegalStateException("Unexpected schema type: " + schema);
+    }
 
     @Override
     public ByteBuffer readBlob(Schema schema) {
@@ -107,5 +111,15 @@ public abstract class SpecificShapeDeserializer implements ShapeDeserializer {
     @Override
     public boolean isNull() {
         throw new UnsupportedOperationException("cannot look ahead for null values");
+    }
+
+    @Override
+    public Flow.Publisher<? extends SerializableStruct> readEventStream(Schema schema) {
+        throw throwForInvalidState(schema);
+    }
+
+    @Override
+    public DataStream readDataStream(Schema schema) {
+        throw throwForInvalidState(schema);
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
@@ -26,11 +26,11 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
      * @return Returns an exception to throw.
      */
     protected RuntimeException throwForInvalidState(String message, Schema schema) {
-        throw new SerializationException(message);
+        throw new IllegalStateException(message);
     }
 
     private RuntimeException throwForInvalidState(Schema schema) {
-        return throwForInvalidState("Unexpected schema type: " + schema, schema);
+        return new IllegalStateException("Unexpected schema type: " + schema);
     }
 
     @Override

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestDeserializer.java
@@ -47,8 +47,7 @@ public final class RequestDeserializer {
         DataStream bodyDataStream = bodyDataStream(request);
         deserBuilder.headers(request.headers())
             .requestRawQueryString(request.uri().getRawQuery())
-            .body(bodyDataStream)
-            .shapeBuilder(inputShapeBuilder);
+            .body(bodyDataStream);
         return this;
     }
 

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
@@ -46,8 +46,7 @@ public final class ResponseDeserializer {
         DataStream bodyDataStream = bodyDataStream(response);
         deserBuilder.headers(response.headers())
             .responseStatus(response.statusCode())
-            .body(bodyDataStream)
-            .shapeBuilder(outputShapeBuilder);
+            .body(bodyDataStream);
         return this;
     }
 


### PR DESCRIPTION
Shape deserialization previously relied on two specific methods of a ShapeBuilder, and ShapeDeserializer lacked methods for reading a data stream and event stream. We recently added data stream and event stream methods to ShapeSerializer, so it makes sense to make ShapeDeserializer have them too. This change makes deserialization of a shape all centralized rather than spread across multiple builder methods. It also wires up more of codegen to work with event streams.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
