### PR TITLE
Dont add docs to client impls, make docs interface

### DIFF
--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
@@ -14,6 +14,7 @@ import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.client.ClientSymbolProperties;
+import software.amazon.smithy.java.codegen.sections.ApplyDocumentation;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.runtime.client.core.Client;
@@ -43,7 +44,7 @@ public final class ClientImplementationGenerator
     ) {
         var impl = symbol.expectProperty(ClientSymbolProperties.CLIENT_IMPL);
         directive.context().writerDelegator().useFileWriter(impl.getDefinitionFile(), impl.getNamespace(), writer -> {
-            writer.pushState(new ClassSection(directive.shape()));
+            writer.pushState(new ClassSection(directive.shape(), ApplyDocumentation.NONE));
             var template = """
                 final class ${impl:T} extends ${client:T} implements ${interface:T} {
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocInjectorInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocInjectorInterceptor.java
@@ -5,8 +5,10 @@
 
 package software.amazon.smithy.java.codegen.integrations.javadoc;
 
+import software.amazon.smithy.java.codegen.sections.ApplyDocumentation;
 import software.amazon.smithy.java.codegen.sections.BuilderSetterSection;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.codegen.sections.DocumentedSection;
 import software.amazon.smithy.java.codegen.sections.EnumVariantSection;
 import software.amazon.smithy.java.codegen.sections.GetterSection;
 import software.amazon.smithy.java.codegen.sections.JavadocSection;
@@ -34,11 +36,11 @@ final class JavadocInjectorInterceptor implements CodeInterceptor.Prepender<Code
     @Override
     public boolean isIntercepted(CodeSection section) {
         // Javadocs are generated for Classes, on member Getters, and on enum variants, operations, and builder setters.
-        return section instanceof ClassSection
-            || section instanceof GetterSection
-            || section instanceof EnumVariantSection
-            || section instanceof OperationSection
-            || section instanceof BuilderSetterSection;
+        if (section instanceof DocumentedSection c) {
+            return c.applyDocumentation() == ApplyDocumentation.DOCUMENT;
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/ApplyDocumentation.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/ApplyDocumentation.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.sections;
+
+/**
+ * Whether documentation is applied to an element, and if so, how.
+ */
+public enum ApplyDocumentation {
+    /**
+     * Generate documentation for the class.
+     */
+    DOCUMENT,
+
+    /**
+     * Do not write documentation (e.g., implicitly inherit documentation of a parent).
+     */
+    NONE
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/BuilderSetterSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/BuilderSetterSection.java
@@ -13,5 +13,4 @@ import software.amazon.smithy.utils.CodeSection;
  *
  * @param memberShape Smithy member that the Builder setter sets
  */
-public record BuilderSetterSection(MemberShape memberShape) implements CodeSection {
-}
+public record BuilderSetterSection(MemberShape memberShape) implements CodeSection, DocumentedSection {}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/ClassSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/ClassSection.java
@@ -12,5 +12,11 @@ import software.amazon.smithy.utils.CodeSection;
  * Contains a Java class definition.
  *
  * @param shape Smithy shape that the Java class defines
+ * @param applyDocumentation Whether and how documentation is applied.
  */
-public record ClassSection(Shape shape) implements CodeSection {}
+public record ClassSection(Shape shape, ApplyDocumentation applyDocumentation) implements CodeSection,
+    DocumentedSection {
+    public ClassSection(Shape shape) {
+        this(shape, ApplyDocumentation.DOCUMENT);
+    }
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/DocumentedSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/DocumentedSection.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.sections;
+
+/**
+ * Applied to sections that can have documentation.
+ */
+public interface DocumentedSection {
+    default ApplyDocumentation applyDocumentation() {
+        return ApplyDocumentation.DOCUMENT;
+    }
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/EnumVariantSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/EnumVariantSection.java
@@ -13,4 +13,4 @@ import software.amazon.smithy.utils.CodeSection;
  *
  * @param memberShape Member shape for enum variant
  */
-public record EnumVariantSection(MemberShape memberShape) implements CodeSection {}
+public record EnumVariantSection(MemberShape memberShape) implements CodeSection, DocumentedSection {}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/GetterSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/GetterSection.java
@@ -13,4 +13,4 @@ import software.amazon.smithy.utils.CodeSection;
  *
  * @param memberShape Member shape that getter provides
  */
-public record GetterSection(MemberShape memberShape) implements CodeSection {}
+public record GetterSection(MemberShape memberShape) implements CodeSection, DocumentedSection {}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/OperationSection.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/sections/OperationSection.java
@@ -19,5 +19,4 @@ public record OperationSection(
     OperationShape operation,
     SymbolProvider symbolProvider,
     Model model
-) implements CodeSection {
-}
+) implements CodeSection, DocumentedSection {}


### PR DESCRIPTION
There's now an interface, DocumentedSection, that's used to trigger the javadoc interceptor. The behavior of this interface can now be configured with the ApplyDocumentation enum. This enum is used to ensure that javadocs are not injected for implementations of client classes, since those should just implicitly inherit the javadocs of the client interface.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
