### PR TITLE
Adding an internal logger

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
@@ -70,6 +70,7 @@ spotless {
     java {
         // Enforce a common license header on all files
         licenseHeaderFile("${project.rootDir}/config/spotless/license-header.txt")
+            .onlyIfContentMatches("^((?!SKIPLICENSECHECK)[\\s\\S])*\$")
         indentWithSpaces()
         endWithNewline()
 

--- a/config/spotbugs/filter.xml
+++ b/config/spotbugs/filter.xml
@@ -10,6 +10,11 @@
         <Class name="~Test\.java$"/>
     </Match>
 
+    <!--  This is copy of Log4j's formatter.  -->
+    <Match>
+        <Class name="software.amazon.smithy.java.logging.ParameterFormatter$StringBuilders"/>
+    </Match>
+
     <!-- Excessive Defensive copies. -->
     <Match>
         <Bug pattern="EI_EXPOSE_REP"/>

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -1,0 +1,78 @@
+import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
+
+plugins {
+    id("smithy-java.module-conventions")
+    alias(libs.plugins.jmh)
+}
+
+description = "This module provides the Logging functionality for Smithy java"
+
+extra["displayName"] = "Smithy :: Java :: Logging"
+extra["moduleName"] = "software.amazon.smithy.java.logging"
+
+val testImplementation: Configuration by configurations.getting
+
+val log4j2TestConfiguration: Configuration by configurations.creating {
+    extendsFrom(testImplementation)
+}
+
+val slf4jTestConfiguration: Configuration by configurations.creating {
+    extendsFrom(testImplementation)
+}
+
+val jclTestConfiguration: Configuration by configurations.creating {
+    extendsFrom(testImplementation)
+}
+
+// These are declared here instead of the version catalog because we don't want other modules to depend on them.
+val log4j2 = "2.12.4"
+val slf4j = "2.0.13"
+val logBack = "1.5.6"
+val jcl = "1.3.2"
+
+dependencies {
+    compileOnly("org.apache.logging.log4j:log4j-api:$log4j2")
+    compileOnly("org.slf4j:slf4j-api:$slf4j")
+    compileOnly("commons-logging:commons-logging:$jcl")
+
+    testCompileOnly("org.apache.logging.log4j:log4j-core:$log4j2")
+    testCompileOnly("ch.qos.logback:logback-classic:$logBack")
+    testCompileOnly("commons-logging:commons-logging:$jcl")
+
+    log4j2TestConfiguration("org.apache.logging.log4j:log4j-core:$log4j2")
+
+    slf4jTestConfiguration("ch.qos.logback:logback-classic:$logBack")
+    slf4jTestConfiguration("org.slf4j:slf4j-api:$slf4j")
+
+    jclTestConfiguration("commons-logging:commons-logging:$jcl")
+}
+
+tasks.named<Test>("test") {
+    exclude("**/*IsolatedTest*")
+}
+
+
+val log4j2Test = tasks.register<Test>("log4j2Test") {
+    description = "Tests if InternalLogger successfully uses Log4j2 if found on classpath"
+    group = VERIFICATION_GROUP
+    include("**/*Log4j2LoggerIsolatedTest*")
+    classpath += log4j2TestConfiguration
+}
+
+val slf4jTest = tasks.register<Test>("slf4jTest") {
+    description = "Tests if InternalLogger successfully uses Slf4j if found on classpath"
+    group = VERIFICATION_GROUP
+    include("**/*Slf4jLoggerIsolatedTest*")
+    classpath += slf4jTestConfiguration
+}
+
+val jclTest = tasks.register<Test>("jclTest") {
+    description = "Tests if InternalLogger successfully uses JCL if found on classpath"
+    group = VERIFICATION_GROUP
+    include("**/*JclLoggerIsolatedTest*")
+    classpath += jclTestConfiguration
+}
+
+tasks.build {
+    dependsOn(log4j2Test, slf4jTest, jclTest)
+}

--- a/logging/src/main/java/software/amazon/smithy/java/logging/InternalLogger.java
+++ b/logging/src/main/java/software/amazon/smithy/java/logging/InternalLogger.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.logging;
+
+public sealed interface InternalLogger permits Log4j2Logger, Slf4jLogger, JclLogger, JdkSystemLogger {
+
+    sealed interface Factory permits Log4j2Logger.Factory, Slf4jLogger.Factory, JclLogger.Factory,
+        JdkSystemLogger.Factory {
+        InternalLogger getLogger(String name);
+    }
+
+    Factory FACTORY = findLoggingFactory();
+
+    private static Factory findLoggingFactory() {
+        Factory factory = getLog4J2Factory();
+        if (factory == null) {
+            factory = getSlf4jFactory();
+        }
+        if (factory == null) {
+            factory = getJclFactory();
+        }
+        if (factory != null) {
+            return factory;
+        }
+        return new JdkSystemLogger.Factory();
+    }
+
+    private static Factory getLog4J2Factory() {
+        try {
+            var f = new Log4j2Logger.Factory();
+            f.getLogger(InternalLogger.class.getName());
+            return f;
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    private static Factory getSlf4jFactory() {
+        try {
+            var f = new Slf4jLogger.Factory();
+            f.getLogger(InternalLogger.class.getName());
+            return f;
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    private static Factory getJclFactory() {
+        try {
+            var f = new JclLogger.Factory();
+            f.getLogger(InternalLogger.class.getName());
+            return f;
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    static InternalLogger getLogger(Class<?> clazz) {
+        return FACTORY.getLogger(clazz.getName());
+    }
+
+    static InternalLogger getLogger(String name) {
+        return FACTORY.getLogger(name);
+    }
+
+    enum Level {
+        TRACE,
+        DEBUG,
+        INFO,
+        WARN,
+        ERROR,
+        FATAL
+    }
+
+    void log(Level level, String message, Object... params);
+
+    void log(Level level, String message, Throwable throwable);
+
+    void log(Level level, String message, Object p0);
+
+    void log(Level level, String message, Object p0, Object p1);
+
+    void log(Level level, String message, Object p0, Object p1, Object p2);
+
+    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3);
+
+    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+
+    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+
+    void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6
+    );
+
+    void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    );
+
+    void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    );
+
+    void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    );
+
+    void trace(String message, Object... params);
+
+    void trace(String message, Throwable throwable);
+
+    void trace(String message, Object p0);
+
+    void trace(String message, Object p0, Object p1);
+
+    void trace(String message, Object p0, Object p1, Object p2);
+
+    void trace(String message, Object p0, Object p1, Object p2, Object p3);
+
+    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+
+    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+
+    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+
+    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+
+    void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    );
+
+    void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    );
+
+    void debug(String message, Object... params);
+
+    void debug(String message, Throwable throwable);
+
+    void debug(String message, Object p0);
+
+    void debug(String message, Object p0, Object p1);
+
+    void debug(String message, Object p0, Object p1, Object p2);
+
+    void debug(String message, Object p0, Object p1, Object p2, Object p3);
+
+    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+
+    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+
+    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+
+    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+
+    void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    );
+
+    void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    );
+
+    void info(String message, Object... params);
+
+    void info(String message, Throwable throwable);
+
+    void info(String message, Object p0);
+
+    void info(String message, Object p0, Object p1);
+
+    void info(String message, Object p0, Object p1, Object p2);
+
+    void info(String message, Object p0, Object p1, Object p2, Object p3);
+
+    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+
+    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+
+    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+
+    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+
+    void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    );
+
+    void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    );
+
+    void warn(String message, Object... params);
+
+    void warn(String message, Throwable throwable);
+
+    void warn(String message, Object p0);
+
+    void warn(String message, Object p0, Object p1);
+
+    void warn(String message, Object p0, Object p1, Object p2);
+
+    void warn(String message, Object p0, Object p1, Object p2, Object p3);
+
+    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+
+    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+
+    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+
+    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+
+    void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    );
+
+    void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    );
+
+    void error(String message, Object... params);
+
+    void error(String message, Throwable throwable);
+
+    void error(String message, Object p0);
+
+    void error(String message, Object p0, Object p1);
+
+    void error(String message, Object p0, Object p1, Object p2);
+
+    void error(String message, Object p0, Object p1, Object p2, Object p3);
+
+    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+
+    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+
+    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+
+    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+
+    void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    );
+
+    void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    );
+
+    void fatal(String message, Object... params);
+
+    void fatal(String message, Throwable throwable);
+
+    void fatal(String message, Object p0);
+
+    void fatal(String message, Object p0, Object p1);
+
+    void fatal(String message, Object p0, Object p1, Object p2);
+
+    void fatal(String message, Object p0, Object p1, Object p2, Object p3);
+
+    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+
+    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+
+    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+
+    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+
+    void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    );
+
+    void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    );
+
+    boolean isTraceEnabled();
+
+    boolean isDebugEnabled();
+
+    boolean isInfoEnabled();
+
+    boolean isWarnEnabled();
+
+    boolean isErrorEnabled();
+
+    boolean isFatalEnabled();
+}

