### PR TITLE
Add size hint to list/map ShapeSerializer

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
@@ -90,7 +90,7 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
     @Override
     public Void listShape(ListShape listShape) {
         writer.write(
-            "serializer.writeList(${schema:L}, ${state:L}, SharedSerde.$USerializer.INSTANCE)",
+            "serializer.writeList(${schema:L}, ${state:L}, ${state:L}.size(), SharedSerde.$USerializer.INSTANCE)",
             CodegenUtils.getDefaultName(listShape, service)
         );
         return null;
@@ -99,7 +99,7 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
     @Override
     public Void mapShape(MapShape mapShape) {
         writer.write(
-            "serializer.writeMap(${schema:L}, ${state:L}, SharedSerde.$USerializer.INSTANCE)",
+            "serializer.writeMap(${schema:L}, ${state:L}, ${state:L}.size(), SharedSerde.$USerializer.INSTANCE)",
             CodegenUtils.getDefaultName(mapShape, service)
         );
         return null;

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfStruct.java
@@ -144,18 +144,18 @@ final class ValidatorOfStruct implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(Schema member, T state, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema member, T state, int size, BiConsumer<T, ShapeSerializer> consumer) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
-        validator.writeList(member, state, consumer);
+        validator.writeList(member, state, size, consumer);
         validator.popPath();
     }
 
     @Override
-    public <T> void writeMap(Schema member, T state, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema member, T state, int size, BiConsumer<T, MapSerializer> consumer) {
         structValidator.setMember(member);
         validator.pushPath(member.memberName());
-        validator.writeMap(member, state, consumer);
+        validator.writeMap(member, state, size, consumer);
         validator.popPath();
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ValidatorOfUnion.java
@@ -179,19 +179,19 @@ final class ValidatorOfUnion implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(Schema member, T state, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema member, T state, int size, BiConsumer<T, ShapeSerializer> consumer) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
-            validator.writeList(member, state, consumer);
+            validator.writeList(member, state, size, consumer);
         }
         validator.popPath();
     }
 
     @Override
-    public <T> void writeMap(Schema member, T state, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema member, T state, int size, BiConsumer<T, MapSerializer> consumer) {
         validator.pushPath(member.memberName());
         if (validateSetValue(member)) {
-            validator.writeMap(member, state, consumer);
+            validator.writeMap(member, state, size, consumer);
         }
         validator.popPath();
     }

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/InterceptingSerializer.java
@@ -44,14 +44,14 @@ public abstract class InterceptingSerializer implements ShapeSerializer {
     }
 
     @Override
-    public final <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
-        before(schema).writeList(schema, listState, consumer);
+    public final <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {
+        before(schema).writeList(schema, listState, size, consumer);
         after(schema);
     }
 
     @Override
-    public final <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
-        before(schema).writeMap(schema, mapState, consumer);
+    public final <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer) {
+        before(schema).writeMap(schema, mapState, size, consumer);
         after(schema);
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ListSerializer.java
@@ -56,15 +56,15 @@ public final class ListSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(Schema schema, T state, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T state, int size, BiConsumer<T, ShapeSerializer> consumer) {
         beforeWrite();
-        delegate.writeList(schema, state, consumer);
+        delegate.writeList(schema, state, size, consumer);
     }
 
     @Override
-    public <T> void writeMap(Schema schema, T state, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T state, int size, BiConsumer<T, MapSerializer> consumer) {
         beforeWrite();
-        delegate.writeMap(schema, state, consumer);
+        delegate.writeMap(schema, state, size, consumer);
     }
 
     @Override

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/NullSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/NullSerializer.java
@@ -27,10 +27,10 @@ final class NullSerializer implements ShapeSerializer {
     public void writeStruct(Schema schema, SerializableStruct struct) {}
 
     @Override
-    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {}
+    public <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {}
 
     @Override
-    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {}
+    public <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer) {}
 
     @Override
     public void writeBoolean(Schema schema, boolean value) {}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ShapeSerializer.java
@@ -53,18 +53,20 @@ public interface ShapeSerializer extends Flushable, AutoCloseable {
      *
      * @param schema    List schema.
      * @param listState State to pass into the consumer.
+     * @param size      Number of elements in the list, or -1 if unknown.
      * @param consumer  Received in the context of the list and writes zero or more values.
      */
-    <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer);
+    <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer);
 
     /**
      * Begin a map and write zero or more entries into it using the provided serializer.
      *
      * @param schema   List schema.
      * @param mapState State to pass into the consumer.
+     * @param size     Number of entries in the map, or -1 if unknown.
      * @param consumer Received in the context of the map and writes zero or more entries.
      */
