### PR TITLE
Switch to unformatted write in documentationTraitInterceptor

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/DocumentationTraitInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/DocumentationTraitInterceptor.java
@@ -19,7 +19,7 @@ final class DocumentationTraitInterceptor implements CodeInterceptor<JavadocSect
 
     @Override
     public void write(JavaWriter writer, String previousText, JavadocSection section) {
-        writer.write(section.shape().expectTrait(DocumentationTrait.class).getValue());
+        writer.writeWithNoFormatting(section.shape().expectTrait(DocumentationTrait.class).getValue());
 
         if (!previousText.isEmpty()) {
             // Add spacing if tags have been added to the javadoc


### PR DESCRIPTION
### Description of changes
Fixes problem where the `DocumentationTraitInterceptor` would fail due to missing formatting parameters if `$` was included in any docs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
