### PR TITLE
Add size hints to documents and deser

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -56,7 +56,8 @@ public final class ListGenerator
                         }
 
                         static ${shape:T} deserialize${name:U}(${schema:T} schema, ${shapeDeserializer:T} deserializer) {
-                            ${shape:T} result = new ${collectionImpl:T}<>();
+                            var size = deserializer.containerSize();
+                            ${shape:T} result = size == -1 ? new ${collectionImpl:T}<>() : new ${collectionImpl:T}<>(size);
                             deserializer.readList(schema, result, ${name:U}MemberDeserializer.INSTANCE);
                             return result;
                         }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
@@ -75,7 +75,8 @@ public class MapGenerator
                         }
 
                         static ${shape:T} deserialize${name:U}(${schema:T} schema, ${shapeDeserializer:T} deserializer) {
-                            ${shape:T} result = new ${collectionImpl:T}<>();
+                            var size = deserializer.containerSize();
+                            ${shape:T} result = size == -1 ? new ${collectionImpl:T}<>() : new ${collectionImpl:T}<>(size);
                             deserializer.readStringMap(schema, result, ${name:U}ValueDeserializer.INSTANCE);
                             return result;
                         }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeDeserializer.java
@@ -143,6 +143,18 @@ public interface ShapeDeserializer extends AutoCloseable {
     <T> void readList(Schema schema, T state, ListMemberConsumer<T> consumer);
 
     /**
+     * If the value about to be read is a list or map, returns the number of entries it contains.
+     *
+     * <p>This method returns -1 if the size of the container is unknown or if the next value is not a list or
+     * container.
+     *
+     * @return the number of entries in the next list or map to read, or -1 when unknown.
+     */
+    default int containerSize() {
+        return -1;
+    }
+
+    /**
      * Attempt to read a map value.
      *
      * @param schema   Schema of the shape.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Document.java
@@ -303,6 +303,15 @@ public interface Document extends SerializableShape {
     }
 
     /**
+     * Get the number of elements in an array document, or the number of key value pairs in a map document.
+     *
+     * @return the number of elements. Defaults to -1 for all other documents.
+     */
+    default int size() {
+        return -1;
+    }
+
+    /**
      * Get the list contents of the Document if it is a list.
      *
      * @return the list contents.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentDeserializer.java
@@ -158,6 +158,11 @@ public class DocumentDeserializer implements ShapeDeserializer {
     }
 
     @Override
+    public int containerSize() {
+        return value.size();
+    }
+
+    @Override
     public <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> mapMemberConsumer) {
         var map = value.asStringMap();
         for (var entry : map.entrySet()) {

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -598,6 +598,11 @@ final class Documents {
         }
 
         @Override
+        public int size() {
+            return values.size();
+        }
+
+        @Override
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeList(schema, values, (values, ser) -> {
                 for (var element : values) {
@@ -616,6 +621,11 @@ final class Documents {
         @Override
         public Map<String, Document> asStringMap() {
             return members;
+        }
+
+        @Override
+        public int size() {
+            return members.size();
         }
 
         @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/DocumentTest.java
@@ -575,4 +575,11 @@ public class DocumentTest {
 
         assertThat(document.discriminator(), equalTo(Person.ID));
     }
+
+    @Test
+    public void documentsDefaultToSizeNegativeOne() {
+        var document = Document.createInteger(1);
+
+        assertThat(document.size(), is(-1));
+    }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
@@ -28,6 +28,7 @@ public class ListDocumentTest {
         var document = Document.createList(values);
 
         assertThat(document.type(), equalTo(ShapeType.LIST));
+        assertThat(document.size(), is(2));
         assertThat(document.asList(), equalTo(values));
         assertThat(document, equalTo(Document.createList(values)));
     }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
@@ -34,6 +34,7 @@ public class MapDocumentTest {
         var map = Document.createStringMap(entries);
 
         assertThat(map.type(), is(ShapeType.MAP));
+        assertThat(map.size(), is(2));
         assertThat(map.asStringMap(), equalTo(entries));
         assertThat(Document.createStringMap(map.asStringMap()), equalTo(map));
     }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderListDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderListDeserializer.java
@@ -33,4 +33,9 @@ final class HttpHeaderListDeserializer extends SpecificShapeDeserializer {
     public boolean isNull() {
         return values == null;
     }
+
+    @Override
+    public int containerSize() {
+        return values == null ? 0 : values.size();
+    }
 }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsDeserializer.java
@@ -29,4 +29,9 @@ final class HttpQueryParamsDeserializer extends SpecificShapeDeserializer {
             consumer.accept(state, e.getKey(), new HttpQueryStringDeserializer(e.getValue()));
         }
     }
+
+    @Override
+    public int containerSize() {
+        return queryParams.size();
+    }
 }

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryStringDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryStringDeserializer.java
@@ -29,4 +29,9 @@ final class HttpQueryStringDeserializer extends BasicStringValueDeserializer {
             consumer.accept(state, new HttpQueryStringDeserializer(List.of(value)));
         }
     }
+
+    @Override
+    public int containerSize() {
+        return values.size();
+    }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonDocument.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonDocument.java
@@ -193,6 +193,14 @@ final class JacksonDocument implements Document {
     }
 
     @Override
+    public int size() {
+        return switch (root.getNodeType()) {
+            case ARRAY, OBJECT -> root.size();
+            default -> -1;
+        };
+    }
+
+    @Override
     public Map<String, Document> asStringMap() {
         if (!root.isObject()) {
             return Document.super.asStringMap();

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDocumentTest.java
@@ -136,6 +136,7 @@ public class JsonDocumentTest {
 
         var document = de.readDocument();
         assertThat(document.type(), is(ShapeType.LIST));
+        assertThat(document.size(), is(3));
 
         var list = document.asList();
         assertThat(list, hasSize(3));
@@ -152,6 +153,7 @@ public class JsonDocumentTest {
 
         var document = de.readDocument();
         assertThat(document.type(), is(ShapeType.MAP));
+        assertThat(document.size(), is(2));
 
         var map = document.asStringMap();
         assertThat(map.keySet(), hasSize(2));
@@ -162,6 +164,15 @@ public class JsonDocumentTest {
         assertThat(map.get("b").type(), is(ShapeType.BOOLEAN));
         assertThat(map.get("b").asBoolean(), is(true));
         assertThat(document.getMember("b").type(), is(ShapeType.BOOLEAN));
+    }
+
+    @Test
+    public void otherDocumentsReturnSizeOfNegativeOne() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("1".getBytes(StandardCharsets.UTF_8));
+        var document = de.readDocument();
+
+        assertThat(document.size(), is(-1));
     }
 
     @Test


### PR DESCRIPTION
Documents and ShapeDeserializers can now provide the size of a container. This information can be used to create exact-sized collections to deserialize values into, avoiding over or under allocating for protocols that know the size of data to be read. For documents, it's the size of a list/map or -1 if not a list/map. For ShapeDeserializer, it's the size of a list/map about to be read, or -1 if unknown or not a list/map.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
