### PR TITLE
Add additional, missing javadocs to generated code

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
@@ -163,14 +163,25 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
         public void run() {
             writer.pushState();
             var template = """
+                /**
+                 * Value contained by this Enum.
+                 */
                 public ${value:N} value() {
                     return value;
                 }
 
+                /**
+                 * Type of this Enum variant.
+                 */
                 public ${type:N} type() {
                     return type;
                 }
 
+                /**
+                 * Create an Enum of an {@link Type#$$UNKNOWN} type containing a value.
+                 *
+                 * @param value value contained by unknown Enum.
+                 */
                 public static ${shape:T} unknown(${value:T} value) {
                     return new ${shape:T}(Type.$$UNKNOWN, value);
                 }
@@ -208,6 +219,12 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
             writer.pushState();
             writer.putContext("illegalArg", IllegalArgumentException.class);
             writer.write("""
+                /**
+                 * Returns a {@link ${shape:T}} constant with the specified value.
+                 *
+                 * @param value value to create {@code ${shape:T}} from.
+                 * @throws ${illegalArg:T} if value does not match a known value.
+                 */
                 public static ${shape:T} from(${value:T} value) {
                     return switch (value) {
                         ${C|}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ShapeBuilder.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ShapeBuilder.java
@@ -34,6 +34,7 @@ public interface ShapeBuilder<T extends SerializableShape> {
      * member to zero to allow the shape to build.
      *
      * @return Returns the builder.
+     * @see <a href="https://smithy.io/2.0/spec/aggregate-types.html#client-error-correction">Client Error Correction</a>
      */
     default ShapeBuilder<T> errorCorrection() {
         return this;


### PR DESCRIPTION
### Description of changes
Adds additional missing javadocs, primarily to generated Enum shapes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
