### PR TITLE
Use ClassValue based TraitMap for perf

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,11 +13,7 @@ dependencies {
     api(libs.smithy.model)
 }
 
-jmh {
-    iterations = 10
-    fork = 1
-    // profilers = ['async:output=flamegraph', 'gc']
-}
+jmh {}
 
 // Run all tests with a different locale to ensure we are not doing anything locale specific.
 val localeTest =

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/TraitMap.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/TraitMap.java
@@ -5,361 +5,84 @@
 
 package software.amazon.smithy.java.runtime.core.schema;
 
-import java.util.IdentityHashMap;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 import software.amazon.smithy.model.traits.Trait;
 
 /**
  * Provides Trait class-based access to traits.
  */
-sealed interface TraitMap {
+final class TraitMap {
+
+    private static final Trait[] NO_TRAITS = new Trait[0];
+    private static final AtomicInteger COUNTER = new AtomicInteger();
+    private static final ClassValue<Integer> ID = new ClassValue<>() {
+        @Override
+        protected Integer computeValue(Class<?> ignore) {
+            return COUNTER.getAndIncrement();
+        }
+    };
+
+    private final Trait[] values;
+
+    private TraitMap(Trait[] traits, boolean initialized) {
+        if (initialized) {
+            // The `traits` array is an already allocated index-based trait array.
+            this.values = traits;
+        } else if (traits == null || traits.length == 0) {
+            this.values = NO_TRAITS;
+        } else {
+            // The `traits` array is just an array of Traits. We need to ensure an ID is assigned to each trait.
+            // Since we're already doing a pass over the traits, we can also allocate exact-sized storage.
+            int largestId = 0;
+            for (Trait trait : traits) {
+                largestId = Math.max(largestId, ID.get(trait.getClass()));
+            }
+            this.values = new Trait[largestId + 1];
+            for (Trait trait : traits) {
+                values[ID.get(trait.getClass())] = trait;
+            }
+        }
+    }
 
     static TraitMap create(Trait[] traits) {
-        // Most schemas have 0-3 traits, and very few schemas have more than 5.
-        return switch (traits == null ? 0 : traits.length) {
-            case 0 -> EMPTY;
-            case 1 -> new TraitMap1(traits[0]);
-            case 2 -> new TraitMap2(traits[0], traits[1]);
-            case 3 -> new TraitMap3(traits[0], traits[1], traits[2]);
-            case 4 -> new TraitMap4(traits[0], traits[1], traits[2], traits[3]);
-            case 5 -> new TraitMap5(traits[0], traits[1], traits[2], traits[3], traits[4]);
-            default -> new MapBasedTraitMap(traits);
-        };
+        return new TraitMap(traits, false);
     }
 
-    TraitMap EMPTY = new TraitMap0();
-
-    <T extends Trait> T get(Class<T> trait);
-
-    boolean isEmpty();
-
-    boolean contains(Class<? extends Trait> trait);
-
-    TraitMap prepend(Trait[] traits);
-
-    final class TraitMap0 implements TraitMap {
-        @Override
-        public boolean contains(Class<? extends Trait> trait) {
-            return false;
-        }
-
-        @Override
-        public <T extends Trait> T get(Class<T> trait) {
+    @SuppressWarnings("unchecked")
+    <T extends Trait> T get(Class<T> trait) {
+        int idx = ID.get(trait);
+        if (idx >= values.length) {
             return null;
         }
-
-        @Override
-        public boolean isEmpty() {
-            return true;
-        }
-
-        @Override
-        public TraitMap prepend(Trait[] traits) {
-            return TraitMap.create(traits);
-        }
+        return (T) values[idx];
     }
 
-    final class TraitMap1 implements TraitMap {
-
-        private final Trait value;
-        private final Class<?> c1;
-
-        private TraitMap1(Trait value) {
-            this.value = value;
-            this.c1 = value.getClass();
-        }
-
-        @Override
-        public boolean contains(Class<? extends Trait> trait) {
-            return trait == c1;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public <T extends Trait> T get(Class<T> trait) {
-            return trait == c1 ? (T) value : null;
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return false;
-        }
-
-        @Override
-        public TraitMap prepend(Trait[] traits) {
-            Trait[] result = copyArray(traits, 1);
-            result[traits.length] = value;
-            return TraitMap.create(result);
-        }
+    boolean isEmpty() {
+        return values.length == 0;
     }
 
-    private static Trait[] copyArray(Trait[] traits, int addSize) {
-        Trait[] result = new Trait[traits.length + addSize];
-        System.arraycopy(traits, 0, result, 0, traits.length);
-        return result;
+    boolean contains(Class<? extends Trait> trait) {
+        int idx = ID.get(trait);
+        return idx < values.length && values[idx] != null;
     }
 
-    final class TraitMap2 implements TraitMap {
+    TraitMap prepend(Trait[] traits) {
+        // Allocate only enough storage required to hold the current traits and given traits.
+        int largestId = values.length - 1;
 
-        private final Trait value1;
-        private final Trait value2;
-        private final Class<?> c1;
-        private final Class<?> c2;
-
-        private TraitMap2(Trait value1, Trait value2) {
-            this.value1 = value1;
-            this.value2 = value2;
-            this.c1 = value1.getClass();
-            this.c2 = value2.getClass();
+        // Ensure traits have a resolved class ID.
+        for (Trait trait : traits) {
+            largestId = Math.max(largestId, ID.get(trait.getClass()));
         }
 
-        @Override
-        public boolean contains(Class<? extends Trait> trait) {
-            return trait == c1 || trait == c2;
+        var values = Arrays.copyOf(this.values, largestId + 1);
+
+        // Overwrite the current values with passed in traits.
+        for (Trait trait : traits) {
+            values[ID.get(trait.getClass())] = trait;
         }
 
-        @SuppressWarnings("unchecked")
-        @Override
-        public <T extends Trait> T get(Class<T> trait) {
-            if (trait == c1) {
-                return (T) value1;
-            } else if (trait == c2) {
-                return (T) value2;
-            } else {
-                return null;
-            }
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return false;
-        }
-
-        @Override
-        public TraitMap prepend(Trait[] traits) {
-            Trait[] result = copyArray(traits, 2);
-            result[traits.length] = value1;
-            result[traits.length + 1] = value2;
-            return TraitMap.create(result);
-        }
-    }
-
-    final class TraitMap3 implements TraitMap {
-
-        private final Trait value1;
-        private final Trait value2;
-        private final Trait value3;
-        private final Class<?> c1;
-        private final Class<?> c2;
-        private final Class<?> c3;
-
-        private TraitMap3(Trait value1, Trait value2, Trait value3) {
-            this.value1 = value1;
-            this.value2 = value2;
-            this.value3 = value3;
-            this.c1 = value1.getClass();
-            this.c2 = value2.getClass();
-            this.c3 = value3.getClass();
-        }
-
-        @Override
-        public boolean contains(Class<? extends Trait> trait) {
-            return trait == c1 || trait == c2 || trait == c3;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public <T extends Trait> T get(Class<T> trait) {
-            if (trait == c1) {
-                return (T) value1;
-            } else if (trait == c2) {
-                return (T) value2;
-            } else if (trait == c3) {
-                return (T) value3;
-            } else {
-                return null;
-            }
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return false;
-        }
-
-        @Override
-        public TraitMap prepend(Trait[] traits) {
-            Trait[] result = copyArray(traits, 3);
-            result[traits.length] = value1;
-            result[traits.length + 1] = value2;
-            result[traits.length + 2] = value3;
-            return TraitMap.create(result);
-        }
-    }
-
-    final class TraitMap4 implements TraitMap {
-
-        private final Trait value1;
-        private final Trait value2;
-        private final Trait value3;
-        private final Trait value4;
-        private final Class<?> c1;
-        private final Class<?> c2;
-        private final Class<?> c3;
-        private final Class<?> c4;
-
-        private TraitMap4(Trait value1, Trait value2, Trait value3, Trait value4) {
-            this.value1 = value1;
-            this.value2 = value2;
-            this.value3 = value3;
-            this.value4 = value4;
-            this.c1 = value1.getClass();
-            this.c2 = value2.getClass();
-            this.c3 = value3.getClass();
-            this.c4 = value4.getClass();
-        }
-
-        @Override
-        public boolean contains(Class<? extends Trait> trait) {
-            return trait == c1 || trait == c2 || trait == c3 || trait == c4;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public <T extends Trait> T get(Class<T> trait) {
-            if (trait == c1) {
-                return (T) value1;
-            } else if (trait == c2) {
-                return (T) value2;
-            } else if (trait == c3) {
-                return (T) value3;
-            } else if (trait == c4) {
-                return (T) value4;
-            } else {
-                return null;
-            }
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return false;
-        }
-
-        @Override
-        public TraitMap prepend(Trait[] traits) {
-            Trait[] result = copyArray(traits, 4);
-            result[traits.length] = value1;
-            result[traits.length + 1] = value2;
-            result[traits.length + 2] = value3;
-            result[traits.length + 3] = value4;
-            return TraitMap.create(result);
-        }
-    }
-
-    final class TraitMap5 implements TraitMap {
-
-        private final Trait value1;
-        private final Trait value2;
-        private final Trait value3;
-        private final Trait value4;
-        private final Trait value5;
-        private final Class<?> c1;
-        private final Class<?> c2;
-        private final Class<?> c3;
-        private final Class<?> c4;
-        private final Class<?> c5;
-
-        private TraitMap5(Trait value1, Trait value2, Trait value3, Trait value4, Trait value5) {
-            this.value1 = value1;
-            this.value2 = value2;
-            this.value3 = value3;
-            this.value4 = value4;
-            this.value5 = value5;
-            this.c1 = value1.getClass();
-            this.c2 = value2.getClass();
-            this.c3 = value3.getClass();
-            this.c4 = value4.getClass();
-            this.c5 = value5.getClass();
-        }
-
-        @Override
-        public boolean contains(Class<? extends Trait> trait) {
-            return trait == c1 || trait == c2 || trait == c3 || trait == c4 || trait == c5;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public <T extends Trait> T get(Class<T> trait) {
-            if (trait == c1) {
-                return (T) value1;
-            } else if (trait == c2) {
-                return (T) value2;
-            } else if (trait == c3) {
-                return (T) value3;
-            } else if (trait == c4) {
-                return (T) value4;
-            } else if (trait == c5) {
-                return (T) value5;
-            } else {
-                return null;
-            }
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return false;
-        }
-
-        @Override
-        public TraitMap prepend(Trait[] traits) {
-            Trait[] result = copyArray(traits, 5);
-            result[traits.length] = value1;
-            result[traits.length + 1] = value2;
-            result[traits.length + 2] = value3;
-            result[traits.length + 3] = value4;
-            result[traits.length + 4] = value5;
-            return TraitMap.create(result);
-        }
-    }
-
-    final class MapBasedTraitMap implements TraitMap {
-
-        private final Map<Class<?>, Trait> map;
-
-        private MapBasedTraitMap(Trait[] traits) {
-            this(new IdentityHashMap<>(traits.length));
-            for (var t : traits) {
-                this.map.put(t.getClass(), t);
-            }
-        }
-
-        private MapBasedTraitMap(Map<Class<?>, Trait> map) {
-            this.map = map;
-        }
-
-        @Override
-        public boolean contains(Class<? extends Trait> trait) {
-            return map.containsKey(trait);
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public <T extends Trait> T get(Class<T> trait) {
-            return (T) map.get(trait);
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return map.isEmpty();
-        }
-
-        @Override
-        public TraitMap prepend(Trait[] traits) {
-            Map<Class<?>, Trait> result = new IdentityHashMap<>(map.size() + traits.length);
-            result.putAll(map);
-            for (var t : traits) {
-                result.put(t.getClass(), t);
-            }
-            return new MapBasedTraitMap(result);
-        }
+        return new TraitMap(values, true);
     }
 }


### PR DESCRIPTION
The previous TraitMap approach showed well in previous benchmarks due to optimizations that made the benchmark more unreliable. This PR moves TraitMap to a single implementation that's based on ClassValue, a class used to attach metadata to classes. In this case, we assign each class an auto-incremented ID and then use that as the "universe" of possible traits for a schema, allowing us to directly index into an array of traits. The previous approach resulted in megamoprhic call sites that were slower in practice than using just a single ClassValue-based implementation. This is also surprisingly faster than a HashMap of Class to Trait, a linear search, binary search, uniform binary search, custom probing hashmaps, etc.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
