### PR TITLE
Add dependency analysis plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(libs.spotbugs)
     implementation(libs.spotless)
     implementation(libs.smithy.gradle.base)
+    implementation(libs.dependency.analysis)
 
     // https://github.com/gradle/gradle/issues/15383
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))

--- a/buildSrc/src/main/kotlin/CodegenExtension.kt
+++ b/buildSrc/src/main/kotlin/CodegenExtension.kt
@@ -1,7 +1,6 @@
-import gradle.kotlin.dsl.accessors._6a08c79e5efb9941460fb21bc6022abc.sourceSets
 import org.gradle.api.Project
-import org.gradle.api.file.Directory
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
 
@@ -20,11 +19,11 @@ fun Project.addGenerateSrcsTask(
     if (name != null) {
         taskName += name
     }
+    val sourceSets = project.the<SourceSetContainer>()
     val task = tasks.register<JavaExec>(taskName) {
         delete(files(output))
         dependsOn("test")
-        classpath =
-            sourceSets["test"].runtimeClasspath + sourceSets["test"].output + sourceSets["it"].resources.sourceDirectories
+        classpath = sourceSets["test"].runtimeClasspath + sourceSets["test"].output + sourceSets["it"].resources.sourceDirectories
         mainClass = className
         environment("output", output)
         service?.let { environment("service", it) }

--- a/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("com.adarshr.test-logger")
     id("com.github.spotbugs")
     id("com.diffplug.spotless")
+    id("com.autonomousapps.dependency-analysis")
 }
 
 // Workaround per: https://github.com/gradle/gradle/issues/15383

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ smithy-gradle = "1.1.0"
 assertj = "3.26.3"
 jackson = "2.17.2"
 netty = "4.1.113.Final"
+dep-analysis = "2.1.4"
 
 [libraries]
 smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy" }
@@ -36,6 +37,7 @@ test-logger-plugin = { module = "com.adarshr:gradle-test-logger-plugin", version
 spotbugs = { module = "com.github.spotbugs.snom:spotbugs-gradle-plugin", version.ref = "spotbugs" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 smithy-gradle-base = { module = "software.amazon.smithy.gradle:smithy-base", version.ref = "smithy-gradle" }
+dependency-analysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dep-analysis" }
 
 [plugins]
 jmh = { id = "me.champeau.jmh", version.ref = "jmh" }


### PR DESCRIPTION
### Description of changes
Add code-quality plugin that checks for unused or incorrectly configure dependencies in gradle builds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
