### PR TITLE
Pass shape ID in protocol settings

### DIFF
--- a/client-aws-rest-json1/src/main/java/software/amazon/smithy/java/runtime/client/aws/restjson1/RestJsonClientProtocol.java
+++ b/client-aws-rest-json1/src/main/java/software/amazon/smithy/java/runtime/client/aws/restjson1/RestJsonClientProtocol.java
@@ -75,7 +75,7 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
 
         @Override
         public ClientProtocol<?, ?> createProtocol(ProtocolSettings settings, RestJson1Trait trait) {
-            return new RestJsonClientProtocol(settings.namespace());
+            return new RestJsonClientProtocol(settings.service().getNamespace());
         }
     }
 }

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ProtocolSettings.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ProtocolSettings.java
@@ -5,18 +5,20 @@
 
 package software.amazon.smithy.java.runtime.client.core;
 
+import software.amazon.smithy.model.shapes.ShapeId;
+
 /**
  * Settings used to instantiate a {@link ClientProtocol} implementation.
  */
 public final class ProtocolSettings {
-    private final String namespace;
+    private final ShapeId service;
 
     public ProtocolSettings(Builder builder) {
-        this.namespace = builder.namespace;
+        this.service = builder.service;
     }
 
-    public String namespace() {
-        return namespace;
+    public ShapeId service() {
+        return service;
     }
 
     public static Builder builder() {
@@ -24,12 +26,12 @@ public final class ProtocolSettings {
     }
 
     public static class Builder {
-        private String namespace;
+        private ShapeId service;
 
         private Builder() {}
 
-        public Builder namespace(String namespace) {
-            this.namespace = namespace;
+        public Builder namespace(ShapeId service) {
+            this.service = service;
             return this;
         }
 

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
@@ -105,7 +105,7 @@ public final class ClientInterfaceGenerator
                     "defaultProtocol",
                     new DefaultProtocolGenerator(
                         writer,
-                        directive.settings().packageNamespace(),
+                        directive.settings().service(),
                         defaultProtocolTrait,
                         directive.context()
                     )
@@ -189,7 +189,7 @@ public final class ClientInterfaceGenerator
     }
 
     private record DefaultProtocolGenerator(
-        JavaWriter writer, String namespace, Trait defaultProtocolTrait, CodeGenerationContext context
+        JavaWriter writer, ShapeId service, Trait defaultProtocolTrait, CodeGenerationContext context
     ) implements
         Runnable {
         @Override
@@ -200,7 +200,7 @@ public final class ClientInterfaceGenerator
             writer.pushState();
             var template = """
                 private static final ${protocolSettings:T} settings = ${protocolSettings:T}.builder()
-                        .namespace(${serviceNamespace:S})
+                        .namespace(${shapeId:T}.from(${service:S}))
                         .build();
                 private static final ${trait:T} protocolTrait = ${initializer:C};
                 private static final ${clientProtocolFactory:T}<${trait:T}> factory = new ${?outer}${outer:T}.${name:L}${/outer}${^outer}${type:T}${/outer}();
@@ -210,7 +210,8 @@ public final class ClientInterfaceGenerator
             writer.putContext("trait", defaultProtocolTrait.getClass());
             var initializer = context.getInitializer(defaultProtocolTrait);
             writer.putContext("initializer", writer.consumer(w -> initializer.accept(w, defaultProtocolTrait)));
-            writer.putContext("serviceNamespace", namespace);
+            writer.putContext("shapeId", ShapeId.class);
+            writer.putContext("service", service);
             var factoryClass = getFactory(defaultProtocolTrait.toShapeId());
             if (factoryClass.isMemberClass()) {
                 writer.putContext("outer", factoryClass.getEnclosingClass());


### PR DESCRIPTION
Many protocols need to know the service shape name and the default namespace to use when deserializing relative shape IDs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
