### PR TITLE
Re-enable integ tests, but remove finalized

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.codegen-plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.codegen-plugin-conventions.gradle.kts
@@ -36,3 +36,6 @@ sourceSets {
         }
     }
 }
+
+// Ensure integ tests are executed as part of test suite
+tasks["test"].finalizedBy("integ")

--- a/buildSrc/src/main/kotlin/smithy-java.examples-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.examples-conventions.gradle.kts
@@ -27,11 +27,6 @@ tasks.named("compileJava") {
     dependsOn("smithyBuild")
 }
 
-// Only run integration tests if explicitly called
-tasks.named("integ") {
-    enabled = false
-}
-
 // Helps Intellij plugin identify models
 sourceSets {
     main {

--- a/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
@@ -1,6 +1,7 @@
 
 plugins {
     id("smithy-java.java-conventions")
+    id("smithy-java.integ-test-conventions")
     id("jacoco")
 }
 
@@ -67,3 +68,6 @@ tasks.jacocoTestReport {
         html.outputLocation.set(file("${layout.buildDirectory.get()}/reports/jacoco"))
     }
 }
+
+// Ensure integ tests are executed as part of test suite
+tasks["test"].finalizedBy("integ")

--- a/buildSrc/src/main/kotlin/smithy-java.protocol-testing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.protocol-testing-conventions.gradle.kts
@@ -25,3 +25,6 @@ sourceSets {
         }
     }
 }
+
+// Ensure integ tests are executed as part of test suite
+tasks["test"].finalizedBy("integ")


### PR DESCRIPTION
### Description of changes
If the integration tests are explicitly disabled IDEA will not run the tests. This re-enables the integration test task but only automatically executes that task form non-example packages.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
