### PR TITLE
Avoid naming conflicts in nested serde

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -58,12 +58,12 @@ public final class ListGenerator
                         static ${shape:T} deserialize${name:U}(${schema:T} schema, ${shapeDeserializer:T} deserializer) {
                             var size = deserializer.containerSize();
                             ${shape:T} result = size == -1 ? new ${collectionImpl:T}<>() : new ${collectionImpl:T}<>(size);
-                            deserializer.readList(schema, result, ${name:U}MemberDeserializer.INSTANCE);
+                            deserializer.readList(schema, result, ${name:U}$$MemberDeserializer.INSTANCE);
                             return result;
                         }
 
-                        private static final class ${name:U}MemberDeserializer implements ${shapeDeserializer:T}.ListMemberConsumer<${shape:B}> {
-                            static final ${name:U}MemberDeserializer INSTANCE = new ${name:U}MemberDeserializer();
+                        private static final class ${name:U}$$MemberDeserializer implements ${shapeDeserializer:T}.ListMemberConsumer<${shape:B}> {
+                            static final ${name:U}$$MemberDeserializer INSTANCE = new ${name:U}$$MemberDeserializer();
 
                             @Override
                             public void accept(${shape:B} state, ${shapeDeserializer:T} deserializer) {

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
@@ -55,14 +55,14 @@ public class MapGenerator
                                         ${keySchema:L},
                                         valueEntry.getKey()${?enumKey}.value()${/enumKey},
                                         valueEntry.getValue(),
-                                        ${name:U}ValueSerializer.INSTANCE
+                                        ${name:U}$$ValueSerializer.INSTANCE
                                     );
                                 }
                             }
                         }
 
-                        private static final class ${name:U}ValueSerializer implements ${biConsumer:T}<${value:B}, ${shapeSerializer:T}> {
-                            private static final ${name:U}ValueSerializer INSTANCE = new ${name:U}ValueSerializer();
+                        private static final class ${name:U}$$ValueSerializer implements ${biConsumer:T}<${value:B}, ${shapeSerializer:T}> {
+                            private static final ${name:U}$$ValueSerializer INSTANCE = new ${name:U}$$ValueSerializer();
 
                             @Override
                             public void accept(${value:B} values, ${shapeSerializer:T} serializer) {
@@ -77,12 +77,12 @@ public class MapGenerator
                         static ${shape:T} deserialize${name:U}(${schema:T} schema, ${shapeDeserializer:T} deserializer) {
                             var size = deserializer.containerSize();
                             ${shape:T} result = size == -1 ? new ${collectionImpl:T}<>() : new ${collectionImpl:T}<>(size);
-                            deserializer.readStringMap(schema, result, ${name:U}ValueDeserializer.INSTANCE);
+                            deserializer.readStringMap(schema, result, ${name:U}$$ValueDeserializer.INSTANCE);
                             return result;
                         }
 
-                        private static final class ${name:U}ValueDeserializer implements ${shapeDeserializer:T}.MapMemberConsumer<${string:T}, ${shape:B}> {
-                            static final ${name:U}ValueDeserializer INSTANCE = new ${name:U}ValueDeserializer();
+                        private static final class ${name:U}$$ValueDeserializer implements ${shapeDeserializer:T}.MapMemberConsumer<${string:T}, ${shape:B}> {
+                            static final ${name:U}$$ValueDeserializer INSTANCE = new ${name:U}$$ValueDeserializer();
 
                             @Override
                             public void accept(${shape:B} state, ${string:T} key, ${shapeDeserializer:T} deserializer) {


### PR DESCRIPTION
### Description of changes
Fixes a problem in code generation where it was possible to cause a naming conflict with Map and List value/member serializers by having a value/member shape with a name ending in `Value` or `Member`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
