### PR TITLE
Use empty node for trait initializers when possible

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/NodeWriter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/NodeWriter.java
@@ -45,6 +45,11 @@ record NodeWriter(JavaWriter writer, Node node) implements NodeVisitor<Void>, Ru
 
     @Override
     public Void objectNode(ObjectNode objectNode) {
+        // Just use empty object node if no members
+        if (objectNode.getMembers().isEmpty()) {
+            writer.write("${node:T}.objectNode()");
+            return null;
+        }
         writer.write("${node:T}.objectNodeBuilder()");
         writer.indent();
         var memberWriter = new MemberNodeWriter(writer);
@@ -102,6 +107,12 @@ record NodeWriter(JavaWriter writer, Node node) implements NodeVisitor<Void>, Ru
 
         @Override
         public Void objectNode(ObjectNode objectNode) {
+            // Just use empty object node if no members
+            if (objectNode.getMembers().isEmpty()) {
+                writer.write("${node:T}.objectNode()");
+                return null;
+            }
+
             writer.write("${node:T}.objectNodeBuilder()");
             writer.indent();
             for (var memberEntry : objectNode.getStringMap().entrySet()) {


### PR DESCRIPTION
### Description of changes
Use `Node.objectnode()` to get an empty object node in trait initializers where possible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