--- a/logging/src/main/java/software/amazon/smithy/java/logging/JclLogger.java
+++ b/logging/src/main/java/software/amazon/smithy/java/logging/JclLogger.java
@@ -1,0 +1,1275 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.logging;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+final class JclLogger implements InternalLogger {
+
+
+    static final class Factory implements InternalLogger.Factory {
+
+        @Override
+        public InternalLogger getLogger(String name) {
+            return new JclLogger(LogFactory.getLog(name));
+        }
+    }
+
+
+    private final Log log;
+
+    JclLogger(Log log) {
+        this.log = log;
+    }
+
+
+    private void internalLog(Level level, String message, Throwable throwable) {
+        switch (level) {
+            case TRACE -> log.trace(message, throwable);
+            case DEBUG -> log.debug(message, throwable);
+            case INFO -> log.info(message, throwable);
+            case WARN -> log.warn(message, throwable);
+            case ERROR -> log.error(message, throwable);
+            case FATAL -> log.fatal(message, throwable);
+        }
+    }
+
+    private boolean isEnabled(Level level) {
+        return switch (level) {
+            case TRACE -> log.isTraceEnabled();
+            case DEBUG -> log.isDebugEnabled();
+            case INFO -> log.isInfoEnabled();
+            case WARN -> log.isWarnEnabled();
+            case ERROR -> log.isErrorEnabled();
+            case FATAL -> log.isFatalEnabled();
+        };
+    }
+
+
+    @Override
+    public void log(Level level, String message, Object... params) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, params), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, params), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Throwable throwable) {
+        if (isEnabled(level)) {
+            internalLog(level, message, throwable);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0) {
+        if (isEnabled(level)) {
+            internalLog(level, ParameterFormatter.format(message, new Object[]{p0}), null);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1}), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}), null);
+            }
+        }
+
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    t
+                );
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object... params) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                log.trace(ParameterFormatter.format(message, params), t);
+            } else {
+                log.trace(ParameterFormatter.format(message, params));
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Throwable throwable) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, throwable);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0) {
+        if (log.isTraceEnabled()) {
+            log.trace(ParameterFormatter.format(message, new Object[]{p0}));
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1}));
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1}), t);
+            } else {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2}));
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2}), t);
+            } else {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}));
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), t);
+            } else {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}));
+            }
+        }
+
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}), t);
+            } else {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}));
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.trace(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isTraceEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                log.trace(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                log.trace(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object... params) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                log.debug(ParameterFormatter.format(message, params), t);
+            } else {
+                log.debug(ParameterFormatter.format(message, params));
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Throwable throwable) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, throwable);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0) {
+        if (log.isDebugEnabled()) {
+            log.debug(ParameterFormatter.format(message, new Object[]{p0}));
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1}));
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1}), t);
+            } else {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2}));
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2}), t);
+            } else {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}));
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), t);
+            } else {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}));
+            }
+        }
+
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}), t);
+            } else {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}));
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.debug(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isDebugEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                log.debug(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                log.debug(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object... params) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                log.info(ParameterFormatter.format(message, params), t);
+            } else {
+                log.info(ParameterFormatter.format(message, params));
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Throwable throwable) {
+        if (log.isInfoEnabled()) {
+            log.info(message, throwable);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0) {
+        if (log.isInfoEnabled()) {
+            log.info(ParameterFormatter.format(message, new Object[]{p0}));
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                log.info(ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1}));
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1}), t);
+            } else {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2}));
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2}), t);
+            } else {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}));
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), t);
+            } else {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}));
+            }
+        }
+
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}), t);
+            } else {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}));
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.info(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isInfoEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                log.info(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                log.info(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object... params) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                log.warn(ParameterFormatter.format(message, params), t);
+            } else {
+                log.warn(ParameterFormatter.format(message, params));
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Throwable throwable) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, throwable);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0) {
+        if (log.isWarnEnabled()) {
+            log.warn(ParameterFormatter.format(message, new Object[]{p0}));
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1}));
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1}), t);
+            } else {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2}));
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2}), t);
+            } else {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}));
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), t);
+            } else {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}));
+            }
+        }
+
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}), t);
+            } else {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}));
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.warn(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isWarnEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                log.warn(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                log.warn(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9})
+                );
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object... params) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                log.error(ParameterFormatter.format(message, params), t);
+            } else {
+                log.error(ParameterFormatter.format(message, params));
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Throwable throwable) {
+        if (log.isErrorEnabled()) {
+            log.error(message, throwable);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0) {
+        if (log.isErrorEnabled()) {
+            log.error(ParameterFormatter.format(message, new Object[]{p0}));
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                log.error(ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1}));
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1}), t);
+            } else {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2}));
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2}), t);
+            } else {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}));
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), t);
+            } else {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}));
+            }
+        }
+
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}), t);
+            } else {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}));
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.error(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isErrorEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                log.error(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                log.error(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object... params) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                log.fatal(ParameterFormatter.format(message, params), t);
+            } else {
+                log.fatal(ParameterFormatter.format(message, params));
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Throwable throwable) {
+        if (log.isFatalEnabled()) {
+            log.fatal(message, throwable);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0) {
+        if (log.isFatalEnabled()) {
+            log.fatal(ParameterFormatter.format(message, new Object[]{p0}));
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1}));
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1}), t);
+            } else {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2}));
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2}), t);
+            } else {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}));
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), t);
+            } else {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}));
+            }
+        }
+
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}), t);
+            } else {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}));
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), t);
+            } else {
+                log.fatal(ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}));
+            }
+        }
+    }
+
+    @Override
+    public void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isFatalEnabled()) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                log.fatal(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                log.fatal(
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9})
+                );
+            }
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return log.isTraceEnabled();
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return log.isDebugEnabled();
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return log.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return log.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return log.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isFatalEnabled() {
+        return log.isFatalEnabled();
+    }
+}

--- a/logging/src/main/java/software/amazon/smithy/java/logging/JdkSystemLogger.java
+++ b/logging/src/main/java/software/amazon/smithy/java/logging/JdkSystemLogger.java
@@ -1,0 +1,1611 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.logging;
+
+
+final class JdkSystemLogger implements InternalLogger {
+
+
+    static final class Factory implements InternalLogger.Factory {
+
+        @Override
+        public InternalLogger getLogger(String name) {
+            return new JdkSystemLogger(System.getLogger(name));
+        }
+    }
+
+    private final System.Logger log;
+
+    JdkSystemLogger(System.Logger log) {
+        this.log = log;
+    }
+
+    private boolean isEnabled(Level level) {
+        return switch (level) {
+            case TRACE -> log.isLoggable(System.Logger.Level.TRACE);
+            case DEBUG -> log.isLoggable(System.Logger.Level.DEBUG);
+            case INFO -> log.isLoggable(System.Logger.Level.INFO);
+            case WARN -> log.isLoggable(System.Logger.Level.WARNING);
+            case ERROR, FATAL -> log.isLoggable(System.Logger.Level.ERROR);
+        };
+    }
+
+    private void internalLog(Level level, String message, Throwable throwable) {
+        switch (level) {
+            case TRACE -> log.log(System.Logger.Level.TRACE, message, throwable);
+            case DEBUG -> log.log(System.Logger.Level.DEBUG, message, throwable);
+            case INFO -> log.log(System.Logger.Level.INFO, message, throwable);
+            case WARN -> log.log(System.Logger.Level.WARNING, message, throwable);
+            case ERROR -> log.log(System.Logger.Level.ERROR, message, throwable);
+            case FATAL -> log.log(System.Logger.Level.ERROR, "[FATAL] " + message, throwable);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object... params) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, params), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, params), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Throwable throwable) {
+        if (isEnabled(level)) {
+            internalLog(level, message, throwable);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0) {
+        if (isEnabled(level)) {
+            internalLog(level, ParameterFormatter.format(message, new Object[]{p0}), null);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1}), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), t);
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}), null);
+            }
+        }
+
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    t
+                );
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(level, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}), null);
+            }
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (isEnabled(level)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                internalLog(
+                    level,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object... params) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, params),
+                    t
+                );
+            } else {
+                internalLog(Level.TRACE, ParameterFormatter.format(message, params), null);
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Throwable throwable) {
+        if (isEnabled(Level.TRACE)) {
+            internalLog(Level.TRACE, message, throwable);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0) {
+        if (isEnabled(Level.TRACE)) {
+            internalLog(Level.TRACE, ParameterFormatter.format(message, new Object[]{p0}), null);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                internalLog(Level.TRACE, ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                internalLog(Level.TRACE, ParameterFormatter.format(message, new Object[]{p0, p1}), null);
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1}),
+                    t
+                );
+            } else {
+                internalLog(Level.TRACE, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), null);
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    null
+                );
+            }
+        }
+
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (isEnabled(Level.TRACE)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.TRACE,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object... params) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, params),
+                    t
+                );
+            } else {
+                internalLog(Level.DEBUG, ParameterFormatter.format(message, params), null);
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Throwable throwable) {
+        if (isEnabled(Level.DEBUG)) {
+            internalLog(Level.DEBUG, message, throwable);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0) {
+        if (isEnabled(Level.DEBUG)) {
+            internalLog(Level.DEBUG, ParameterFormatter.format(message, new Object[]{p0}), null);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                internalLog(Level.DEBUG, ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                internalLog(Level.DEBUG, ParameterFormatter.format(message, new Object[]{p0, p1}), null);
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1}),
+                    t
+                );
+            } else {
+                internalLog(Level.DEBUG, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), null);
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    null
+                );
+            }
+        }
+
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (isEnabled(Level.DEBUG)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.DEBUG,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object... params) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, params),
+                    t
+                );
+            } else {
+                internalLog(Level.INFO, ParameterFormatter.format(message, params), null);
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Throwable throwable) {
+        if (isEnabled(Level.INFO)) {
+            internalLog(Level.INFO, message, throwable);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0) {
+        if (isEnabled(Level.INFO)) {
+            internalLog(Level.INFO, ParameterFormatter.format(message, new Object[]{p0}), null);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                internalLog(Level.INFO, ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                internalLog(Level.INFO, ParameterFormatter.format(message, new Object[]{p0, p1}), null);
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1}),
+                    t
+                );
+            } else {
+                internalLog(Level.INFO, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), null);
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2}),
+                    t
+                );
+            } else {
+                internalLog(Level.INFO, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), null);
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    null
+                );
+            }
+        }
+
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (isEnabled(Level.INFO)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.INFO,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object... params) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, params),
+                    t
+                );
+            } else {
+                internalLog(Level.WARN, ParameterFormatter.format(message, params), null);
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Throwable throwable) {
+        if (isEnabled(Level.WARN)) {
+            internalLog(Level.WARN, message, throwable);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0) {
+        if (isEnabled(Level.WARN)) {
+            internalLog(Level.WARN, ParameterFormatter.format(message, new Object[]{p0}), null);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                internalLog(Level.WARN, ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                internalLog(Level.WARN, ParameterFormatter.format(message, new Object[]{p0, p1}), null);
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1}),
+                    t
+                );
+            } else {
+                internalLog(Level.WARN, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), null);
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2}),
+                    t
+                );
+            } else {
+                internalLog(Level.WARN, ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}), null);
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    null
+                );
+            }
+        }
+
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (isEnabled(Level.WARN)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.WARN,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object... params) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, params),
+                    t
+                );
+            } else {
+                internalLog(Level.ERROR, ParameterFormatter.format(message, params), null);
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Throwable throwable) {
+        if (isEnabled(Level.ERROR)) {
+            internalLog(Level.ERROR, message, throwable);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0) {
+        if (isEnabled(Level.ERROR)) {
+            internalLog(Level.ERROR, ParameterFormatter.format(message, new Object[]{p0}), null);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                internalLog(Level.ERROR, ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                internalLog(Level.ERROR, ParameterFormatter.format(message, new Object[]{p0, p1}), null);
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1}),
+                    t
+                );
+            } else {
+                internalLog(Level.ERROR, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), null);
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    null
+                );
+            }
+        }
+
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (isEnabled(Level.ERROR)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.ERROR,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object... params) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == params.length - 1
+                && params[params.length - 1] instanceof Throwable t) {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, params),
+                    t
+                );
+            } else {
+                internalLog(Level.FATAL, ParameterFormatter.format(message, params), null);
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Throwable throwable) {
+        if (isEnabled(Level.FATAL)) {
+            internalLog(Level.FATAL, message, throwable);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0) {
+        if (isEnabled(Level.FATAL)) {
+            internalLog(Level.FATAL, ParameterFormatter.format(message, new Object[]{p0}), null);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 1 && p1 instanceof Throwable t) {
+                internalLog(Level.FATAL, ParameterFormatter.format(message, new Object[]{p0}), t);
+            } else {
+                internalLog(Level.FATAL, ParameterFormatter.format(message, new Object[]{p0, p1}), null);
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 2 && p2 instanceof Throwable t) {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1}),
+                    t
+                );
+            } else {
+                internalLog(Level.FATAL, ParameterFormatter.format(message, new Object[]{p0, p1, p2}), null);
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 3 && p3 instanceof Throwable t) {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 4 && p4 instanceof Throwable t) {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    null
+                );
+            }
+        }
+
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 5 && p5 instanceof Throwable t) {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 6 && p6 instanceof Throwable t) {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (isEnabled(Level.FATAL)) {
+            if (ParameterFormatter.countArgumentPlaceholders(message) == 9 && p9 instanceof Throwable t) {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    t
+                );
+            } else {
+                internalLog(
+                    Level.FATAL,
+                    ParameterFormatter.format(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9}),
+                    null
+                );
+            }
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return isEnabled(Level.TRACE);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return isEnabled(Level.DEBUG);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return isEnabled(Level.INFO);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return isEnabled(Level.WARN);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return isEnabled(Level.ERROR);
+    }
+
+    @Override
+    public boolean isFatalEnabled() {
+        return isEnabled(Level.FATAL);
+    }
+}

