### PR TITLE
Use an object node for transport settings

### DIFF
--- a/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestServerJavaClientCodegenRunner.java
+++ b/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestServerJavaClientCodegenRunner.java
@@ -33,7 +33,12 @@ public final class TestServerJavaClientCodegenRunner {
                 ObjectNode.builder()
                     .withMember("service", "smithy.java.codegen.server.test#TestService")
                     .withMember("namespace", "smithy.java.codegen.server.test")
-                    .withMember("transport", "http-java")
+                    .withMember(
+                        "transport",
+                        ObjectNode.builder()
+                            .withMember("http-java", ObjectNode.builder().build())
+                            .build()
+                    )
                     .build()
             )
             .model(model)

--- a/examples/restjson-example/smithy-build.json
+++ b/examples/restjson-example/smithy-build.json
@@ -6,7 +6,9 @@
       "namespace": "software.amazon.smithy.java.runtime.example",
       "headerFile": "license.txt",
       "protocol": "aws.protocols#restJson1",
-      "transport": "http-java"
+      "transport": {
+        "http-java": {}
+      }
     },
     "java-server-codegen": {
       "service": "smithy.example#PersonDirectory",


### PR DESCRIPTION
### Description of changes
Updates the transport default configuration to take in an object node so we can optionally add transport settings in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
