### PR TITLE
Use unionBuilder for union types

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaGenerator.java
@@ -224,23 +224,24 @@ final class SchemaGenerator implements ShapeVisitor<Void>, Runnable {
 
     @Override
     public Void structureShape(StructureShape shape) {
-        generateStructMemberSchemas(shape);
+        generateStructMemberSchemas(shape, "structureBuilder");
         return null;
     }
 
     @Override
     public Void unionShape(UnionShape shape) {
-        generateStructMemberSchemas(shape);
+        generateStructMemberSchemas(shape, "unionBuilder");
         return null;
     }
 
-    private void generateStructMemberSchemas(Shape shape) {
+    private void generateStructMemberSchemas(Shape shape, String builderMethod) {
         writer.pushState();
         writer.putContext("hasMembers", !shape.members().isEmpty());
+        writer.putContext("builderMethod", builderMethod);
         writer.write(
             """
                 ${?recursive}${C}
-                ${/recursive}static final ${schemaClass:T} ${name:L} = ${?recursive}${name:L}_BUILDER${/recursive}${^recursive}${schemaClass:T}.structureBuilder(ID${traits:C})${/recursive}${?hasMembers}
+                ${/recursive}static final ${schemaClass:T} ${name:L} = ${?recursive}${name:L}_BUILDER${/recursive}${^recursive}${schemaClass:T}.${builderMethod:L}(ID${traits:C})${/recursive}${?hasMembers}
                     ${C|}
                     ${/hasMembers}.build();
                 """,


### PR DESCRIPTION
### Description of changes
Union schema builders currently (erroneously) use `structureBuilder` to create schemas. This can cause unions to be incorrectly registered as structures. This PR corrects union schemas to use the `unionBuilder` schema builder.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
