### PR TITLE
Update to use NullableIndex and respect clientOptional

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -19,12 +19,14 @@ import software.amazon.smithy.codegen.core.TopologicalIndex;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.NullableIndex;
 import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.selector.PathFinder;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 import software.amazon.smithy.utils.CaseUtils;
@@ -133,14 +135,16 @@ public final class CodegenUtils {
     }
 
     /**
-     * Determines if a given member represents a nullable type
+     * Determines if a given member represents a nullable type.
      *
-     * @param shape member to check for nullability
+     * @param model Model to use for resolving Nullable index.
+     * @param member member to check for nullability.
      *
      * @return if the shape is a nullable type
      */
-    public static boolean isNullableMember(MemberShape shape) {
-        return !shape.isRequired() && !shape.hasNonNullDefault();
+    public static boolean isNullableMember(Model model, MemberShape member) {
+        return member.hasTrait(ClientOptionalTrait.class)
+            || NullableIndex.of(model).isMemberNullable(member, NullableIndex.CheckMode.SERVER);
     }
 
     /**

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
@@ -61,7 +61,7 @@ record StructureSerializerGenerator(
             var state = isError && memberName.equals("message") ? "getMessage()" : memberName;
 
             writer.pushState();
-            writer.putContext("nullable", CodegenUtils.isNullableMember(member));
+            writer.putContext("nullable", CodegenUtils.isNullableMember(model, member));
             writer.putContext("memberName", memberName);
             writer.writeInline("""
                 ${?nullable}if (${memberName:L} != null) {


### PR DESCRIPTION
### Description of changes
Updates codegen to use NullableIndex for determining nullability and to respect clientOptional. 
All pojos will use the `SERVER` nullability mode with one change. All members marked as `clientOptional` will be treated as nullable. ClientOptional members will be checked by validation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
