### PR TITLE
Update union error to illegal argument exception

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -366,14 +366,14 @@ public final class UnionGenerator
                 """);
 
             writer.pushState();
-            writer.putContext("serdeException", SerializationException.class);
+            writer.putContext("illegalArgument", IllegalArgumentException.class);
             writer.write("""
                 private void checkForExistingValue() {
                     if (this.value != null) {
                         if (this.value.type() == Type.$$UNKNOWN) {
-                            throw new ${serdeException:T}("Cannot change union from unknown to known variant");
+                            throw new ${illegalArgument:T}("Cannot change union from unknown to known variant");
                         }
-                        throw new ${serdeException:T}("Only one value may be set for unions");
+                        throw new ${illegalArgument:T}("Only one value may be set for unions");
                     }
                 }
                 """);


### PR DESCRIPTION
### Description
Updates the error for changing the type of a generated union in the builder to be an `IllegalArgumentException` as this could be encountered outside of a serialization context.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