-    <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer);
+    <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer);
 
     /**
      * Serialize a boolean.

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/SpecificShapeSerializer.java
@@ -39,12 +39,12 @@ public abstract class SpecificShapeSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {
         throw throwForInvalidState(schema);
     }
 
     @Override
-    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer) {
         throw throwForInvalidState(schema);
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializer.java
@@ -76,7 +76,7 @@ public final class ToStringSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(Schema schema, T state, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T state, int size, BiConsumer<T, ShapeSerializer> consumer) {
         builder.append('[');
         consumer.accept(state, new ListSerializer(this, this::writeComma));
         builder.append(']');
@@ -89,7 +89,7 @@ public final class ToStringSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(Schema schema, T state, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T state, int size, BiConsumer<T, MapSerializer> consumer) {
         builder.append('{');
         consumer.accept(state, new ToStringMapSerializer(this));
         builder.append('}');

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/document/Documents.java
@@ -604,7 +604,7 @@ final class Documents {
 
         @Override
         public void serializeContents(ShapeSerializer serializer) {
-            serializer.writeList(schema, values, (values, ser) -> {
+            serializer.writeList(schema, values, values.size(), (values, ser) -> {
                 for (var element : values) {
                     element.serialize(ser);
                 }
@@ -640,7 +640,7 @@ final class Documents {
 
         @Override
         public void serializeContents(ShapeSerializer serializer) {
-            serializer.writeMap(schema, members, (members, s) -> {
+            serializer.writeMap(schema, members, members.size(), (members, s) -> {
                 var key = schema.member("key");
                 for (var entry : members.entrySet()) {
                     s.writeEntry(key, entry.getKey(), entry.getValue(), Document::serialize);

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/ValidatorTest.java
@@ -109,10 +109,10 @@ public class ValidatorTest {
         Validator validator = Validator.builder().maxDepth(3).build();
 
         var errors = validator.validate(s1 -> {
-            s1.writeList(schemas.get(0), null, (v2, s2) -> {
-                s2.writeList(schemas.get(1), null, (v3, s3) -> {
-                    s3.writeList(schemas.get(2), null, (v4, s4) -> {
-                        s4.writeList(schemas.get(3), null, (v5, s5) -> {
+            s1.writeList(schemas.get(0), null, 1, (v2, s2) -> {
+                s2.writeList(schemas.get(1), null, 1, (v3, s3) -> {
+                    s3.writeList(schemas.get(2), null, 1, (v4, s4) -> {
+                        s4.writeList(schemas.get(3), null, 1, (v5, s5) -> {
                             s5.writeString(PreludeSchemas.STRING, "Hi");
                         });
                     });
@@ -158,16 +158,16 @@ public class ValidatorTest {
         Validator validator = Validator.builder().maxDepth(25).build();
 
         var errors = validator.validate(s1 -> {
-            s1.writeList(schemas.get(0), null, (v2, s2) -> {
-                s2.writeList(schemas.get(1), null, (v3, s3) -> {
-                    s3.writeList(schemas.get(2), null, (v4, s4) -> {
-                        s4.writeList(schemas.get(3), null, (v5, s5) -> {
-                            s5.writeList(schemas.get(4), null, (v6, s6) -> {
-                                s6.writeList(schemas.get(5), null, (v7, s7) -> {
-                                    s7.writeList(schemas.get(6), null, (v8, s8) -> {
-                                        s8.writeList(schemas.get(7), null, (v9, s9) -> {
-                                            s9.writeList(schemas.get(8), null, (v10, s10) -> {
-                                                s10.writeList(schemas.get(9), null, (v11, s11) -> {
+            s1.writeList(schemas.get(0), null, 1, (v2, s2) -> {
+                s2.writeList(schemas.get(1), null, 1, (v3, s3) -> {
+                    s3.writeList(schemas.get(2), null, 1, (v4, s4) -> {
+                        s4.writeList(schemas.get(3), null, 1, (v5, s5) -> {
+                            s5.writeList(schemas.get(4), null, 1, (v6, s6) -> {
+                                s6.writeList(schemas.get(5), null, 1, (v7, s7) -> {
+                                    s7.writeList(schemas.get(6), null, 1, (v8, s8) -> {
+                                        s8.writeList(schemas.get(7), null, 1, (v9, s9) -> {
+                                            s9.writeList(schemas.get(8), null, 1, (v10, s10) -> {
+                                                s10.writeList(schemas.get(9), null, 1, (v11, s11) -> {
                                                     s10.writeString(PreludeSchemas.STRING, "Hi");
                                                 });
                                             });
@@ -300,7 +300,7 @@ public class ValidatorTest {
             .build();
 
         var errors = validator.validate(s -> {
-            s.writeList(list, list.member("member"), (member, ls) -> {
+            s.writeList(list, list.member("member"), 3, (member, ls) -> {
                 ls.writeString(member, "n");
                 ls.writeString(member, "no");
                 ls.writeString(member, "good");
@@ -331,7 +331,7 @@ public class ValidatorTest {
             .build();
 
         var errors = validator.validate(s -> {
-            s.writeMap(map, map.member("key"), (mapKey, ms) -> {
+            s.writeMap(map, map.member("key"), 4, (mapKey, ms) -> {
                 ms.writeEntry(mapKey, "fine", null, (v, vs) -> vs.writeString(PreludeSchemas.STRING, "ok"));
                 ms.writeEntry(mapKey, "a", null, (v, vs) -> vs.writeString(PreludeSchemas.STRING, "too few"));
                 ms.writeEntry(mapKey, "b", null, (v, vs) -> vs.writeString(PreludeSchemas.STRING, "too few"));
@@ -539,7 +539,7 @@ public class ValidatorTest {
             .build();
 
         var errors = validator.validate(s -> {
-            s.writeList(listSchema, listSchema.member("member"), (member, ls) -> {
+            s.writeList(listSchema, listSchema.member("member"), 2, (member, ls) -> {
                 ls.writeString(member, "this is fine"); // fine
                 ls.writeNull(member); // fine
             });
@@ -574,7 +574,7 @@ public class ValidatorTest {
             .build();
 
         var errors = validator.validate(s -> {
-            s.writeList(listSchema, listSchema.member("member"), (member, ls) -> {
+            s.writeList(listSchema, listSchema.member("member"), 2, (member, ls) -> {
                 ls.writeString(member, "this is fine"); // fine
                 ls.writeNull(member); // bad
             });
@@ -598,7 +598,7 @@ public class ValidatorTest {
             .build();
 
         var errors = validator.validate(s -> {
-            s.writeMap(mapSchema, mapSchema, (schema, ms) -> {
+            s.writeMap(mapSchema, mapSchema, 2, (schema, ms) -> {
                 ms.writeEntry(
                     schema.member("key"),
                     "hi",
@@ -715,12 +715,18 @@ public class ValidatorTest {
                 (Consumer<ShapeSerializer>) serializer -> serializer.writeList(
                     PreludeSchemas.STRING,
                     null,
+                    0,
                     (v, s) -> {}
                 )
             ),
             Arguments.of(
                 ShapeType.MAP,
-                (Consumer<ShapeSerializer>) serializer -> serializer.writeMap(PreludeSchemas.STRING, null, (v, s) -> {})
+                (Consumer<ShapeSerializer>) serializer -> serializer.writeMap(
+                    PreludeSchemas.STRING,
+                    null,
+                    0,
+                    (v, s) -> {}
+                )
             )
         );
     }
@@ -939,6 +945,7 @@ public class ValidatorTest {
                 (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeList(
                     schema,
                     null,
+                    1,
                     (v, ls) -> ls.writeString(PreludeSchemas.STRING, "a")
                 )
             ),
@@ -953,6 +960,7 @@ public class ValidatorTest {
                 (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeMap(
                     schema,
                     null,
+                    1,
                     (mapStateValue, mapSerializer) -> mapSerializer.writeEntry(
                         PreludeSchemas.STRING,
                         "a",
@@ -987,6 +995,7 @@ public class ValidatorTest {
                 (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeList(
                     schema,
                     null,
+                    0,
                     (v, ls) -> {}
                 )
             ),
@@ -999,7 +1008,7 @@ public class ValidatorTest {
                         .build();
                 },
                 (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> {
-                    serializer.writeMap(schema, null, (mapStateValue, mapSerializer) -> {});
+                    serializer.writeMap(schema, null, 0, (mapStateValue, mapSerializer) -> {});
                 }
             ),
 
@@ -1029,6 +1038,7 @@ public class ValidatorTest {
                 (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> serializer.writeList(
                     schema,
                     null,
+                    11,
                     (v, ls) -> {
                         for (int i = 0; i < 11; i++) {
                             ls.writeString(PreludeSchemas.STRING, "a");
@@ -1045,7 +1055,7 @@ public class ValidatorTest {
                         .build();
                 },
                 (BiConsumer<Schema, ShapeSerializer>) (schema, serializer) -> {
-                    serializer.writeMap(schema, null, (mapState, mapSerializer) -> {
+                    serializer.writeMap(schema, null, 11, (mapState, mapSerializer) -> {
                         for (int i = 0; i < 11; i++) {
                             mapSerializer.writeEntry(
                                 PreludeSchemas.STRING,
@@ -1117,7 +1127,7 @@ public class ValidatorTest {
             .putMember("member", PreludeSchemas.STRING)
             .build();
         var validator = Validator.builder().build();
-        var errors = validator.validate(e -> e.writeList(schema, null, (v, ser) -> {}));
+        var errors = validator.validate(e -> e.writeList(schema, null, 0, (v, ser) -> {}));
 
         assertThat(errors, hasSize(1));
         assertThat(errors.get(0), instanceOf(ValidationError.LengthValidationFailure.class));
@@ -1133,7 +1143,7 @@ public class ValidatorTest {
             .putMember("member", PreludeSchemas.STRING)
             .build();
         var validator = Validator.builder().build();
-        var errors = validator.validate(e -> e.writeList(schema, schema.member("member"), (member, ser) -> {
+        var errors = validator.validate(e -> e.writeList(schema, schema.member("member"), 2, (member, ser) -> {
             ser.writeString(member, "a");
             ser.writeString(member, "b");
         }));
@@ -1152,7 +1162,7 @@ public class ValidatorTest {
             .putMember("member", PreludeSchemas.STRING)
             .build();
         var validator = Validator.builder().build();
-        var errors = validator.validate(e -> e.writeList(schema, schema.member("member"), (member, ser) -> {
+        var errors = validator.validate(e -> e.writeList(schema, schema.member("member"), 3, (member, ser) -> {
             ser.writeString(member, "a");
             ser.writeString(member, "b");
             ser.writeString(member, "c");

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/ToStringSerializerTest.java
@@ -64,7 +64,7 @@ public class ToStringSerializerTest {
 
         var str = ToStringSerializer.serialize(e -> {
             e.writeStruct(schema, SerializableStruct.create(schema, (s, ser) -> {
-                ser.writeMap(s.member("foo"), mapSchema, (innerMapSchema, map) -> {
+                ser.writeMap(s.member("foo"), mapSchema, 2, (innerMapSchema, map) -> {
                     map.writeEntry(innerMapSchema.member("key"), "a", innerMapSchema, (mapSchema2, ms) -> {
                         ms.writeString(mapSchema2.member("value"), "hi");
                     });

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/ListDocumentTest.java
@@ -59,7 +59,7 @@ public class ListDocumentTest {
             }
 
             @Override
-            public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+            public <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {
                 assertThat(schema.type(), equalTo(ShapeType.LIST));
                 consumer.accept(listState, new SpecificShapeSerializer() {
                     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/MapDocumentTest.java
@@ -65,7 +65,7 @@ public class MapDocumentTest {
             }
 
             @Override
-            public <T> void writeMap(Schema schema, T state, BiConsumer<T, MapSerializer> consumer) {
+            public <T> void writeMap(Schema schema, T state, int size, BiConsumer<T, MapSerializer> consumer) {
                 assertThat(schema.type(), equalTo(ShapeType.MAP));
                 consumer.accept(state, new MapSerializer() {
                     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/serde/document/TypedDocumentMemberTest.java
@@ -548,6 +548,7 @@ public class TypedDocumentMemberTest {
                 (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeList(
                     schema,
                     null,
+                    1,
                     (v, c) -> c.writeInteger(PreludeSchemas.INTEGER, 1)
                 ),
                 (Function<Document, Object>) d -> Document.createTyped(Document.createList(d.asList())).asList()
@@ -560,6 +561,7 @@ public class TypedDocumentMemberTest {
                 (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
                     null,
+                    1,
                     (mapValue, mapSerializer) -> mapSerializer.writeEntry(
                         schema.member("key"),
                         "a",
@@ -577,6 +579,7 @@ public class TypedDocumentMemberTest {
                 (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
                     null,
+                    1,
                     (mapState, m) -> m.writeEntry(
                         schema.member("key"),
                         "a",

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
@@ -118,7 +118,7 @@ public final class Person implements SerializableStruct {
             serializer.writeTimestamp(SCHEMA_BIRTHDAY, birthday);
         }
         if (!queryParams.isEmpty()) {
-            serializer.writeMap(SCHEMA_QUERY_PARAMS, this, Person::writeQueryParamsMember);
+            serializer.writeMap(SCHEMA_QUERY_PARAMS, this, queryParams.size(), Person::writeQueryParamsMember);
         }
     }
 
@@ -134,7 +134,12 @@ public final class Person implements SerializableStruct {
     }
 
     private static void writeQueryParamsMemberEntry(List<String> values, ShapeSerializer serializer) {
-        serializer.writeList(SCHEMA_QUERY_PARAMS_VALUE, values, Person::writeQueryParamsMemberEntryElement);
+        serializer.writeList(
+            SCHEMA_QUERY_PARAMS_VALUE,
+            values,
+            values.size(),
+            Person::writeQueryParamsMemberEntryElement
+        );
     }
 
     private static void writeQueryParamsMemberEntryElement(List<String> listValue, ShapeSerializer serializer) {

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
@@ -76,8 +76,8 @@ public final class PojoWithValidatedCollection implements SerializableStruct {
 
     @Override
     public void serializeMembers(ShapeSerializer st) {
-        st.writeList(SCHEMA_LIST, list, InnerListSerializer.INSTANCE);
-        st.writeMap(SCHEMA_MAP, map, InnerMapSerializer.INSTANCE);
+        st.writeList(SCHEMA_LIST, list, list.size(), InnerListSerializer.INSTANCE);
+        st.writeMap(SCHEMA_MAP, map, map.size(), InnerMapSerializer.INSTANCE);
     }
 
     private static final class InnerListSerializer implements BiConsumer<List<ValidatedPojo>, ShapeSerializer> {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpHeaderSerializer.java
@@ -30,7 +30,7 @@ final class HttpHeaderSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {
         // Consumer is generally going to be something generic - like a shared serializer for iterating
         // lists of strings and writing them back out to the delegate serializer (this). However, this
         // means writeHeader, below, will receive something like the schema for smithy.api#String

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpPrefixHeadersSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpPrefixHeadersSerializer.java
@@ -26,7 +26,7 @@ final class HttpPrefixHeadersSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer) {
         consumer.accept(mapState, prefixHeadersMapSerializer);
     }
 

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQueryParamsSerializer.java
@@ -23,7 +23,7 @@ final class HttpQueryParamsSerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer) {
         consumer.accept(mapState, mapEntrySerializer);
     }
 
@@ -42,7 +42,12 @@ final class HttpQueryParamsSerializer extends SpecificShapeSerializer {
                 }
 
                 @Override
-                public <L> void writeList(Schema schema, L listState, BiConsumer<L, ShapeSerializer> consumer) {
+                public <L> void writeList(
+                    Schema schema,
+                    L listState,
+                    int size,
+                    BiConsumer<L, ShapeSerializer> consumer
+                ) {
                     consumer.accept(listState, new SpecificShapeSerializer() {
                         @Override
                         public void writeString(Schema schema, String value) {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpQuerySerializer.java
@@ -14,7 +14,6 @@ import java.time.Instant;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
-import software.amazon.smithy.java.runtime.core.serde.ListSerializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.TimestampFormatter;
@@ -30,8 +29,8 @@ final class HttpQuerySerializer extends SpecificShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
-        consumer.accept(listState, new ListSerializer(this, position -> {}));
+    public <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {
+        consumer.accept(listState, this);
     }
 
     void writeQuery(Schema schema, Supplier<String> supplier) {

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/PayloadSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/PayloadSerializer.java
@@ -93,13 +93,13 @@ final class PayloadSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
-        structSerializer.writeList(schema, listState, consumer);
+    public <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {
+        structSerializer.writeList(schema, listState, size, consumer);
     }
 
     @Override
-    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
-        structSerializer.writeMap(schema, mapState, consumer);
+    public <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer) {
+        structSerializer.writeMap(schema, mapState, size, consumer);
     }
 
     @Override

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonDocument.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonDocument.java
@@ -234,7 +234,7 @@ final class JacksonDocument implements Document {
             case INTEGER -> encoder.writeInteger(schema, asInteger());
             case DOUBLE -> encoder.writeDouble(schema, asDouble());
             case STRING -> encoder.writeString(schema, asString());
-            case MAP -> encoder.writeMap(schema, asStringMap(), (stringMap, mapSerializer) -> {
+            case MAP -> encoder.writeMap(schema, asStringMap(), size(), (stringMap, mapSerializer) -> {
                 for (var entry : stringMap.entrySet()) {
                     mapSerializer.writeEntry(
                         STRING_MAP_KEY,
@@ -244,7 +244,7 @@ final class JacksonDocument implements Document {
                     );
                 }
             });
-            case LIST -> encoder.writeList(schema, asList(), (list, c) -> {
+            case LIST -> encoder.writeList(schema, asList(), size(), (list, c) -> {
                 for (Document entry : list) {
                     entry.serializeContents(c);
                 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonSerializer.java
@@ -206,7 +206,7 @@ final class JacksonJsonSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeList(Schema schema, T listState, BiConsumer<T, ShapeSerializer> consumer) {
+    public <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {
         try {
             generator.writeStartArray();
             consumer.accept(listState, this);
@@ -217,7 +217,7 @@ final class JacksonJsonSerializer implements ShapeSerializer {
     }
 
     @Override
-    public <T> void writeMap(Schema schema, T mapState, BiConsumer<T, MapSerializer> consumer) {
+    public <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer) {
         try {
             generator.writeStartObject();
             consumer.accept(mapState, new JacksonMapSerializer(this));


### PR DESCRIPTION
A size can now be provided when serializing a list or map to a ShapeSerializer so that a serializer knows how many elements to expect. For example, in formats like CBOR, this means the difference between indefinite length types and normal types.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
