### PR TITLE
Update member name resolution to uncapitalize acronyms at start

### DIFF
--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/NamingTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/NamingTest.java
@@ -116,6 +116,13 @@ public class NamingTest extends AbstractCodegenFileTest {
         assertTrue(fileStr.contains("public final class ACRONYMInsideStruct implements SerializableStruct"));
     }
 
+    @Test
+    void acronymMemberName() {
+        var fileStr = getFileStringForClass("CasingInput");
+        assertTrue(fileStr.contains("private final transient String acronymMemberName"));
+        assertTrue(fileStr.contains("public String acronymMemberName() {"));
+    }
+
     static List<Arguments> enumCaseArgs() {
         return List.of(
             Arguments.of("CAMEL_CASE", "camelCase"),

--- a/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/naming-test.smithy
+++ b/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/naming-test.smithy
@@ -81,6 +81,7 @@ operation Casing {
         ACRONYM_Inside_Member: String
         acronymInsideStruct: ACRONYMInsideStruct
         enums: EnumCasing
+        ACRONYMMemberName: String
     }
 }
 


### PR DESCRIPTION
### Description of changes
Previously member names with Camel case starting with acronyms, like `URIMember` would only uncapitalize the first character, i.e. `uRIMember`. This pr updates the member name resolution to continue uncapitalizing a string until the next character is not a capital so the example string above would be converted to `uriMember`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
