### PR TITLE
Fix regression in execution of integ tests

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.integ-test-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.integ-test-conventions.gradle.kts
@@ -14,6 +14,3 @@ tasks.register<Test>("integ") {
     testClassesDirs = project.the<SourceSetContainer>()["it"].output.classesDirs
     classpath = project.the<SourceSetContainer>()["it"].runtimeClasspath
 }
-
-// Execute all integration tests by default as part of test suite
-tasks["test"].finalizedBy("integ")


### PR DESCRIPTION
### Description of changes
Integ tests should not be executed for all java packages in the project. This was previously removed, but was erroneously added back in as part of a merge conflict resolution.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
