### PR TITLE
Add capability to chain identity resolvers

### DIFF
--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/identity/IdentityResolver.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/identity/IdentityResolver.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.auth.api.identity;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 
@@ -30,4 +31,15 @@ public interface IdentityResolver<IdentityT extends Identity> {
      * @return the class of the identity.
      */
     Class<IdentityT> identityType();
+
+
+    /**
+     * Combines multiple identity resolvers with the same identity type into a single resolver.
+     *
+     * @param resolvers Resolvers to combine.
+     * @return the combined resolvers.
+     */
+    static <I extends Identity> IdentityResolver<I> chain(List<IdentityResolver<I>> resolvers) {
+        return new IdentityResolverChain<I>(resolvers);
+    }
 }

--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/identity/IdentityResolverChain.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/identity/IdentityResolverChain.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.auth.api.identity;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
+
+final class IdentityResolverChain<IdentityT extends Identity> implements IdentityResolver<IdentityT> {
+    private final Class<IdentityT> identityClass;
+    private final List<IdentityResolver<IdentityT>> resolvers;
+
+    public IdentityResolverChain(List<IdentityResolver<IdentityT>> resolvers) {
+        this.resolvers = Objects.requireNonNull(resolvers, "resolvers cannot be null");
+        if (resolvers.isEmpty()) {
+            throw new IllegalArgumentException("Cannot chain empty resolvers list.");
+        }
+        identityClass = resolvers.get(0).identityType();
+    }
+
+    @Override
+    public CompletableFuture<IdentityT> resolveIdentity(AuthProperties requestProperties) {
+        CompletableFuture<IdentityT> result = resolvers.get(0).resolveIdentity(requestProperties);
+        for (var idx = 1; idx < resolvers.size(); idx++) {
+            var next = resolvers.get(idx);
+            result = result.exceptionallyComposeAsync(exc -> {
+                if (exc instanceof IdentityNotFoundException) {
+                    return next.resolveIdentity(requestProperties);
+                }
+                return CompletableFuture.failedFuture(exc);
+            });
+        }
+        return result;
+    }
+
+    @Override
+    public Class<IdentityT> identityType() {
+        return identityClass;
+    }
+}

--- a/auth-api/src/test/java/software/amazon/smithy/java/runtime/auth/api/identity/IdentityResolverChainTest.java
+++ b/auth-api/src/test/java/software/amazon/smithy/java/runtime/auth/api/identity/IdentityResolverChainTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.auth.api.identity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
+
+public class IdentityResolverChainTest {
+    private static final TokenIdentity TEST_IDENTITY = TokenIdentity.create("==MyToken==");
+
+    @Test
+    void testIdentityResolverChainContinuesOnIdentityNotFound() throws ExecutionException, InterruptedException {
+        var resolver = IdentityResolver.chain(List.of(EmptyResolver.INSTANCE, TestResolver.INSTANCE));
+        var result = resolver.resolveIdentity(AuthProperties.empty()).get();
+        assertEquals(result, TEST_IDENTITY);
+    }
+
+    @Test
+    void testIdentityResolverChainStopsOnUnexpectedFailure() throws ExecutionException, InterruptedException {
+        var resolver = IdentityResolver.chain(
+            List.of(EmptyResolver.INSTANCE, FailingResolver.INSTANCE, TestResolver.INSTANCE)
+        );
+        var exc = assertThrows(ExecutionException.class, () -> resolver.resolveIdentity(AuthProperties.empty()).get());
+        assertEquals(exc.getCause(), FailingResolver.ILLEGAL_ARGUMENT_EXCEPTION);
+    }
+
+
+    /**
+     * Always returns exceptional result with {@link IdentityNotFoundException}.
+     */
+    private static final class EmptyResolver implements IdentityResolver<TokenIdentity> {
+        private static final EmptyResolver INSTANCE = new EmptyResolver();
+
+        @Override
+        public CompletableFuture<TokenIdentity> resolveIdentity(AuthProperties requestProperties) {
+            return CompletableFuture.failedFuture(
+                new IdentityNotFoundException(
+                    "No token. Womp Womp.",
+                    EmptyResolver.class,
+                    TokenIdentity.class
+                )
+            );
+        }
+
+        @Override
+        public Class<TokenIdentity> identityType() {
+            return TokenIdentity.class;
+        }
+    }
+
+    /**
+     * Always return a successful result with a token identity.
+     */
+    private static final class TestResolver implements IdentityResolver<TokenIdentity> {
+        private static final TestResolver INSTANCE = new TestResolver();
+
+        @Override
+        public CompletableFuture<TokenIdentity> resolveIdentity(AuthProperties requestProperties) {
+            return CompletableFuture.completedFuture(TEST_IDENTITY);
+        }
+
+        @Override
+        public Class<TokenIdentity> identityType() {
+            return TokenIdentity.class;
+        }
+    }
+
+    /**
+     * Always returns a failed future with a {@link IllegalArgumentException}.
+     */
+    private static final class FailingResolver implements IdentityResolver<TokenIdentity> {
+        private static final FailingResolver INSTANCE = new FailingResolver();
+        private static final IllegalArgumentException ILLEGAL_ARGUMENT_EXCEPTION = new IllegalArgumentException("BAD!");
+
+        @Override
+        public CompletableFuture<TokenIdentity> resolveIdentity(AuthProperties requestProperties) {
+            return CompletableFuture.failedFuture(ILLEGAL_ARGUMENT_EXCEPTION);
+        }
+
+        @Override
+        public Class<TokenIdentity> identityType() {
+            return TokenIdentity.class;
+        }
+    }
+}


### PR DESCRIPTION
### Description of changes
Customers might want to check multiple locations (in some priority order) for an identity, returning the first valid identity found. For example, AWS clients follow a standard credential chain: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html

This PR adds the ability to chain identity resolvers as a feature of the framework.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
