### PR TITLE
Do a copy instead of using the Base64 ByteBuffer method

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/ByteBufferUtils.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/ByteBufferUtils.java
@@ -6,7 +6,6 @@
 package software.amazon.smithy.java.runtime.core;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public final class ByteBufferUtils {
@@ -15,10 +14,14 @@ public final class ByteBufferUtils {
     }
 
     public static String base64Encode(ByteBuffer buffer) {
+        byte[] bytes;
         if (isExact(buffer)) {
-            return Base64.getEncoder().encodeToString(buffer.array());
+            bytes = buffer.array();
+        } else {
+            bytes = new byte[buffer.remaining()];
+            buffer.asReadOnlyBuffer().get(bytes);
         }
-        return StandardCharsets.UTF_8.decode(Base64.getEncoder().encode(buffer.asReadOnlyBuffer())).toString();
+        return Base64.getEncoder().encodeToString(bytes);
     }
 
     public static byte[] getBytes(ByteBuffer buffer) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The new way is much faster if we have a non exact ByteBuffer.
Old : 
```
Result "software.amazon.smithy.java.runtime.core.validation.Base64EncodingBench.base64EncodeReadOnly":
  64.639 ±(99.9%) 5.692 ns/op [Average]
```

New :
```
Result "software.amazon.smithy.java.runtime.core.validation.Base64EncodingBench.base64EncodeReadOnly":
  36.229 ±(99.9%) 2.299 ns/op [Average]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
