### PR TITLE
Add extension to create codegen task

### DIFF
--- a/buildSrc/src/main/kotlin/CodegenExtension.kt
+++ b/buildSrc/src/main/kotlin/CodegenExtension.kt
@@ -1,0 +1,20 @@
+import gradle.kotlin.dsl.accessors._6a08c79e5efb9941460fb21bc6022abc.sourceSets
+import org.gradle.api.Project
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.*
+
+/**
+ * Creates a task to execute building of Java classes using an executable class.
+ * Generated classes can then be used by integration tests and benchmarks
+ */
+fun Project.addGenerateSrcsTask(className: String): TaskProvider<JavaExec> {
+    val generatedSrcDir = layout.buildDirectory.dir("generated-src").get()
+    return tasks.register<JavaExec>("generateSources") {
+        delete(files(generatedSrcDir))
+        dependsOn("test")
+        classpath = sourceSets["test"].runtimeClasspath + sourceSets["test"].output + sourceSets["it"].resources.sourceDirectories
+        mainClass = className
+        environment("output", generatedSrcDir)
+    }
+}

--- a/codegen/client/build.gradle.kts
+++ b/codegen/client/build.gradle.kts
@@ -14,27 +14,13 @@ dependencies {
     testImplementation(libs.smithy.aws.traits)
 }
 
-// Execute building of Java classes using an executable class
-// These classes will then be used by integration tests and benchmarks
-val generatedSrcDir = layout.buildDirectory.dir("generated-src").get()
-val generateSrcTask = tasks.register<JavaExec>("generateSources") {
-    delete(files(generatedSrcDir))
-    dependsOn("test")
-    classpath = sourceSets["test"].runtimeClasspath + sourceSets["test"].output + sourceSets["it"].resources.sourceDirectories
-    mainClass = "software.amazon.smithy.java.codegen.client.TestServerJavaClientCodegenRunner"
-    environment("service", "smithy.java.codegen.server.test#TestService")
-    environment("namespace", "smithy.java.codegen.server.test")
-    environment("output", generatedSrcDir)
-}
-
 tasks {
+    val generateSrcTask = addGenerateSrcsTask("software.amazon.smithy.java.codegen.client.TestServerJavaClientCodegenRunner")
+
     integ {
         dependsOn(generateSrcTask)
     }
     compileItJava {
         dependsOn(generateSrcTask)
-    }
-    spotbugsIt {
-        enabled = false
     }
 }

