### PR TITLE
Add hint for required setters

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/BuilderSetterDocumentationInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/BuilderSetterDocumentationInterceptor.java
@@ -8,15 +8,19 @@ package software.amazon.smithy.java.codegen.integrations.javadoc;
 import software.amazon.smithy.java.codegen.sections.BuilderSetterSection;
 import software.amazon.smithy.java.codegen.sections.JavadocSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 
 /**
- * Adds the {@code @return} tag to builder setters with a static value.
+ * Adds the {@code @return} tag and "required" hint to builder setters.
  */
-final class BuilderReturnInterceptor implements CodeInterceptor.Appender<JavadocSection, JavaWriter> {
+final class BuilderSetterDocumentationInterceptor implements CodeInterceptor.Appender<JavadocSection, JavaWriter> {
 
     @Override
     public void append(JavaWriter writer, JavadocSection section) {
+        if (section.shape().hasTrait(RequiredTrait.class)) {
+            writer.writeWithNoFormatting("<p><strong>Required</strong>");
+        }
         writer.writeWithNoFormatting("@return this builder.");
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegration.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegration.java
@@ -36,7 +36,7 @@ public final class JavadocIntegration implements JavaCodegenIntegration {
             new SmithyGeneratedInterceptor(),
             new JavadocInjectorInterceptor(),
             new OperationErrorInterceptor(),
-            new BuilderReturnInterceptor(),
+            new BuilderSetterDocumentationInterceptor(),
             new ExternalDocumentationTraitInterceptor(),
             new SinceTraitInterceptor(),
             new DeprecatedTraitInterceptor(),


### PR DESCRIPTION
### Description of changes
Adds a hint to builder setter docs to indicate a setter is required.

For example, the following documented member in a smithy model: 
```
structure CoffeeItem {
    /// A type of coffee
    @required
    type: CoffeeType
}
```

Would generated the following builder setter javadoc:
```
       /**
         * A type of coffee
         *
         * <p><strong>Required</strong>
         * @return this builder.
         */
        public Builder typeMember(CoffeeType typeMember) {
        ....
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
