### PR TITLE
Adopt minor optimizations to JSON serializer

### DIFF
--- a/examples/restjson-example/src/jmh/java/software/amazon/smithy/java/runtime/SerdeBenchmarks.java
+++ b/examples/restjson-example/src/jmh/java/software/amazon/smithy/java/runtime/SerdeBenchmarks.java
@@ -51,6 +51,14 @@ public class SerdeBenchmarks {
     }
 
     @Benchmark
+    public void documentToJson(Blackhole bh) throws IOException {
+        try (var sink = new ByteArrayOutputStream(); var serializer = codec.createSerializer(sink)) {
+            inputAsDocument.serialize(serializer);
+            bh.consume(sink.size());
+        }
+    }
+
+    @Benchmark
     public void jsonToShape(Blackhole bh) {
         String json = "{\"name\":\"Michael\",\"Age\":999,\"birthday\":1709591329,"
             + "\"favoriteColor\":\"Green\",\"binary\":\"SGVsbG8=\"}";


### PR DESCRIPTION
1. Let Jackson base64 encode blobs
2. Jackson handles adding commas between list values, so remove use of ListSerializer.
3. Move common cases of finite double and float before NaN and +-Inf
4. Make a dedicated and reusable class for serializing contents of a document.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
