### PR TITLE
Fix pre commit hook

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -21,5 +21,5 @@ fi
 
 for file in $changedSmithyFiles; do
   smithy format $file
-  git add -u
+  git add -u $changedSmithyFiles
 done


### PR DESCRIPTION
### Description of changes
Corrects git pre-commit hooks to only format staged files. 

Previously, calling `git add -u` with no argument was causing all changed files to be added even if not staged.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
