### PR TITLE
Remove mediaType from Codec

### DIFF
--- a/aws/client-restjson/src/main/java/software/amazon/smithy/java/runtime/aws/client/restjson/RestJsonClientProtocol.java
+++ b/aws/client-restjson/src/main/java/software/amazon/smithy/java/runtime/aws/client/restjson/RestJsonClientProtocol.java
@@ -61,6 +61,11 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
     }
 
     @Override
+    protected String payloadMediaType() {
+        return "application/json";
+    }
+
+    @Override
     protected HttpErrorDeserializer getErrorDeserializer(Context context) {
         return errorDeserializer;
     }
@@ -73,6 +78,7 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
         return AwsEventEncoderFactory.forInputStream(
             inputOperation,
             codec(),
+            payloadMediaType(),
             (e) -> new EventStreamingException("InternalServerException", "Internal Server Error")
         );
     }

--- a/aws/event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventEncoderFactory.java
+++ b/aws/event-streams/src/main/java/software/amazon/smithy/java/runtime/events/aws/AwsEventEncoderFactory.java
@@ -19,37 +19,42 @@ public class AwsEventEncoderFactory implements EventEncoderFactory<AwsEventFrame
 
     private final Schema schema;
     private final Codec codec;
+    private final String payloadMediaType;
     private final Function<Throwable, EventStreamingException> exceptionHandler;
 
     private AwsEventEncoderFactory(
         Schema schema,
         Codec codec,
+        String payloadMediaType,
         Function<Throwable, EventStreamingException> exceptionHandler
     ) {
         this.schema = schema;
         this.codec = codec;
+        this.payloadMediaType = payloadMediaType;
         this.exceptionHandler = exceptionHandler;
     }
 
     public static AwsEventEncoderFactory forInputStream(
         InputEventStreamingApiOperation<?, ?, ?> operation,
         Codec codec,
+        String payloadMediaType,
         Function<Throwable, EventStreamingException> exceptionHandler
     ) {
-        return new AwsEventEncoderFactory(operation.inputEventSchema(), codec, exceptionHandler);
+        return new AwsEventEncoderFactory(operation.inputEventSchema(), codec, payloadMediaType, exceptionHandler);
     }
 
     public static AwsEventEncoderFactory forOutputStream(
         OutputEventStreamingApiOperation<?, ?, ?> operation,
         Codec codec,
+        String payloadMediaType,
         Function<Throwable, EventStreamingException> exceptionHandler
     ) {
-        return new AwsEventEncoderFactory(operation.outputEventSchema(), codec, exceptionHandler);
+        return new AwsEventEncoderFactory(operation.outputEventSchema(), codec, payloadMediaType, exceptionHandler);
     }
 
     @Override
     public EventEncoder<AwsEventFrame> newEventEncoder() {
-        return new AwsEventShapeEncoder(schema, codec, exceptionHandler);
+        return new AwsEventShapeEncoder(schema, codec, payloadMediaType, exceptionHandler);
     }
 
     @Override

--- a/client-http-binding/src/main/java/software/amazon/smithy/java/runtime/client/http/binding/HttpBindingClientProtocol.java
+++ b/client-http-binding/src/main/java/software/amazon/smithy/java/runtime/client/http/binding/HttpBindingClientProtocol.java
@@ -42,6 +42,8 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
 
     abstract protected Codec codec();
 
