### PR TITLE
Make ClientPipeline, ClientCall not public

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientCall.java
@@ -30,7 +30,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
  * @param <I> Input to send.
  * @param <O> Output to return.
  */
-public final class ClientCall<I extends SerializableStruct, O extends SerializableStruct> {
+final class ClientCall<I extends SerializableStruct, O extends SerializableStruct> {
 
     private final I input;
     private final EndpointResolver endpointResolver;

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientPipeline.java
@@ -36,7 +36,7 @@ import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
  * @param <RequestT>
  * @param <ResponseT>
  */
-public final class ClientPipeline<RequestT, ResponseT> {
+final class ClientPipeline<RequestT, ResponseT> {
 
     private static final InternalLogger LOGGER = InternalLogger.getLogger(ClientPipeline.class);
     private static final URI UNRESOLVED;


### PR DESCRIPTION
Treating ClientPipeline and ClientCall as implementation details of the Client gives us more freedom to change these classes in the future without risk of breaking others.

With more interfaces potentially being added to `client-core` (like `client-auth-api`, `client-endpoint-api` and maybe more in the future), it means more people will take a dependency on `client-core` directly. So I was thinking of the public surface area of `client-core` and felt it was better to keep it minimal. I think we can make it `public` in the future if we really think others might use it directly without `Client`. Just think it's safer to treat them package-private initially.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
