### PR TITLE
Add option to rename generated service and client shapes

### DIFF
--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/ClientJavaSymbolProvider.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/ClientJavaSymbolProvider.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.codegen.client;
 import static java.lang.String.format;
 
 import software.amazon.smithy.codegen.core.Symbol;
-import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaSymbolProvider;
 import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.model.Model;
@@ -18,35 +17,37 @@ import software.amazon.smithy.model.shapes.ServiceShape;
  * Maps Smithy types to Java Symbols for Client code generation.
  */
 final class ClientJavaSymbolProvider extends JavaSymbolProvider {
+    private final String serviceName;
 
-    public ClientJavaSymbolProvider(Model model, ServiceShape service, String packageNamespace) {
+    public ClientJavaSymbolProvider(Model model, ServiceShape service, String packageNamespace, String serviceName) {
         super(model, service, packageNamespace);
+        this.serviceName = serviceName;
     }
 
     @Override
     public Symbol serviceShape(ServiceShape serviceShape) {
-        var name = CodegenUtils.getDefaultName(serviceShape, serviceShape);
-        return getSymbolFromName(name, false).toBuilder()
-            .putProperty(ClientSymbolProperties.ASYNC_SYMBOL, getSymbolFromName(name + "Async", true))
+        return getSymbolFromName(false).toBuilder()
+            .putProperty(ClientSymbolProperties.ASYNC_SYMBOL, getSymbolFromName(true))
             .build();
     }
 
-    private Symbol getSymbolFromName(String name, boolean async) {
+    private Symbol getSymbolFromName(boolean async) {
+        var name = async ? serviceName + "AsyncClient" : serviceName + "Client";
         var symbol = Symbol.builder()
-            .name(name + "Client")
+            .name(name)
             .putProperty(SymbolProperties.IS_PRIMITIVE, false)
             .putProperty(ClientSymbolProperties.ASYNC, async)
             .namespace(format("%s.client", packageNamespace()), ".")
-            .definitionFile(format("./%s/client/%sClient.java", packageNamespace().replace(".", "/"), name))
+            .definitionFile(format("./%s/client/%s.java", packageNamespace().replace(".", "/"), name))
             .build();
 
         return symbol.toBuilder()
             .putProperty(
                 ClientSymbolProperties.CLIENT_IMPL,
                 symbol.toBuilder()
-                    .name(name + "ClientImpl")
+                    .name(name + "Impl")
                     .definitionFile(
-                        format("./%s/client/%sClientImpl.java", packageNamespace().replace(".", "/"), name)
+                        format("./%s/client/%sImpl.java", packageNamespace().replace(".", "/"), name)
                     )
                     .build()
             )

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/DirectedJavaClientCodegen.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/DirectedJavaClientCodegen.java
@@ -33,7 +33,8 @@ final class DirectedJavaClientCodegen implements
         return new ClientJavaSymbolProvider(
             directive.model(),
             directive.service(),
-            directive.settings().packageNamespace()
+            directive.settings().packageNamespace(),
+            directive.settings().name()
         );
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
@@ -27,6 +27,7 @@ public final class JavaCodegenSettings {
     private static final InternalLogger LOGGER = InternalLogger.getLogger(JavaCodegenSettings.class);
 
     private static final String SERVICE = "service";
+    private static final String NAME = "name";
     private static final String NAMESPACE = "namespace";
     private static final String HEADER_FILE = "headerFile";
     private static final String NON_NULL_ANNOTATION = "nonNullAnnotation";
@@ -34,8 +35,20 @@ public final class JavaCodegenSettings {
     private static final String TRANSPORT = "transport";
     private static final String DEFAULT_PLUGINS = "defaultPlugins";
     private static final String DEFAULT_SETTINGS = "defaultSettings";
+    private static final List<String> PROPERTIES = List.of(
+        SERVICE,
+        NAME,
+        NAMESPACE,
+        HEADER_FILE,
+        NON_NULL_ANNOTATION,
+        DEFAULT_PROTOCOL,
+        TRANSPORT,
+        DEFAULT_PLUGINS,
+        DEFAULT_SETTINGS
+    );
 
     private final ShapeId service;
+    private final String name;
     private final String packageNamespace;
     private final String header;
     private final Symbol nonNullAnnotationSymbol;
@@ -47,6 +60,7 @@ public final class JavaCodegenSettings {
 
     JavaCodegenSettings(
         ShapeId service,
+        String name,
         String packageNamespace,
         String headerFile,
         String sourceLocation,
@@ -57,6 +71,7 @@ public final class JavaCodegenSettings {
         List<String> defaultSettings
     ) {
         this.service = Objects.requireNonNull(service);
+        this.name = StringUtils.capitalize(Objects.requireNonNullElse(name, service.getName()));
         this.packageNamespace = Objects.requireNonNull(packageNamespace);
         this.header = getHeader(headerFile, Objects.requireNonNull(sourceLocation));
 
@@ -96,20 +111,10 @@ public final class JavaCodegenSettings {
      * @return Parsed settings
      */
     public static JavaCodegenSettings fromNode(ObjectNode settingsNode) {
-        settingsNode.warnIfAdditionalProperties(
-            List.of(
-                SERVICE,
-                NAMESPACE,
-                HEADER_FILE,
-                NON_NULL_ANNOTATION,
-                DEFAULT_PROTOCOL,
-                TRANSPORT,
-                DEFAULT_PLUGINS,
-                DEFAULT_SETTINGS
-            )
-        );
+        settingsNode.warnIfAdditionalProperties(PROPERTIES);
         return new JavaCodegenSettings(
             settingsNode.expectStringMember(SERVICE).expectShapeId(),
+            settingsNode.getStringMemberOrDefault(NAME, null),
             settingsNode.expectStringMember(NAMESPACE).getValue(),
             settingsNode.getStringMemberOrDefault(HEADER_FILE, null),
             settingsNode.getSourceLocation().getFilename(),
@@ -127,6 +132,10 @@ public final class JavaCodegenSettings {
 
     public ShapeId service() {
         return service;
+    }
+
+    public String name() {
+        return name;
     }
 
     public String packageNamespace() {

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/CodegenContextTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/CodegenContextTest.java
@@ -66,6 +66,7 @@ public class CodegenContextTest {
             model,
             new JavaCodegenSettings(
                 SERVICE_ID,
+                null,
                 "ns.foo",
                 null,
                 "",
@@ -128,6 +129,7 @@ public class CodegenContextTest {
             model,
             new JavaCodegenSettings(
                 NO_PROTOCOL_SERVICE_ID,
+                null,
                 "ns.foo",
                 null,
                 "",

--- a/codegen/server/src/main/java/software/amazon/smithy/java/codegen/server/DirectedJavaServerCodegen.java
+++ b/codegen/server/src/main/java/software/amazon/smithy/java/codegen/server/DirectedJavaServerCodegen.java
@@ -44,7 +44,8 @@ public class DirectedJavaServerCodegen implements
         return new ServiceJavaSymbolProvider(
             directive.model(),
             directive.service(),
-            directive.settings().packageNamespace()
+            directive.settings().packageNamespace(),
+            directive.settings().name()
         );
     }
 

--- a/codegen/server/src/main/java/software/amazon/smithy/java/codegen/server/ServiceJavaSymbolProvider.java
+++ b/codegen/server/src/main/java/software/amazon/smithy/java/codegen/server/ServiceJavaSymbolProvider.java
@@ -8,19 +8,19 @@ package software.amazon.smithy.java.codegen.server;
 import static java.lang.String.format;
 
 import software.amazon.smithy.codegen.core.Symbol;
-import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaSymbolProvider;
 import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.utils.StringUtils;
 
 public class ServiceJavaSymbolProvider extends JavaSymbolProvider {
+    private final String serviceName;
 
-    public ServiceJavaSymbolProvider(Model model, ServiceShape service, String packageNamespace) {
+    public ServiceJavaSymbolProvider(Model model, ServiceShape service, String packageNamespace, String serviceName) {
         super(model, service, packageNamespace);
+        this.serviceName = serviceName;
     }
 
     @Override
@@ -53,16 +53,15 @@ public class ServiceJavaSymbolProvider extends JavaSymbolProvider {
 
     @Override
     public Symbol serviceShape(ServiceShape serviceShape) {
-        return getServerJavaClassSymbol(serviceShape);
+        return getServerJavaClassSymbol();
     }
 
-    private Symbol getServerJavaClassSymbol(Shape shape) {
-        String name = CodegenUtils.getDefaultName(shape, service());
+    private Symbol getServerJavaClassSymbol() {
         return Symbol.builder()
-            .name(name)
+            .name(serviceName)
             .putProperty(SymbolProperties.IS_PRIMITIVE, false)
             .namespace(format("%s.service", packageNamespace()), ".")
-            .declarationFile(format("./%s/service/%s.java", packageNamespace().replace(".", "/"), name))
+            .declarationFile(format("./%s/service/%s.java", packageNamespace().replace(".", "/"), serviceName))
             .build();
     }
 }

--- a/examples/dynamodb/smithy-build.json
+++ b/examples/dynamodb/smithy-build.json
@@ -3,6 +3,7 @@
   "plugins": {
     "java-client-codegen": {
       "service": "com.amazonaws.dynamodb#DynamoDB_20120810",
+      "name": "DynamoDB",
       "namespace": "software.amazon.smithy.java.runtime.examples.dynamodb",
       "protocol": "aws.protocols#awsJson1_0",
       "defaultSettings": [

--- a/examples/end-to-end-example/model/coffee.smithy
+++ b/examples/end-to-end-example/model/coffee.smithy
@@ -13,6 +13,7 @@ enum CoffeeType {
 
 /// A structure which defines a coffee item which can be ordered
 structure CoffeeItem {
+    /// A type of coffee
     @required
     type: CoffeeType
 

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
@@ -119,7 +119,7 @@ public final class ProtocolTestExtension implements BeforeAllCallback, AfterAllC
             }
             case SERVER -> {
                 var symbolProvider = SymbolProvider.cache(
-                    new ServiceJavaSymbolProvider(serviceModel, service, serviceId.getNamespace())
+                    new ServiceJavaSymbolProvider(serviceModel, service, serviceId.getNamespace(), serviceId.getName())
                 );
                 Map<Class<?>, MockOperation> mockOperationMap = new HashMap<>();
                 var serverTestOperations = new ArrayList<ServerTestOperation>();


### PR DESCRIPTION
### Description of changes
Allow users of code generators to set the name of the generated service or client to something other than the service shape name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
