### PR TITLE
Only store the bare minimum allocated trait map

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/TraitKey.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/TraitKey.java
@@ -93,7 +93,7 @@ public final class TraitKey<T extends Trait> {
     public static final TraitKey<XmlNamespaceTrait> XML_NAMESPACE_TRAIT = TraitKey.get(XmlNamespaceTrait.class);
 
     private final Class<T> traitClass;
-    private final int id;
+    final int id;
 
     /**
      * Gets the key for a trait for use with methods like {@link Schema#getTrait}.
@@ -119,9 +119,5 @@ public final class TraitKey<T extends Trait> {
      */
     public Class<T> traitClass() {
         return traitClass;
-    }
-
-    int id() {
-        return id;
     }
 }

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/TraitMapTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/schema/TraitMapTest.java
@@ -17,20 +17,20 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
-import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.traits.XmlNameTrait;
 
 public class TraitMapTest {
     @Test
     public void emptyTraitMap() {
-        var tm = TraitMap.create(null);
+        var tm = TraitMap.create();
 
         assertThat(tm.get(TraitKey.REQUIRED_TRAIT), is(nullValue()));
     }
 
     @Test
     public void emptyTraitMapPrepend() {
-        var tm = TraitMap.create(null);
-        var tm2 = tm.prepend(new Trait[]{new SensitiveTrait()});
+        var tm = TraitMap.create();
+        var tm2 = tm.prepend(new SensitiveTrait());
 
         assertThat(tm.get(TraitKey.SENSITIVE_TRAIT), is(nullValue()));
         assertThat(tm2.get(TraitKey.SENSITIVE_TRAIT), instanceOf(SensitiveTrait.class));
@@ -38,8 +38,8 @@ public class TraitMapTest {
 
     @Test
     public void emptyGivenTraitMapPrepend() {
-        var tm = TraitMap.create(new Trait[]{new SensitiveTrait()});
-        var tm2 = tm.prepend(new Trait[0]);
+        var tm = TraitMap.create(new SensitiveTrait());
+        var tm2 = tm.prepend();
 
         assertThat(tm.get(TraitKey.SENSITIVE_TRAIT), not(nullValue()));
         assertThat(tm, sameInstance(tm2));
@@ -47,8 +47,8 @@ public class TraitMapTest {
 
     @Test
     public void prependWithSmallerMin() {
-        var tm = TraitMap.create(new Trait[]{new DefaultTrait(Node.from(1))});
-        var tm2 = tm.prepend(new Trait[]{new RequiredTrait()});
+        var tm = TraitMap.create(new DefaultTrait(Node.from(1)));
+        var tm2 = tm.prepend(new RequiredTrait());
 
         assertThat(tm2.get(TraitKey.REQUIRED_TRAIT), instanceOf(RequiredTrait.class));
         assertThat(tm2.get(TraitKey.DEFAULT_TRAIT), instanceOf(DefaultTrait.class));
@@ -56,10 +56,19 @@ public class TraitMapTest {
 
     @Test
     public void prependWithLargerMax() {
-        var tm = TraitMap.create(new Trait[]{new RequiredTrait()});
-        var tm2 = tm.prepend(new Trait[]{new DefaultTrait(Node.from(1))});
+        var tm = TraitMap.create(new RequiredTrait());
+        var tm2 = tm.prepend(new DefaultTrait(Node.from(1)));
 
         assertThat(tm2.get(TraitKey.REQUIRED_TRAIT), instanceOf(RequiredTrait.class));
+        assertThat(tm2.get(TraitKey.DEFAULT_TRAIT), instanceOf(DefaultTrait.class));
+    }
+
+    @Test
+    public void prependWithMuchSmallerIndex() {
+        var tm = TraitMap.create(new XmlNameTrait("hi"));
+        var tm2 = tm.prepend(new DefaultTrait(Node.from(1)));
+
+        assertThat(tm2.get(TraitKey.XML_NAME_TRAIT), instanceOf(XmlNameTrait.class));
         assertThat(tm2.get(TraitKey.DEFAULT_TRAIT), instanceOf(DefaultTrait.class));
     }
 }

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDeserializerTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonDeserializerTest.java
@@ -360,7 +360,7 @@ public class JsonDeserializerTest {
         TimestampFormatter defaultFormat,
         String json
     ) {
-        Trait[] traits = trait == null ? null : new Trait[]{trait};
+        Trait[] traits = trait == null ? new Trait[0] : new Trait[]{trait};
         var schema = Schema.createTimestamp(ShapeId.from("smithy.foo#Time"), traits);
 
         var codecBuilder = JsonCodec.builder().useTimestampFormat(useTrait);


### PR DESCRIPTION
Allocates the minimum required array size for a trait map, based on the span of trait indices (and +2 for null padding used for unconditionally clamped array access).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
