### PR TITLE
Add support for response status deserialization

### DIFF
--- a/client-aws-rest-json1/src/it/java/software/amazon/smithy/java/runtime/client/aws/restjson1/ProtocolTests.java
+++ b/client-aws-rest-json1/src/it/java/software/amazon/smithy/java/runtime/client/aws/restjson1/ProtocolTests.java
@@ -58,9 +58,6 @@ public class ProtocolTests {
         skipTests = {
             // Null values are not skipped in deserialization
             "RestJsonDeserializesDenseSetMapAndSkipsNull",
-            // STATUS is not supported yet? TODO?
-            "RestJsonHttpResponseCodeWithNoPayload",
-            "RestJsonHttpResponseCode",
             // Invalid ints, bools, etc in headers
             "RestJsonInputAndOutputWithNumericHeaders",
             "RestJsonInputAndOutputWithBooleanHeaders",

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpBindingDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/HttpBindingDeserializer.java
@@ -149,7 +149,10 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
                         structMemberConsumer.accept(state, member, new PayloadDeserializer(payloadCodec, body));
                     }
                 }
-                default -> throw new UnsupportedOperationException(bindingLoc + "not supported");
+                case STATUS -> {
+                    structMemberConsumer.accept(state, member, new ResponseStatusDeserializer(responseStatus));
+                }
+                default -> throw new UnsupportedOperationException(bindingLoc + " not supported");
             }
         }
 

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseStatusDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseStatusDeserializer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.http.binding;
+
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.serde.SpecificShapeDeserializer;
+
+final class ResponseStatusDeserializer extends SpecificShapeDeserializer {
+    private final int responseStatus;
+
+    public ResponseStatusDeserializer(int responseStatus) {
+        this.responseStatus = responseStatus;
+    }
+
+    @Override
+    public int readInteger(Schema schema) {
+        return responseStatus;
+    }
+}


### PR DESCRIPTION
### Description of changes
Adds support for the [httpResponseCode trait](https://smithy.io/2.0/spec/http-bindings.html#smithy-api-httpresponsecode-trait) in the HttpBinding serializer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
