### PR TITLE
Remove unsupported tags from generated javadocs

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocFormatterInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocFormatterInterceptor.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.codegen.integrations.javadoc;
 
 import java.util.Scanner;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import software.amazon.smithy.java.codegen.sections.JavadocSection;
@@ -23,6 +24,84 @@ import software.amazon.smithy.utils.StringUtils;
 final class JavadocFormatterInterceptor implements CodeInterceptor<JavadocSection, JavaWriter> {
     private static final int MAX_LINE_LENGTH = 100;
     private static final Pattern PATTERN = Pattern.compile("<([a-z]+)*>.*?</\\1>", Pattern.DOTALL);
+    // HTML tags supported by javadocs for Java17. Note: this list is not directly documented in JavaDocs documentation
+    // and is instead found by inspecting the JDK doclint/HtmlTag.java file.
+    private static final Set<String> SUPPORTED_TAGS = Set.of(
+        "A",
+        "ABBR",
+        "ACRONYM",
+        "ADDRESS",
+        "ARTICLE",
+        "ASIDE",
+        "B",
+        "BDI",
+        "BIG",
+        "BLOCKQUOTE",
+        "BODY",
+        "BR",
+        "CAPTION",
+        "CENTER",
+        "CITE",
+        "CODE",
+        "COL",
+        "DD",
+        "DEL",
+        "DFN",
+        "DIV",
+        "DT",
+        "EM",
+        "FONT",
+        "FIGURE",
+        "FIGCAPTION",
+        "FRAME",
+        "FRAMESET",
+        "H1",
+        "H2",
+        "H3",
+        "H4",
+        "H5",
+        "H6",
+        "HEAD",
+        "HR",
+        "HTML",
+        "I",
+        "IFRAME",
+        "IMG",
+        "INS",
+        "KBD",
+        "LI",
+        "LINK",
+        "MAIN",
+        "MARK",
+        "META",
+        "NAV",
+        "NOFRAMES",
+        "NOSCRIPT",
+        "P",
+        "PRE",
+        "Q",
+        "S",
+        "SAMP",
+        "SCRIPT",
+        "SECTION",
+        "SMALL",
+        "SPAN",
+        "STRIKE",
+        "STRONG",
+        "STYLE",
+        "SUB",
+        "SUP",
+        "TD",
+        "TEMPLATE",
+        "TH",
+        "TIME",
+        "TITLE",
+        "TT",
+        "U",
+        "UL",
+        "WBR",
+        "VAR"
+    );
 
     @Override
     public Class<JavadocSection> sectionType() {
@@ -38,39 +117,44 @@ final class JavadocFormatterInterceptor implements CodeInterceptor<JavadocSectio
 
     private void writeDocStringContents(JavaWriter writer, String contents) {
         writer.writeWithNoFormatting("/**");
+        writer.writeInlineWithNoFormatting(" * ");
+        writeDocstringBody(writer, contents, 0);
+        writer.writeWithNoFormatting("\n */");
+    }
 
+    private void writeDocstringBody(JavaWriter writer, String contents, int nestingLevel) {
         // Split out any HTML-tag wrapped sections as we do not want to wrap
         // any customer documentation with tags
         Matcher matcher = PATTERN.matcher(contents);
         int lastMatchPos = 0;
-        writer.writeInlineWithNoFormatting(" * ");
         while (matcher.find()) {
             // write all contents up to the match.
-            writeDocstringLine(writer, contents.substring(lastMatchPos, matcher.start()));
+            writeDocstringLine(writer, contents.substring(lastMatchPos, matcher.start()), nestingLevel);
 
-            // write match contents
-            writer.writeInlineWithNoFormatting(
-                contents.substring(matcher.start(), matcher.end()).replace("\n", "\n * ")
-            );
+            // write match contents if the HTML tag is supported
+            var htmlTag = matcher.group(1);
+            if (SUPPORTED_TAGS.contains(htmlTag.toUpperCase())) {
+                writer.writeInlineWithNoFormatting("<" + htmlTag + ">");
+                var offsetForTagStart = 2 + htmlTag.length();
+                var tagContents = contents.substring(matcher.start() + offsetForTagStart, matcher.end());
+                writeDocstringBody(writer, tagContents, nestingLevel + 1);
+            }
+
             lastMatchPos = matcher.end();
         }
-
         // Write out all remaining contents
-        writeDocstringLine(writer, contents.substring(lastMatchPos));
-        writer.writeWithNoFormatting("\n */");
+        writeDocstringLine(writer, contents.substring(lastMatchPos), nestingLevel);
     }
 
-    private void writeDocstringLine(JavaWriter writer, String string) {
+    private void writeDocstringLine(JavaWriter writer, String string, int nestingLevel) {
         for (Scanner it = new Scanner(string); it.hasNextLine();) {
             var s = it.nextLine();
-            writer.writeInlineWithNoFormatting(
-                StringUtils.wrap(
-                    s,
-                    MAX_LINE_LENGTH,
-                    writer.getNewline() + " * ",
-                    false
-                )
-            );
+            // If we are outs of an HTML tag, wrap the string. Otherwise, ignore wrapping.
+            var str = nestingLevel == 0
+                ? StringUtils.wrap(s, MAX_LINE_LENGTH, writer.getNewline() + " * ", false)
+                : s;
+            writer.writeInlineWithNoFormatting(str);
+
             if (it.hasNextLine()) {
                 writer.writeInlineWithNoFormatting(writer.getNewline() + " * ");
             }

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -214,4 +214,26 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
             )
         );
     }
+
+    @Test
+    void skipsUnsupportedTagBlocks() {
+        var fileContents = getFileStringForClass("UnsupportedTagsInput");
+        assertThat(
+            fileContents,
+            containsString(
+                """
+                        /**
+                         * Documentation includes html tags that are not supported by Javadoc. These unsupported blocks should
+                         * be skipped.<pre>
+                         * This should be included.
+                         * </pre>
+                         * <pre>
+                         *     <code>CodeIsSupported</code>
+                         *
+                         * </pre>
+                         */
+                    """
+            )
+        );
+    }
 }

--- a/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
+++ b/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
@@ -13,6 +13,7 @@ service TestService {
         Unstable
         Rollup
         EnumVariants
+        UnsupportedTags
     ]
 }
 
@@ -120,4 +121,22 @@ enum EnumWithDocs {
     /// General Docs
     @unstable
     ALSO_DOCUMENTED
+}
+
+operation UnsupportedTags {
+    input := {
+        /// Documentation includes html tags that are not supported by Javadoc. These unsupported blocks should be skipped.
+        /// <pre>
+        /// This should be included.
+        /// </pre>
+        /// <note>
+        /// Note is not a valid javadoc tag, so this should be skipped.
+        /// </note>
+        ///
+        /// <pre>
+        ///     <code>CodeIsSupported</code>
+        ///     <important>Important is not supported</important>
+        /// </pre>
+        value: String
+    }
 }


### PR DESCRIPTION
### Description of changes
Strips out unsupported HTML tags from generated javadocs. This should enable us to generate javadocs for any generated clients/servers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
