### PR TITLE
Update union codegen to avoid repeating logic

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -83,7 +83,7 @@ public final class UnionGenerator
                         if (other == null || getClass() != other.getClass()) {
                             return false;
                         }
-                        return getValue().equals(((${shape:T}) other).getValue());
+                        return ${objects:T}.equals(getValue(), ((${shape:T}) other).getValue());
                     }
 
                     ${builder:C|}


### PR DESCRIPTION
### Description of changes
Updates union codegen to reduce duplicate logic in each variant. In particular: 
- Makes equals and hashcode implementations common on base abstract class
- Simplifies builder setters. 

For the test `UnionType` union this decreased line count from `1209` to `861` (-`348`)

[generated code](https://github.com/smithy-lang/smithy-java/pull/254)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
