### PR TITLE
Auto-detect service shape if only a single service is present

### DIFF
--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/JavaClientCodegenPlugin.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/JavaClientCodegenPlugin.java
@@ -28,7 +28,7 @@ public final class JavaClientCodegenPlugin implements SmithyBuildPlugin {
     public void execute(PluginContext context) {
         CodegenDirector<JavaWriter, JavaCodegenIntegration, CodeGenerationContext, JavaCodegenSettings> runner = new CodegenDirector<>();
 
-        var settings = JavaCodegenSettings.fromNode(context.getSettings());
+        var settings = JavaCodegenSettings.fromNode(context.getSettings(), context.getModel());
         runner.settings(settings);
         runner.directedCodegen(new DirectedJavaClientCodegen());
         runner.fileManifest(context.getFileManifest());

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenPlugin.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenPlugin.java
@@ -23,7 +23,7 @@ public class TestJavaCodegenPlugin implements SmithyBuildPlugin {
     public void execute(PluginContext context) {
         CodegenDirector<JavaWriter, JavaCodegenIntegration, CodeGenerationContext, JavaCodegenSettings> runner = new CodegenDirector<>();
 
-        var settings = JavaCodegenSettings.fromNode(context.getSettings());
+        var settings = JavaCodegenSettings.fromNode(context.getSettings(), context.getModel());
         runner.settings(settings);
         runner.directedCodegen(new TestJavaCodegen());
         runner.fileManifest(context.getFileManifest());

--- a/codegen/server/src/main/java/software/amazon/smithy/java/codegen/server/JavaServerCodegenPlugin.java
+++ b/codegen/server/src/main/java/software/amazon/smithy/java/codegen/server/JavaServerCodegenPlugin.java
@@ -28,7 +28,7 @@ public class JavaServerCodegenPlugin implements SmithyBuildPlugin {
     public void execute(PluginContext context) {
         CodegenDirector<JavaWriter, JavaCodegenIntegration, CodeGenerationContext, JavaCodegenSettings> runner = new CodegenDirector<>();
 
-        var settings = JavaCodegenSettings.fromNode(context.getSettings());
+        var settings = JavaCodegenSettings.fromNode(context.getSettings(), context.getModel());
         runner.settings(settings);
         runner.directedCodegen(new DirectedJavaServerCodegen());
         runner.fileManifest(context.getFileManifest());

--- a/examples/dynamodb/smithy-build.json
+++ b/examples/dynamodb/smithy-build.json
@@ -2,7 +2,6 @@
   "version": "1.0",
   "plugins": {
     "java-client-codegen": {
-      "service": "com.amazonaws.dynamodb#DynamoDB_20120810",
       "namespace": "software.amazon.smithy.java.runtime.examples.dynamodb",
       "protocol": "aws.protocols#awsJson1_0",
       "defaultSettings": [

--- a/examples/end-to-end-example/smithy-build.json
+++ b/examples/end-to-end-example/smithy-build.json
@@ -2,7 +2,6 @@
   "version": "1.0",
   "plugins": {
     "java-client-codegen": {
-      "service": "com.example#CoffeeShop",
       // TODO: Make plugin aware of existing?
       "namespace": "software.amazon.smithy.java.client.example",
       "headerFile": "license.txt",
@@ -12,7 +11,6 @@
       }
     },
     "java-server-codegen": {
-      "service": "com.example#CoffeeShop",
       "namespace": "software.amazon.smithy.java.server.example",
       "headerFile": "license.txt"
     }

--- a/examples/event-streaming/smithy-build.json
+++ b/examples/event-streaming/smithy-build.json
@@ -2,7 +2,6 @@
   "version": "1.0",
   "plugins": {
     "java-client-codegen": {
-      "service": "smithy.example.eventstreaming#FizzBuzzService",
       "namespace": "software.amazon.smithy.java.examples.eventstreaming",
       "protocol": "aws.protocols#restJson1",
       "transport": {

--- a/examples/restjson-example/smithy-build.json
+++ b/examples/restjson-example/smithy-build.json
@@ -2,7 +2,6 @@
   "version": "1.0",
   "plugins": {
     "java-client-codegen": {
-      "service": "smithy.example#PersonDirectory",
       "namespace": "software.amazon.smithy.java.runtime.example",
       "headerFile": "license.txt",
       "protocol": "aws.protocols#restJson1",

--- a/examples/server-example/smithy-build.json
+++ b/examples/server-example/smithy-build.json
@@ -2,7 +2,6 @@
   "version": "1.0",
   "plugins": {
     "java-server-codegen": {
-      "service": "smithy.example#BeerService",
       "namespace": "software.amazon.smithy.java.server.example",
       "headerFile": "license.txt"
     }


### PR DESCRIPTION
### Description of changes
Proposed change update the codegen plugins to automatically detect the service shape if only a single service shape is present in the model provided to the plugin. Users will still need to specify a service to use if more than one service is present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
