### PR TITLE
Add docs to builder setters.

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.SymbolProperties;
+import software.amazon.smithy.java.codegen.sections.BuilderSetterSection;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.sections.GetterSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
@@ -704,7 +705,7 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
             writer.pushState();
             writer.putContext("objects", Objects.class);
             for (var member : shape.members()) {
-                writer.pushState();
+                writer.pushState(new BuilderSetterSection(member));
                 writer.putContext("memberName", symbolProvider.toMemberName(member));
                 writer.putContext("memberSymbol", symbolProvider.toSymbol(member));
                 writer.putContext("tracked", CodegenUtils.isRequiredWithNoDefault(member));

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/BuilderReturnInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/BuilderReturnInterceptor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.integrations.javadoc;
+
+import software.amazon.smithy.java.codegen.sections.BuilderSetterSection;
+import software.amazon.smithy.java.codegen.sections.JavadocSection;
+import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.utils.CodeInterceptor;
+
+/**
+ * Adds the {@code @return} tag to builder setters with a static value.
+ */
+final class BuilderReturnInterceptor implements CodeInterceptor.Appender<JavadocSection, JavaWriter> {
+
+    @Override
+    public void append(JavaWriter writer, JavadocSection section) {
+        writer.writeWithNoFormatting("@return this builder.");
+    }
+
+    @Override
+    public Class<JavadocSection> sectionType() {
+        return JavadocSection.class;
+    }
+
+    @Override
+    public boolean isIntercepted(JavadocSection section) {
+        return section.parent() instanceof BuilderSetterSection;
+    }
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocInjectorInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocInjectorInterceptor.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.codegen.integrations.javadoc;
 
+import software.amazon.smithy.java.codegen.sections.BuilderSetterSection;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.sections.EnumVariantSection;
 import software.amazon.smithy.java.codegen.sections.GetterSection;
@@ -32,17 +33,17 @@ final class JavadocInjectorInterceptor implements CodeInterceptor.Prepender<Code
 
     @Override
     public boolean isIntercepted(CodeSection section) {
-        // Javadocs are generated for Classes, on member Getters, and on enum variants
+        // Javadocs are generated for Classes, on member Getters, and on enum variants, operations, and builder setters.
         return section instanceof ClassSection
             || section instanceof GetterSection
             || section instanceof EnumVariantSection
-            || section instanceof OperationSection;
+            || section instanceof OperationSection
+            || section instanceof BuilderSetterSection;
     }
 
     @Override
     public void prepend(JavaWriter writer, CodeSection section) {
         var shape = getShape(section);
-
         writer.injectSection(new JavadocSection(shape, section));
         if (shape.hasTrait(UnstableTrait.class)) {
             writer.write("@$T", SmithyUnstableApi.class);
@@ -64,6 +65,8 @@ final class JavadocInjectorInterceptor implements CodeInterceptor.Prepender<Code
             return gs.memberShape();
         } else if (section instanceof EnumVariantSection es) {
             return es.memberShape();
+        } else if (section instanceof BuilderSetterSection bs) {
+            return bs.memberShape();
         } else if (section instanceof OperationSection os) {
             return os.operation();
         } else {

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegration.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegration.java
@@ -36,6 +36,7 @@ public final class JavadocIntegration implements JavaCodegenIntegration {
             new SmithyGeneratedInterceptor(),
             new JavadocInjectorInterceptor(),
             new OperationErrorInterceptor(),
+            new BuilderReturnInterceptor(),
             new ExternalDocumentationTraitInterceptor(),
             new SinceTraitInterceptor(),
             new DeprecatedTraitInterceptor(),

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/OperationErrorInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/OperationErrorInterceptor.java
@@ -10,6 +10,9 @@ import software.amazon.smithy.java.codegen.sections.OperationSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.utils.CodeInterceptor;
 
+/**
+ * Adds the {@code @throws} javadoc tag to operations for all modeled errors the operation might throw.
+ */
 final class OperationErrorInterceptor implements CodeInterceptor.Appender<JavadocSection, JavaWriter> {
 
     @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/BuilderSetterSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/BuilderSetterSection.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.sections;
+
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.utils.CodeSection;
+
+/**
+ * Contains a setter method on a builder.
+ *
+ * @param memberShape Smithy member that the Builder setter sets
+ */
+public record BuilderSetterSection(MemberShape memberShape) implements CodeSection {
+}

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -236,4 +236,23 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
             )
         );
     }
+
+    @Test
+    void addsBuilderSettersDocs() {
+        var fileContents = getFileStringForClass("BuilderSettersInput");
+        assertThat(
+            fileContents,
+            containsString("""
+                        /**
+                         * Member with docs
+                         *
+                         * @return this builder.
+                         */
+                        public Builder foo(String foo) {
+                            this.foo = foo;
+                            return this;
+                        }
+                """)
+        );
+    }
 }

--- a/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
+++ b/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
@@ -14,6 +14,7 @@ service TestService {
         Rollup
         EnumVariants
         UnsupportedTags
+        BuilderSetters
     ]
 }
 
@@ -138,5 +139,12 @@ operation UnsupportedTags {
         ///     <important>Important is not supported</important>
         /// </pre>
         value: String
+    }
+}
+
+operation BuilderSetters {
+    input := {
+        /// Member with docs
+        foo: String
     }
 }


### PR DESCRIPTION
### Description of changes
Adds documentation to builder setters. This documentation will include any docstrings and documentation traits on the member being set as well as a `@return` tag.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
