### PR TITLE
Remove ClientCall from ClientProtocol interface

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
@@ -109,7 +109,7 @@ public final class ClientPipeline<RequestT, ResponseT> {
 
         interceptor.readBeforeSerialization(inputHook);
         // Use the UNRESOLVED URI of "/" for now, and resolve the actual endpoint later.
-        RequestT request = protocol.createRequest(call, UNRESOLVED);
+        RequestT request = protocol.createRequest(call.operation(), input, context, UNRESOLVED);
         var requestHook = new RequestHook<>(context, input, request);
         interceptor.readAfterSerialization(requestHook);
 

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
@@ -7,8 +7,10 @@ package software.amazon.smithy.java.runtime.client.core;
 
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
+import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
 import software.amazon.smithy.java.runtime.core.schema.ApiException;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
@@ -42,11 +44,18 @@ public interface ClientProtocol<RequestT, ResponseT> {
     /**
      * Creates the underlying transport request.
      *
-     * @param call     Call being sent.
-     * @param endpoint Where to send the request.
+     * @param operation Operation to create request for.
+     * @param input     Input shape for the request.
+     * @param context   Context for the request.
+     * @param endpoint  Where to send the request.
      * @return Returns the request to send.
      */
-    RequestT createRequest(ClientCall<?, ?> call, URI endpoint);
+    <I extends SerializableStruct, O extends SerializableStruct> RequestT createRequest(
+        ApiOperation<I, O> operation,
+        I input,
+        Context context,
+        URI endpoint
+    );
 
     /**
      * Updates the underlying transport request to use the service endpoint.

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpBindingClientProtocol.java
@@ -9,9 +9,11 @@ import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.client.core.ClientCall;
 import software.amazon.smithy.java.runtime.core.schema.ApiException;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.InputEventStreamingApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.OutputEventStreamingApiOperation;
@@ -55,14 +57,19 @@ public class HttpBindingClientProtocol<F extends Frame<?>> extends HttpClientPro
     }
 
     @Override
-    public SmithyHttpRequest createRequest(ClientCall<?, ?> call, URI endpoint) {
+    public <I extends SerializableStruct, O extends SerializableStruct> SmithyHttpRequest createRequest(
+        ApiOperation<I, O> operation,
+        I input,
+        Context context,
+        URI endpoint
+    ) {
         RequestSerializer serializer = HttpBinding.requestSerializer()
-            .operation(call.operation())
+            .operation(operation)
             .payloadCodec(codec)
-            .shapeValue(call.input())
+            .shapeValue(input)
             .endpoint(endpoint);
 
-        if (call.operation() instanceof InputEventStreamingApiOperation<?, ?, ?> i) {
+        if (operation instanceof InputEventStreamingApiOperation<?, ?, ?> i) {
             serializer.eventEncoderFactory(getEventEncoderFactory(i));
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use operation, input, context separately.

This is something I ran into as part of https://github.com/smithy-lang/smithy-java/pull/283. To move ClientProtocol to `client-api` I want to break the dependency on ClientCall. ClientCall carries a lot of things (like intercetpors, auth/endpoint resolvers, etc.) that ClientProtocol should not care. So this change makes the ClientProtocol interface more minimal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
