### PR TITLE
Make JsonFieldMapper an enum

### DIFF
--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
@@ -59,9 +59,7 @@ public final class JsonCodec implements Codec {
         var timestampResolver = builder.useTimestampFormat
             ? new TimestampResolver.UseTimestampFormatTrait(builder.defaultTimestampFormat)
             : new TimestampResolver.StaticFormat(builder.defaultTimestampFormat);
-        var fieldMapper = builder.useJsonName
-            ? new JsonFieldMapper.UseJsonNameTrait()
-            : JsonFieldMapper.UseMemberName.INSTANCE;
+        var fieldMapper = builder.useJsonName ? JsonFieldMapper.JSON_NAME : JsonFieldMapper.MEMBER_NAME;
         settings = new Settings(
             timestampResolver,
             fieldMapper,

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonFieldMapper.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonFieldMapper.java
@@ -14,30 +14,9 @@ import software.amazon.smithy.model.traits.JsonNameTrait;
 /**
  * Provides a mapping to and from members and JSON field names.
  */
-public sealed interface JsonFieldMapper {
-    /**
-     * Determines the schema of a member inside a container based on a JSON field name.
-     *
-     * @param container Container that contains members.
-     * @param field     JSON object field name.
-     * @return the resolved member schema or null if not found.
-     */
-    Schema fieldToMember(Schema container, String field);
+public enum JsonFieldMapper {
 
-    /**
-     * Converts a member schema a JSON object field name.
-     *
-     * @param member Member to convert to a field.
-     * @return the resolved object field name.
-     */
-    String memberToField(Schema member);
-
-    /**
-     * Uses the member name and ignores the jsonName trait.
-     */
-    final class UseMemberName implements JsonFieldMapper {
-        static final UseMemberName INSTANCE = new UseMemberName();
-
+    MEMBER_NAME {
         @Override
         public Schema fieldToMember(Schema container, String field) {
             return container.member(field);
@@ -52,13 +31,9 @@ public sealed interface JsonFieldMapper {
         public String toString() {
             return "FieldMapper{useJsonName=false}";
         }
-    }
+    },
 
-    /**
-     * Uses the jsonName trait if present, otherwise falls back to the member name.
-     */
-    final class UseJsonNameTrait implements JsonFieldMapper {
-
+    JSON_NAME {
         private final Map<Schema, Map<String, Schema>> jsonNameCache = new ConcurrentHashMap<>();
 
         @Override
@@ -90,5 +65,22 @@ public sealed interface JsonFieldMapper {
         public String toString() {
             return "FieldMapper{useJsonName=true}";
         }
-    }
+    };
+
+    /**
+     * Determines the schema of a member inside a container based on a JSON field name.
+     *
+     * @param container Container that contains members.
+     * @param field     JSON object field name.
+     * @return the resolved member schema or null if not found.
+     */
+    public abstract Schema fieldToMember(Schema container, String field);
+
+    /**
+     * Converts a member schema a JSON object field name.
+     *
+     * @param member Member to convert to a field.
+     * @return the resolved object field name.
+     */
+    public abstract String memberToField(Schema member);
 }


### PR DESCRIPTION
This allows JSON implementations to more easily add optimiziations for specific kinds of field mappers without having to use instanceOf.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
