### PR TITLE
Add faster TraitMap implementations

### DIFF
--- a/core/src/jmh/java/software/amazon/smithy/java/runtime/core/schema/TraitMapBench.java
+++ b/core/src/jmh/java/software/amazon/smithy/java/runtime/core/schema/TraitMapBench.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.schema;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.HttpChecksumRequiredTrait;
+import software.amazon.smithy.model.traits.HttpHeaderTrait;
+import software.amazon.smithy.model.traits.HttpLabelTrait;
+import software.amazon.smithy.model.traits.HttpPayloadTrait;
+import software.amazon.smithy.model.traits.HttpPrefixHeadersTrait;
+import software.amazon.smithy.model.traits.HttpQueryParamsTrait;
+import software.amazon.smithy.model.traits.HttpQueryTrait;
+import software.amazon.smithy.model.traits.SensitiveTrait;
+import software.amazon.smithy.model.traits.Trait;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(
+    iterations = 2,
+    time = 1
+)
+@Measurement(
+    iterations = 3,
+    time = 1
+)
+@BenchmarkMode(Mode.AverageTime)
+public class TraitMapBench {
+
+    @Benchmark
+    public void getTrait(TraitState s, Blackhole bh) {
+        bh.consume(s.traitMap.get(SensitiveTrait.class));
+    }
+
+    @State(Scope.Benchmark)
+    public static class TraitState {
+        // <Size>-<Position of trait to find>
+        @Param(
+            {
+                "1-0",
+                "2-0",
+                "2-1",
+                "3-0",
+                "3-1",
+                "3-2",
+                "4-0",
+                "4-1",
+                "4-2",
+                "4-3",
+                "5-0",
+                "5-1",
+                "5-2",
+                "5-3",
+                "5-4",
+                "6-0",
+                "6-1",
+                "6-2",
+                "6-3",
+                "6-4",
+                "6-5"
+            }
+        )
+        private String config;
+
+        @Param({"default", "map"})
+        private String traitMapType;
+
+        TraitMap traitMap;
+
+        @Setup
+        public void setup() throws Exception {
+            String[] split = config.split("-");
+            int size = Integer.parseInt(split[0]);
+            int position = Integer.parseInt(split[1]);
+            Trait[] traits = new Trait[size];
+            traits[position] = new SensitiveTrait();
+            Deque<Trait> remaining = new ArrayDeque<>(size);
+            remaining.add(DeprecatedTrait.builder().build());
+            remaining.add(new ErrorTrait("client"));
+            remaining.add(new HttpLabelTrait());
+            remaining.add(new HttpQueryTrait("foo"));
+            remaining.add(new HttpHeaderTrait("foo"));
+            remaining.add(new HttpPayloadTrait());
+            remaining.add(new HttpPrefixHeadersTrait("a"));
+            remaining.add(new HttpQueryParamsTrait());
+            remaining.add(new HttpChecksumRequiredTrait());
+
+            if (size > 1) {
+                for (int i = 0; i < size; i++) {
+                    if (i != position) {
+                        traits[i] = remaining.pop();
+                    }
+                }
+            }
+
+            if (traitMapType.equals("map")) {
+                var ctor = TraitMap.MapBasedTraitMap.class.getDeclaredConstructors()[0];
+                ctor.setAccessible(true);
+                this.traitMap = (TraitMap) ctor.newInstance((Object) traits);
+            } else {
+                this.traitMap = TraitMap.create(traits);
+            }
+        }
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/TraitMap.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/TraitMap.java
@@ -5,30 +5,29 @@
 
 package software.amazon.smithy.java.runtime.core.schema;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import software.amazon.smithy.model.traits.Trait;
 
 /**
  * Provides Trait class-based access to traits.
- *
- * <p>TODO: Add enum based getters for prelude traits.
  */
 sealed interface TraitMap {
 
     static TraitMap create(Trait[] traits) {
-        if (traits == null) {
-            return EMPTY;
-        }
-        return switch (traits.length) {
+        // Most schemas have 0-3 traits, and very few schemas have more than 5.
+        return switch (traits == null ? 0 : traits.length) {
             case 0 -> EMPTY;
-            case 1 -> new SingleValueTraitMap(traits[0]);
-            case 2, 3, 4, 5 -> new ArrayBasedTraitMap(traits);
+            case 1 -> new TraitMap1(traits[0]);
+            case 2 -> new TraitMap2(traits[0], traits[1]);
+            case 3 -> new TraitMap3(traits[0], traits[1], traits[2]);
+            case 4 -> new TraitMap4(traits[0], traits[1], traits[2], traits[3]);
+            case 5 -> new TraitMap5(traits[0], traits[1], traits[2], traits[3], traits[4]);
             default -> new MapBasedTraitMap(traits);
         };
     }
 
-    TraitMap EMPTY = new EmptyTraitMap();
+    TraitMap EMPTY = new TraitMap0();
 
     <T extends Trait> T get(Class<T> trait);
 
@@ -38,7 +37,7 @@ sealed interface TraitMap {
 
     TraitMap prepend(Trait[] traits);
 
-    final class EmptyTraitMap implements TraitMap {
+    final class TraitMap0 implements TraitMap {
         @Override
         public boolean contains(Class<? extends Trait> trait) {
             return false;
@@ -56,31 +55,29 @@ sealed interface TraitMap {
 
         @Override
         public TraitMap prepend(Trait[] traits) {
-            if (traits.length == 0) {
-                return this;
-            } else {
-                return TraitMap.create(traits);
-            }
+            return TraitMap.create(traits);
         }
     }
 
-    final class SingleValueTraitMap implements TraitMap {
+    final class TraitMap1 implements TraitMap {
 
         private final Trait value;
+        private final Class<?> c1;
 
-        private SingleValueTraitMap(Trait value) {
+        private TraitMap1(Trait value) {
             this.value = value;
+            this.c1 = value.getClass();
         }
 
         @Override
         public boolean contains(Class<? extends Trait> trait) {
-            return trait == value.getClass();
+            return trait == c1;
         }
 
         @SuppressWarnings("unchecked")
         @Override
         public <T extends Trait> T get(Class<T> trait) {
-            return trait == value.getClass() ? (T) value : null;
+            return trait == c1 ? (T) value : null;
         }
 
         @Override
@@ -90,70 +87,237 @@ sealed interface TraitMap {
 
         @Override
         public TraitMap prepend(Trait[] traits) {
-            if (traits.length == 0) {
-                return this;
-            } else {
-                Trait[] result = new Trait[traits.length + 1];
-                System.arraycopy(traits, 0, result, 0, traits.length);
-                result[traits.length] = value;
-                return TraitMap.create(result);
-            }
+            Trait[] result = copyArray(traits, 1);
+            result[traits.length] = value;
+            return TraitMap.create(result);
         }
     }
 
-    final class ArrayBasedTraitMap implements TraitMap {
+    private static Trait[] copyArray(Trait[] traits, int addSize) {
+        Trait[] result = new Trait[traits.length + addSize];
+        System.arraycopy(traits, 0, result, 0, traits.length);
+        return result;
+    }
 
-        private final Object[] types;
-        private final Object[] values;
+    final class TraitMap2 implements TraitMap {
 
-        private ArrayBasedTraitMap(Trait[] t) {
-            types = new Object[t.length];
-            values = new Object[t.length];
-            for (int i = 0; i < t.length; i++) {
-                var v = t[i];
-                types[i] = v.getClass();
-                values[i] = v;
-            }
+        private final Trait value1;
+        private final Trait value2;
+        private final Class<?> c1;
+        private final Class<?> c2;
+
+        private TraitMap2(Trait value1, Trait value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+            this.c1 = value1.getClass();
+            this.c2 = value2.getClass();
         }
 
         @Override
         public boolean contains(Class<? extends Trait> trait) {
-            for (Object type : types) {
-                if (type == trait) {
-                    return true;
-                }
-            }
-            return false;
+            return trait == c1 || trait == c2;
         }
 
-        @Override
         @SuppressWarnings("unchecked")
+        @Override
         public <T extends Trait> T get(Class<T> trait) {
-            for (int i = 0; i < types.length; i++) {
-                if (types[i] == trait) {
-                    return (T) values[i];
-                }
+            if (trait == c1) {
+                return (T) value1;
+            } else if (trait == c2) {
+                return (T) value2;
+            } else {
+                return null;
             }
-            return null;
         }
 
         @Override
         public boolean isEmpty() {
-            return values.length == 0;
+            return false;
         }
 
         @Override
         public TraitMap prepend(Trait[] traits) {
-            if (traits.length == 0) {
-                return this;
-            } else if (values.length == 0) {
-                return TraitMap.create(traits);
+            Trait[] result = copyArray(traits, 2);
+            result[traits.length] = value1;
+            result[traits.length + 1] = value2;
+            return TraitMap.create(result);
+        }
+    }
+
+    final class TraitMap3 implements TraitMap {
+
+        private final Trait value1;
+        private final Trait value2;
+        private final Trait value3;
+        private final Class<?> c1;
+        private final Class<?> c2;
+        private final Class<?> c3;
+
+        private TraitMap3(Trait value1, Trait value2, Trait value3) {
+            this.value1 = value1;
+            this.value2 = value2;
+            this.value3 = value3;
+            this.c1 = value1.getClass();
+            this.c2 = value2.getClass();
+            this.c3 = value3.getClass();
+        }
+
+        @Override
+        public boolean contains(Class<? extends Trait> trait) {
+            return trait == c1 || trait == c2 || trait == c3;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T extends Trait> T get(Class<T> trait) {
+            if (trait == c1) {
+                return (T) value1;
+            } else if (trait == c2) {
+                return (T) value2;
+            } else if (trait == c3) {
+                return (T) value3;
             } else {
-                Trait[] result = new Trait[traits.length + this.values.length];
-                System.arraycopy(traits, 0, result, 0, traits.length);
-                System.arraycopy(this.values, 0, result, traits.length, this.values.length);
-                return TraitMap.create(result);
+                return null;
             }
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public TraitMap prepend(Trait[] traits) {
+            Trait[] result = copyArray(traits, 3);
+            result[traits.length] = value1;
+            result[traits.length + 1] = value2;
+            result[traits.length + 2] = value3;
+            return TraitMap.create(result);
+        }
+    }
+
+    final class TraitMap4 implements TraitMap {
+
+        private final Trait value1;
+        private final Trait value2;
+        private final Trait value3;
+        private final Trait value4;
+        private final Class<?> c1;
+        private final Class<?> c2;
+        private final Class<?> c3;
+        private final Class<?> c4;
+
+        private TraitMap4(Trait value1, Trait value2, Trait value3, Trait value4) {
+            this.value1 = value1;
+            this.value2 = value2;
+            this.value3 = value3;
+            this.value4 = value4;
+            this.c1 = value1.getClass();
+            this.c2 = value2.getClass();
+            this.c3 = value3.getClass();
+            this.c4 = value4.getClass();
+        }
+
+        @Override
+        public boolean contains(Class<? extends Trait> trait) {
+            return trait == c1 || trait == c2 || trait == c3 || trait == c4;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T extends Trait> T get(Class<T> trait) {
+            if (trait == c1) {
+                return (T) value1;
+            } else if (trait == c2) {
+                return (T) value2;
+            } else if (trait == c3) {
+                return (T) value3;
+            } else if (trait == c4) {
+                return (T) value4;
+            } else {
+                return null;
+            }
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public TraitMap prepend(Trait[] traits) {
+            Trait[] result = copyArray(traits, 4);
+            result[traits.length] = value1;
+            result[traits.length + 1] = value2;
+            result[traits.length + 2] = value3;
+            result[traits.length + 3] = value4;
+            return TraitMap.create(result);
+        }
+    }
+
+    final class TraitMap5 implements TraitMap {
+
+        private final Trait value1;
+        private final Trait value2;
+        private final Trait value3;
+        private final Trait value4;
+        private final Trait value5;
+        private final Class<?> c1;
+        private final Class<?> c2;
+        private final Class<?> c3;
+        private final Class<?> c4;
+        private final Class<?> c5;
+
+        private TraitMap5(Trait value1, Trait value2, Trait value3, Trait value4, Trait value5) {
+            this.value1 = value1;
+            this.value2 = value2;
+            this.value3 = value3;
+            this.value4 = value4;
+            this.value5 = value5;
+            this.c1 = value1.getClass();
+            this.c2 = value2.getClass();
+            this.c3 = value3.getClass();
+            this.c4 = value4.getClass();
+            this.c5 = value5.getClass();
+        }
+
+        @Override
+        public boolean contains(Class<? extends Trait> trait) {
+            return trait == c1 || trait == c2 || trait == c3 || trait == c4 || trait == c5;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T extends Trait> T get(Class<T> trait) {
+            if (trait == c1) {
+                return (T) value1;
+            } else if (trait == c2) {
+                return (T) value2;
+            } else if (trait == c3) {
+                return (T) value3;
+            } else if (trait == c4) {
+                return (T) value4;
+            } else if (trait == c5) {
+                return (T) value5;
+            } else {
+                return null;
+            }
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public TraitMap prepend(Trait[] traits) {
+            Trait[] result = copyArray(traits, 5);
+            result[traits.length] = value1;
+            result[traits.length + 1] = value2;
+            result[traits.length + 2] = value3;
+            result[traits.length + 3] = value4;
+            result[traits.length + 4] = value5;
+            return TraitMap.create(result);
         }
     }
 
@@ -162,7 +326,7 @@ sealed interface TraitMap {
         private final Map<Class<?>, Trait> map;
 
         private MapBasedTraitMap(Trait[] traits) {
-            this(new HashMap<>(traits.length));
+            this(new IdentityHashMap<>(traits.length));
             for (var t : traits) {
                 this.map.put(t.getClass(), t);
             }
@@ -190,16 +354,12 @@ sealed interface TraitMap {
 
         @Override
         public TraitMap prepend(Trait[] traits) {
-            if (traits.length == 0) {
-                return this;
-            } else {
-                Map<Class<?>, Trait> result = new HashMap<>(map.size() + traits.length);
-                result.putAll(map);
-                for (var t : traits) {
-                    result.put(t.getClass(), t);
-                }
-                return new MapBasedTraitMap(result);
+            Map<Class<?>, Trait> result = new IdentityHashMap<>(map.size() + traits.length);
+            result.putAll(map);
+            for (var t : traits) {
+                result.put(t.getClass(), t);
             }
+            return new MapBasedTraitMap(result);
         }
     }
 }


### PR DESCRIPTION
It looks like we don't need an enum-based trait map for prelude traits with these custom TraitMap classes for common cases of 0-5 traits. An enum based trait map are about 0.9 ns/op, and we're able to exceed that with O(N) identity lookups of classes stored in local variables up until around the 4th or 5th element, so the return on adding an entirely different access pattern for only prelude traits doesn't make as much sense.

In the following benchmark, the number represents `<Size>-<Position>` where position is the element position of the trait the benchmark is trying to find. "default" uses the optimal classes being added in the PR. When it gets to a size of 6, both "default" and "map" are the same thing so for these cases "default" was omitted.

```
Benchmark               (config)  (traitMapType)  Mode  Cnt  Score   Error  Units
TraitMapBench.getTrait       1-0         default  avgt   10  0.780 ± 0.010  ns/op
TraitMapBench.getTrait       1-0             map  avgt   10  2.126 ± 0.009  ns/op
TraitMapBench.getTrait       2-0         default  avgt   10  0.784 ± 0.025  ns/op
TraitMapBench.getTrait       2-0             map  avgt   10  2.130 ± 0.021  ns/op
TraitMapBench.getTrait       2-1         default  avgt   10  0.887 ± 0.021  ns/op
TraitMapBench.getTrait       2-1             map  avgt   10  2.803 ± 0.023  ns/op
TraitMapBench.getTrait       3-0         default  avgt   10  0.778 ± 0.006  ns/op
TraitMapBench.getTrait       3-0             map  avgt   10  2.129 ± 0.021  ns/op
TraitMapBench.getTrait       3-1         default  avgt   10  0.884 ± 0.019  ns/op
TraitMapBench.getTrait       3-1             map  avgt   10  2.133 ± 0.017  ns/op
TraitMapBench.getTrait       3-2         default  avgt   10  0.896 ± 0.020  ns/op
TraitMapBench.getTrait       3-2             map  avgt   10  2.138 ± 0.027  ns/op
TraitMapBench.getTrait       4-0         default  avgt   10  0.792 ± 0.008  ns/op
TraitMapBench.getTrait       4-0             map  avgt   10  2.141 ± 0.029  ns/op
TraitMapBench.getTrait       4-1         default  avgt   10  0.882 ± 0.006  ns/op
TraitMapBench.getTrait       4-1             map  avgt   10  2.137 ± 0.024  ns/op
TraitMapBench.getTrait       4-2         default  avgt   10  0.883 ± 0.008  ns/op
TraitMapBench.getTrait       4-2             map  avgt   10  2.136 ± 0.023  ns/op
TraitMapBench.getTrait       4-3         default  avgt   10  1.005 ± 0.037  ns/op
TraitMapBench.getTrait       4-3             map  avgt   10  3.392 ± 0.061  ns/op
TraitMapBench.getTrait       5-0         default  avgt   10  0.780 ± 0.010  ns/op
TraitMapBench.getTrait       5-0             map  avgt   10  2.130 ± 0.013  ns/op
TraitMapBench.getTrait       5-1         default  avgt   10  0.879 ± 0.005  ns/op
TraitMapBench.getTrait       5-1             map  avgt   10  2.127 ± 0.012  ns/op
TraitMapBench.getTrait       5-2         default  avgt   10  0.899 ± 0.032  ns/op
TraitMapBench.getTrait       5-2             map  avgt   10  2.144 ± 0.030  ns/op
TraitMapBench.getTrait       5-3         default  avgt   10  1.015 ± 0.028  ns/op
TraitMapBench.getTrait       5-3             map  avgt   10  2.142 ± 0.064  ns/op
TraitMapBench.getTrait       5-4         default  avgt   10  1.105 ± 0.007  ns/op
TraitMapBench.getTrait       5-4             map  avgt   10  2.158 ± 0.045  ns/op
TraitMapBench.getTrait       6-0             map  avgt   10  2.135 ± 0.017  ns/op
TraitMapBench.getTrait       6-1             map  avgt   10  2.140 ± 0.023  ns/op
TraitMapBench.getTrait       6-2             map  avgt   10  2.153 ± 0.027  ns/op
TraitMapBench.getTrait       6-3             map  avgt   10  2.169 ± 0.049  ns/op
TraitMapBench.getTrait       6-4             map  avgt   10  2.147 ± 0.014  ns/op
TraitMapBench.getTrait       6-5             map  avgt   10  2.141 ± 0.015  ns/op
```