### PR TITLE
Add support for paginated trait

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodeGenerationContext.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodeGenerationContext.java
@@ -31,9 +31,11 @@ import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.LengthTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
+import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.model.traits.PatternTrait;
 import software.amazon.smithy.model.traits.ProtocolDefinitionTrait;
 import software.amazon.smithy.model.traits.RangeTrait;
+import software.amazon.smithy.model.traits.RequestCompressionTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.RequiresLengthTrait;
 import software.amazon.smithy.model.traits.RetryableTrait;
@@ -66,7 +68,6 @@ public class CodeGenerationContext
         SparseTrait.ID,
         UniqueItemsTrait.ID,
         RequiresLengthTrait.ID,
-        RetryableTrait.ID,
         ErrorTrait.ID,
         DefaultTrait.ID,
         // Base Prelude Protocol traits
@@ -80,7 +81,12 @@ public class CodeGenerationContext
         EventHeaderTrait.ID,
         EventPayloadTrait.ID,
         HostLabelTrait.ID,
-        EndpointTrait.ID
+        EndpointTrait.ID,
+        // Prelude behavior traits
+        PaginatedTrait.ID,
+        IdempotencyTokenTrait.ID,
+        RetryableTrait.ID,
+        RequestCompressionTrait.ID
     );
 
     private final Model model;

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/CoreIntegration.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/CoreIntegration.java
@@ -34,6 +34,7 @@ public class CoreIntegration implements JavaCodegenIntegration {
     @Override
     public List<TraitInitializer<? extends Trait>> traitInitializers() {
         return List.of(
+            new PaginatedTraitInitializer(),
             new HttpApiKeyAuthTraitInitializer(),
             new RequestCompressionTraitInitializer(),
             new DefaultTraitInitializer(),

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/PaginatedTraitInitializer.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/PaginatedTraitInitializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.integrations.core;
+
+import software.amazon.smithy.java.codegen.TraitInitializer;
+import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.model.traits.PaginatedTrait;
+
+final class PaginatedTraitInitializer implements TraitInitializer<PaginatedTrait> {
+    @Override
+    public Class<PaginatedTrait> traitClass() {
+        return PaginatedTrait.class;
+    }
+
+    @Override
+    public void accept(JavaWriter writer, PaginatedTrait paginatedTrait) {
+        writer.pushState();
+        writer.putContext("input", paginatedTrait.getInputToken());
+        writer.putContext("output", paginatedTrait.getOutputToken());
+        writer.putContext("pageSize", paginatedTrait.getPageSize());
+        writer.putContext("items", paginatedTrait.getItems());
+        writer.putContext("paginated", PaginatedTrait.class);
+        writer.writeInline(
+            "${paginated:T}.builder()"
+                + "${?input}.inputToken(${input:S})${/input}"
+                + "${?output}.outputToken(${output:S})${/output}"
+                + "${?items}.items(${items:S})${/items}"
+                + "${?pageSize}.pageSize(${pageSize:S})${/pageSize}"
+                + ".build()"
+        );
+        writer.popState();
+    }
+}

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/CodegenContextTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/CodegenContextTest.java
@@ -30,8 +30,10 @@ import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.LengthTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
+import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.model.traits.PatternTrait;
 import software.amazon.smithy.model.traits.RangeTrait;
+import software.amazon.smithy.model.traits.RequestCompressionTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.RequiresLengthTrait;
 import software.amazon.smithy.model.traits.RetryableTrait;
@@ -86,11 +88,9 @@ public class CodegenContextTest {
                 RangeTrait.ID,
                 RequiredTrait.ID,
                 SensitiveTrait.ID,
-                IdempotencyTokenTrait.ID,
                 SparseTrait.ID,
                 UniqueItemsTrait.ID,
                 RequiresLengthTrait.ID,
-                RetryableTrait.ID,
                 ErrorTrait.ID,
                 DefaultTrait.ID,
                 // Base Prelude Protocol traits
@@ -110,7 +110,12 @@ public class CodegenContextTest {
                 HttpTrait.ID,
                 // Auth traits
                 HttpQueryTrait.ID,
-                HttpPayloadTrait.ID
+                HttpPayloadTrait.ID,
+                // Prelude behavior traits
+                PaginatedTrait.ID,
+                IdempotencyTokenTrait.ID,
+                RetryableTrait.ID,
+                RequestCompressionTrait.ID
             )
         );
     }
@@ -144,11 +149,9 @@ public class CodegenContextTest {
                 RangeTrait.ID,
                 RequiredTrait.ID,
                 SensitiveTrait.ID,
-                IdempotencyTokenTrait.ID,
                 SparseTrait.ID,
                 UniqueItemsTrait.ID,
                 RequiresLengthTrait.ID,
-                RetryableTrait.ID,
                 ErrorTrait.ID,
                 DefaultTrait.ID,
                 // Base Prelude Protocol traits
@@ -162,7 +165,12 @@ public class CodegenContextTest {
                 EventHeaderTrait.ID,
                 EventPayloadTrait.ID,
                 HostLabelTrait.ID,
-                EndpointTrait.ID
+                EndpointTrait.ID,
+                // Prelude behavior traits
+                PaginatedTrait.ID,
+                IdempotencyTokenTrait.ID,
+                RetryableTrait.ID,
+                RequestCompressionTrait.ID
             )
         );
     }


### PR DESCRIPTION
### Description of changes
Adds the `@paginated` trait to the list of default runtime traits to include and adds a trait initializer for the paginated trait.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