+    abstract protected String payloadMediaType();
+
     abstract protected HttpErrorDeserializer getErrorDeserializer(Context context);
 
     protected EventEncoderFactory<F> getEventEncoderFactory(InputEventStreamingApiOperation<?, ?, ?> inputOperation) {
@@ -62,6 +64,7 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
         RequestSerializer serializer = HttpBinding.requestSerializer()
             .operation(operation)
             .payloadCodec(codec())
+            .payloadMediaType(payloadMediaType())
             .shapeValue(input)
             .endpoint(endpoint);
 
@@ -91,6 +94,7 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
         var outputBuilder = operation.outputBuilder();
         ResponseDeserializer deser = HttpBinding.responseDeserializer()
             .payloadCodec(codec())
+            .payloadMediaType(payloadMediaType())
             .outputShapeBuilder(outputBuilder)
             .response(response);
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/Codec.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/serde/Codec.java
@@ -22,13 +22,6 @@ public interface Codec extends AutoCloseable {
     default void close() {}
 
     /**
-     * Returns the default media type used by this codec.
-     *
-     * @return Returns the default media type.
-     */
-    String getMediaType();
-
-    /**
      * Create a serializer from this Codec that serializes a shape into the sink.
      *
      * @param sink Where to serialize a shape.

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestDeserializer.java
@@ -38,6 +38,21 @@ public final class RequestDeserializer {
     }
 
     /**
+     * Set the expected media type to be used when a payload is deserialized.
+     *
+     * <p>If a media type is provided, then this deserializer will validate that the media type on the wire matches
+     * the expected media type. If no media type is provided, then this deserializer will perform no validation
+     * prior to attempting to parse the request payload with the codec.
+     *
+     * @param payloadMediaType Media type used with payloads.
+     * @return Returns the deserializer.
+     */
+    public RequestDeserializer payloadMediaType(String payloadMediaType) {
+        deserBuilder.payloadMediaType(payloadMediaType);
+        return this;
+    }
+
+    /**
      * HTTP request to deserialize.
      *
      * @param request Request to deserialize into the builder.

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/RequestSerializer.java
@@ -25,6 +25,7 @@ public final class RequestSerializer {
 
     private Codec payloadCodec;
     private ApiOperation<?, ?> operation;
+    private String payloadMediaType;
     private URI endpoint;
     private SerializableShape shapeValue;
     private EventEncoderFactory<?> eventStreamEncodingFactory;
@@ -51,6 +52,17 @@ public final class RequestSerializer {
      */
     public RequestSerializer payloadCodec(Codec payloadCodec) {
         this.payloadCodec = payloadCodec;
+        return this;
+    }
+
+    /**
+     * Set the required media typed used in payloads serialized by the provided codec.
+     *
+     * @param payloadMediaType Media type to use in the payload.
+     * @return the serializer.
+     */
+    public RequestSerializer payloadMediaType(String payloadMediaType) {
+        this.payloadMediaType = payloadMediaType;
         return this;
     }
 
@@ -98,11 +110,12 @@ public final class RequestSerializer {
         Objects.requireNonNull(shapeValue, "shapeValue is not set");
         Objects.requireNonNull(operation, "operation is not set");
         Objects.requireNonNull(payloadCodec, "payloadCodec is not set");
-        Objects.requireNonNull(payloadCodec, "endpoint is not set");
-        Objects.requireNonNull(payloadCodec, "value is not set");
+        Objects.requireNonNull(endpoint, "endpoint is not set");
+        Objects.requireNonNull(shapeValue, "value is not set");
+        Objects.requireNonNull(payloadMediaType, "payloadMediaType is not set");
 
         var httpTrait = operation.schema().expectTrait(HttpTrait.class);
-        var serializer = new HttpBindingSerializer(httpTrait, payloadCodec, bindingMatcher);
+        var serializer = new HttpBindingSerializer(httpTrait, payloadCodec, payloadMediaType, bindingMatcher);
         shapeValue.serialize(serializer);
         serializer.flush();
 

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
@@ -37,6 +37,21 @@ public final class ResponseDeserializer {
     }
 
     /**
+     * Set the expected media type to be used when a payload is deserialized.
+     *
+     * <p>If a media type is provided, then this deserializer will validate that the media type on the wire matches
+     * the expected media type. If no media type is provided, then this deserializer will perform no validation
+     * prior to attempting to parse the response payload with the codec.
+     *
+     * @param payloadMediaType Media type of the payload.
+     * @return the deserializer.
+     */
+    public ResponseDeserializer payloadMediaType(String payloadMediaType) {
+        deserBuilder.payloadMediaType(payloadMediaType);
+        return this;
+    }
+
+    /**
      * HTTP response to deserialize.
      *
      * @param response Response to deserialize into the builder.

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseSerializer.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.model.traits.HttpTrait;
  */
 public final class ResponseSerializer {
     private Codec payloadCodec;
+    private String payloadMediaType;
     private ApiOperation<?, ?> operation;
     private SerializableShape shapeValue;
     private EventEncoderFactory<?> eventEncoderFactory;
@@ -46,6 +47,17 @@ public final class ResponseSerializer {
      */
     public ResponseSerializer payloadCodec(Codec payloadCodec) {
         this.payloadCodec = payloadCodec;
+        return this;
+    }
+
+    /**
+     * Set the required media typed used in payloads serialized by the provided codec.
+     *
+     * @param payloadMediaType Media type to use in the payload.
+     * @return the serializer.
+     */
+    public ResponseSerializer payloadMediaType(String payloadMediaType) {
+        this.payloadMediaType = payloadMediaType;
         return this;
     }
 
@@ -82,9 +94,10 @@ public final class ResponseSerializer {
         Objects.requireNonNull(shapeValue, "shapeValue is not set");
         Objects.requireNonNull(operation, "operation is not set");
         Objects.requireNonNull(payloadCodec, "payloadCodec is not set");
+        Objects.requireNonNull(payloadMediaType, "payloadMediaType is not set");
 
         var httpTrait = operation.schema().expectTrait(HttpTrait.class);
-        var serializer = new HttpBindingSerializer(httpTrait, payloadCodec, bindingMatcher);
+        var serializer = new HttpBindingSerializer(httpTrait, payloadCodec, payloadMediaType, bindingMatcher);
         shapeValue.serialize(serializer);
         serializer.flush();
 

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/JsonCodec.java
@@ -76,11 +76,6 @@ public final class JsonCodec implements Codec {
     }
 
     @Override
-    public String getMediaType() {
-        return "application/json";
-    }
-
-    @Override
     public ShapeSerializer createSerializer(OutputStream sink) {
         return provider.newSerializer(sink, settings);
     }

--- a/server-aws-rest-json1/src/main/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1Protocol.java
+++ b/server-aws-rest-json1/src/main/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1Protocol.java
@@ -118,7 +118,8 @@ final class AwsRestJson1Protocol extends ServerProtocol {
                     .body(job.request().getDataStream())
                     .build()
             )
-            .payloadCodec(codec);
+            .payloadCodec(codec)
+            .payloadMediaType("application/json");
 
         try {
             deser.deserialize().get();


### PR DESCRIPTION
Codecs don't necessarily know the media-type associated with them. That is something a protocol should decide. For example, the same codec might use "application/json" with one protocol and "application/x-amz-json-1.0" in another. Anything that previoulsy got a media type from a codec has been updated to now accept a media type in its constructor or builder.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
