### PR TITLE
Remove ClientCall from ClientProtocol.deserialize

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
@@ -19,10 +19,8 @@ import software.amazon.smithy.java.runtime.client.core.interceptors.ClientInterc
 import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
 import software.amazon.smithy.java.runtime.client.endpoint.api.EndpointResolver;
 import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
-import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.TypeRegistry;
-import software.amazon.smithy.model.shapes.ShapeId;
 
 public abstract class Client {
 
@@ -92,10 +90,7 @@ public abstract class Client {
             .supportedAuthSchemes(callConfig.supportedAuthSchemes())
             .authSchemeResolver(callConfig.authSchemeResolver())
             .identityResolvers(callIdentityResolvers)
-            .errorCreator((c, id) -> {
-                ShapeId shapeId = ShapeId.from(id);
-                return operationRegistry.createBuilder(shapeId, ModeledApiException.class);
-            })
+            .typeRegistry(operationRegistry)
             .build();
 
         return callPipeline.send(call);

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import software.amazon.smithy.java.context.Context;
@@ -21,9 +20,8 @@ import software.amazon.smithy.java.runtime.auth.api.scheme.AuthSchemeResolver;
 import software.amazon.smithy.java.runtime.client.core.interceptors.ClientInterceptor;
 import software.amazon.smithy.java.runtime.client.endpoint.api.EndpointResolver;
 import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
-import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
-import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.runtime.core.serde.TypeRegistry;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -38,7 +36,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
     private final EndpointResolver endpointResolver;
     private final ApiOperation<I, O> operation;
     private final Context context;
-    private final BiFunction<Context, String, ShapeBuilder<ModeledApiException>> errorCreator;
+    private final TypeRegistry typeRegistry;
     private final ClientInterceptor interceptor;
     private final AuthSchemeResolver authSchemeResolver;
     private final Map<ShapeId, AuthScheme<?, ?>> supportedAuthSchemes;
@@ -49,7 +47,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
         input = Objects.requireNonNull(builder.input, "input is null");
         operation = Objects.requireNonNull(builder.operation, "operation is null");
         context = Objects.requireNonNull(builder.context, "context is null");
-        errorCreator = Objects.requireNonNull(builder.errorCreator, "errorCreator is null");
+        typeRegistry = Objects.requireNonNull(builder.typeRegistry, "typeRegistry is null");
         endpointResolver = Objects.requireNonNull(builder.endpointResolver, "endpointResolver is null");
         interceptor = Objects.requireNonNull(builder.interceptor, "interceptor is null");
         authSchemeResolver = Objects.requireNonNull(builder.authSchemeResolver, "authSchemeResolver is null");
@@ -117,15 +115,12 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
     }
 
     /**
-     * Get the error creator of the call.
+     * Get the type registry of the call.
      *
-     * <p>If the errorCreator is null or that function returns null, a protocol must create an appropriate error based
-     * on protocol hints.
-     *
-     * @return Return the error creator.
+     * @return Return the type registry.
      */
-    public BiFunction<Context, String, ShapeBuilder<ModeledApiException>> errorCreator() {
-        return errorCreator;
+    public TypeRegistry typeRegistry() {
+        return typeRegistry;
     }
 
     /**
@@ -176,7 +171,7 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
         private EndpointResolver endpointResolver;
         private ApiOperation<I, O> operation;
         private Context context;
-        private BiFunction<Context, String, ShapeBuilder<ModeledApiException>> errorCreator;
+        private TypeRegistry typeRegistry;
         private ClientInterceptor interceptor = ClientInterceptor.NOOP;
         private AuthSchemeResolver authSchemeResolver;
         private final List<AuthScheme<?, ?>> supportedAuthSchemes = new ArrayList<>();
@@ -219,18 +214,13 @@ public final class ClientCall<I extends SerializableStruct, O extends Serializab
         }
 
         /**
-         * Sets a function used to create an error based on the context and extracted shape ID.
+         * Sets the TypeRegistry of the call.
          *
-         * <p>If the function returns null or no function is provided, the protocol will create an error based on
-         * protocol hints (e.g., HTTP status codes).
-         *
-         * @param errorCreator Function to create the builder for an error.
+         * @param typeRegistry TypeRegistry to use.
          * @return Returns the builder.
          */
-        public Builder<I, O> errorCreator(
-            BiFunction<Context, String, ShapeBuilder<ModeledApiException>> errorCreator
-        ) {
-            this.errorCreator = errorCreator;
+        public Builder<I, O> typeRegistry(TypeRegistry typeRegistry) {
+            this.typeRegistry = typeRegistry;
             return this;
         }
 

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
@@ -229,7 +229,7 @@ public final class ClientPipeline<RequestT, ResponseT> {
 
         interceptor.readBeforeDeserialization(responseHook);
 
-        return protocol.deserializeResponse(call.operation(), context, call.errorCreator(), request, modifiedResponse)
+        return protocol.deserializeResponse(call.operation(), context, call.typeRegistry(), request, modifiedResponse)
             .thenApply(shape -> {
                 var outputHook = new OutputHook<>(context, input, request, response, shape);
                 RuntimeException error = null;

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientProtocol.java
@@ -7,14 +7,12 @@ package software.amazon.smithy.java.runtime.client.core;
 
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiFunction;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.runtime.client.endpoint.api.Endpoint;
 import software.amazon.smithy.java.runtime.core.schema.ApiException;
 import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
-import software.amazon.smithy.java.runtime.core.schema.ModeledApiException;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
-import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.runtime.core.serde.TypeRegistry;
 
 /**
  * Handles request and response serialization.
@@ -77,19 +75,22 @@ public interface ClientProtocol<RequestT, ResponseT> {
     /**
      * Deserializes the output from the transport response or throws a modeled or unmodeled exception.
      *
-     * <p>For modeled exceptions, the {@code errorCreator} is used to build the error. If the errorCreator returns null
-     * or none is provided, the protocol can create an error based on protocol hints (e.g., HTTP status codes).
+     * <p>For modeled exceptions, the {@code typeRegistry} can be used to build the error. If the typeRegistry is null
+     * or is unaware of a desired shape, the protocol can create an error based on protocol hints (e.g., HTTP status
+     * codes).
      *
-     * @param request  Request that was sent for this response.
-     * @param response Response to deserialize.
-     * @param errorCreator A function used to create an error based on the context and extracted shape ID.
+     * @param operation    Operation to create request for.
+     * @param context      Context for the request.
+     * @param typeRegistry TypeRegistry that can be used to create shapes.
+     * @param request      Request that was sent for this response.
+     * @param response     Response to deserialize.
      * @return the deserialized output shape.
      * @throws ApiException if an error occurs, including deserialized modeled errors and protocol errors.
      */
     <I extends SerializableStruct, O extends SerializableStruct> CompletableFuture<O> deserializeResponse(
         ApiOperation<I, O> operation,
         Context context,
-        BiFunction<Context, String, ShapeBuilder<ModeledApiException>> errorCreator,
+        TypeRegistry typeRegistry,
         RequestT request,
         ResponseT response
     );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a follow up of https://github.com/smithy-lang/smithy-java/pull/284 where I failed to notice that deserialize also has `ClientCall`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
