### PR TITLE
Add publication to be able to publish packages to maven local

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,3 +10,10 @@ task("addPrePushHooks") {
     }
     println("Pre-push hooks added")
 }
+
+val smithyJavaVersion = project.file("VERSION").readText().replace(System.lineSeparator(), "")
+allprojects {
+    group = "software.amazon.smithy.java"
+    version = smithyJavaVersion
+}
+println("Smithy-Java version: '${smithyJavaVersion}'")

--- a/buildSrc/src/main/kotlin/smithy-java.codegen-plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.codegen-plugin-conventions.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.Project
 plugins {
     id("smithy-java.module-conventions")
     id("smithy-java.integ-test-conventions")
+    id("smithy-java.publishing-conventions")
 }
 
 // Workaround per: https://github.com/gradle/gradle/issues/15383

--- a/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     id("smithy-java.java-conventions")
     id("smithy-java.integ-test-conventions")
+    id("smithy-java.publishing-conventions")
     id("jacoco")
 }
 

--- a/buildSrc/src/main/kotlin/smithy-java.protocol-testing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.protocol-testing-conventions.gradle.kts
@@ -1,4 +1,3 @@
-import gradle.kotlin.dsl.accessors._393fb14d292c021aa4a5c68db9b29ae3.sourceSets
 import org.gradle.kotlin.dsl.project
 
 plugins {

--- a/buildSrc/src/main/kotlin/smithy-java.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.publishing-conventions.gradle.kts
@@ -1,0 +1,57 @@
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.extra
+import org.gradle.kotlin.dsl.provideDelegate
+
+plugins {
+    `maven-publish`
+}
+
+/*
+ * Staging repository
+ * ====================================================
+ *
+ * Configure publication to staging repo for jreleaser
+ */
+publishing {
+    repositories {
+        maven {
+            name = "stagingRepository"
+            url = uri("${rootProject.buildDir}/staging")
+        }
+    }
+    // Add license spec to all maven publications
+    publications {
+        afterEvaluate {
+            create<MavenPublication>("mavenJava") {
+                val displayName: String by extra
+                pom {
+                    name.set(displayName)
+                    description.set(project.description)
+                    url.set("https://github.com/smithy-lang/smithy-java")
+                    licenses {
+                        license {
+                            name.set("Apache License 2.0")
+                            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                            distribution.set("repo")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("smithy")
+                            name.set("Smithy")
+                            organization.set("Amazon Web Services")
+                            organizationUrl.set("https://aws.amazon.com")
+                            roles.add("developer")
+                        }
+                    }
+                    scm {
+                        url.set("https://github.com/smithy-lang/smithy-java.git")
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
### Description of changes
Adds publishing conventions and applies these conventions to modules and codegen plugins so the project packages can be published to local maven cache.

Note: This does not actually configure publishing to a real maven repo. That will be added nearer to public release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
