### PR TITLE
Fix compile issues with generated client code for eventstreaming

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -127,6 +127,16 @@ public final class CodegenUtils {
     }
 
     /**
+     * Determines if a shape is an event stream.
+     *
+     * @param shape shape to check
+     * @return returns true if the shape is an event stream union
+     */
+    public static boolean isEventStream(Shape shape) {
+        return shape.isUnionShape() && shape.hasTrait(StreamingTrait.class);
+    }
+
+    /**
      * Checks if a symbol resolves to a Java Array type.
      *
      * @param symbol symbol to check

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
@@ -66,7 +66,7 @@ public class OperationGenerator
 
                         ${?hasInputEventStream}
                         @Override
-                        public ${supplier:T}<${sdkShapeBuilder:T}<${inputType:T}>> inputEventBuilderSupplier() {
+                        public ${supplier:T}<${sdkShapeBuilder:T}<${inputEventType:T}>> inputEventBuilderSupplier() {
                             return () -> ${inputEventType:T}.builder();
                         }
                         ${/hasInputEventStream}
@@ -75,6 +75,13 @@ public class OperationGenerator
                         public ${sdkShapeBuilder:N}<${outputType:T}> outputBuilder() {
                             return ${outputType:T}.builder();
                         }
+
+                        ${?hasOutputEventStream}
+                        @Override
+                        public ${supplier:T}<${sdkShapeBuilder:T}<${outputEventType:T}>> outputEventBuilderSupplier() {
+                            return () -> ${outputEventType:T}.builder();
+                        }
+                        ${/hasOutputEventStream}
 
                         @Override
                         public ${sdkSchema:N} schema() {
@@ -177,6 +184,7 @@ public class OperationGenerator
                     );
                 });
                 eventStreamIndex.getOutputInfo(shape).ifPresent(info -> {
+                    writer.putContext("supplier", Supplier.class);
                     writer.putContext("hasOutputEventStream", true);
                     writer.putContext(
                         "outputEventType",

--- a/examples/event-streaming/build.gradle.kts
+++ b/examples/event-streaming/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("smithy-java.examples-conventions")
+    alias(libs.plugins.jmh)
+}
+
+dependencies {
+    api(project(":aws:client-restjson"))
+    api(libs.smithy.aws.traits)
+}
+
+tasks {
+    spotbugsMain {
+        enabled = false
+    }
+
+    spotbugsIt {
+        enabled = false
+    }
+}

--- a/examples/event-streaming/model/main.smithy
+++ b/examples/event-streaming/model/main.smithy
@@ -1,0 +1,102 @@
+$version: "2.0"
+
+namespace smithy.example.eventstreaming
+
+use aws.protocols#restJson1
+
+@restJson1
+service MessageService {
+    operations: [
+        ExchangeMessages
+        PublishMessages
+        ReceiveMessages
+    ]
+}
+
+@http(method: "POST", uri: "/exchange")
+operation ExchangeMessages {
+    input := {
+        @httpHeader("x-chat-room")
+        room: String
+
+        @httpPayload
+        stream: InputMessageStream
+    }
+
+    output := {
+        @httpPayload
+        stream: OutputMessageStream
+    }
+
+    errors: [
+        RoomNotFound
+    ]
+}
+
+@http(method: "POST", uri: "/publish")
+operation PublishMessages {
+    input := {
+        @httpHeader("x-chat-room")
+        room: String
+
+        @httpPayload
+        stream: InputMessageStream
+    }
+
+    errors: [
+        RoomNotFound
+    ]
+}
+
+@http(method: "POST", uri: "/receive")
+operation ReceiveMessages {
+    output := {
+        @httpHeader("x-chat-room")
+        room: String
+
+        @httpPayload
+        stream: OutputMessageStream
+    }
+}
+
+@streaming
+union InputMessageStream {
+    message: MessageEvent
+    leave: LeaveEvent
+}
+
+@streaming
+union OutputMessageStream {
+    message: MessageEvent
+    leave: LeaveEvent
+    terminate: TerminateEvent
+}
+
+structure MessageEvent {
+    @required
+    @eventHeader
+    timestamp: DateTime
+
+    @required
+    message: String
+}
+
+structure LeaveEvent {
+    @required
+    @eventHeader
+    timestamp: DateTime
+}
+
+@timestampFormat("date-time")
+timestamp DateTime
+
+@error("client")
+structure TerminateEvent {
+    message: String
+}
+
+@error("client")
+@httpError(404)
+structure RoomNotFound {
+    message: String
+}

--- a/examples/event-streaming/smithy-build.json
+++ b/examples/event-streaming/smithy-build.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0",
+  "plugins": {
+    "java-client-codegen": {
+      "service": "smithy.example.eventstreaming#MessageService",
+      "namespace": "software.amazon.smithy.java.examples.eventstreaming",
+      "protocol": "aws.protocols#restJson1",
+      "transport": {
+        "http-java": {}
+      }
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,6 +40,7 @@ include("server-aws-rest-json1")
 include(":examples:restjson-example")
 include(":examples:dynamodb")
 include(":examples:server-example")
+include(":examples:event-streaming")
 
 // AWS specific
 include(":aws:event-streams")


### PR DESCRIPTION
The generated client isn't tested yet, but atleast it compiles.

Adds an event streaming example model. For now it only tests codegen works. Later will add tests to use the generated client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