--- a/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestServerJavaClientCodegenRunner.java
+++ b/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestServerJavaClientCodegenRunner.java
@@ -31,8 +31,8 @@ public final class TestServerJavaClientCodegenRunner {
             .fileManifest(FileManifest.create(Paths.get(System.getenv("output"))))
             .settings(
                 ObjectNode.builder()
-                    .withMember("service", System.getenv("service"))
-                    .withMember("namespace", System.getenv("namespace"))
+                    .withMember("service", "smithy.java.codegen.server.test#TestService")
+                    .withMember("namespace", "smithy.java.codegen.server.test")
                     .build()
             )
             .model(model)

--- a/codegen/core/build.gradle.kts
+++ b/codegen/core/build.gradle.kts
@@ -11,27 +11,16 @@ dependencies {
     itImplementation(project(":json-codec"))
 }
 
-// Execute building of Java classes using an executable class
-// These classes will then be used by integration tests and benchmarks
-val generatedSrcDir = layout.buildDirectory.dir("generated-src").get()
-tasks.register<JavaExec>("generateSources") {
-    delete(generatedSrcDir)
-    dependsOn("test")
-    classpath = sourceSets["test"].runtimeClasspath + sourceSets["test"].output + sourceSets["it"].resources.sourceDirectories
-    mainClass = "software.amazon.smithy.java.codegen.utils.TestJavaCodegenRunner"
-    environment("service", "smithy.java.codegen.test#TestService")
-    environment("namespace", "software.amazon.smithy.java.codegen.test")
-    environment("output", generatedSrcDir)
-}
-
 tasks {
-    test {
-        finalizedBy("integ")
-    }
+    val generateSrcs = addGenerateSrcsTask("software.amazon.smithy.java.codegen.utils.TestJavaCodegenRunner")
+
     integ {
-        dependsOn("generateSources")
+        dependsOn(generateSrcs)
     }
     compileItJava {
-        dependsOn("generateSources")
+        dependsOn(generateSrcs)
+    }
+    test {
+        finalizedBy(integ)
     }
 }

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenRunner.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenRunner.java
@@ -30,8 +30,8 @@ public final class TestJavaCodegenRunner {
             .fileManifest(FileManifest.create(Paths.get(System.getenv("output"))))
             .settings(
                 ObjectNode.builder()
-                    .withMember("service", System.getenv("service"))
-                    .withMember("namespace", System.getenv("namespace"))
+                    .withMember("service", "smithy.java.codegen.test#TestService")
+                    .withMember("namespace", "software.amazon.smithy.java.codegen.test")
                     .build()
             )
             .model(model)

--- a/codegen/server/build.gradle.kts
+++ b/codegen/server/build.gradle.kts
@@ -11,27 +11,16 @@ dependencies {
     implementation(project(":server-core"))
 }
 
-// Execute building of Java classes using an executable class
-// These classes will then be used by integration tests and benchmarks
-val generatedSrcDir = layout.buildDirectory.dir("generated-src").get()
-val generateSrcTask = tasks.register<JavaExec>("generateSources") {
-    delete(generatedSrcDir)
-    dependsOn("test")
-    classpath = sourceSets["test"].runtimeClasspath + sourceSets["test"].output + sourceSets["it"].resources.sourceDirectories
-    mainClass = "software.amazon.smithy.java.codegen.server.TestServerJavaCodegenRunner"
-    environment("service", "smithy.java.codegen.server.test#TestService")
-    environment("namespace", "smithy.java.codegen.server.test")
-    environment("output", generatedSrcDir)
-}
-
 tasks {
-    test {
-        finalizedBy("integ")
-    }
+    val generateSrcTask = addGenerateSrcsTask("software.amazon.smithy.java.codegen.server.TestServerJavaCodegenRunner")
+
     integ {
         dependsOn(generateSrcTask)
     }
     compileItJava {
         dependsOn(generateSrcTask)
+    }
+    test {
+        finalizedBy(integ)
     }
 }

--- a/codegen/server/src/test/java/software/amazon/smithy/java/codegen/server/TestServerJavaCodegenRunner.java
+++ b/codegen/server/src/test/java/software/amazon/smithy/java/codegen/server/TestServerJavaCodegenRunner.java
@@ -30,8 +30,8 @@ public final class TestServerJavaCodegenRunner {
             .fileManifest(FileManifest.create(Paths.get(System.getenv("output"))))
             .settings(
                 ObjectNode.builder()
-                    .withMember("service", System.getenv("service"))
-                    .withMember("namespace", System.getenv("namespace"))
+                    .withMember("service", "smithy.java.codegen.server.test#TestService")
+                    .withMember("namespace", "smithy.java.codegen.server.test")
                     .build()
             )
             .model(model)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ jackson = "2.17.1"
 smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy" }
 smithy-codegen = { module = "software.amazon.smithy:smithy-codegen-core", version.ref = "smithy" }
 smithy-aws-traits = { module = "software.amazon.smithy:smithy-aws-traits", version.ref = "smithy" }
+smithy-protocol-traits = { module = "software.amazon.smithy:smithy-protocol-traits", version.ref = "smithy" }
+smithy-aws-protocol-tests = { module = "software.amazon.smithy:smithy-aws-protocol-tests", version.ref = "smithy" }
 
 jackson-core = {module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson"}
 jackson-databind = {module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson"}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,9 @@ include(":codegen:client")
 include(":codegen:server")
 include(":codegen:types")
 
+// Protocol tests
+include(":protocol-tests:client")
+
 include("tracing-api")
 
 include(":http-api")


### PR DESCRIPTION
### Description of changes
Trim down on the amount of code in gradle build scripts associated with creating a codegen task by adding an extension. 
This will help limit the duplication across scripts as we add more codegen tasks for protocol tests. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
