### PR TITLE
Use internal logger instead of java system logger

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.codegen-plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.codegen-plugin-conventions.gradle.kts
@@ -13,6 +13,7 @@ group = "software.amazon.smithy.java.codegen"
 dependencies {
     implementation(libs.smithy.codegen)
     implementation(project(":core"))
+    implementation(project(":logging"))
 
     // Avoid circular dependency in codegen core
     if (project.name != "core") {

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.client.ClientSymbolProperties;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.auth.api.scheme.AuthScheme;
 import software.amazon.smithy.java.runtime.client.core.Client;
 import software.amazon.smithy.java.runtime.client.core.ClientProtocolFactory;
@@ -43,7 +44,7 @@ import software.amazon.smithy.utils.StringUtils;
 public final class ClientInterfaceGenerator
     implements Consumer<GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings>> {
 
-    private static final System.Logger LOGGER = System.getLogger(ClientInterfaceGenerator.class.getName());
+    private static final InternalLogger LOGGER = InternalLogger.getLogger(ClientInterfaceGenerator.class);
 
     @Override
     public void accept(GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
@@ -242,7 +243,7 @@ public final class ClientInterfaceGenerator
                     );
                 }
             } else {
-                LOGGER.log(System.Logger.Level.WARNING, "Could not find implementation for auth scheme " + scheme);
+                LOGGER.warn("Could not find implementation for auth scheme {}", scheme);
             }
         }
         return result.values();

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Objects;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -22,7 +23,7 @@ import software.amazon.smithy.utils.StringUtils;
  */
 @SmithyUnstableApi
 public final class JavaCodegenSettings {
-    private static final System.Logger LOGGER = System.getLogger(JavaCodegenSettings.class.getName());
+    private static final InternalLogger LOGGER = InternalLogger.getLogger(JavaCodegenSettings.class);
 
     private static final String SERVICE = "service";
     private static final String NAMESPACE = "namespace";
@@ -147,7 +148,7 @@ public final class JavaCodegenSettings {
         if (!file.exists()) {
             throw new CodegenException("Header file " + file.getAbsolutePath() + " does not exist.");
         }
-        LOGGER.log(System.Logger.Level.TRACE, () -> "Reading header file: " + file.getAbsolutePath());
+        LOGGER.trace("Reading header file: {}" + file.getAbsolutePath());
         return IoUtils.readUtf8File(file.getAbsolutePath());
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.core.schema.Unit;
 import software.amazon.smithy.java.runtime.core.serde.DataStream;
 import software.amazon.smithy.java.runtime.core.serde.document.Document;
@@ -60,7 +61,7 @@ import software.amazon.smithy.utils.CaseUtils;
  */
 public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider {
 
-    private static final System.Logger LOGGER = System.getLogger(JavaSymbolProvider.class.getName());
+    private static final InternalLogger LOGGER = InternalLogger.getLogger(JavaSymbolProvider.class);
     private static final Symbol UNIT_SYMBOL = CodegenUtils.fromClass(Unit.class);
 
     private final Model model;
@@ -76,7 +77,7 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
     @Override
     public Symbol toSymbol(Shape shape) {
         Symbol symbol = shape.accept(this);
-        LOGGER.log(System.Logger.Level.TRACE, () -> "Creating symbol from " + shape + ": " + symbol);
+        LOGGER.trace("Creating symbol from {}: {}", shape, symbol);
         return symbol;
     }
 


### PR DESCRIPTION
### Description of changes
Small update to use the new internal logger for all codegen logging.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
