### PR TITLE
Implement "smart" resolver chain for identity resolvers

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/identity/IdentityResolver.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/identity/IdentityResolver.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.client.core.auth.identity;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.identity.Identity;
@@ -32,35 +31,6 @@ public interface IdentityResolver<IdentityT extends Identity> {
      * @return the class of the identity.
      */
     Class<IdentityT> identityType();
-
-    /**
-     * Combines multiple identity resolvers with the same identity type into a single resolver.
-     *
-     * <p>By default the chained resolver will attempt to re-use the last successful provider when resolving the identity.
-     *
-     * @param resolvers Resolvers to combine.
-     * @return the combined resolvers.
-     */
-    static <I extends Identity> IdentityResolver<I> chain(List<IdentityResolver<I>> resolvers) {
-        return new IdentityResolverChain<>(resolvers, true);
-    }
-
-    /**
-     * Combines multiple identity resolvers with the same identity type into a single resolver.
-     *
-     * <p>By default
-     *
-     * @param resolvers Resolvers to combine.
-     * @param reuseLastProvider if the chained resolver should attempt to re-use the last successful provider when
-     *                          resolving the identity.
-     * @return the combined resolvers.
-     */
-    static <I extends Identity> IdentityResolver<I> chain(
-        List<IdentityResolver<I>> resolvers,
-        boolean reuseLastProvider
-    ) {
-        return new IdentityResolverChain<>(resolvers, reuseLastProvider);
-    }
 
     /**
      * Create an implementation of {@link IdentityResolver} that returns a specific, pre-defined instance of {@link Identity}.


### PR DESCRIPTION
### Description
Implements "smart" chaining in the resolver chain. This chain can optionally cache the last successful resolver when chaining resolvers, avoiding the need to go through the full chain each time an identity is resolver.

If the cached resolver fails, the chaining resolver will fall back to checking the full resolution chain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
