### PR TITLE
Add support for relativeDate and relativeVersion filtering

### DIFF
--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/JavaClientCodegenPlugin.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/JavaClientCodegenPlugin.java
@@ -11,6 +11,7 @@ import software.amazon.smithy.codegen.core.directed.CodegenDirector;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.transforms.RemoveDeprecatedShapesTransformer;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -33,7 +34,9 @@ public final class JavaClientCodegenPlugin implements SmithyBuildPlugin {
         runner.directedCodegen(new DirectedJavaClientCodegen());
         runner.fileManifest(context.getFileManifest());
         runner.service(settings.service());
-        runner.model(context.getModel());
+        // Filter out any deprecated shapes
+        var model = RemoveDeprecatedShapesTransformer.transform(context.getModel(), settings);
+        runner.model(model);
         runner.integrationClass(JavaCodegenIntegration.class);
         runner.performDefaultCodegenTransforms();
         runner.createDedicatedInputsAndOutputs();

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -11,6 +11,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.ReservedWords;
@@ -61,6 +62,15 @@ public final class CodegenUtils {
         ShapeType.INT_ENUM,
         ShapeType.UNION,
         ShapeType.STRUCTURE
+    );
+    // Semver regex from spec.
+    // See: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    private static final Pattern SEMVER_REGEX = Pattern.compile(
+        "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    );
+    // YYYY-MM-DD calendar date with optional hyphens.
+    private static final Pattern ISO_8601_DATE_REGEX = Pattern.compile(
+        "^([0-9]{4})-?(1[0-2]|0[1-9])-?(3[01]|0[1-9]|[12][0-9])$"
     );
 
     private CodegenUtils() {
@@ -400,5 +410,23 @@ public final class CodegenUtils {
         } catch (ClassNotFoundException exc) {
             throw new CodegenException("Could not find class " + name + ". Check your dependencies.", exc);
         }
+    }
+
+    /**
+     * Checks if a given string is a valid Semantic Version (SemVer) string.
+     *
+     * @see <a href="https://semver.org/">SemVer</a>
+     */
+    public static boolean isSemVer(String string) {
+        return SEMVER_REGEX.matcher(string).matches();
+    }
+
+    /**
+     * Checks if a given string is a valid ISO 8601 Calendar Date.
+     *
+     * @see <a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a>
+     */
+    public static boolean isISO8601Date(String string) {
+        return ISO_8601_DATE_REGEX.matcher(string).matches();
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/transforms/RemoveDeprecatedShapesTransformer.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/transforms/RemoveDeprecatedShapesTransformer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.transforms;
+
+import java.util.HashSet;
+import java.util.Set;
+import software.amazon.smithy.java.codegen.CodegenUtils;
+import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.neighbor.Walker;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Filters out shapes that filters out shapes that have were deprecated before a specified version or date.
+ *
+ * <p><strong>Note:</strong>This transform should only be used to filter client-side shapes as services must often
+ * continue to support shapes even after they are initially deprecated.
+ *
+ * @see <a href="https://smithy.io/2.0/guides/building-codegen/configuring-the-generator.html#relativedate-client-and-type-codegen-only">Codegen Deprecated Shape Filtering</a>
+ */
+// TODO: Upstream to Directed codegen standard transforms.
+@SmithyInternalApi
+public final class RemoveDeprecatedShapesTransformer {
+
+    public static Model transform(Model model, JavaCodegenSettings settings) {
+        var relativeDate = settings.relativeDate();
+        var relativeVersion = settings.relativeVersion();
+
+        // If there are no filters. Exit without traversing shapes
+        if (relativeVersion == null && relativeDate == null) {
+            return model;
+        }
+
+        var serviceShape = model.expectShape(settings.service());
+        Set<Shape> shapesToRemove = new HashSet<>();
+        for (var shape : new Walker(model).walkShapes(serviceShape)) {
+            if (shape.hasTrait(DeprecatedTrait.class)) {
+                var sinceOptional = shape.expectTrait(DeprecatedTrait.class).getSince();
+
+                if (sinceOptional.isEmpty()) {
+                    continue;
+                }
+
+                var since = sinceOptional.get();
+                // Remove any shapes that were deprecated before the specified date
+                if (relativeDate != null && CodegenUtils.isISO8601Date(since)) {
+                    if (relativeDate.compareTo(since) > 0) {
+                        shapesToRemove.add(shape);
+                    }
+                }
+
+                // Remove any shapes that were deprecated before the specified version.
+                if (relativeVersion != null && CodegenUtils.isSemVer(since)) {
+                    if (compareSemVer(relativeVersion, since) > 0) {
+                        shapesToRemove.add(shape);
+                    }
+                }
+            }
+        }
+
+        return ModelTransformer.create().removeShapes(model, shapesToRemove);
+    }
+
+    static int compareSemVer(String semVer1, String semVer2) {
+        String[] versionComponents1 = semVer1.split("\\.");
+        String[] versionComponents2 = semVer2.split("\\.");
+
+        int maxLength = Math.max(versionComponents1.length, versionComponents2.length);
+        for (int i = 0; i < maxLength; i++) {
+            // Treat all implicit components as 0's
+            var component1 = i >= versionComponents1.length ? "0" : versionComponents1[i];
+            var component2 = i >= versionComponents2.length ? "0" : versionComponents2[i];
+            var comparison = component1.compareTo(component2);
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return 0;
+    }
+}

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/CodegenContextTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/CodegenContextTest.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.codegen;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.BeforeAll;
@@ -64,18 +63,10 @@ public class CodegenContextTest {
     void getsCorrectRuntimeTraitsForProtocolsAndAuth() {
         var context = new CodeGenerationContext(
             model,
-            new JavaCodegenSettings(
-                SERVICE_ID,
-                null,
-                "ns.foo",
-                null,
-                "",
-                "",
-                null,
-                null,
-                Collections.emptyList(),
-                Collections.emptyList()
-            ),
+            JavaCodegenSettings.builder()
+                .service(SERVICE_ID.toString())
+                .packageNamespace("ns.foo")
+                .build(),
             new JavaSymbolProvider(model, model.expectShape(SERVICE_ID).asServiceShape().get(), "ns.foo"),
             new MockManifest(),
             List.of()
@@ -127,18 +118,10 @@ public class CodegenContextTest {
     void getsCorrectTraitsWithNoProtocolOrAuth() {
         var context = new CodeGenerationContext(
             model,
-            new JavaCodegenSettings(
-                NO_PROTOCOL_SERVICE_ID,
-                null,
-                "ns.foo",
-                null,
-                "",
-                "",
-                null,
-                null,
-                Collections.emptyList(),
-                Collections.emptyList()
-            ),
+            JavaCodegenSettings.builder()
+                .service(NO_PROTOCOL_SERVICE_ID.toString())
+                .packageNamespace("ns.foo")
+                .build(),
             new JavaSymbolProvider(model, model.expectShape(NO_PROTOCOL_SERVICE_ID).asServiceShape().get(), "ns.foo"),
             new MockManifest(),
             List.of()

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/RelativeDeprecationFilteringTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/RelativeDeprecationFilteringTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.codegen.utils.AbstractCodegenFileTest;
+import software.amazon.smithy.model.node.ObjectNode;
+
+public class RelativeDeprecationFilteringTest extends AbstractCodegenFileTest {
+    private static final URL TEST_FILE = Objects.requireNonNull(
+        RelativeDeprecationFilteringTest.class.getResource("relative-deprecated-test.smithy")
+    );
+
+    @Override
+    protected URL testFile() {
+        return TEST_FILE;
+    }
+
+    protected ObjectNode settings() {
+        return ObjectNode.builder()
+            .withMember("service", "smithy.java.codegen#TestService")
+            .withMember("namespace", "test.smithy.codegen")
+            .withMember("relativeDate", "1990-01-01")
+            .withMember("relativeVersion", "1.1.0")
+            .build();
+    }
+
+    @Test
+    void expectedUnfilteredDateExist() {
+        var fileStr = getFileStringForClass("NotYetDeprecatedDate");
+        System.out.println(fileStr);
+        var expected = "public final class NotYetDeprecatedDate implements ApiOperation";
+        assertTrue(fileStr.contains(expected));
+    }
+
+    @Test
+    void expectedFilteredDateDoesNotExist() {
+        var fileStringOptional = manifest.getFileString(
+            Paths.get("/test/smithy/codegen/model/DeprecatedOperationDate.java")
+        );
+        assertTrue(fileStringOptional.isEmpty());
+    }
+
+    @Test
+    void expectedUnfilteredVersionExist() {
+        var fileStr = getFileStringForClass("NotYetDeprecatedVersion");
+        var expected = "public final class NotYetDeprecatedVersion implements ApiOperation";
+        assertTrue(fileStr.contains(expected));
+    }
+
+    @Test
+    void expectedFilteredVersionDoesNotExist() {
+        var fileStringOptional = manifest.getFileString(
+            Paths.get("/test/smithy/codegen/model/DeprecatedOperationVersion.java")
+        );
+        assertTrue(fileStringOptional.isEmpty());
+    }
+}

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/transforms/TransformsTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/transforms/TransformsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.transforms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TransformsTest {
+    static List<Arguments> semverSupplier() {
+        return List.of(
+            Arguments.of("1.0.0", "1.0.0", 0),
+            Arguments.of("1.0.0", "1.0.1", -1),
+            Arguments.of("1.1.0", "1.1.1", -1),
+            Arguments.of("1.1.0", "1.0.1", 1),
+            Arguments.of("1.1.1", "1.1.1.1", -1),
+            Arguments.of("1.0.0.1", "1.0.0", 1),
+            Arguments.of("1.0.0", "1.0", 0),
+            Arguments.of("20.20.0.1", "20.20.1.0", -1),
+            Arguments.of("20.20.1.0", "20.20.1.0-PATCH", -1)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("semverSupplier")
+    void testSemverComparison(String semver1, String semver2, int expected) {
+        var result = RemoveDeprecatedShapesTransformer.compareSemVer(semver1, semver2);
+        switch (expected) {
+            case 0 -> assertEquals(result, 0);
+            case -1 -> assertTrue(result < 0);
+            case 1 -> assertTrue(result > 0);
+        }
+    }
+}

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenPlugin.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenPlugin.java
@@ -11,6 +11,7 @@ import software.amazon.smithy.codegen.core.directed.CodegenDirector;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.transforms.RemoveDeprecatedShapesTransformer;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 
 public class TestJavaCodegenPlugin implements SmithyBuildPlugin {
@@ -28,7 +29,9 @@ public class TestJavaCodegenPlugin implements SmithyBuildPlugin {
         runner.directedCodegen(new TestJavaCodegen());
         runner.fileManifest(context.getFileManifest());
         runner.service(settings.service());
-        runner.model(context.getModel());
+        // Filter out any deprecated shapes
+        var model = RemoveDeprecatedShapesTransformer.transform(context.getModel(), settings);
+        runner.model(model);
         runner.integrationClass(JavaCodegenIntegration.class);
         runner.performDefaultCodegenTransforms();
         runner.createDedicatedInputsAndOutputs();

--- a/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/relative-deprecated-test.smithy
+++ b/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/relative-deprecated-test.smithy
@@ -1,0 +1,49 @@
+$version: "2"
+
+namespace smithy.java.codegen
+
+service TestService {
+    version: "today"
+    operations: [
+        DeprecatedOperationDate
+        NotYetDeprecatedDate
+        DeprecatedOperationVersion
+        NotYetDeprecatedVersion
+    ]
+}
+
+/// This operation is deprecated long before the time
+/// the `relativeDate` sets and so should be filtered out.
+@deprecated(since: "1792-01-01")
+operation DeprecatedOperationDate {
+    input := {
+        value: String
+    }
+}
+
+/// This operation is deprecated after the time
+/// the `relativeDate` sets and so should NOT be filtered out.
+@deprecated(since: "2025-01-01")
+operation NotYetDeprecatedDate {
+    input := {
+        value: String
+    }
+}
+
+/// This operation is deprecated before the version
+/// the `relativeVersion` sets and so should be filtered out.
+@deprecated(since: "1.0.1")
+operation DeprecatedOperationVersion {
+    input := {
+        value: String
+    }
+}
+
+/// This operation is deprecated after the version
+/// the `relativeVersion` sets and so should NOT be filtered out.
+@deprecated(since: "1.1.1")
+operation NotYetDeprecatedVersion {
+    input := {
+        value: String
+    }
+}


### PR DESCRIPTION
### Description of changes
Adds support for [relativeDate](https://smithy.io/2.0/guides/building-codegen/configuring-the-generator.html#relativedate-client-and-type-codegen-only) and [relativeVersion](https://smithy.io/2.0/guides/building-codegen/configuring-the-generator.html#relativeversion-client-and-type-codegen-only) filtering of deprecated shapes.

Also updates the Codegen settings to use a builder now that we have so many optional settings.

Note: this is in codegen core because it will be re-used by type codegen as well. Only server-codegen will not do this filtering.

Note also: At some point this logic should be upstreamed to the Directed codegen runner so the filtering can be re-used across generators.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
