### PR TITLE
Add MemberLookup to reduce map lookups in serde

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/MemberLookup.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/MemberLookup.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.core.schema;
+
+/**
+ * A container that provides members by name.
+ */
+public interface MemberLookup {
+    /**
+     * Get a member by name.
+     *
+     * @param memberName Member by name to get.
+     * @return Returns the found member or null if not found.
+     */
+    Schema member(String memberName);
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Schema.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Schema.java
@@ -22,8 +22,8 @@ import software.amazon.smithy.model.traits.Trait;
  *
  * <p>Note: when creating a structure schema, all required members must come before optional members.
  */
-public abstract sealed class Schema permits RootSchema, MemberSchema, DeferredRootSchema,
-    DeferredMemberSchema {
+public abstract sealed class Schema implements MemberLookup
+    permits RootSchema, MemberSchema, DeferredRootSchema, DeferredMemberSchema {
 
     private final ShapeType type;
     private final ShapeId id;
@@ -422,12 +422,7 @@ public abstract sealed class Schema permits RootSchema, MemberSchema, DeferredRo
         return Collections.emptyList();
     }
 
-    /**
-     * Get a member by name or return a default value.
-     *
-     * @param memberName Member by name to get.
-     * @return Returns the found member or null if not found.
-     */
+    @Override
     public Schema member(String memberName) {
         return null;
     }

--- a/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonDeserializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/runtime/json/jackson/JacksonJsonDeserializer.java
@@ -235,10 +235,10 @@ final class JacksonJsonDeserializer implements ShapeDeserializer {
     @Override
     public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> structMemberConsumer) {
         try {
-            var fieldMapper = settings.fieldMapper();
+            var fieldToMember = settings.fieldMapper().fieldToMember(schema);
             for (var memberName = parser.nextFieldName(); memberName != null; memberName = parser.nextFieldName()) {
                 if (parser.nextToken() != VALUE_NULL) {
-                    var member = fieldMapper.fieldToMember(schema, memberName);
+                    var member = fieldToMember.member(memberName);
                     if (member != null) {
                         structMemberConsumer.accept(state, member, this);
                     } else if (schema.type() == ShapeType.STRUCTURE) {


### PR DESCRIPTION
When serializing a struct or union with JSON and jsonName traits, the JsonFieldMapper required a CHM lookup for the containing structure and then a HashMap lookup for each member, over and over. This change introduces a MemberLookup interface that Schema implements, and it's used to lookup members by name. When deserializing structs without JSON name, the JsonFieldMapper just uses the Schema directly, so there's no perf hit in this PR. When deserializing with jsonName, JsonFieldMapper first does a cache lookup in CHM, then gets the container for the structure, and uses it for each member to deserializing, turning the N cache lookups for the parent container to 1 lookup.

When member lookups by char/byte are added for faster CBOR and JSON parsing, we can add those canonicalizing and lookup methods to MemberLookup too so that looking up a member using the jsonName trait is just as fast as looking one up using member name (plus the single CHM lookup to cache the computed table).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
