### PR TITLE
Ensure intellij plugin correctly picks up smithy sources in examples

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.codegen-test-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.codegen-test-conventions.gradle.kts
@@ -24,3 +24,12 @@ afterEvaluate {
 tasks.named("compileJava") {
     dependsOn("smithyBuild")
 }
+
+// Helps Intellij plugin identify models
+sourceSets {
+    main {
+        java {
+            srcDir("model")
+        }
+    }
+}


### PR DESCRIPTION
### Description of changes
The intellij plugin currently does not correctly detect smithy sources that arent added to the main source set. Ensures the smithy models used for examples are correctly detected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
