### PR TITLE
Add an `add()` method to Context to merge overrides

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
@@ -60,14 +60,13 @@ public abstract class Client {
      * @return Returns the deserialized output.
      */
     @Deprecated // TODO: update usages to use the other call() signature
+    // Context is unused right now. This method will be removed after updating codegen to use other call() signature.
     protected <I extends SerializableStruct, O extends SerializableStruct> CompletableFuture<O> call(
         I input,
         ApiOperation<I, O> operation,
         Context context
     ) {
-        RequestOverrideConfig.Builder overrideConfigBuilder = RequestOverrideConfig.builder();
-        context.keys().forEachRemaining(key -> copyContext(key, context, overrideConfigBuilder));
-        return call(input, operation, overrideConfigBuilder.build());
+        return call(input, operation, RequestOverrideConfig.builder().build());
     }
 
     /**

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientConfig.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientConfig.java
@@ -112,7 +112,7 @@ public final class ClientConfig {
             .identityResolvers(identityResolvers);
         interceptors.forEach(builder::addInterceptor);
         supportedAuthSchemes.forEach(builder::putSupportedAuthSchemes);
-        context.keys().forEachRemaining(key -> copyContext(key, context, builder));
+        builder.addContext(context);
         return builder;
     }
 
@@ -151,13 +151,7 @@ public final class ClientConfig {
 
         // TODO: Currently there is no concept of mutable v/s immutable parts of Context.
         //       We just merge the client's Context with the Context of the operation's call.
-        overrideConfig.context()
-            .keys()
-            .forEachRemaining(key -> copyContext(key, overrideConfig.context(), builder));
-    }
-
-    private <T> void copyContext(Context.Key<T> key, Context src, Builder dst) {
-        dst.putConfig(key, src.get(key));
+        builder.addContext(overrideConfig.context());
     }
 
     /**
@@ -171,7 +165,7 @@ public final class ClientConfig {
         private AuthSchemeResolver authSchemeResolver;
         private final List<AuthScheme<?, ?>> supportedAuthSchemes = new ArrayList<>();
         private final List<IdentityResolver<?>> identityResolvers = new ArrayList<>();
-        private final Context context = Context.create();
+        private Context context = Context.create();
 
         // TODO: Add getters for each, so that a ClientPlugin can read the existing values.
 
@@ -319,6 +313,17 @@ public final class ClientConfig {
          */
         public <T> Builder putConfigIfAbsent(Context.Key<T> key, T value) {
             context.putIfAbsent(key, value);
+            return this;
+        }
+
+        /**
+         * Add the given Context in. If a key was already present, it is overridden.
+         *
+         * @param context Context to merge in.
+         * @return the builder.
+         */
+        Builder addContext(Context context) {
+            this.context.add(context);
             return this;
         }
 


### PR DESCRIPTION
The goal was to remove `.keys()` method to allow iteration over all keys of a Context, to prevent someone who doesn't have Java visibility to the Context.Key definition from being able to access that key's value. e.g., If a Context.Key is package-private, then only classes from the same Java package can access the value of the key from a Context.

`.keys()` was mainly there to support being able to copy a Context into new one. So instead of `.keys()` was looking to add specific `copy/add` methods to `Context` itself, so access to all keys would be hidden inside `Context`. However, as seen in this PR, to support `add()`, `.keys()` is needed to know what all keys to add.

Does Context need to be an interface? If it was a final class instead, we'd be able to remove `.keys()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
