### PR TITLE
Make signing async

### DIFF
--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/NullSigner.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/NullSigner.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.auth.api;
 
+import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.auth.api.identity.Identity;
 
 /**
@@ -29,7 +30,7 @@ final class NullSigner implements Signer {
      * @return the request as-is.
      */
     @Override
-    public Object sign(Object request, Identity identity, AuthProperties properties) {
-        return request;
+    public CompletableFuture<Object> sign(Object request, Identity identity, AuthProperties properties) {
+        return CompletableFuture.completedFuture(request);
     }
 }

--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/Signer.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/Signer.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.runtime.auth.api;
 
+import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.auth.api.identity.Identity;
 
 /**
@@ -24,7 +25,7 @@ public interface Signer<RequestT, IdentityT extends Identity> {
      * @param properties Signing properties.
      * @return the signed request.
      */
-    RequestT sign(RequestT request, IdentityT identity, AuthProperties properties);
+    CompletableFuture<RequestT> sign(RequestT request, IdentityT identity, AuthProperties properties);
 
     @SuppressWarnings("unchecked")
     static <RequestT, IdentityT extends Identity> Signer<RequestT, IdentityT> nullSigner() {

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
@@ -204,7 +204,7 @@ public final class ClientPipeline<RequestT, ResponseT> {
         CompletableFuture<IdentityT> identity
     ) {
         public CompletableFuture<RequestT> sign(RequestT request) {
-            return identity.thenApply(
+            return identity.thenCompose(
                 identity -> authScheme.signer().sign(request, identity, signerProperties)
             );
         }

--- a/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestAuthScheme.java
+++ b/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestAuthScheme.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.codegen.client;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.AuthSchemeFactory;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
@@ -54,8 +55,14 @@ public final class TestAuthScheme implements AuthScheme<SmithyHttpRequest, Ident
 
     private static final class TestSigner implements Signer<SmithyHttpRequest, Identity> {
         @Override
-        public SmithyHttpRequest sign(SmithyHttpRequest request, Identity identity, AuthProperties properties) {
-            return request.withAddedHeaders(SIGNATURE_HEADER, "smithy-test-signature");
+        public CompletableFuture<SmithyHttpRequest> sign(
+            SmithyHttpRequest request,
+            Identity identity,
+            AuthProperties properties
+        ) {
+            return CompletableFuture.completedFuture(
+                request.withAddedHeaders(SIGNATURE_HEADER, "smithy-test-signature")
+            );
         }
     }
 

--- a/http-auth/src/main/java/software/amazon/smithy/runtime/http/auth/HttpBasicAuthSigner.java
+++ b/http-auth/src/main/java/software/amazon/smithy/runtime/http/auth/HttpBasicAuthSigner.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
@@ -25,7 +26,11 @@ final class HttpBasicAuthSigner implements Signer<SmithyHttpRequest, LoginIdenti
     private HttpBasicAuthSigner() {}
 
     @Override
-    public SmithyHttpRequest sign(SmithyHttpRequest request, LoginIdentity identity, AuthProperties properties) {
+    public CompletableFuture<SmithyHttpRequest> sign(
+        SmithyHttpRequest request,
+        LoginIdentity identity,
+        AuthProperties properties
+    ) {
         var identityString = identity.username() + ":" + identity.password();
         var base64Value = Base64.getEncoder().encodeToString(identityString.getBytes(StandardCharsets.UTF_8));
         var headers = new LinkedHashMap<>(request.headers().map());
@@ -33,6 +38,6 @@ final class HttpBasicAuthSigner implements Signer<SmithyHttpRequest, LoginIdenti
         if (existing != null) {
             LOGGER.debug("Replaced existing Authorization header value.");
         }
-        return request.withHeaders(HttpHeaders.of(headers, (k, v) -> true));
+        return CompletableFuture.completedFuture(request.withHeaders(HttpHeaders.of(headers, (k, v) -> true)));
     }
 }

--- a/http-auth/src/main/java/software/amazon/smithy/runtime/http/auth/HttpBearerAuthSigner.java
+++ b/http-auth/src/main/java/software/amazon/smithy/runtime/http/auth/HttpBearerAuthSigner.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.runtime.http.auth;
 import java.net.http.HttpHeaders;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
@@ -23,12 +24,16 @@ final class HttpBearerAuthSigner implements Signer<SmithyHttpRequest, TokenIdent
     private HttpBearerAuthSigner() {}
 
     @Override
-    public SmithyHttpRequest sign(SmithyHttpRequest request, TokenIdentity identity, AuthProperties properties) {
+    public CompletableFuture<SmithyHttpRequest> sign(
+        SmithyHttpRequest request,
+        TokenIdentity identity,
+        AuthProperties properties
+    ) {
         var headers = new LinkedHashMap<>(request.headers().map());
         var existing = headers.put(AUTHORIZATION_HEADER, List.of(SCHEME + " " + identity.token()));
         if (existing != null) {
             LOGGER.debug("Replaced existing Authorization header value.");
         }
-        return request.withHeaders(HttpHeaders.of(headers, (k, v) -> true));
+        return CompletableFuture.completedFuture(request.withHeaders(HttpHeaders.of(headers, (k, v) -> true)));
     }
 }

--- a/http-auth/src/main/java/software/amazon/smithy/runtime/http/auth/HttpDigestAuthSigner.java
+++ b/http-auth/src/main/java/software/amazon/smithy/runtime/http/auth/HttpDigestAuthSigner.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.runtime.http.auth;
 
+import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
 import software.amazon.smithy.java.runtime.auth.api.identity.LoginIdentity;
@@ -19,7 +20,11 @@ final class HttpDigestAuthSigner implements Signer<SmithyHttpRequest, LoginIdent
     private HttpDigestAuthSigner() {}
 
     @Override
-    public SmithyHttpRequest sign(SmithyHttpRequest request, LoginIdentity identity, AuthProperties properties) {
+    public CompletableFuture<SmithyHttpRequest> sign(
+        SmithyHttpRequest request,
+        LoginIdentity identity,
+        AuthProperties properties
+    ) {
         throw new UnsupportedOperationException();
     }
 }

--- a/http-auth/src/test/java/software/amazon/smithy/runtime/http/auth/HttpApiKeyAuthSignerTest.java
+++ b/http-auth/src/test/java/software/amazon/smithy/runtime/http/auth/HttpApiKeyAuthSignerTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.identity.ApiKeyIdentity;
@@ -26,96 +27,96 @@ public class HttpApiKeyAuthSignerTest {
         .build();
 
     @Test
-    void testApiKeyAuthSignerAddsHeaderNoScheme() {
+    void testApiKeyAuthSignerAddsHeaderNoScheme() throws ExecutionException, InterruptedException {
         var authProperties = AuthProperties.builder()
             .put(HttpApiKeyAuthScheme.IN, HttpApiKeyAuthTrait.Location.HEADER)
             .put(HttpApiKeyAuthScheme.NAME, "x-api-key")
             .build();
 
-        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties);
+        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties).get();
         var authHeader = signedRequest.headers().map().get("x-api-key");
         assertNotNull(authHeader);
         assertEquals(authHeader.get(0), API_KEY);
     }
 
     @Test
-    void testApiKeyAuthSignerAddsHeaderParamWithCustomScheme() {
+    void testApiKeyAuthSignerAddsHeaderParamWithCustomScheme() throws ExecutionException, InterruptedException {
         var authProperties = AuthProperties.builder()
             .put(HttpApiKeyAuthScheme.IN, HttpApiKeyAuthTrait.Location.HEADER)
             .put(HttpApiKeyAuthScheme.NAME, "x-api-key")
             .put(HttpApiKeyAuthScheme.SCHEME, "SCHEME")
             .build();
 
-        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties);
+        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties).get();
         var authHeader = signedRequest.headers().map().get("x-api-key");
         assertNotNull(authHeader);
         assertEquals(authHeader.get(0), "SCHEME " + API_KEY);
     }
 
     @Test
-    void testOverwritesExistingHeader() {
+    void testOverwritesExistingHeader() throws ExecutionException, InterruptedException {
         var authProperties = AuthProperties.builder()
             .put(HttpApiKeyAuthScheme.IN, HttpApiKeyAuthTrait.Location.HEADER)
             .put(HttpApiKeyAuthScheme.NAME, "x-api-key")
             .put(HttpApiKeyAuthScheme.SCHEME, "SCHEME")
             .build();
         var updateRequest = TEST_REQUEST.withAddedHeaders("x-api-key", "foo");
-        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(updateRequest, TEST_IDENTITY, authProperties);
+        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(updateRequest, TEST_IDENTITY, authProperties).get();
         var authHeader = signedRequest.headers().map().get("x-api-key");
         assertNotNull(authHeader);
         assertEquals(authHeader.get(0), "SCHEME " + API_KEY);
     }
 
     @Test
-    void testApiKeyAuthSignerAddsQueryParam() {
+    void testApiKeyAuthSignerAddsQueryParam() throws ExecutionException, InterruptedException {
         var authProperties = AuthProperties.builder()
             .put(HttpApiKeyAuthScheme.IN, HttpApiKeyAuthTrait.Location.QUERY)
             .put(HttpApiKeyAuthScheme.NAME, "apiKey")
             .build();
 
-        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties);
+        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties).get();
         var queryParam = signedRequest.uri().getQuery();
         assertNotNull(queryParam);
         assertEquals(queryParam, "apiKey=my-api-key");
     }
 
     @Test
-    void testApiKeyAuthSignerAddsQueryParamIgnoresScheme() {
+    void testApiKeyAuthSignerAddsQueryParamIgnoresScheme() throws ExecutionException, InterruptedException {
         var authProperties = AuthProperties.builder()
             .put(HttpApiKeyAuthScheme.IN, HttpApiKeyAuthTrait.Location.QUERY)
             .put(HttpApiKeyAuthScheme.NAME, "apiKey")
             .put(HttpApiKeyAuthScheme.SCHEME, "SCHEME")
             .build();
 
-        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties);
+        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties).get();
         var queryParam = signedRequest.uri().getQuery();
         assertNotNull(queryParam);
         assertEquals(queryParam, "apiKey=my-api-key");
     }
 
     @Test
-    void testApiKeyAuthSignerAddsQueryParamsAppendsToExisting() {
+    void testApiKeyAuthSignerAddsQueryParamsAppendsToExisting() throws ExecutionException, InterruptedException {
         var authProperties = AuthProperties.builder()
             .put(HttpApiKeyAuthScheme.IN, HttpApiKeyAuthTrait.Location.QUERY)
             .put(HttpApiKeyAuthScheme.NAME, "apiKey")
             .build();
         var updatedRequest = TEST_REQUEST.withUri(URI.create("https://www.example.com?x=1"));
 
-        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(updatedRequest, TEST_IDENTITY, authProperties);
+        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(updatedRequest, TEST_IDENTITY, authProperties).get();
         var queryParam = signedRequest.uri().getQuery();
         assertNotNull(queryParam);
         assertEquals(queryParam, "x=1&apiKey=my-api-key");
     }
 
     @Test
-    void testOverwritesExistingQuery() {
+    void testOverwritesExistingQuery() throws ExecutionException, InterruptedException {
         var authProperties = AuthProperties.builder()
             .put(HttpApiKeyAuthScheme.IN, HttpApiKeyAuthTrait.Location.QUERY)
             .put(HttpApiKeyAuthScheme.NAME, "apiKey")
             .build();
         var updatedRequest = TEST_REQUEST.withUri(URI.create("https://www.example.com?x=1&apiKey=foo"));
 
-        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(updatedRequest, TEST_IDENTITY, authProperties);
+        var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(updatedRequest, TEST_IDENTITY, authProperties).get();
         var queryParam = signedRequest.uri().getQuery();
         assertNotNull(queryParam);
         assertEquals(queryParam, "x=1&apiKey=my-api-key");

--- a/http-auth/src/test/java/software/amazon/smithy/runtime/http/auth/HttpBasicAuthSignerTest.java
+++ b/http-auth/src/test/java/software/amazon/smithy/runtime/http/auth/HttpBasicAuthSignerTest.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.identity.LoginIdentity;
@@ -22,7 +23,7 @@ import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
 
 public class HttpBasicAuthSignerTest {
     @Test
-    void testBasicAuthSigner() {
+    void testBasicAuthSigner() throws ExecutionException, InterruptedException {
         var username = "username";
         var password = "password";
         var testIdentity = LoginIdentity.create(username, password);
@@ -34,14 +35,14 @@ public class HttpBasicAuthSignerTest {
 
         var expectedHeader = "Basic " + Base64.getEncoder()
             .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
-        var signedRequest = HttpBasicAuthSigner.INSTANCE.sign(request, testIdentity, AuthProperties.empty());
+        var signedRequest = HttpBasicAuthSigner.INSTANCE.sign(request, testIdentity, AuthProperties.empty()).get();
         var authHeader = signedRequest.headers().map().get("Authorization");
         assertNotNull(authHeader);
         assertEquals(authHeader.get(0), expectedHeader);
     }
 
     @Test
-    void overwritesExistingHeader() {
+    void overwritesExistingHeader() throws ExecutionException, InterruptedException {
         var username = "username";
         var password = "password";
         var testIdentity = LoginIdentity.create(username, password);
@@ -54,7 +55,7 @@ public class HttpBasicAuthSignerTest {
 
         var expectedHeader = "Basic " + Base64.getEncoder()
             .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
-        var signedRequest = HttpBasicAuthSigner.INSTANCE.sign(request, testIdentity, AuthProperties.empty());
+        var signedRequest = HttpBasicAuthSigner.INSTANCE.sign(request, testIdentity, AuthProperties.empty()).get();
         var authHeader = signedRequest.headers().map().get("Authorization");
         assertNotNull(authHeader);
         assertEquals(authHeader.get(0), expectedHeader);

--- a/http-auth/src/test/java/software/amazon/smithy/runtime/http/auth/HttpBearerAuthSignerTest.java
+++ b/http-auth/src/test/java/software/amazon/smithy/runtime/http/auth/HttpBearerAuthSignerTest.java
@@ -12,6 +12,7 @@ import java.net.URI;
 import java.net.http.HttpHeaders;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.identity.TokenIdentity;
@@ -20,7 +21,7 @@ import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
 
 public class HttpBearerAuthSignerTest {
     @Test
-    void testBearerAuthSigner() {
+    void testBearerAuthSigner() throws ExecutionException, InterruptedException {
         var tokenIdentity = TokenIdentity.create("token");
         var request = SmithyHttpRequest.builder()
             .httpVersion(SmithyHttpVersion.HTTP_1_1)
@@ -28,14 +29,14 @@ public class HttpBearerAuthSignerTest {
             .uri(URI.create("https://www.example.com"))
             .build();
 
-        var signedRequest = HttpBearerAuthSigner.INSTANCE.sign(request, tokenIdentity, AuthProperties.empty());
+        var signedRequest = HttpBearerAuthSigner.INSTANCE.sign(request, tokenIdentity, AuthProperties.empty()).get();
         var authHeader = signedRequest.headers().map().get("Authorization");
         assertNotNull(authHeader);
         assertEquals(authHeader.get(0), "Bearer token");
     }
 
     @Test
-    void overwritesExistingHeader() {
+    void overwritesExistingHeader() throws ExecutionException, InterruptedException {
         var tokenIdentity = TokenIdentity.create("token");
         var request = SmithyHttpRequest.builder()
             .httpVersion(SmithyHttpVersion.HTTP_1_1)
@@ -44,7 +45,7 @@ public class HttpBearerAuthSignerTest {
             .uri(URI.create("https://www.example.com"))
             .build();
 
-        var signedRequest = HttpBearerAuthSigner.INSTANCE.sign(request, tokenIdentity, AuthProperties.empty());
+        var signedRequest = HttpBearerAuthSigner.INSTANCE.sign(request, tokenIdentity, AuthProperties.empty()).get();
         var authHeader = signedRequest.headers().map().get("Authorization");
         assertNotNull(authHeader);
         assertEquals(authHeader.get(0), "Bearer token");


### PR DESCRIPTION
### Description of changes
Changes signers to be async.

While we might revert this in the future, so long as access to the body of the request is asynchronous, it makes sense for signers to be asynchronous as well as they may need access to the contents of the body. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
