### PR TITLE
Add factory method for auth option with no overrides

### DIFF
--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/scheme/AuthSchemeOption.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/scheme/AuthSchemeOption.java
@@ -42,7 +42,7 @@ public record AuthSchemeOption(
      * @param schemeId id of auth scheme to create an option for.
      * @return AuthSchemeOption instance with no identity or signer property overrides.
      */
-    public static AuthSchemeOption forId(String schemeId) {
-        return new AuthSchemeOption(schemeId, AuthProperties.empty(), AuthProperties.empty());
+    public AuthSchemeOption(String schemeId) {
+        this(schemeId, AuthProperties.empty(), AuthProperties.empty());
     }
 }

--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/scheme/AuthSchemeResolver.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/scheme/AuthSchemeResolver.java
@@ -29,7 +29,7 @@ public interface AuthSchemeResolver {
      *
      * <p>This resolver can be used to bypass auth logic when testing clients.
      */
-    AuthSchemeResolver NO_AUTH = (param) -> List.of(AuthSchemeOption.forId(NoAuthAuthScheme.INSTANCE.schemeId()));
+    AuthSchemeResolver NO_AUTH = (param) -> List.of(new AuthSchemeOption(NoAuthAuthScheme.INSTANCE.schemeId()));
 
     /**
      * Resolve the auth scheme options using the given parameters.
@@ -60,7 +60,7 @@ public interface AuthSchemeResolver {
         public List<AuthSchemeOption> resolveAuthScheme(AuthSchemeResolverParams params) {
             var result = new ArrayList<AuthSchemeOption>();
             for (var schemeId : params.operationAuthSchemes()) {
-                result.add(AuthSchemeOption.forId(schemeId));
+                result.add(new AuthSchemeOption(schemeId));
             }
             return result;
         }

--- a/codegen/client/src/it/java/software/amazon/smithy/java/codegen/client/AuthSchemeTest.java
+++ b/codegen/client/src/it/java/software/amazon/smithy/java/codegen/client/AuthSchemeTest.java
@@ -32,7 +32,7 @@ public class AuthSchemeTest {
         };
         var client = TestServiceClient.builder()
             .protocol(new RestJsonClientProtocol())
-            .authSchemeResolver(params -> List.of(AuthSchemeOption.forId(TestAuthScheme.ID)))
+            .authSchemeResolver(params -> List.of(new AuthSchemeOption(TestAuthScheme.ID)))
             .endpoint("https://httpbin.org")
             .addInterceptor(interceptor)
             .value(2L)


### PR DESCRIPTION
### Description of changes
Adds a static factory method to create an auth scheme option with no property overrides from a scheme Id. 
Most instances of auth scheme options will have no overrides, so this just cuts down a bit on repeating the full constructor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
