### PR TITLE
Touch up quickstart based on initial testing

### DIFF
--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -15,6 +15,9 @@ Then, to create a new project from this template, use the [Smithy CLI](https://s
 smithy init -t quickstart --url git@github.com:smithy-lang/smithy-java.git
 ```
 
+Generate a Gradle wrapper for the template by running `gradle wrapper` from the root of
+the generated project.
+
 ### Running and testing server
 To run and test the server, run `./gradlew run` from the root of a project created from this
 template. That will start the server running on port 8888. 

--- a/examples/quickstart/client/build.gradle.kts
+++ b/examples/quickstart/client/build.gradle.kts
@@ -45,6 +45,9 @@ tasks.register<Test>("integ") {
     useJUnitPlatform()
     testClassesDirs = sourceSets["it"].output.classesDirs
     classpath = sourceSets["it"].runtimeClasspath
+    testLogging {
+        showStandardStreams = true
+    }
 }
 
 // Junit test dependencies

--- a/smithy-templates.json
+++ b/smithy-templates.json
@@ -5,9 +5,6 @@
       "documentation": "Smithy-Java quickstart example with client and server.",
       "path": "examples/quickstart",
       "include": [
-        "gradle/wrapper",
-        "gradlew",
-        "gradlew.bat",
         "gradle.properties",
         ".gitignore"
       ]


### PR DESCRIPTION
### Description of changes
Touches up the quickstart example based on some initial testing/trial: 
1. Removes gradle wrapper in favor of letting customers generate for themselves. There appears to be a bug in smithy init with the nested directory inclusion. 
2. Adds test logging so integ test results can be seen without needing to run in an IDE like Intellij


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
