### PR TITLE
Implements "smart" chaining in resolver chain.

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/identity/IdentityResolver.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/identity/IdentityResolver.java
@@ -36,11 +36,30 @@ public interface IdentityResolver<IdentityT extends Identity> {
     /**
      * Combines multiple identity resolvers with the same identity type into a single resolver.
      *
+     * <p>By default the chained resolver will attempt to re-use the last successful provider when resolving the identity.
+     *
      * @param resolvers Resolvers to combine.
      * @return the combined resolvers.
      */
     static <I extends Identity> IdentityResolver<I> chain(List<IdentityResolver<I>> resolvers) {
-        return new IdentityResolverChain<>(resolvers);
+        return new IdentityResolverChain<>(resolvers, true);
+    }
+
+    /**
+     * Combines multiple identity resolvers with the same identity type into a single resolver.
+     *
+     * <p>By default
+     *
+     * @param resolvers Resolvers to combine.
+     * @param reuseLastProvider if the chained resolver should attempt to re-use the last successful provider when
+     *                          resolving the identity.
+     * @return the combined resolvers.
+     */
+    static <I extends Identity> IdentityResolver<I> chain(
+        List<IdentityResolver<I>> resolvers,
+        boolean reuseLastProvider
+    ) {
+        return new IdentityResolverChain<>(resolvers, reuseLastProvider);
     }
 
     /**

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/identity/IdentityResolverChain.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/identity/IdentityResolverChain.java
@@ -5,18 +5,25 @@
 
 package software.amazon.smithy.java.runtime.client.core.auth.identity;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.identity.Identity;
 
 final class IdentityResolverChain<IdentityT extends Identity> implements IdentityResolver<IdentityT> {
+    private static final InternalLogger LOGGER = InternalLogger.getLogger(IdentityResolverChain.class);
     private final Class<IdentityT> identityClass;
     private final List<IdentityResolver<IdentityT>> resolvers;
 
-    public IdentityResolverChain(List<IdentityResolver<IdentityT>> resolvers) {
+    private final boolean reuseLastProvider;
+    private IdentityResolver<IdentityT> lastUsedResolver;
+
+    public IdentityResolverChain(List<IdentityResolver<IdentityT>> resolvers, boolean reuseLastProvider) {
         this.resolvers = Objects.requireNonNull(resolvers, "resolvers cannot be null");
+        this.reuseLastProvider = reuseLastProvider;
         if (resolvers.isEmpty()) {
             throw new IllegalArgumentException("Cannot chain empty resolvers list.");
         }
@@ -24,22 +31,65 @@ final class IdentityResolverChain<IdentityT extends Identity> implements Identit
     }
 
     @Override
+    public Class<IdentityT> identityType() {
+        return identityClass;
+    }
+
+    @Override
     public CompletableFuture<IdentityT> resolveIdentity(AuthProperties requestProperties) {
-        CompletableFuture<IdentityT> result = resolvers.get(0).resolveIdentity(requestProperties);
-        for (var idx = 1; idx < resolvers.size(); idx++) {
-            var next = resolvers.get(idx);
-            result = result.exceptionallyComposeAsync(exc -> {
+        if (reuseLastProvider && lastUsedResolver != null) {
+            // Attempt to resolve identity using cached resolver, otherwise fall back to default chain.
+            return lastUsedResolver.resolveIdentity(requestProperties).exceptionallyComposeAsync(exc -> {
                 if (exc instanceof IdentityNotFoundException) {
-                    return next.resolveIdentity(requestProperties);
+                    LOGGER.debug(
+                        "Could not resolve identity using previously successful resolver {}. " +
+                            "Falling back to default chain.",
+                        lastUsedResolver,
+                        exc
+                    );
+                    lastUsedResolver = null;
+                    return this.resolveIdentity(requestProperties);
                 }
                 return CompletableFuture.failedFuture(exc);
             });
         }
-        return result;
+
+        List<String> excMessages = new ArrayList<>(resolvers.size());
+        return executeChain(resolvers.get(0), requestProperties, excMessages, 0);
     }
 
-    @Override
-    public Class<IdentityT> identityType() {
-        return identityClass;
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<IdentityT> executeChain(
+        IdentityResolver<IdentityT> resolver,
+        AuthProperties requestProperties,
+        List<String> excMessages,
+        int idx
+    ) {
+        lastUsedResolver = resolver;
+        var result = resolver.resolveIdentity(requestProperties);
+        if (idx + 1 < resolvers.size()) {
+            var nextResolver = resolvers.get(idx + 1);
+            return result.exceptionallyCompose(exc -> {
+                if (exc instanceof IdentityNotFoundException) {
+                    excMessages.add(exc.getMessage());
+                    return executeChain(nextResolver, requestProperties, excMessages, idx + 1);
+                }
+                return CompletableFuture.failedFuture(exc);
+            });
+        }
+        return result.exceptionallyComposeAsync(exc -> {
+            if (exc instanceof IdentityNotFoundException) {
+                excMessages.add(exc.getMessage());
+                lastUsedResolver = null;
+                return CompletableFuture.failedFuture(
+                    new IdentityNotFoundException(
+                        "Could not resolve identity with any resolvers in the chain : " + excMessages,
+                        (Class<? extends IdentityResolver<?>>) this.getClass(),
+                        identityClass
+                    )
+                );
+            }
+            return CompletableFuture.failedFuture(exc);
+        });
     }
 }


### PR DESCRIPTION
### Description of changes
Implements "smart" chaining in the resolver chain. This chain can optionally cache the last successful resolver when chaining resolvers, avoiding the need to go through the full chain each time an identity is resolver. 

If the cached resolver fails, the chaining resolver will fall back to checking the full resolution chain.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
