### PR TITLE
Serialize blobs directly when possible

### DIFF
--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonSerializer.java
@@ -97,7 +97,13 @@ final class JacksonJsonSerializer implements ShapeSerializer {
     @Override
     public void writeBlob(Schema schema, ByteBuffer value) {
         try {
-            generator.writeBinary(new ByteBufferBackedInputStream(value), value.remaining());
+            int len = value.remaining();
+            if (value.hasArray()) {
+                generator.writeBinary(value.array(), value.arrayOffset() + value.position(), len);
+            } else {
+                // don't disturb the mark on the existing buffer
+                generator.writeBinary(new ByteBufferBackedInputStream(value.duplicate()), len);
+            }
         } catch (Exception e) {
             throw new SerializationException(e);
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This saves us needing to read from a byte array that may be accessible into a temporary read buffer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
