### PR TITLE
Move formatting checks from pre-commit to pre-push

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 ## Development
 
-### Pre-commit hooks
-Pre-commit hooks are automatically added for unix users via the `addPreCommitHooks` gradle task.
+### Pre-push hooks
+Pre-push hooks are automatically added for unix users via the `addPrePushHooks` gradle task.
 **Note**: In order to successfully execute the pre-defined hooks you must have the `smithy` CLI installed. 
 See [installation instructions](https://smithy.io/2.0/guides/smithy-cli/cli_installation.html) if you do not already have the CLI installed.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-task("addPreCommitHooks") {
+task("addPrePushHooks") {
     onlyIf("unix") {
         !Os.isFamily(Os.FAMILY_WINDOWS)
     }
     exec {
-        commandLine("ln", "-s", "-f", "../../git-hooks/pre-commit", ".git/hooks/pre-commit")
+        commandLine("ln", "-s", "-f", "../../git-hooks/pre-push", ".git/hooks/pre-push")
     }
-    println("Pre-commit hooks added")
+    println("Pre-push hooks added")
 }

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -9,17 +9,24 @@ changedJavaFiles=$(git diff --staged --name-only | grep '\.java' | xargs -I {} b
 if [ -n "$changedJavaFiles" ]; then
   echo "[git hook] Executing spotless formatter on staged files before commit" 
   ./gradlew spotlessApply -DspotlessFiles=$changedJavaFiles
-  # Stage updates
-  git add -u $changedJavaFiles
+  if [ -n "$(git diff --staged --name-only | head -n1)"]; then
+      echo "[git hook] Spotless formatter made changes. Commit them and re-push."
+      exit 1
+  fi
 fi 
 
 # Execute smithy formatter on any updated smithy files 
-changedSmithyFiles=$(git diff --staged --name-only | grep '\.smithy')
+changedSmithyFiles=$(git diff --name-only | grep '\.smithy')
 if [ -n "$changedSmithyFiles" ]; then
   echo "[git hook] Formatting staged smithy files before commit"
 fi
 
 for file in $changedSmithyFiles; do
   smithy format $file
-  git add -u $changedSmithyFiles
+  if [ -n "$(git diff --name-only | head -n1)"]; then
+      echo "[git hook] smithy-format made changes. Commit them and re-push."
+      exit 1
+  fi
 done
+
+


### PR DESCRIPTION
I have two issues with the pre-commit hook:
1. I work locally by making lots of commits to track "good" points in my development so I can easily revert things that don't work. The pre-commit hook makes the commit process a lot slower.
2. It doesn't appear to always work. In my last few commits, spotlessApply has created formatting changes to files that I didn't touch. I think this is an issue with how `git add` was being run in the pre-commit hook, because these changes would always be sitting unstaged in my local repository after the hook ran.