### PR TITLE
Add method to check if a stream can be replayed

### DIFF
--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/ByteBufferDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/ByteBufferDataStream.java
@@ -39,6 +39,11 @@ final class ByteBufferDataStream implements DataStream {
     }
 
     @Override
+    public boolean isReplayable() {
+        return true;
+    }
+
+    @Override
     public CompletableFuture<ByteBuffer> asByteBuffer() {
         return CompletableFuture.completedFuture(buffer.duplicate());
     }

--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/EmptyDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/EmptyDataStream.java
@@ -38,6 +38,11 @@ final class EmptyDataStream implements DataStream {
     }
 
     @Override
+    public boolean isReplayable() {
+        return true;
+    }
+
+    @Override
     public long contentLength() {
         return 0;
     }

--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/FileDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/FileDataStream.java
@@ -43,6 +43,11 @@ final class FileDataStream implements DataStream {
     }
 
     @Override
+    public boolean isReplayable() {
+        return true;
+    }
+
+    @Override
     public CompletableFuture<InputStream> asInputStream() {
         try {
             return CompletableFuture.completedFuture(Files.newInputStream(file));

--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/InputStreamDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/InputStreamDataStream.java
@@ -41,6 +41,11 @@ final class InputStreamDataStream implements DataStream {
     }
 
     @Override
+    public boolean isReplayable() {
+        return false;
+    }
+
+    @Override
     public long contentLength() {
         return contentLength;
     }

--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/PublisherDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/PublisherDataStream.java
@@ -13,11 +13,18 @@ final class PublisherDataStream implements DataStream {
     private final Flow.Publisher<ByteBuffer> publisher;
     private final long contentLength;
     private final String contentType;
+    private final boolean isReplayable;
 
-    PublisherDataStream(Flow.Publisher<ByteBuffer> publisher, long contentLength, String contentType) {
+    PublisherDataStream(Flow.Publisher<ByteBuffer> publisher, long contentLength, String contentType, boolean replay) {
         this.publisher = publisher;
         this.contentLength = contentLength;
         this.contentType = contentType;
+        this.isReplayable = replay;
+    }
+
+    @Override
+    public boolean isReplayable() {
+        return isReplayable;
     }
 
     @Override

--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/WrappedDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/WrappedDataStream.java
@@ -15,11 +15,13 @@ final class WrappedDataStream implements DataStream {
     private final DataStream delegate;
     private final String contentType;
     private final long contentLength;
+    private boolean isReplayable;
 
-    WrappedDataStream(DataStream delegate, long contentLength, String contentType) {
+    WrappedDataStream(DataStream delegate, long contentLength, String contentType, boolean isReplayable) {
         this.delegate = delegate;
         this.contentLength = contentLength;
         this.contentType = contentType;
+        this.isReplayable = isReplayable;
     }
 
     @Override
@@ -50,6 +52,11 @@ final class WrappedDataStream implements DataStream {
     @Override
     public boolean hasByteBuffer() {
         return delegate.hasByteBuffer();
+    }
+
+    @Override
+    public boolean isReplayable() {
+        return isReplayable;
     }
 
     @Override

--- a/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/ByteBufferDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/ByteBufferDataStreamTest.java
@@ -21,5 +21,6 @@ public class ByteBufferDataStreamTest {
 
         assertThat(ds.hasByteBuffer(), is(true));
         assertThat(ds.waitForByteBuffer(), equalTo(ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.isReplayable(), is(true));
     }
 }

--- a/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/FileDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/FileDataStreamTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.io.datastream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -21,6 +22,7 @@ public class FileDataStreamTest {
         assertThat(ds.contentLength(), equalTo(6L));
         assertThat(ds.contentType(), equalTo("text/plain"));
         assertThat(ds.asByteBuffer().get(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.isReplayable(), is(true));
     }
 
     @Test

--- a/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/InputStreamDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/InputStreamDataStreamTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.runtime.io.datastream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.nio.ByteBuffer;
@@ -23,6 +24,7 @@ public class InputStreamDataStreamTest {
         assertThat(ds.contentLength(), equalTo(-1L));
         assertThat(ds.contentType(), nullValue());
         assertThat(ds.asByteBuffer().get(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.isReplayable(), is(false));
     }
 
     @Test


### PR DESCRIPTION
This method allows things like signing to know if it's possible to read the payload, sign it, and then still send the payload in the request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
