### PR TITLE
Fix incorrect javadocs

### DIFF
--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/scheme/AuthSchemeOption.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/scheme/AuthSchemeOption.java
@@ -40,7 +40,6 @@ public record AuthSchemeOption(
      * identity or signer property overrides.
      *
      * @param schemeId id of auth scheme to create an option for.
-     * @return AuthSchemeOption instance with no identity or signer property overrides.
      */
     public AuthSchemeOption(String schemeId) {
         this(schemeId, AuthProperties.empty(), AuthProperties.empty());


### PR DESCRIPTION
### Description of changes
A javadoc issue is causing failures in the CI action (see: https://github.com/smithy-lang/smithy-java/actions/runs/10496026021 ). This PR removes the problematic tag.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
