### PR TITLE
Add expect method to auth properties to reduce null checking in signers

### DIFF
--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/AuthProperties.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/AuthProperties.java
@@ -52,6 +52,22 @@ public final class AuthProperties {
     }
 
     /**
+     * Get the value of a property.
+     *
+     * @param property Property to get.
+     * @return the value of the property.
+     * @throws ExpectationNotMetException if the property is not found.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T expect(AuthProperty<T> property) {
+        var value = properties.get(property);
+        if (value == null) {
+            throw new ExpectationNotMetException("Could not find expected property: " + property);
+        }
+        return (T) value;
+    }
+
+    /**
      * Get the properties that are set on the AuthProperties object.
      *
      * @return the properties.

--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/ExpectationNotMetException.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/ExpectationNotMetException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.auth.api;
+
+
+/**
+ * Thrown by {@link AuthProperties} methods that expect a property to exist.
+ */
+public class ExpectationNotMetException extends RuntimeException {
+    public ExpectationNotMetException(String message) {
+        super(message);
+    }
+}

--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/scheme/NoAuthAuthScheme.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/scheme/NoAuthAuthScheme.java
@@ -18,7 +18,7 @@ import software.amazon.smithy.java.runtime.auth.api.identity.IdentityResolvers;
  */
 final class NoAuthAuthScheme implements AuthScheme<Object, Identity> {
 
-    public static NoAuthAuthScheme INSTANCE = new NoAuthAuthScheme();
+    public static final NoAuthAuthScheme INSTANCE = new NoAuthAuthScheme();
     private static final IdentityResolver<Identity> NULL_IDENTITY_RESOLVER = new NullIdentityResolver();
 
     private NoAuthAuthScheme() {}


### PR DESCRIPTION
### Description of changes
Signers often require that an Auth property is present to perform signing. For example, SigV4 requires that a region property be present. This PR adds a convenience method to `expect` a property. This will reduce the number of null checks in signer implementations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
