### PR TITLE
Add one-shot Codec::serialize method

### DIFF
--- a/aws/client-json-protocols/src/main/java/software/amazon/smithy/java/runtime/client/aws/jsonprotocols/AwsJsonProtocol.java
+++ b/aws/client-json-protocols/src/main/java/software/amazon/smithy/java/runtime/client/aws/jsonprotocols/AwsJsonProtocol.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.client.aws.jsonprotocols;
 
-import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.net.http.HttpHeaders;
 import java.nio.charset.StandardCharsets;
@@ -73,15 +72,7 @@ abstract sealed class AwsJsonProtocol extends HttpClientProtocol permits AwsJson
             )
         );
 
-        // TODO: Use NoSyncBAOS that returns the bytes directly.
-        var sink = new ByteArrayOutputStream();
-        try (var serializer = codec.createSerializer(sink)) {
-            input.serialize(serializer);
-            serializer.flush();
-            builder.body(DataStream.ofBytes(sink.toByteArray(), contentType()));
-        }
-
-        return builder.build();
+        return builder.body(DataStream.ofByteBuffer(codec.serialize(input), contentType())).build();
     }
 
     @Override

--- a/aws/event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventShapeEncoder.java
+++ b/aws/event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventShapeEncoder.java
@@ -86,11 +86,10 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
                 HeaderValue.fromString(exceptionSchema.memberName())
             );
             headers.put(":content-type", HeaderValue.fromString(codec.getMediaType()));
-            var os = new ByteArrayOutputStream();
-            try (var serializer = codec.createSerializer(os)) {
-                me.serialize(serializer);
-            }
-            frame = new AwsEventFrame(new Message(headers, os.toByteArray()));
+            var payload = codec.serialize(me);
+            var bytes = new byte[payload.remaining()];
+            payload.get(bytes);
+            frame = new AwsEventFrame(new Message(headers, bytes));
         } else {
             EventStreamingException es = exceptionHandler.apply(exception);
             var headers = new HashMap<String, HeaderValue>();

--- a/examples/restjson-example/build.gradle.kts
+++ b/examples/restjson-example/build.gradle.kts
@@ -9,9 +9,6 @@ dependencies {
 }
 
 jmh {
-    warmupIterations = 2
-    iterations = 5
-    fork = 1
     //profilers.add("async:output=flamegraph")
     //profilers.add('gc')
 }

--- a/examples/restjson-example/model/person-image.smithy
+++ b/examples/restjson-example/model/person-image.smithy
@@ -3,7 +3,9 @@ $version: "2"
 namespace smithy.example
 
 resource PersonImage {
-    identifiers: { name: String }
+    identifiers: {
+        name: String
+    }
     read: GetPersonImage
     put: PutPersonImage
 }

--- a/examples/restjson-example/model/person.smithy
+++ b/examples/restjson-example/model/person.smithy
@@ -5,8 +5,14 @@ namespace smithy.example
 use trials#Trials
 
 resource Person {
-    identifiers: { name: String }
-    properties: { favoriteColor: String, age: Integer, birthday: Birthday }
+    identifiers: {
+        name: String
+    }
+    properties: {
+        favoriteColor: String
+        age: Integer
+        birthday: Birthday
+    }
     put: PutPerson
     resources: [
         PersonImage


### PR DESCRIPTION
The new method allows implementers to provide more efficient non-streaming serialization methods if they want, and the default implementation uses an unsynchronized variant of ByteArrayOutputStream that avoids the cost of repeated monitor acquisition. Next, we need to purge anything that asks for or offers a `byte[]` in the rest of the pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
