### PR TITLE
Rename formatter, tests and variables to be more accurate from nullAnnotation to nonNullAnnotation

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
@@ -26,29 +26,29 @@ public final class JavaCodegenSettings {
     private static final String SERVICE = "service";
     private static final String NAMESPACE = "namespace";
     private static final String HEADER_FILE = "headerFile";
-    private static final String NULL_ANNOTATION = "nullAnnotation";
+    private static final String NON_NULL_ANNOTATION = "nonNullAnnotation";
 
     private final ShapeId service;
     private final String packageNamespace;
     private final String header;
 
-    private final Symbol nullAnnotationSymbol;
+    private final Symbol nonNullAnnotationSymbol;
 
     JavaCodegenSettings(
         ShapeId service,
         String packageNamespace,
         String headerFile,
         String sourceLocation,
-        String nullAnnotationFullyQualifiedName
+        String nonNullAnnotationFullyQualifiedName
     ) {
         this.service = Objects.requireNonNull(service);
         this.packageNamespace = Objects.requireNonNull(packageNamespace);
         this.header = getHeader(headerFile, Objects.requireNonNull(sourceLocation));
 
-        if (!StringUtils.isEmpty(nullAnnotationFullyQualifiedName)) {
-            nullAnnotationSymbol = buildSymbolFromFullyQualifiedName(nullAnnotationFullyQualifiedName);
+        if (!StringUtils.isEmpty(nonNullAnnotationFullyQualifiedName)) {
+            nonNullAnnotationSymbol = buildSymbolFromFullyQualifiedName(nonNullAnnotationFullyQualifiedName);
         } else {
-            nullAnnotationSymbol = null;
+            nonNullAnnotationSymbol = null;
         }
     }
 
@@ -59,13 +59,13 @@ public final class JavaCodegenSettings {
      * @return Parsed settings
      */
     public static JavaCodegenSettings fromNode(ObjectNode settingsNode) {
-        settingsNode.warnIfAdditionalProperties(List.of(SERVICE, NAMESPACE, HEADER_FILE, NULL_ANNOTATION));
+        settingsNode.warnIfAdditionalProperties(List.of(SERVICE, NAMESPACE, HEADER_FILE, NON_NULL_ANNOTATION));
         return new JavaCodegenSettings(
             settingsNode.expectStringMember(SERVICE).expectShapeId(),
             settingsNode.expectStringMember(NAMESPACE).getValue(),
             settingsNode.getStringMemberOrDefault(HEADER_FILE, null),
             settingsNode.getSourceLocation().getFilename(),
-            settingsNode.getStringMemberOrDefault(NULL_ANNOTATION, "")
+            settingsNode.getStringMemberOrDefault(NON_NULL_ANNOTATION, "")
         );
     }
 
@@ -81,8 +81,8 @@ public final class JavaCodegenSettings {
         return header;
     }
 
-    public Symbol getNullAnnotationSymbol() {
-        return nullAnnotationSymbol;
+    public Symbol getNonNullAnnotationSymbol() {
+        return nonNullAnnotationSymbol;
     }
 
     private static Symbol buildSymbolFromFullyQualifiedName(String fullyQualifiedName) {

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/writer/JavaWriter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/writer/JavaWriter.java
@@ -41,7 +41,7 @@ public class JavaWriter extends DeferredSymbolWriter<JavaWriter, JavaImportConta
         putFormatter('T', new JavaTypeFormatter());
         putFormatter('B', new BoxedTypeFormatter());
         putFormatter('U', new CapitalizingFormatter());
-        putFormatter('N', new NullAnnotationFormatter());
+        putFormatter('N', new NonNullAnnotationFormatter());
 
     }
 
@@ -201,17 +201,17 @@ public class JavaWriter extends DeferredSymbolWriter<JavaWriter, JavaImportConta
     }
 
     /**
-     * Implements a formatter for {@code $N} that adds null annotation
+     * Implements a formatter for {@code $N} that adds non null annotation
      */
-    private final class NullAnnotationFormatter implements BiFunction<Object, String, String> {
+    private final class NonNullAnnotationFormatter implements BiFunction<Object, String, String> {
         private final JavaTypeFormatter javaTypeFormatter = new JavaTypeFormatter();
 
         @Override
         public String apply(Object type, String indent) {
 
-            Symbol nullAnnotationSymbol = settings.getNullAnnotationSymbol();
+            Symbol nonNullAnnotationSymbol = settings.getNonNullAnnotationSymbol();
 
-            if (nullAnnotationSymbol == null) {
+            if (nonNullAnnotationSymbol == null) {
                 return javaTypeFormatter.apply(type, indent);
             }
 
@@ -221,7 +221,7 @@ public class JavaWriter extends DeferredSymbolWriter<JavaWriter, JavaImportConta
                 return javaTypeFormatter.apply(typeSymbol, indent);
             }
 
-            return format("@$T $T", nullAnnotationSymbol, typeSymbol);
+            return format("@$T $T", nonNullAnnotationSymbol, typeSymbol);
         }
     }
 }

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/NonNullAnnotationTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/NonNullAnnotationTest.java
@@ -5,6 +5,11 @@
 
 package software.amazon.smithy.java.codegen;
 
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
@@ -13,9 +18,9 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.codegen.utils.AbstractCodegenFileTest;
 import software.amazon.smithy.model.node.ObjectNode;
 
-public class NullAnnotationTest extends AbstractCodegenFileTest {
+public class NonNullAnnotationTest extends AbstractCodegenFileTest {
     private static final URL TEST_FILE = Objects.requireNonNull(
-        NullAnnotationTest.class.getResource("null-annotation-test.smithy")
+        NonNullAnnotationTest.class.getResource("null-annotation-test.smithy")
     );
 
     @Override
@@ -26,12 +31,12 @@ public class NullAnnotationTest extends AbstractCodegenFileTest {
     @Override
     protected ObjectNode settings() {
         return super.settings().toBuilder()
-            .withMember("nullAnnotation", "software.amazon.smithy.java.codegen.utils.TestNonNullAnnotation")
+            .withMember("nonNullAnnotation", "software.amazon.smithy.java.codegen.utils.TestNonNullAnnotation")
             .build();
     }
 
     @Test
-    void nullAnnotationsOnFieldsAndGetter() {
+    void nonNullAnnotationsOnFieldsAndGetter() {
         var fileStr = getFileStringForClass("NonNullAnnotationStructInput");
         var expectedField = "private transient final @TestNonNullAnnotation RequiredStruct requiredStruct;";
         var expectedGetter = "public @TestNonNullAnnotation RequiredStruct requiredStruct()";
@@ -45,7 +50,7 @@ public class NullAnnotationTest extends AbstractCodegenFileTest {
     }
 
     @Test
-    void nullAnnotationNotAddedForPrimitive() {
+    void nonNullAnnotationNotAddedForPrimitive() {
         var fileStr = getFileStringForClass("NonNullAnnotationStructInput");
 
         var expectedField = "private transient final boolean requiredPrimitive;";
@@ -57,7 +62,7 @@ public class NullAnnotationTest extends AbstractCodegenFileTest {
     }
 
     @Test
-    void nullAnnotationAddedForUnionVariant() {
+    void nonNullAnnotationAddedForUnionVariant() {
         var fileStr = getFileStringForClass("TestUnion");
         var expectedGetterBoxed = "public @TestNonNullAnnotation String boxedVariant() {";
         var expectedGetterPrimitive = "public @TestNonNullAnnotation String primitiveVariant() {";
@@ -71,7 +76,7 @@ public class NullAnnotationTest extends AbstractCodegenFileTest {
     }
 
     @Test
-    void nullAnnotationAddedForEnumVariant() {
+    void nonNullAnnotationAddedForEnumVariant() {
         var fileStr = getFileStringForClass("TestEnum");
         var expectedValueGetter = "public @TestNonNullAnnotation String value() {";
         var expectedValueField = "private final @TestNonNullAnnotation String value;";


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Rename formater, tests, and variables from `nullAnnotation` to `nonNullAnnotation` to be more accurate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
