### PR TITLE
Make TypeRegistry an interface

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
@@ -79,9 +79,7 @@ public abstract class Client {
         Context context
     ) {
         // Create a copy of the type registry that adds the errors this operation can encounter.
-        TypeRegistry operationRegistry = TypeRegistry.builder()
-            .putAllTypes(typeRegistry, operation.typeRegistry())
-            .build();
+        TypeRegistry operationRegistry = TypeRegistry.compose(operation.typeRegistry(), typeRegistry);
 
         var call = ClientCall.<I, O>builder()
             .input(input)

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiFunction;
@@ -38,7 +37,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
     private final EndpointResolver endpointResolver;
     private final ApiOperation<I, O> operation;
     private final Context context;
-    private final BiFunction<Context, String, Optional<ShapeBuilder<ModeledApiException>>> errorCreator;
+    private final BiFunction<Context, String, ShapeBuilder<ModeledApiException>> errorCreator;
     private final ClientInterceptor interceptor;
     private final AuthSchemeResolver authSchemeResolver;
     private final Map<String, AuthScheme<?, ?>> supportedAuthSchemes;
@@ -124,9 +123,9 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
      * @param context Context to pass to the creator.
      * @param shapeId Nullable ID of the error shape to create, if known. A string is used because sometimes the
      *                only information we have is just a name.
-     * @return Returns the error deserializer if present.
+     * @return Returns the error deserializer, or null if no deserializer could be found.
      */
-    public Optional<ShapeBuilder<ModeledApiException>> createExceptionBuilder(Context context, String shapeId) {
+    public ShapeBuilder<ModeledApiException> createExceptionBuilder(Context context, String shapeId) {
         return errorCreator.apply(context, shapeId);
     }
 
@@ -178,7 +177,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
         private EndpointResolver endpointResolver;
         private ApiOperation<I, O> operation;
         private Context context;
-        private BiFunction<Context, String, Optional<ShapeBuilder<ModeledApiException>>> errorCreator;
+        private BiFunction<Context, String, ShapeBuilder<ModeledApiException>> errorCreator;
         private ClientInterceptor interceptor = ClientInterceptor.NOOP;
         private AuthSchemeResolver authSchemeResolver;
         private final List<AuthScheme<?, ?>> supportedAuthSchemes = new ArrayList<>();
@@ -230,7 +229,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
          * @return Returns the builder.
          */
         public Builder<I, O> errorCreator(
-            BiFunction<Context, String, Optional<ShapeBuilder<ModeledApiException>>> errorCreator
+            BiFunction<Context, String, ShapeBuilder<ModeledApiException>> errorCreator
         ) {
             this.errorCreator = errorCreator;
             return this;

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
@@ -133,7 +133,7 @@ public class HttpBindingClientProtocol<F extends Frame<?>> extends HttpClientPro
             })
             // Attempt to match the extracted error ID to a modeled error type.
             .flatMap(
-                errorId -> call.createExceptionBuilder(call.context(), errorId)
+                errorId -> Optional.ofNullable(call.createExceptionBuilder(call.context(), errorId))
                     .<CompletableFuture<? extends ApiException>>map(
                         error -> createModeledException(codec, response, error)
                     )

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
@@ -167,7 +167,7 @@ public class OperationGenerator
             });
     }
 
-
+    // Registers errors of an operation with the type registry.
     private record TypeRegistryGenerator(
         JavaWriter writer,
         OperationShape shape,
@@ -180,8 +180,6 @@ public class OperationGenerator
         public void run() {
             writer.write("private final ${typeRegistry:T} typeRegistry = ${typeRegistry:T}.builder()");
             writer.indent();
-            writer.write(".putType(${inputType:T}.ID, ${inputType:T}.class, ${inputType:T}::builder)");
-            writer.write(".putType(${outputType:T}.ID, ${outputType:T}.class, ${outputType:T}::builder)");
             for (var errorId : shape.getErrors(service)) {
                 var errorShape = model.expectShape(errorId);
                 writer.write(".putType($1T.ID, $1T.class, $1T::builder)", symbolProvider.toSymbol(errorShape));

--- a/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
+++ b/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
@@ -16,9 +16,6 @@ import software.amazon.smithy.java.runtime.client.aws.restjson1.RestJsonClientPr
 import software.amazon.smithy.java.runtime.client.core.interceptors.ClientInterceptor;
 import software.amazon.smithy.java.runtime.client.core.interceptors.RequestHook;
 import software.amazon.smithy.java.runtime.client.http.JavaHttpClientTransport;
-import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
-import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
-import software.amazon.smithy.java.runtime.core.schema.TypeRegistry;
 import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
@@ -28,7 +25,6 @@ import software.amazon.smithy.java.runtime.example.model.PutPersonImageInput;
 import software.amazon.smithy.java.runtime.example.model.PutPersonImageOutput;
 import software.amazon.smithy.java.runtime.example.model.PutPersonInput;
 import software.amazon.smithy.java.runtime.example.model.PutPersonOutput;
-import software.amazon.smithy.java.runtime.example.model.ValidationError;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.json.JsonCodec;
 
@@ -108,18 +104,6 @@ public class GenericTest {
 
         // Now serialize that to see that it round-trips.
         System.out.println(codec.serializeToString(inputCopy));
-    }
-
-    @Test
-    public void testTypeRegistry() {
-        TypeRegistry registry = TypeRegistry.builder()
-            .putType(PutPersonInput.ID, PutPersonInput.class, PutPersonInput::builder)
-            .putType(ValidationError.ID, ValidationError.class, ValidationError::builder)
-            .build();
-
-        registry.create(ValidationError.ID, ModeledApiException.class)
-            .map(ShapeBuilder::build)
-            .ifPresent(System.out::println);
     }
 
     @Test


### PR DESCRIPTION
An interface allows for more abstraction over other potential ways to match shape IDs to builders. The registry now returns null instead of Optional values. Updated codegen to only register errors with operation registries as those are the only place they're being used.

A followup is to generate service-wide errors into the registry of a client, and merge it with the operation registry. Further merging would be to support framework errors and potentially synthetic errors.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
