### PR TITLE
Only create transport and protocol if not set

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientConfig.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientConfig.java
@@ -184,6 +184,15 @@ public final class ClientConfig {
         }
 
         /**
+         * Check if transport has been set on the builder.
+         *
+         * @return true if transport has been set
+         */
+        public boolean hasTransport() {
+            return this.transport != null;
+        }
+
+        /**
          * Set the protocol to use when sending requests.
          *
          * @param protocol Client protocol used to send requests.
@@ -192,6 +201,15 @@ public final class ClientConfig {
         public Builder protocol(ClientProtocol<?, ?> protocol) {
             this.protocol = protocol;
             return this;
+        }
+
+        /**
+         * Check if a protocol has been set on the builder.
+         *
+         * @return true if a protocol has been set
+         */
+        public boolean hasProtocol() {
+            return this.protocol != null;
         }
 
         /**


### PR DESCRIPTION
### Description of changes:*
Update to only create default transport and protocol if they are not already set.

Example of generated code in client `build()` method with this change: 
```
        private Builder() {

        }

        @Override
        public CoffeeShopClient build() {
            if (!configBuilder().hasProtocol()) {
                configBuilder().protocol(new RestJsonClientProtocol.Factory().createProtocol(settings, protocolTrait));
            }
            if (!configBuilder().hasTransport()) {
                configBuilder().transport(new JavaHttpClientTransport());
            }
            return new CoffeeShopClientImpl(this);
        }
 ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
