### PR TITLE
Revert 286 to make JsonFieldMapper an interface

### DIFF
--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
@@ -59,7 +59,9 @@ public final class JsonCodec implements Codec {
         var timestampResolver = builder.useTimestampFormat
             ? new TimestampResolver.UseTimestampFormatTrait(builder.defaultTimestampFormat)
             : new TimestampResolver.StaticFormat(builder.defaultTimestampFormat);
-        var fieldMapper = builder.useJsonName ? JsonFieldMapper.JSON_NAME : JsonFieldMapper.MEMBER_NAME;
+        var fieldMapper = builder.useJsonName
+            ? new JsonFieldMapper.UseJsonNameTrait()
+            : JsonFieldMapper.UseMemberName.INSTANCE;
         settings = new Settings(
             timestampResolver,
             fieldMapper,

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonFieldMapper.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonFieldMapper.java
@@ -14,9 +14,32 @@ import software.amazon.smithy.model.traits.JsonNameTrait;
 /**
  * Provides a mapping to and from members and JSON field names.
  */
-public enum JsonFieldMapper {
+public sealed interface JsonFieldMapper {
+    /**
+     * Determines the schema of a member inside a container based on a JSON field name.
+     *
+     * @param container Container that contains members.
+     * @param field     JSON object field name.
+     * @return the resolved member schema or null if not found.
+     */
+    Schema fieldToMember(Schema container, String field);
 
-    MEMBER_NAME {
+    /**
+     * Converts a member schema a JSON object field name.
+     *
+     * @param member Member to convert to a field.
+     * @return the resolved object field name.
+     */
+    String memberToField(Schema member);
+
+    /**
+     * Uses the member name and ignores the jsonName trait.
+     */
+    final class UseMemberName implements JsonFieldMapper {
+        static final UseMemberName INSTANCE = new UseMemberName();
+
+        private UseMemberName() {}
+
         @Override
         public Schema fieldToMember(Schema container, String field) {
             return container.member(field);
@@ -31,9 +54,13 @@ public enum JsonFieldMapper {
         public String toString() {
             return "FieldMapper{useJsonName=false}";
         }
-    },
+    }
 
-    JSON_NAME {
+    /**
+     * Uses the jsonName trait if present, otherwise falls back to the member name.
+     */
+    final class UseJsonNameTrait implements JsonFieldMapper {
+
         private final Map<Schema, Map<String, Schema>> jsonNameCache = new ConcurrentHashMap<>();
 
         @Override
@@ -41,15 +68,13 @@ public enum JsonFieldMapper {
             var members = jsonNameCache.get(container);
 
             if (members == null) {
-                members = new HashMap<>(container.members().size());
+                Map<String, Schema> fresh = new HashMap<>(container.members().size());
                 for (Schema m : container.members()) {
                     var jsonName = m.getTrait(JsonNameTrait.class);
-                    if (jsonName != null) {
-                        members.put(jsonName.getValue(), m);
-                    } else {
-                        members.put(m.memberName(), m);
-                    }
+                    fresh.put(jsonName != null ? jsonName.getValue() : m.memberName(), m);
                 }
+                var previous = jsonNameCache.putIfAbsent(container, fresh);
+                members = previous == null ? fresh : previous;
             }
 
             return members.get(field);
@@ -65,22 +90,5 @@ public enum JsonFieldMapper {
         public String toString() {
             return "FieldMapper{useJsonName=true}";
         }
-    };
-
-    /**
-     * Determines the schema of a member inside a container based on a JSON field name.
-     *
-     * @param container Container that contains members.
-     * @param field     JSON object field name.
-     * @return the resolved member schema or null if not found.
-     */
-    public abstract Schema fieldToMember(Schema container, String field);
-
-    /**
-     * Converts a member schema a JSON object field name.
-     *
-     * @param member Member to convert to a field.
-     * @return the resolved object field name.
-     */
-    public abstract String memberToField(Schema member);
+    }
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/TimestampResolver.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/TimestampResolver.java
@@ -93,7 +93,9 @@ public sealed interface TimestampResolver {
             var result = cache.get(schema);
             if (result == null) {
                 var trait = schema.getTrait(TimestampFormatTrait.class);
-                result = trait != null ? TimestampFormatter.of(trait) : defaultFormat;
+                var fresh = trait != null ? TimestampFormatter.of(trait) : defaultFormat;
+                var previous = cache.putIfAbsent(schema, fresh);
+                result = previous == null ? fresh : previous;
             }
             return result;
         }


### PR DESCRIPTION
To void contention by using a global cache of JSON names across all clients, this commit reverts #286. Implementations that can optimize getting member names of structures when using member names can now just check if the fieldMapper is == to UseMemberName.INSTANCE since the only instance of UseMemberName can be the INSTANCE.

This commit also updates the caches so that they actually populate.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
