### PR TITLE
Only cast traits using the default trait initializer

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/DefaultTraitInitializer.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/DefaultTraitInitializer.java
@@ -8,8 +8,10 @@ package software.amazon.smithy.java.codegen.integrations.core;
 import software.amazon.smithy.java.codegen.TraitInitializer;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.model.traits.DefaultTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
-final class DefaultTraitInitializer implements TraitInitializer<DefaultTrait> {
+@SmithyInternalApi
+public final class DefaultTraitInitializer implements TraitInitializer<DefaultTrait> {
 
     @Override
     public Class<DefaultTrait> traitClass() {


### PR DESCRIPTION
### Description of changes
Default trait initializers for protocols need to be cast to the correct trait type. Custom trait initializers do not need this same casting. 

This PR updates codegen to only add an cast for protocol traits when strictly required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