--- a/logging/src/main/java/software/amazon/smithy/java/logging/Log4j2Logger.java
+++ b/logging/src/main/java/software/amazon/smithy/java/logging/Log4j2Logger.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.logging;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.spi.ExtendedLogger;
+import org.apache.logging.log4j.spi.ExtendedLoggerWrapper;
+
+final class Log4j2Logger extends ExtendedLoggerWrapper implements InternalLogger {
+
+
+    static final class Factory implements InternalLogger.Factory {
+
+        @Override
+        public InternalLogger getLogger(String name) {
+            return new Log4j2Logger((ExtendedLogger) LogManager.getLogger(name));
+        }
+    }
+
+    private Log4j2Logger(ExtendedLogger logger) {
+        super(logger, logger.getName(), logger.getMessageFactory());
+    }
+
+    @Override
+    public void log(Level level, String message, Object... params) {
+        log(convert(level), message, params);
+    }
+
+    private org.apache.logging.log4j.Level convert(Level level) {
+        return switch (level) {
+            case TRACE -> org.apache.logging.log4j.Level.TRACE;
+            case DEBUG -> org.apache.logging.log4j.Level.DEBUG;
+            case INFO -> org.apache.logging.log4j.Level.INFO;
+            case WARN -> org.apache.logging.log4j.Level.WARN;
+            case ERROR -> org.apache.logging.log4j.Level.ERROR;
+            case FATAL -> org.apache.logging.log4j.Level.FATAL;
+        };
+    }
+
+    @Override
+    public void log(Level level, String message, Throwable throwable) {
+        log(convert(level), message, throwable);
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0) {
+        log(convert(level), message, p0);
+
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1) {
+        log(convert(level), message, p0, p1);
+
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2) {
+        log(convert(level), message, p0, p1, p2);
+
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3) {
+        log(convert(level), message, p0, p1, p2, p3);
+
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        log(convert(level), message, p0, p1, p2, p3, p4);
+
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5
+    ) {
+        log(convert(level), message, p0, p1, p2, p3, p4, p5);
+
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6
+    ) {
+        log(convert(level), message, p0, p1, p2, p3, p4, p5, p6);
+
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        log(convert(level), message, p0, p1, p2, p3, p4, p5, p6, p7);
+
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        log(convert(level), message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        log(convert(level), message, p0, p1, p2, p3, p4, p5, p6, p7, p9);
+    }
+}

--- a/logging/src/main/java/software/amazon/smithy/java/logging/ParameterFormatter.java
+++ b/logging/src/main/java/software/amazon/smithy/java/logging/ParameterFormatter.java
@@ -1,0 +1,1009 @@
+/*
+ * SKIPLICENSECHECK
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package software.amazon.smithy.java.logging;
+
+import static java.lang.Character.toLowerCase;
+
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.logging.log4j.util.Chars;
+
+/**
+ * Supports parameter formatting as used in ParameterizedMessage and ReusableParameterizedMessage.
+ */
+final class ParameterFormatter {
+    /**
+     * Prefix for recursion.
+     */
+    static final String RECURSION_PREFIX = "[...";
+    /**
+     * Suffix for recursion.
+     */
+    static final String RECURSION_SUFFIX = "...]";
+
+    /**
+     * Prefix for errors.
+     */
+    static final String ERROR_PREFIX = "[!!!";
+    /**
+     * Separator for errors.
+     */
+    static final String ERROR_SEPARATOR = "=>";
+    /**
+     * Separator for error messages.
+     */
+    static final String ERROR_MSG_SEPARATOR = ":";
+    /**
+     * Suffix for errors.
+     */
+    static final String ERROR_SUFFIX = "!!!]";
+
+    private static final char DELIM_START = '{';
+    private static final char DELIM_STOP = '}';
+    private static final char ESCAPE_CHAR = '\\';
+
+    private static ThreadLocal<SimpleDateFormat> threadLocalSimpleDateFormat = new ThreadLocal<>();
+
+    private ParameterFormatter() {
+    }
+
+    /**
+     * Counts the number of unescaped placeholders in the given messagePattern.
+     *
+     * @param messagePattern the message pattern to be analyzed.
+     * @return the number of unescaped placeholders.
+     */
+    static int countArgumentPlaceholders(final String messagePattern) {
+        if (messagePattern == null) {
+            return 0;
+        }
+        final int length = messagePattern.length();
+        int result = 0;
+        boolean isEscaped = false;
+        for (int i = 0; i < length - 1; i++) {
+            final char curChar = messagePattern.charAt(i);
+            if (curChar == ESCAPE_CHAR) {
+                isEscaped = !isEscaped;
+            } else if (curChar == DELIM_START) {
+                if (!isEscaped && messagePattern.charAt(i + 1) == DELIM_STOP) {
+                    result++;
+                    i++;
+                }
+                isEscaped = false;
+            } else {
+                isEscaped = false;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Counts the number of unescaped placeholders in the given messagePattern.
+     *
+     * @param messagePattern the message pattern to be analyzed.
+     * @return the number of unescaped placeholders.
+     */
+    static int countArgumentPlaceholders2(final String messagePattern, final int[] indices) {
+        if (messagePattern == null) {
+            return 0;
+        }
+        final int length = messagePattern.length();
+        int result = 0;
+        boolean isEscaped = false;
+        for (int i = 0; i < length - 1; i++) {
+            final char curChar = messagePattern.charAt(i);
+            if (curChar == ESCAPE_CHAR) {
+                isEscaped = !isEscaped;
+                indices[0] = -1; // escaping means fast path is not available...
+                result++;
+            } else if (curChar == DELIM_START) {
+                if (!isEscaped && messagePattern.charAt(i + 1) == DELIM_STOP) {
+                    indices[result] = i;
+                    result++;
+                    i++;
+                }
+                isEscaped = false;
+            } else {
+                isEscaped = false;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Counts the number of unescaped placeholders in the given messagePattern.
+     *
+     * @param messagePattern the message pattern to be analyzed.
+     * @return the number of unescaped placeholders.
+     */
+    static int countArgumentPlaceholders3(final char[] messagePattern, final int length, final int[] indices) {
+        int result = 0;
+        boolean isEscaped = false;
+        for (int i = 0; i < length - 1; i++) {
+            final char curChar = messagePattern[i];
+            if (curChar == ESCAPE_CHAR) {
+                isEscaped = !isEscaped;
+            } else if (curChar == DELIM_START) {
+                if (!isEscaped && messagePattern[i + 1] == DELIM_STOP) {
+                    indices[result] = i;
+                    result++;
+                    i++;
+                }
+                isEscaped = false;
+            } else {
+                isEscaped = false;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Replace placeholders in the given messagePattern with arguments.
+     *
+     * @param messagePattern the message pattern containing placeholders.
+     * @param arguments      the arguments to be used to replace placeholders.
+     * @return the formatted message.
+     */
+    static String format(final String messagePattern, final Object[] arguments) {
+        final StringBuilder result = new StringBuilder();
+        final int argCount = arguments == null ? 0 : arguments.length;
+        formatMessage(result, messagePattern, arguments, argCount);
+        return result.toString();
+    }
+
+    /**
+     * Replace placeholders in the given messagePattern with arguments.
+     *
+     * @param buffer the buffer to write the formatted message into
+     * @param messagePattern the message pattern containing placeholders.
+     * @param arguments      the arguments to be used to replace placeholders.
+     */
+    static void formatMessage2(
+        final StringBuilder buffer,
+        final String messagePattern,
+        final Object[] arguments,
+        final int argCount,
+        final int[] indices
+    ) {
+        if (messagePattern == null || arguments == null || argCount == 0) {
+            buffer.append(messagePattern);
+            return;
+        }
+        int previous = 0;
+        for (int i = 0; i < argCount; i++) {
+            buffer.append(messagePattern, previous, indices[i]);
+            previous = indices[i] + 2;
+            recursiveDeepToString(arguments[i], buffer, null);
+        }
+        buffer.append(messagePattern, previous, messagePattern.length());
+    }
+
+    /**
+     * Replace placeholders in the given messagePattern with arguments.
+     *
+     * @param buffer the buffer to write the formatted message into
+     * @param messagePattern the message pattern containing placeholders.
+     * @param arguments      the arguments to be used to replace placeholders.
+     */
+    static void formatMessage3(
+        final StringBuilder buffer,
+        final char[] messagePattern,
+        final int patternLength,
+        final Object[] arguments,
+        final int argCount,
+        final int[] indices
+    ) {
+        if (messagePattern == null) {
+            return;
+        }
+        if (arguments == null || argCount == 0) {
+            buffer.append(messagePattern);
+            return;
+        }
+        int previous = 0;
+        for (int i = 0; i < argCount; i++) {
+            buffer.append(messagePattern, previous, indices[i]);
+            previous = indices[i] + 2;
+            recursiveDeepToString(arguments[i], buffer, null);
+        }
+        buffer.append(messagePattern, previous, patternLength);
+    }
+
+    /**
+     * Replace placeholders in the given messagePattern with arguments.
+     *
+     * @param buffer the buffer to write the formatted message into
+     * @param messagePattern the message pattern containing placeholders.
+     * @param arguments      the arguments to be used to replace placeholders.
+     */
+    static void formatMessage(
+        final StringBuilder buffer,
+        final String messagePattern,
+        final Object[] arguments,
+        final int argCount
+    ) {
+        if (messagePattern == null || arguments == null || argCount == 0) {
+            buffer.append(messagePattern);
+            return;
+        }
+        int escapeCounter = 0;
+        int currentArgument = 0;
+        int i = 0;
+        final int len = messagePattern.length();
+        for (; i < len - 1; i++) { // last char is excluded from the loop
+            final char curChar = messagePattern.charAt(i);
+            if (curChar == ESCAPE_CHAR) {
+                escapeCounter++;
+            } else {
+                if (isDelimPair(curChar, messagePattern, i)) { // looks ahead one char
+                    i++;
+
+                    // write escaped escape chars
+                    writeEscapedEscapeChars(escapeCounter, buffer);
+
+                    if (isOdd(escapeCounter)) {
+                        // i.e. escaped: write escaped escape chars
+                        writeDelimPair(buffer);
+                    } else {
+                        // unescaped
+                        writeArgOrDelimPair(arguments, argCount, currentArgument, buffer);
+                        currentArgument++;
+                    }
+                } else {
+                    handleLiteralChar(buffer, escapeCounter, curChar);
+                }
+                escapeCounter = 0;
+            }
+        }
+        handleRemainingCharIfAny(messagePattern, len, buffer, escapeCounter, i);
+    }
+
+    /**
+     * Returns {@code true} if the specified char and the char at {@code curCharIndex + 1} in the specified message
+     * pattern together form a "{}" delimiter pair, returns {@code false} otherwise.
+     */
+    // Profiling showed this method is important to log4j performance. Modify with care!
+    // 22 bytes (allows immediate JVM inlining: < 35 bytes) LOG4J2-1096
+    private static boolean isDelimPair(final char curChar, final String messagePattern, final int curCharIndex) {
+        return curChar == DELIM_START && messagePattern.charAt(curCharIndex + 1) == DELIM_STOP;
+    }
+
+    /**
+     * Detects whether the message pattern has been fully processed or if an unprocessed character remains and processes
+     * it if necessary, returning the resulting position in the result char array.
+     */
+    // Profiling showed this method is important to log4j performance. Modify with care!
+    // 28 bytes (allows immediate JVM inlining: < 35 bytes) LOG4J2-1096
+    private static void handleRemainingCharIfAny(
+        final String messagePattern,
+        final int len,
+        final StringBuilder buffer,
+        final int escapeCounter,
+        final int i
+    ) {
+        if (i == len - 1) {
+            final char curChar = messagePattern.charAt(i);
+            handleLastChar(buffer, escapeCounter, curChar);
+        }
+    }
+
+    /**
+     * Processes the last unprocessed character and returns the resulting position in the result char array.
+     */
+    // Profiling showed this method is important to log4j performance. Modify with care!
+    // 28 bytes (allows immediate JVM inlining: < 35 bytes) LOG4J2-1096
+    private static void handleLastChar(final StringBuilder buffer, final int escapeCounter, final char curChar) {
+        if (curChar == ESCAPE_CHAR) {
+            writeUnescapedEscapeChars(escapeCounter + 1, buffer);
+        } else {
+            handleLiteralChar(buffer, escapeCounter, curChar);
+        }
+    }
+
+    /**
+     * Processes a literal char (neither an '\' escape char nor a "{}" delimiter pair) and returns the resulting
+     * position.
+     */
+    // Profiling showed this method is important to log4j performance. Modify with care!
+    // 16 bytes (allows immediate JVM inlining: < 35 bytes) LOG4J2-1096
+    private static void handleLiteralChar(final StringBuilder buffer, final int escapeCounter, final char curChar) {
+        // any other char beside ESCAPE or DELIM_START/STOP-combo
+        // write unescaped escape chars
+        writeUnescapedEscapeChars(escapeCounter, buffer);
+        buffer.append(curChar);
+    }
+
+    /**
+     * Writes "{}" to the specified result array at the specified position and returns the resulting position.
+     */
+    // Profiling showed this method is important to log4j performance. Modify with care!
+    // 18 bytes (allows immediate JVM inlining: < 35 bytes) LOG4J2-1096
+    private static void writeDelimPair(final StringBuilder buffer) {
+        buffer.append(DELIM_START);
+        buffer.append(DELIM_STOP);
+    }
+
+    /**
+     * Returns {@code true} if the specified parameter is odd.
+     */
+    // Profiling showed this method is important to log4j performance. Modify with care!
+    // 11 bytes (allows immediate JVM inlining: < 35 bytes) LOG4J2-1096
+    private static boolean isOdd(final int number) {
+        return (number & 1) == 1;
+    }
+
+    /**
+     * Writes a '\' char to the specified result array (starting at the specified position) for each <em>pair</em> of
+     * '\' escape chars encountered in the message format and returns the resulting position.
+     */
+    // Profiling showed this method is important to log4j performance. Modify with care!
+    // 11 bytes (allows immediate JVM inlining: < 35 bytes) LOG4J2-1096
+    private static void writeEscapedEscapeChars(final int escapeCounter, final StringBuilder buffer) {
+        final int escapedEscapes = escapeCounter >> 1; // divide by two
+        writeUnescapedEscapeChars(escapedEscapes, buffer);
+    }
+
+    /**
+     * Writes the specified number of '\' chars to the specified result array (starting at the specified position) and
+     * returns the resulting position.
+     */
+    // Profiling showed this method is important to log4j performance. Modify with care!
+    // 20 bytes (allows immediate JVM inlining: < 35 bytes) LOG4J2-1096
+    private static void writeUnescapedEscapeChars(int escapeCounter, final StringBuilder buffer) {
+        while (escapeCounter > 0) {
+            buffer.append(ESCAPE_CHAR);
+            escapeCounter--;
+        }
+    }
+
+    /**
+     * Appends the argument at the specified argument index (or, if no such argument exists, the "{}" delimiter pair) to
+     * the specified result char array at the specified position and returns the resulting position.
+     */
+    // Profiling showed this method is important to log4j performance. Modify with care!
+    // 25 bytes (allows immediate JVM inlining: < 35 bytes) LOG4J2-1096
+    private static void writeArgOrDelimPair(
+        final Object[] arguments,
+        final int argCount,
+        final int currentArgument,
+        final StringBuilder buffer
+    ) {
+        if (currentArgument < argCount) {
+            recursiveDeepToString(arguments[currentArgument], buffer, null);
+        } else {
+            writeDelimPair(buffer);
+        }
+    }
+
+    /**
+     * This method performs a deep toString of the given Object.
+     * Primitive arrays are converted using their respective Arrays.toString methods while
+     * special handling is implemented for "container types", i.e. Object[], Map and Collection because those could
+     * contain themselves.
+     * <p>
+     * It should be noted that neither AbstractMap.toString() nor AbstractCollection.toString() implement such a
+     * behavior. They only check if the container is directly contained in itself, but not if a contained container
+     * contains the original one. Because of that, Arrays.toString(Object[]) isn't safe either.
+     * Confusing? Just read the last paragraph again and check the respective toString() implementation.
+     * </p>
+     * <p>
+     * This means, in effect, that logging would produce a usable output even if an ordinary System.out.println(o)
+     * would produce a relatively hard-to-debug StackOverflowError.
+     * </p>
+     * @param o The object.
+     * @return The String representation.
+     */
+    static String deepToString(final Object o) {
+        if (o == null) {
+            return null;
+        }
+        // Check special types to avoid unnecessary StringBuilder usage
+        if (o instanceof String) {
+            return (String) o;
+        }
+        if (o instanceof Integer) {
+            return Integer.toString((Integer) o);
+        }
+        if (o instanceof Long) {
+            return Long.toString((Long) o);
+        }
+        if (o instanceof Double) {
+            return Double.toString((Double) o);
+        }
+        if (o instanceof Boolean) {
+            return Boolean.toString((Boolean) o);
+        }
+        if (o instanceof Character) {
+            return Character.toString((Character) o);
+        }
+        if (o instanceof Short) {
+            return Short.toString((Short) o);
+        }
+        if (o instanceof Float) {
+            return Float.toString((Float) o);
+        }
+        if (o instanceof Byte) {
+            return Byte.toString((Byte) o);
+        }
+        final StringBuilder str = new StringBuilder();
+        recursiveDeepToString(o, str, null);
+        return str.toString();
+    }
+
+    /**
+     * This method performs a deep toString of the given Object.
+     * Primitive arrays are converted using their respective Arrays.toString methods while
+     * special handling is implemented for "container types", i.e. Object[], Map and Collection because those could
+     * contain themselves.
+     * <p>
+     * dejaVu is used in case of those container types to prevent an endless recursion.
+     * </p>
+     * <p>
+     * It should be noted that neither AbstractMap.toString() nor AbstractCollection.toString() implement such a
+     * behavior.
+     * They only check if the container is directly contained in itself, but not if a contained container contains the
+     * original one. Because of that, Arrays.toString(Object[]) isn't safe either.
+     * Confusing? Just read the last paragraph again and check the respective toString() implementation.
+     * </p>
+     * <p>
+     * This means, in effect, that logging would produce a usable output even if an ordinary System.out.println(o)
+     * would produce a relatively hard-to-debug StackOverflowError.
+     * </p>
+     *
+     * @param o      the Object to convert into a String
+     * @param str    the StringBuilder that o will be appended to
+     * @param dejaVu a list of container identities that were already used.
+     */
+    static void recursiveDeepToString(final Object o, final StringBuilder str, final Set<String> dejaVu) {
+        if (appendSpecialTypes(o, str)) {
+            return;
+        }
+        if (isMaybeRecursive(o)) {
+            appendPotentiallyRecursiveValue(o, str, dejaVu);
+        } else {
+            tryObjectToString(o, str);
+        }
+    }
+
+    private static boolean appendSpecialTypes(final Object o, final StringBuilder str) {
+        return StringBuilders.appendSpecificTypes(str, o) || appendDate(o, str);
+    }
+
+    private static boolean appendDate(final Object o, final StringBuilder str) {
+        if (!(o instanceof Date)) {
+            return false;
+        }
+        final Date date = (Date) o;
+        final SimpleDateFormat format = getSimpleDateFormat();
+        str.append(format.format(date));
+        return true;
+    }
+
+    private static SimpleDateFormat getSimpleDateFormat() {
+        SimpleDateFormat result = threadLocalSimpleDateFormat.get();
+        if (result == null) {
+            result = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+            threadLocalSimpleDateFormat.set(result);
+        }
+        return result;
+    }
+
+    /**
+     * Returns {@code true} if the specified object is an array, a Map or a Collection.
+     */
+    private static boolean isMaybeRecursive(final Object o) {
+        return o.getClass().isArray() || o instanceof Map || o instanceof Collection;
+    }
+
+    private static void appendPotentiallyRecursiveValue(
+        final Object o,
+        final StringBuilder str,
+        final Set<String> dejaVu
+    ) {
+        final Class<?> oClass = o.getClass();
+        if (oClass.isArray()) {
+            appendArray(o, str, dejaVu, oClass);
+        } else if (o instanceof Map) {
+            appendMap(o, str, dejaVu);
+        } else if (o instanceof Collection) {
+            appendCollection(o, str, dejaVu);
+        }
+    }
+
+    private static void appendArray(
+        final Object o,
+        final StringBuilder str,
+        Set<String> dejaVu,
+        final Class<?> oClass
+    ) {
+        if (oClass == byte[].class) {
+            str.append(Arrays.toString((byte[]) o));
+        } else if (oClass == short[].class) {
+            str.append(Arrays.toString((short[]) o));
+        } else if (oClass == int[].class) {
+            str.append(Arrays.toString((int[]) o));
+        } else if (oClass == long[].class) {
+            str.append(Arrays.toString((long[]) o));
+        } else if (oClass == float[].class) {
+            str.append(Arrays.toString((float[]) o));
+        } else if (oClass == double[].class) {
+            str.append(Arrays.toString((double[]) o));
+        } else if (oClass == boolean[].class) {
+            str.append(Arrays.toString((boolean[]) o));
+        } else if (oClass == char[].class) {
+            str.append(Arrays.toString((char[]) o));
+        } else {
+            if (dejaVu == null) {
+                dejaVu = new HashSet<>();
+            }
+            // special handling of container Object[]
+            final String id = identityToString(o);
+            if (dejaVu.contains(id)) {
+                str.append(RECURSION_PREFIX).append(id).append(RECURSION_SUFFIX);
+            } else {
+                dejaVu.add(id);
+                final Object[] oArray = (Object[]) o;
+                str.append('[');
+                boolean first = true;
+                for (final Object current : oArray) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        str.append(", ");
+                    }
+                    recursiveDeepToString(current, str, new HashSet<>(dejaVu));
+                }
+                str.append(']');
+            }
+            //str.append(Arrays.deepToString((Object[]) o));
+        }
+    }
+
+    private static void appendMap(final Object o, final StringBuilder str, Set<String> dejaVu) {
+        // special handling of container Map
+        if (dejaVu == null) {
+            dejaVu = new HashSet<>();
+        }
+        final String id = identityToString(o);
+        if (dejaVu.contains(id)) {
+            str.append(RECURSION_PREFIX).append(id).append(RECURSION_SUFFIX);
+        } else {
+            dejaVu.add(id);
+            final Map<?, ?> oMap = (Map<?, ?>) o;
+            str.append('{');
+            boolean isFirst = true;
+            for (final Object o1 : oMap.entrySet()) {
+                final Map.Entry<?, ?> current = (Map.Entry<?, ?>) o1;
+                if (isFirst) {
+                    isFirst = false;
+                } else {
+                    str.append(", ");
+                }
+                final Object key = current.getKey();
+                final Object value = current.getValue();
+                recursiveDeepToString(key, str, new HashSet<>(dejaVu));
+                str.append('=');
+                recursiveDeepToString(value, str, new HashSet<>(dejaVu));
+            }
+            str.append('}');
+        }
+    }
+
+    private static void appendCollection(final Object o, final StringBuilder str, Set<String> dejaVu) {
+        // special handling of container Collection
+        if (dejaVu == null) {
+            dejaVu = new HashSet<>();
+        }
+        final String id = identityToString(o);
+        if (dejaVu.contains(id)) {
+            str.append(RECURSION_PREFIX).append(id).append(RECURSION_SUFFIX);
+        } else {
+            dejaVu.add(id);
+            final Collection<?> oCol = (Collection<?>) o;
+            str.append('[');
+            boolean isFirst = true;
+            for (final Object anOCol : oCol) {
+                if (isFirst) {
+                    isFirst = false;
+                } else {
+                    str.append(", ");
+                }
+                recursiveDeepToString(anOCol, str, new HashSet<>(dejaVu));
+            }
+            str.append(']');
+        }
+    }
+
+    private static void tryObjectToString(final Object o, final StringBuilder str) {
+        // it's just some other Object, we can only use toString().
+        try {
+            str.append(o.toString());
+        } catch (final Throwable t) {
+            handleErrorInObjectToString(o, str, t);
+        }
+    }
+
+    private static void handleErrorInObjectToString(final Object o, final StringBuilder str, final Throwable t) {
+        str.append(ERROR_PREFIX);
+        str.append(identityToString(o));
+        str.append(ERROR_SEPARATOR);
+        final String msg = t.getMessage();
+        final String className = t.getClass().getName();
+        str.append(className);
+        if (!className.equals(msg)) {
+            str.append(ERROR_MSG_SEPARATOR);
+            str.append(msg);
+        }
+        str.append(ERROR_SUFFIX);
+    }
+
+    /**
+     * This method returns the same as if Object.toString() would not have been
+     * overridden in obj.
+     * <p>
+     * Note that this isn't 100% secure as collisions can always happen with hash codes.
+     * </p>
+     * <p>
+     * Copied from Object.hashCode():
+     * </p>
+     * <blockquote>
+     * As much as is reasonably practical, the hashCode method defined by
+     * class {@code Object} does return distinct integers for distinct
+     * objects. (This is typically implemented by converting the internal
+     * address of the object into an integer, but this implementation
+     * technique is not required by the Java&#8482; programming language.)
+     * </blockquote>
+     *
+     * @param obj the Object that is to be converted into an identity string.
+     * @return the identity string as also defined in Object.toString()
+     */
+    static String identityToString(final Object obj) {
+        if (obj == null) {
+            return null;
+        }
+        return obj.getClass().getName() + '@' + Integer.toHexString(System.identityHashCode(obj));
+    }
+
+    private static final class StringBuilders {
+
+        private static final Class<?> timeClass;
+
+        static {
+            Class<?> clazz;
+            try {
+                clazz = Class.forName("java.sql.Time");
+            } catch (Exception ex) {
+                clazz = null;
+            }
+            timeClass = clazz;
+        }
+
+        private StringBuilders() {
+        }
+
+        /**
+         * Appends in the following format: double quoted value.
+         *
+         * @param sb a string builder
+         * @param value a value
+         * @return {@code "value"}
+         */
+        public static StringBuilder appendDqValue(final StringBuilder sb, final Object value) {
+            return sb.append(Chars.DQUOTE).append(value).append(Chars.DQUOTE);
+        }
+
+        /**
+         * Appends in the following format: key=double quoted value.
+         *
+         * @param sb a string builder
+         * @param entry a map entry
+         * @return {@code key="value"}
+         */
+        public static StringBuilder appendKeyDqValue(final StringBuilder sb, final Map.Entry<String, String> entry) {
+            return appendKeyDqValue(sb, entry.getKey(), entry.getValue());
+        }
+
+        /**
+         * Appends in the following format: key=double quoted value.
+         *
+         * @param sb a string builder
+         * @param key a key
+         * @param value a value
+         * @return the specified StringBuilder
+         */
+        public static StringBuilder appendKeyDqValue(final StringBuilder sb, final String key, final Object value) {
+            return sb.append(key).append(Chars.EQ).append(Chars.DQUOTE).append(value).append(Chars.DQUOTE);
+        }
+
+        /**
+         * Appends a text representation of the specified object to the specified StringBuilder,
+         * if possible without allocating temporary objects.
+         *
+         * @param stringBuilder the StringBuilder to append the value to
+         * @param obj the object whose text representation to append to the StringBuilder
+         */
+        public static void appendValue(final StringBuilder stringBuilder, final Object obj) {
+            if (!appendSpecificTypes(stringBuilder, obj)) {
+                stringBuilder.append(obj);
+            }
+        }
+
+        public static boolean appendSpecificTypes(final StringBuilder stringBuilder, final Object obj) {
+            if (obj == null || obj instanceof String) {
+                stringBuilder.append((String) obj);
+            } else if (obj instanceof CharSequence) {
+                stringBuilder.append((CharSequence) obj);
+            } else if (obj instanceof Integer) { // LOG4J2-1437 unbox auto-boxed primitives to avoid calling toString()
+                stringBuilder.append(((Integer) obj).intValue());
+            } else if (obj instanceof Long) {
+                stringBuilder.append(((Long) obj).longValue());
+            } else if (obj instanceof Double) {
+                stringBuilder.append(((Double) obj).doubleValue());
+            } else if (obj instanceof Boolean) {
+                stringBuilder.append(((Boolean) obj).booleanValue());
+            } else if (obj instanceof Character) {
+                stringBuilder.append(((Character) obj).charValue());
+            } else if (obj instanceof Short) {
+                stringBuilder.append(((Short) obj).shortValue());
+            } else if (obj instanceof Float) {
+                stringBuilder.append(((Float) obj).floatValue());
+            } else if (obj instanceof Byte) {
+                stringBuilder.append(((Byte) obj).byteValue());
+            } else if (isTime(obj) || obj instanceof java.time.temporal.Temporal) {
+                stringBuilder.append(obj);
+            } else {
+                return false;
+            }
+            return true;
+        }
+
+        /*
+            Check to see if obj is an instance of java.sql.time without requiring the java.sql module.
+         */
+        private static boolean isTime(final Object obj) {
+            return timeClass != null && timeClass.isAssignableFrom(obj.getClass());
+        }
+
+
+        /**
+         * Returns true if the specified section of the left CharSequence equals the specified section of the right
+         * CharSequence.
+         *
+         * @param left the left CharSequence
+         * @param leftOffset start index in the left CharSequence
+         * @param leftLength length of the section in the left CharSequence
+         * @param right the right CharSequence to compare a section of
+         * @param rightOffset start index in the right CharSequence
+         * @param rightLength length of the section in the right CharSequence
+         * @return true if equal, false otherwise
+         */
+        public static boolean equals(
+            final CharSequence left,
+            final int leftOffset,
+            final int leftLength,
+            final CharSequence right,
+            final int rightOffset,
+            final int rightLength
+        ) {
+            if (leftLength == rightLength) {
+                for (int i = 0; i < rightLength; i++) {
+                    if (left.charAt(i + leftOffset) != right.charAt(i + rightOffset)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        /**
+         * Returns true if the specified section of the left CharSequence equals, ignoring case, the specified section of
+         * the right CharSequence.
+         *
+         * @param left the left CharSequence
+         * @param leftOffset start index in the left CharSequence
+         * @param leftLength length of the section in the left CharSequence
+         * @param right the right CharSequence to compare a section of
+         * @param rightOffset start index in the right CharSequence
+         * @param rightLength length of the section in the right CharSequence
+         * @return true if equal ignoring case, false otherwise
+         */
+        public static boolean equalsIgnoreCase(
+            final CharSequence left,
+            final int leftOffset,
+            final int leftLength,
+            final CharSequence right,
+            final int rightOffset,
+            final int rightLength
+        ) {
+            if (leftLength == rightLength) {
+                for (int i = 0; i < rightLength; i++) {
+                    if (toLowerCase(left.charAt(i + leftOffset)) != toLowerCase(right.charAt(i + rightOffset))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        /**
+         * Ensures that the char[] array of the specified StringBuilder does not exceed the specified number of characters.
+         * This method is useful to ensure that excessively long char[] arrays are not kept in memory forever.
+         *
+         * @param stringBuilder the StringBuilder to check
+         * @param maxSize the maximum number of characters the StringBuilder is allowed to have
+         * @since 2.9
+         */
+        public static void trimToMaxSize(final StringBuilder stringBuilder, final int maxSize) {
+            if (stringBuilder != null && stringBuilder.capacity() > maxSize) {
+                stringBuilder.setLength(maxSize);
+                stringBuilder.trimToSize();
+            }
+        }
+
+        public static void escapeJson(final StringBuilder toAppendTo, final int start) {
+            int escapeCount = 0;
+            for (int i = start; i < toAppendTo.length(); i++) {
+                final char c = toAppendTo.charAt(i);
+                switch (c) {
+                    case '\b':
+                    case '\t':
+                    case '\f':
+                    case '\n':
+                    case '\r':
+                    case '"':
+                    case '\\':
+                        escapeCount++;
+                        break;
+                    default:
+                        if (Character.isISOControl(c)) {
+                            escapeCount += 5;
+                        }
+                }
+            }
+
+            final int lastChar = toAppendTo.length() - 1;
+            toAppendTo.setLength(toAppendTo.length() + escapeCount);
+            int lastPos = toAppendTo.length() - 1;
+
+            for (int i = lastChar; lastPos > i; i--) {
+                final char c = toAppendTo.charAt(i);
+                switch (c) {
+                    case '\b':
+                        lastPos = escapeAndDecrement(toAppendTo, lastPos, 'b');
+                        break;
+
+                    case '\t':
+                        lastPos = escapeAndDecrement(toAppendTo, lastPos, 't');
+                        break;
+
+                    case '\f':
+                        lastPos = escapeAndDecrement(toAppendTo, lastPos, 'f');
+                        break;
+
+                    case '\n':
+                        lastPos = escapeAndDecrement(toAppendTo, lastPos, 'n');
+                        break;
+
+                    case '\r':
+                        lastPos = escapeAndDecrement(toAppendTo, lastPos, 'r');
+                        break;
+
+                    case '"':
+                    case '\\':
+                        lastPos = escapeAndDecrement(toAppendTo, lastPos, c);
+                        break;
+
+                    default:
+                        if (Character.isISOControl(c)) {
+                            // all iso control characters are in U+00xx, JSON output format is "\\u00XX"
+                            toAppendTo.setCharAt(lastPos--, Chars.getUpperCaseHex(c & 0xF));
+                            toAppendTo.setCharAt(lastPos--, Chars.getUpperCaseHex((c & 0xF0) >> 4));
+                            toAppendTo.setCharAt(lastPos--, '0');
+                            toAppendTo.setCharAt(lastPos--, '0');
+                            toAppendTo.setCharAt(lastPos--, 'u');
+                            toAppendTo.setCharAt(lastPos--, '\\');
+                        } else {
+                            toAppendTo.setCharAt(lastPos, c);
+                            lastPos--;
+                        }
+                }
+            }
+        }
+
+        private static int escapeAndDecrement(final StringBuilder toAppendTo, int lastPos, final char c) {
+            toAppendTo.setCharAt(lastPos--, c);
+            toAppendTo.setCharAt(lastPos--, '\\');
+            return lastPos;
+        }
+
+        public static void escapeXml(final StringBuilder toAppendTo, final int start) {
+            int escapeCount = 0;
+            for (int i = start; i < toAppendTo.length(); i++) {
+                final char c = toAppendTo.charAt(i);
+                switch (c) {
+                    case '&':
+                        escapeCount += 4;
+                        break;
+                    case '<':
+                    case '>':
+                        escapeCount += 3;
+                        break;
+                    case '"':
+                    case '\'':
+                        escapeCount += 5;
+                }
+            }
+
+            final int lastChar = toAppendTo.length() - 1;
+            toAppendTo.setLength(toAppendTo.length() + escapeCount);
+            int lastPos = toAppendTo.length() - 1;
+
+            for (int i = lastChar; lastPos > i; i--) {
+                final char c = toAppendTo.charAt(i);
+                switch (c) {
+                    case '&':
+                        toAppendTo.setCharAt(lastPos--, ';');
+                        toAppendTo.setCharAt(lastPos--, 'p');
+                        toAppendTo.setCharAt(lastPos--, 'm');
+                        toAppendTo.setCharAt(lastPos--, 'a');
+                        toAppendTo.setCharAt(lastPos--, '&');
+                        break;
+                    case '<':
+                        toAppendTo.setCharAt(lastPos--, ';');
+                        toAppendTo.setCharAt(lastPos--, 't');
+                        toAppendTo.setCharAt(lastPos--, 'l');
+                        toAppendTo.setCharAt(lastPos--, '&');
+                        break;
+                    case '>':
+                        toAppendTo.setCharAt(lastPos--, ';');
+                        toAppendTo.setCharAt(lastPos--, 't');
+                        toAppendTo.setCharAt(lastPos--, 'g');
+                        toAppendTo.setCharAt(lastPos--, '&');
+                        break;
+                    case '"':
+                        toAppendTo.setCharAt(lastPos--, ';');
+                        toAppendTo.setCharAt(lastPos--, 't');
+                        toAppendTo.setCharAt(lastPos--, 'o');
+                        toAppendTo.setCharAt(lastPos--, 'u');
+                        toAppendTo.setCharAt(lastPos--, 'q');
+                        toAppendTo.setCharAt(lastPos--, '&');
+                        break;
+                    case '\'':
+                        toAppendTo.setCharAt(lastPos--, ';');
+                        toAppendTo.setCharAt(lastPos--, 's');
+                        toAppendTo.setCharAt(lastPos--, 'o');
+                        toAppendTo.setCharAt(lastPos--, 'p');
+                        toAppendTo.setCharAt(lastPos--, 'a');
+                        toAppendTo.setCharAt(lastPos--, '&');
+                        break;
+                    default:
+                        toAppendTo.setCharAt(lastPos--, c);
+                }
+            }
+        }
+    }
+
+}

--- a/logging/src/main/java/software/amazon/smithy/java/logging/Slf4jLogger.java
+++ b/logging/src/main/java/software/amazon/smithy/java/logging/Slf4jLogger.java
@@ -1,0 +1,933 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.slf4j.spi.LoggingEventBuilder;
+
+final class Slf4jLogger implements InternalLogger {
+
+    private static final Marker FATAL = MarkerFactory.getMarker("FATAL");
+
+    private final Logger log;
+
+    Slf4jLogger(Logger log) {
+        this.log = log;
+    }
+
+    static final class Factory implements InternalLogger.Factory {
+        @Override
+        public InternalLogger getLogger(String name) {
+            return new Slf4jLogger(LoggerFactory.getLogger(name));
+        }
+    }
+
+    private org.slf4j.event.Level convert(Level level) {
+        return switch (level) {
+            case TRACE -> org.slf4j.event.Level.TRACE;
+            case DEBUG -> org.slf4j.event.Level.DEBUG;
+            case INFO -> org.slf4j.event.Level.INFO;
+            case WARN -> org.slf4j.event.Level.WARN;
+            case ERROR, FATAL -> org.slf4j.event.Level.ERROR;
+        };
+    }
+
+    private boolean isEnabled(Level level) {
+        return switch (level) {
+            case TRACE -> log.isTraceEnabled();
+            case DEBUG -> log.isDebugEnabled();
+            case INFO -> log.isInfoEnabled();
+            case WARN -> log.isWarnEnabled();
+            case ERROR -> log.isErrorEnabled();
+            case FATAL -> log.isErrorEnabled(FATAL);
+        };
+    }
+
+    @Override
+    public void log(Level level, String message, Object... params) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, params);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Throwable throwable) {
+        if (isEnabled(level)) {
+            logBuilder(level).setMessage(message).setCause(throwable).log();
+        }
+
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0, p1);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0, p1, p2);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0, p1, p2, p3);
+        }
+    }
+
+    @Override
+    public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0, p1, p2, p3, p4);
+        }
+    }
+
+    private LoggingEventBuilder logBuilder(Level level) {
+        var builder = log.atLevel(convert(level));
+        if (level == Level.FATAL) {
+            builder = builder.addMarker(FATAL);
+        }
+        return builder;
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5
+    ) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0, p1, p2, p3, p4, p5);
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6
+    ) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0, p1, p2, p3, p4, p5, p6);
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0, p1, p2, p3, p4, p5, p6, p7);
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+        }
+    }
+
+    @Override
+    public void log(
+        Level level,
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (isEnabled(level)) {
+            logBuilder(level).log(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object... params) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, params);
+        }
+    }
+
+    @Override
+    public void trace(String message, Throwable throwable) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, throwable);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0, p1);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0, p1, p2);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0, p1, p2, p3);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0, p1, p2, p3, p4);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0, p1, p2, p3, p4, p5);
+        }
+    }
+
+    @Override
+    public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0, p1, p2, p3, p4, p5, p6);
+        }
+    }
+
+    @Override
+    public void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0, p1, p2, p3, p4, p5, p6, p7);
+        }
+    }
+
+    @Override
+    public void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+        }
+    }
+
+    @Override
+    public void trace(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isTraceEnabled()) {
+            log.trace(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object... params) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, params);
+        }
+    }
+
+    @Override
+    public void debug(String message, Throwable throwable) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, throwable);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0, p1);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0, p1, p2);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0, p1, p2, p3);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0, p1, p2, p3, p4);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0, p1, p2, p3, p4, p5);
+        }
+    }
+
+    @Override
+    public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0, p1, p2, p3, p4, p5, p6);
+        }
+    }
+
+    @Override
+    public void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0, p1, p2, p3, p4, p5, p6, p7);
+        }
+    }
+
+    @Override
+    public void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+        }
+    }
+
+    @Override
+    public void debug(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isDebugEnabled()) {
+            log.debug(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        }
+    }
+
+    @Override
+    public void info(String message, Object... params) {
+        if (log.isInfoEnabled()) {
+            log.info(message, params);
+        }
+    }
+
+    @Override
+    public void info(String message, Throwable throwable) {
+        if (log.isInfoEnabled()) {
+            log.info(message, throwable);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0, p1);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0, p1, p2);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0, p1, p2, p3);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0, p1, p2, p3, p4);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0, p1, p2, p3, p4, p5);
+        }
+    }
+
+    @Override
+    public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0, p1, p2, p3, p4, p5, p6);
+        }
+    }
+
+    @Override
+    public void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0, p1, p2, p3, p4, p5, p6, p7);
+        }
+    }
+
+    @Override
+    public void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+        }
+    }
+
+    @Override
+    public void info(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isInfoEnabled()) {
+            log.info(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object... params) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, params);
+        }
+    }
+
+    @Override
+    public void warn(String message, Throwable throwable) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, throwable);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0, p1);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0, p1, p2);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0, p1, p2, p3);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0, p1, p2, p3, p4);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0, p1, p2, p3, p4, p5);
+        }
+    }
+
+    @Override
+    public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0, p1, p2, p3, p4, p5, p6);
+        }
+    }
+
+    @Override
+    public void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0, p1, p2, p3, p4, p5, p6, p7);
+        }
+    }
+
+    @Override
+    public void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+        }
+    }
+
+    @Override
+    public void warn(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        }
+
+    }
+
+    @Override
+    public void error(String message, Object... params) {
+        if (log.isErrorEnabled()) {
+            log.error(message, params);
+        }
+
+    }
+
+    @Override
+    public void error(String message, Throwable throwable) {
+        if (log.isErrorEnabled()) {
+            log.error(message, throwable);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0, p1);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0, p1, p2);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0, p1, p2, p3);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0, p1, p2, p3, p4);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0, p1, p2, p3, p4, p5);
+        }
+    }
+
+    @Override
+    public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0, p1, p2, p3, p4, p5, p6);
+        }
+    }
+
+    @Override
+    public void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0, p1, p2, p3, p4, p5, p6, p7);
+        }
+    }
+
+    @Override
+    public void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+        }
+    }
+
+    @Override
+    public void error(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isErrorEnabled()) {
+            log.error(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object... params) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, params);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Throwable throwable) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, throwable);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0, p1);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0, p1, p2);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0, p1, p2, p3);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0, p1, p2, p3, p4);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0, p1, p2, p3, p4, p5);
+        }
+    }
+
+    @Override
+    public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0, p1, p2, p3, p4, p5, p6);
+        }
+    }
+
+    @Override
+    public void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7
+    ) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0, p1, p2, p3, p4, p5, p6, p7);
+        }
+    }
+
+    @Override
+    public void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8
+    ) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+        }
+    }
+
+    @Override
+    public void fatal(
+        String message,
+        Object p0,
+        Object p1,
+        Object p2,
+        Object p3,
+        Object p4,
+        Object p5,
+        Object p6,
+        Object p7,
+        Object p8,
+        Object p9
+    ) {
+        if (log.isErrorEnabled(FATAL)) {
+            log.error(FATAL, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return log.isTraceEnabled();
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return log.isDebugEnabled();
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return log.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return log.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return log.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isFatalEnabled() {
+        return log.isErrorEnabled(FATAL);
+    }
+}

--- a/logging/src/test/java/software/amazon/smithy/java/logging/JclLoggerIsolatedTest.java
+++ b/logging/src/test/java/software/amazon/smithy/java/logging/JclLoggerIsolatedTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogConfigurationException;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class JclLoggerIsolatedTest {
+
+    @BeforeAll
+    public static void setupLoggers() {
+        System.setProperty("org.apache.commons.logging.LogFactory", JclLogFactory.class.getName());
+        LogFactory.release(Thread.currentThread().getContextClassLoader());
+    }
+
+    @AfterAll
+    public static void tearDownLoggers() {
+        System.clearProperty("org.apache.commons.logging.LogFactory");
+        LogFactory.release(Thread.currentThread().getContextClassLoader());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JclLog.BUFFER.getBuffer().setLength(0);
+        JclLog.warnEnabled = true;
+    }
+
+    @Test
+    void smokeTest() {
+        InternalLogger logger = InternalLogger.getLogger(JclLoggerIsolatedTest.class);
+        logger.error("test1");
+        logger.warn("test2: {}", "abc");
+        logger.fatal("{}: test3: {} {}", "a", "b", "c", new NullPointerException("BANG!"));
+
+        var lines = JclLog.BUFFER.toString().split(System.lineSeparator());
+        assertThat(lines).hasSizeGreaterThan(5);
+        assertThat(lines[0]).startsWith("ERROR test1");
+        assertThat(lines[1]).startsWith("WARN test2: abc");
+        assertThat(lines[2]).startsWith("FATAL a: test3: b c");
+        assertThat(lines[3]).startsWith("java.lang.NullPointerException: BANG!");
+        assertThat(lines[4]).contains(
+            "at software.amazon.smithy.java.logging.JclLoggerIsolatedTest.smokeTest(JclLoggerIsolatedTest.java:"
+        );
+    }
+
+    @Test
+    void levelTest() {
+        InternalLogger logger = InternalLogger.getLogger(JclLoggerIsolatedTest.class);
+        JclLog.warnEnabled = false;
+        logger.error("test1");
+        logger.warn("test2: {}", "abc");
+        logger.fatal("{}: test3: {} {}", "a", "b", "c", new NullPointerException("BANG!"));
+
+        var lines = JclLog.BUFFER.toString().split(System.lineSeparator());
+        assertThat(lines).hasSizeGreaterThan(4);
+        assertThat(lines[0]).startsWith("ERROR test1");
+        assertThat(lines[1]).startsWith("FATAL a: test3: b c");
+        assertThat(lines[2]).startsWith("java.lang.NullPointerException: BANG!");
+        assertThat(lines[3]).contains(
+            "at software.amazon.smithy.java.logging.JclLoggerIsolatedTest.levelTest(JclLoggerIsolatedTest.java:"
+        );
+    }
+
+    @Test
+    void dynamicLevelTest() {
+        InternalLogger logger = InternalLogger.getLogger(JclLoggerIsolatedTest.class);
+        JclLog.warnEnabled = false;
+        logger.log(InternalLogger.Level.ERROR, "test1");
+        logger.log(InternalLogger.Level.WARN, "test2: {}", "abc");
+        logger.log(
+            InternalLogger.Level.FATAL,
+            "{}: test3: {} {}",
+            "a",
+            "b",
+            "c",
+            new NullPointerException("BANG!")
+        );
+
+        var lines = JclLog.BUFFER.toString().split(System.lineSeparator());
+        assertThat(lines).hasSizeGreaterThan(4);
+        assertThat(lines[0]).startsWith("ERROR test1");
+        assertThat(lines[1]).startsWith("FATAL a: test3: b c");
+        assertThat(lines[2]).startsWith("java.lang.NullPointerException: BANG!");
+        assertThat(lines[3]).contains(
+            "at software.amazon.smithy.java.logging.JclLoggerIsolatedTest.dynamicLevelTest(JclLoggerIsolatedTest.java:"
+        );
+    }
+
+    public static final class JclLogFactory extends LogFactory {
+        @Override
+        public Object getAttribute(String name) {
+            return null;
+        }
+
+        @Override
+        public String[] getAttributeNames() {
+            return new String[0];
+        }
+
+        @Override
+        public Log getInstance(Class clazz) throws LogConfigurationException {
+            return new JclLog();
+        }
+
+        @Override
+        public Log getInstance(String name) throws LogConfigurationException {
+            return new JclLog();
+        }
+
+        @Override
+        public void release() {
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+        }
+
+        @Override
+        public void setAttribute(String name, Object value) {
+        }
+    }
+
+
+    static final class JclLog implements Log {
+        static final StringWriter BUFFER = new StringWriter();
+        static final PrintWriter WRITER = new PrintWriter(BUFFER);
+
+        static volatile boolean warnEnabled = true;
+
+        public JclLog() {
+        }
+
+        @Override
+        public void debug(Object message) {
+            WRITER.write("DEBUG ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+        }
+
+        @Override
+        public void debug(Object message, Throwable t) {
+            WRITER.write("DEBUG ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+            if (t != null) {
+                t.printStackTrace(WRITER);
+            }
+        }
+
+        @Override
+        public void info(Object message) {
+            WRITER.write("INFO ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+        }
+
+        @Override
+        public void info(Object message, Throwable t) {
+            WRITER.write("INFO ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+            if (t != null) {
+                t.printStackTrace(WRITER);
+            }
+        }
+
+        @Override
+        public void warn(Object message) {
+            if (!warnEnabled) {
+                throw new IllegalStateException();
+            }
+            WRITER.write("WARN ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+        }
+
+        @Override
+        public void warn(Object message, Throwable t) {
+            if (!warnEnabled) {
+                throw new IllegalStateException();
+            }
+            WRITER.write("WARN ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+            if (t != null) {
+                t.printStackTrace(WRITER);
+            }
+        }
+
+        @Override
+        public void error(Object message) {
+            WRITER.write("ERROR ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+        }
+
+        @Override
+        public void error(Object message, Throwable t) {
+            WRITER.write("ERROR ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+            if (t != null) {
+                t.printStackTrace(WRITER);
+            }
+        }
+
+        @Override
+        public void fatal(Object message) {
+            WRITER.write("FATAL ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+        }
+
+        @Override
+        public void fatal(Object message, Throwable t) {
+            WRITER.write("FATAL ");
+            WRITER.write(String.valueOf(message));
+            WRITER.write(System.lineSeparator());
+            if (t != null) {
+                t.printStackTrace(WRITER);
+            }
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isFatalEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isTraceEnabled() {
+            return false;
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return warnEnabled;
+        }
+
+        @Override
+        public void trace(Object message) {
+        }
+
+        @Override
+        public void trace(Object message, Throwable t) {
+        }
+    }
+
+}

--- a/logging/src/test/java/software/amazon/smithy/java/logging/JdkSystemLoggerTest.java
+++ b/logging/src/test/java/software/amazon/smithy/java/logging/JdkSystemLoggerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class JdkSystemLoggerTest {
+
+    private static TestLogger testLog;
+
+    @BeforeAll
+    public static void setupLoggers() {
+        testLog = new TestLogger(JdkSystemLoggerTest.class.getName());
+        LogManager.getLogManager().addLogger(testLog);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        testLog.buffer.getBuffer().setLength(0);
+        testLog.warnEnabled = true;
+    }
+
+
+    @Test
+    void smokeTest() {
+        InternalLogger logger = InternalLogger.getLogger(JdkSystemLoggerTest.class);
+        logger.error("test1");
+        logger.warn("test2: {}", "abc");
+        logger.fatal("{}: test3: {} {}", "a", "b", "c", new NullPointerException("BANG!"));
+
+        var lines = testLog.buffer.toString().split(System.lineSeparator());
+        assertThat(lines).hasSizeGreaterThan(5);
+        assertThat(lines[0]).startsWith("SEVERE test1");
+        assertThat(lines[1]).startsWith("WARNING test2: abc");
+        assertThat(lines[2]).startsWith("SEVERE [FATAL] a: test3: b c");
+        assertThat(lines[3]).startsWith("java.lang.NullPointerException: BANG!");
+        assertThat(lines[4]).contains(
+            "at software.amazon.smithy.java.logging.JdkSystemLoggerTest.smokeTest(JdkSystemLoggerTest.java:"
+        );
+    }
+
+    @Test
+    void levelTest() {
+        InternalLogger logger = InternalLogger.getLogger(JdkSystemLoggerTest.class);
+        testLog.warnEnabled = false;
+        logger.error("test1");
+        logger.warn("test2: {}", "abc");
+        logger.fatal("{}: test3: {} {}", "a", "b", "c", new NullPointerException("BANG!"));
+
+        var lines = testLog.buffer.toString().split(System.lineSeparator());
+        assertThat(lines).hasSizeGreaterThan(4);
+        assertThat(lines[0]).startsWith("SEVERE test1");
+        assertThat(lines[1]).startsWith("SEVERE [FATAL] a: test3: b c");
+        assertThat(lines[2]).startsWith("java.lang.NullPointerException: BANG!");
+        assertThat(lines[3]).contains(
+            "at software.amazon.smithy.java.logging.JdkSystemLoggerTest.levelTest(JdkSystemLoggerTest.java:"
+        );
+    }
+
+    @Test
+    void dynamicLevelTest() {
+        InternalLogger logger = InternalLogger.getLogger(JdkSystemLoggerTest.class);
+        testLog.warnEnabled = false;
+        logger.log(InternalLogger.Level.ERROR, "test1");
+        logger.log(InternalLogger.Level.WARN, "test2: {}", "abc");
+        logger.log(
+            InternalLogger.Level.FATAL,
+            "{}: test3: {} {}",
+            "a",
+            "b",
+            "c",
+            new NullPointerException("BANG!")
+        );
+
+        var lines = testLog.buffer.toString().split(System.lineSeparator());
+        assertThat(lines).hasSizeGreaterThan(4);
+        assertThat(lines[0]).startsWith("SEVERE test1");
+        assertThat(lines[1]).startsWith("SEVERE [FATAL] a: test3: b c");
+        assertThat(lines[2]).startsWith("java.lang.NullPointerException: BANG!");
+        assertThat(lines[3]).contains(
+            "at software.amazon.smithy.java.logging.JdkSystemLoggerTest.dynamicLevelTest(JdkSystemLoggerTest.java:"
+        );
+    }
+
+
+    private static final class TestLogger extends java.util.logging.Logger {
+        final StringWriter buffer = new StringWriter();
+        final PrintWriter writer = new PrintWriter(buffer);
+
+        boolean warnEnabled = true;
+
+        TestLogger(String name) {
+            super(name, null);
+        }
+
+        @Override
+        public void log(Level level, String msg) {
+            if (level == java.util.logging.Level.WARNING && !warnEnabled) {
+                throw new IllegalStateException();
+            }
+            writer.write(level + " ");
+            writer.write(msg);
+            writer.write(System.lineSeparator());
+        }
+
+        @Override
+        public void log(Level level, String msg, Throwable thrown) {
+            if (level == java.util.logging.Level.WARNING && !warnEnabled) {
+                throw new IllegalStateException();
+            }
+            writer.write(level + " ");
+            writer.write(msg);
+            writer.write(System.lineSeparator());
+            if (thrown != null) {
+                thrown.printStackTrace(writer);
+            }
+        }
+
+        @Override
+        public boolean isLoggable(Level level) {
+            return level != java.util.logging.Level.WARNING || warnEnabled;
+        }
+    }
+
+}

--- a/logging/src/test/java/software/amazon/smithy/java/logging/Log4j2LoggerIsolatedTest.java
+++ b/logging/src/test/java/software/amazon/smithy/java/logging/Log4j2LoggerIsolatedTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.WriterAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class Log4j2LoggerIsolatedTest {
+
+    private static final StringWriter WRITER = new StringWriter();
+    private static WriterAppender APPENDER;
+
+    @BeforeAll
+    public static void setupLoggers() {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration cfg = ctx.getConfiguration();
+        cfg.getLoggerConfig("").setLevel(org.apache.logging.log4j.Level.TRACE);
+        APPENDER = WriterAppender.newBuilder()
+            .setTarget(WRITER)
+            .setName("Log4j2LoggerTestAppender")
+            .setLayout(PatternLayout.newBuilder().withPattern("%level %m%n").build())
+            .build();
+        cfg.addAppender(APPENDER);
+
+        cfg.start();
+
+        ctx.getRootLogger()
+            .removeAppender(
+                ctx.getRootLogger().getAppenders().values().stream().findAny().get()
+            );
+        ctx.getRootLogger().addAppender(APPENDER);
+
+        ctx.updateLoggers();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        WRITER.getBuffer().setLength(0);
+    }
+
+    @Test
+    void smokeTest() {
+        InternalLogger logger = InternalLogger.getLogger(Log4j2LoggerIsolatedTest.class);
+        logger.error("test1");
+        logger.warn("test2: {}", "abc");
+        logger.fatal("{}: test3: {} {}", "a", "b", "c", new NullPointerException("BANG!"));
+
+        var lines = WRITER.toString().split(System.lineSeparator());
+        assertThat(lines).hasSizeGreaterThan(5);
+        assertThat(lines[0]).startsWith("ERROR test1");
+        assertThat(lines[1]).startsWith("WARN test2: abc");
+        assertThat(lines[2]).startsWith("FATAL a: test3: b c");
+        assertThat(lines[3]).startsWith("java.lang.NullPointerException: BANG!");
+        assertThat(lines[4]).contains(
+            "at software.amazon.smithy.java.logging.Log4j2LoggerIsolatedTest.smokeTest(Log4j2LoggerIsolatedTest.java:"
+        );
+    }
+
+    @Test
+    void dynamicLevelSmokeTest() {
+        InternalLogger logger = InternalLogger.getLogger(Log4j2LoggerIsolatedTest.class);
+        logger.log(InternalLogger.Level.ERROR, "test1");
+        logger.log(InternalLogger.Level.WARN, "test2: {}", "abc");
+        logger.log(
+            InternalLogger.Level.FATAL,
+            "{}: test3: {} {}",
+            "a",
+            "b",
+            "c",
+            new NullPointerException("BANG!")
+        );
+
+        var lines = WRITER.toString().split(System.lineSeparator());
+        assertThat(lines).hasSizeGreaterThan(5);
+        assertThat(lines[0]).startsWith("ERROR test1");
+        assertThat(lines[1]).startsWith("WARN test2: abc");
+        assertThat(lines[2]).startsWith("FATAL a: test3: b c");
+        assertThat(lines[3]).startsWith("java.lang.NullPointerException: BANG!");
+        assertThat(lines[4]).contains(
+            "at software.amazon.smithy.java.logging.Log4j2LoggerIsolatedTest.dynamicLevelSmokeTest(Log4j2LoggerIsolatedTest.java:"
+        );
+    }
+}

--- a/logging/src/test/java/software/amazon/smithy/java/logging/Slf4jLoggerIsolatedTest.java
+++ b/logging/src/test/java/software/amazon/smithy/java/logging/Slf4jLoggerIsolatedTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+public class Slf4jLoggerIsolatedTest {
+
+    private static final ListAppender<ILoggingEvent> LIST_APPENDER = new ListAppender<>();
+
+    @BeforeAll
+    public static void setupLoggers() {
+        Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        logger.addAppender(LIST_APPENDER);
+        LIST_APPENDER.start();
+    }
+
+    @AfterEach
+    public void clean() {
+        LIST_APPENDER.list.clear();
+    }
+
+    @Test
+    void smokeTest() {
+        InternalLogger logger = InternalLogger.getLogger(Slf4jLoggerIsolatedTest.class);
+
+        logger.error("test1");
+        logger.warn("test2: {}", "abc");
+        logger.fatal("{}: test3: {} {}", "a", "b", "c", new NullPointerException("BANG!"));
+
+        assertEquals(ch.qos.logback.classic.Level.ERROR, LIST_APPENDER.list.get(0).getLevel());
+        assertEquals("test1", LIST_APPENDER.list.get(0).getFormattedMessage());
+        assertEquals(Slf4jLoggerIsolatedTest.class.getName(), LIST_APPENDER.list.get(0).getLoggerName());
+
+        assertEquals(ch.qos.logback.classic.Level.WARN, LIST_APPENDER.list.get(1).getLevel());
+        assertEquals("test2: abc", LIST_APPENDER.list.get(1).getFormattedMessage());
+
+        assertEquals(ch.qos.logback.classic.Level.ERROR, LIST_APPENDER.list.get(2).getLevel());
+        assertEquals("a: test3: b c", LIST_APPENDER.list.get(2).getFormattedMessage());
+        assertEquals(
+            NullPointerException.class.getName(),
+            LIST_APPENDER.list.get(2).getThrowableProxy().getClassName()
+        );
+        assertEquals("BANG!", LIST_APPENDER.list.get(2).getThrowableProxy().getMessage());
+        assertEquals("FATAL", LIST_APPENDER.list.get(2).getMarkerList().get(0).getName());
+    }
+
+    @Test
+    void dynamicLevelSmokeTest() {
+        InternalLogger logger = InternalLogger.getLogger(Slf4jLoggerIsolatedTest.class);
+        logger.log(InternalLogger.Level.ERROR, "test1");
+        logger.log(InternalLogger.Level.WARN, "test2: {}", "abc");
+        logger.log(
+            InternalLogger.Level.FATAL,
+            "{}: test3: {} {}",
+            "a",
+            "b",
+            "c",
+            new NullPointerException("BANG!")
+        );
+
+        assertEquals(ch.qos.logback.classic.Level.ERROR, LIST_APPENDER.list.get(0).getLevel());
+        assertEquals("test1", LIST_APPENDER.list.get(0).getFormattedMessage());
+        assertEquals(Slf4jLoggerIsolatedTest.class.getName(), LIST_APPENDER.list.get(0).getLoggerName());
+
+        assertEquals(ch.qos.logback.classic.Level.WARN, LIST_APPENDER.list.get(1).getLevel());
+        assertEquals("test2: abc", LIST_APPENDER.list.get(1).getFormattedMessage());
+
+        assertEquals(ch.qos.logback.classic.Level.ERROR, LIST_APPENDER.list.get(2).getLevel());
+        assertEquals("a: test3: b c", LIST_APPENDER.list.get(2).getFormattedMessage());
+        assertEquals(
+            NullPointerException.class.getName(),
+            LIST_APPENDER.list.get(2).getThrowableProxy().getClassName()
+        );
+        assertEquals("BANG!", LIST_APPENDER.list.get(2).getThrowableProxy().getMessage());
+        assertEquals("FATAL", LIST_APPENDER.list.get(2).getMarkerList().get(0).getName());
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,5 +30,4 @@ include(":client-aws-rest-json1")
 // Examples
 include(":examples:restjson-example")
 include("server-core")
-
-
+include("logging")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding an internal logger which tries to bind to to Log4j2, Slf4j, JCL and the JDK system logger in that order. The Internal Logger interface is based on the Log4J2 Logger interface sans the Lazy Lambda logger methods. This allows us to have a logger that is functional and performant without taking a dependency on any logging library. The parameter format is that for Log4j2, i.e `{}`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
