### PR TITLE
Add HttpHeaders abstraction

### DIFF
--- a/aws/client-awsjson/src/main/java/software/amazon/smithy/java/runtime/aws/client/awsjson/AwsJsonProtocol.java
+++ b/aws/client-awsjson/src/main/java/software/amazon/smithy/java/runtime/aws/client/awsjson/AwsJsonProtocol.java
@@ -6,7 +6,6 @@
 package software.amazon.smithy.java.runtime.aws.client.awsjson;
 
 import java.net.URI;
-import java.net.http.HttpHeaders;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +17,7 @@ import software.amazon.smithy.java.runtime.client.http.HttpErrorDeserializer;
 import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.TypeRegistry;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
@@ -63,12 +63,11 @@ abstract sealed class AwsJsonProtocol extends HttpClientProtocol permits AwsJson
         builder.headers(
             HttpHeaders.of(
                 Map.of(
-                    "X-Amz-Target",
+                    "x-amz-target",
                     List.of(target),
-                    "Content-Type",
+                    "content-type",
                     List.of(contentType())
-                ),
-                (k, v) -> true
+                )
             )
         );
 

--- a/aws/sigv4/src/jmh/java/software/amazon/smithy/java/aws/runtime/client/auth/scheme/sigv4/SigV4SignerTrials.java
+++ b/aws/sigv4/src/jmh/java/software/amazon/smithy/java/aws/runtime/client/auth/scheme/sigv4/SigV4SignerTrials.java
@@ -7,7 +7,6 @@ package software.amazon.smithy.java.aws.runtime.client.auth.scheme.sigv4;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.http.HttpHeaders;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -25,6 +24,7 @@ import org.openjdk.jmh.annotations.State;
 import software.amazon.smithy.java.aws.runtime.client.core.identity.AwsCredentialsIdentity;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
@@ -102,7 +102,7 @@ public class SigV4SignerTrials {
         Map<String, List<String>> headers,
         String body
     ) {
-        var httpHeaders = HttpHeaders.of(headers, (k, v) -> true);
+        var httpHeaders = HttpHeaders.of(headers);
         var uriString = "http://example.com";
         if (!queryParameters.isEmpty()) {
             var queryBuilder = new QueryStringBuilder();

--- a/aws/sigv4/src/test/java/software/amazon/smithy/java/aws/runtime/client/auth/scheme/sigv4/SigV4TestRunner.java
+++ b/aws/sigv4/src/test/java/software/amazon/smithy/java/aws/runtime/client/auth/scheme/sigv4/SigV4TestRunner.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.aws.runtime.client.auth.scheme.sigv4;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.http.HttpHeaders;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Clock;
@@ -26,6 +25,7 @@ import java.util.stream.Stream;
 import software.amazon.smithy.java.aws.runtime.client.core.identity.AwsCredentialsIdentity;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
@@ -133,7 +133,7 @@ public class SigV4TestRunner {
                 }
                 if (!inBody) {
                     var splitLine = line.split(":");
-                    if (splitLine[0].equals("Host")) {
+                    if (splitLine[0].equalsIgnoreCase("host")) {
                         hostValue = splitLine[1];
                     }
                     headers.put(splitLine[0], List.of(splitLine[1]));
@@ -147,12 +147,11 @@ public class SigV4TestRunner {
                 }
             }
 
-            var httpHeaders = HttpHeaders.of(headers, (k, v) -> true);
             return SmithyHttpRequest.builder()
                 .method(method)
                 .httpVersion(SmithyHttpVersion.HTTP_1_1)
                 .uri(URI.create("http://" + Objects.requireNonNull(hostValue) + path))
-                .headers(httpHeaders)
+                .headers(HttpHeaders.of(headers))
                 .body(body != null ? DataStream.ofBytes(body.toString().getBytes()) : null)
                 .build();
         }

--- a/client-http-binding/src/test/java/software/amazon/smithy/java/runtime/client/http/binding/HttpBindingErrorDeserializerTest.java
+++ b/client-http-binding/src/test/java/software/amazon/smithy/java/runtime/client/http/binding/HttpBindingErrorDeserializerTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-import java.net.http.HttpHeaders;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -25,6 +24,7 @@ import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.TypeRegistry;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
 import software.amazon.smithy.java.runtime.json.JsonCodec;
@@ -98,12 +98,11 @@ public class HttpBindingErrorDeserializerTest {
             .headers(
                 HttpHeaders.of(
                     Map.of(
-                        "Content-Length",
+                        "content-length",
                         List.of("2"),
                         "x-amzn-errortype",
                         List.of("com.foo#SomeUnknownError")
-                    ),
-                    (k, v) -> true
+                    )
                 )
             )
             .body(DataStream.ofString("{}"));

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/AmznErrorHeaderExtractor.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/AmznErrorHeaderExtractor.java
@@ -19,12 +19,12 @@ public final class AmznErrorHeaderExtractor implements HttpErrorDeserializer.Hea
 
     @Override
     public boolean hasHeader(SmithyHttpResponse response) {
-        return response.headers().firstValue(ERROR_HEADER).isPresent();
+        return response.headers().firstValue(ERROR_HEADER) != null;
     }
 
     @Override
     public ShapeId resolveId(SmithyHttpResponse response, String serviceNamespace, TypeRegistry registry) {
-        var header = response.headers().firstValue(ERROR_HEADER).orElse(null);
+        var header = response.headers().firstValue(ERROR_HEADER);
         return header == null ? null : toShapeId(header, serviceNamespace, registry);
     }
 

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpEndpointProperties.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/HttpEndpointProperties.java
@@ -5,9 +5,9 @@
 
 package software.amazon.smithy.java.runtime.client.http;
 
-import java.net.http.HttpHeaders;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.runtime.client.core.endpoint.EndpointResolver;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 
 public final class HttpEndpointProperties {
 

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/JavaHttpClientTransport.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/JavaHttpClientTransport.java
@@ -16,6 +16,7 @@ import java.util.concurrent.Flow;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.client.core.ClientTransport;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
@@ -94,7 +95,7 @@ public class JavaHttpClientTransport implements ClientTransport<SmithyHttpReques
         return SmithyHttpResponse.builder()
             .httpVersion(javaToSmithyVersion(response.version()))
             .statusCode(response.statusCode())
-            .headers(response.headers())
+            .headers(HttpHeaders.of(response.headers().map()))
             .body(new ListByteBufferToByteBuffer(response.body())) // Flatten the List<ByteBuffer> to ByteBuffer.
             .build();
     }

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/auth/HttpApiKeyAuthSigner.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/auth/HttpApiKeyAuthSigner.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.client.http.auth;
 
-import java.net.http.HttpHeaders;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -13,6 +12,7 @@ import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
 import software.amazon.smithy.java.runtime.auth.api.identity.ApiKeyIdentity;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.io.uri.QueryStringBuilder;
 import software.amazon.smithy.java.runtime.io.uri.URIBuilder;
@@ -43,7 +43,7 @@ final class HttpApiKeyAuthSigner implements Signer<SmithyHttpRequest, ApiKeyIden
                 if (existing != null) {
                     LOGGER.debug("Replaced header value for {}", name);
                 }
-                yield CompletableFuture.completedFuture(request.withHeaders(HttpHeaders.of(updated, (k, v) -> true)));
+                yield CompletableFuture.completedFuture(request.withHeaders(HttpHeaders.of(updated)));
             }
             case QUERY -> {
                 var uriBuilder = URIBuilder.of(request.uri());

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/auth/HttpBasicAuthSigner.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/auth/HttpBasicAuthSigner.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.client.http.auth;
 
-import java.net.http.HttpHeaders;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.LinkedHashMap;
@@ -15,12 +14,13 @@ import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
 import software.amazon.smithy.java.runtime.auth.api.identity.LoginIdentity;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 
 final class HttpBasicAuthSigner implements Signer<SmithyHttpRequest, LoginIdentity> {
     static final HttpBasicAuthSigner INSTANCE = new HttpBasicAuthSigner();
     private static final InternalLogger LOGGER = InternalLogger.getLogger(HttpBasicAuthSigner.class);
-    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String AUTHORIZATION_HEADER = "authorization";
     private static final String SCHEME = "Basic";
 
     private HttpBasicAuthSigner() {}
@@ -38,6 +38,6 @@ final class HttpBasicAuthSigner implements Signer<SmithyHttpRequest, LoginIdenti
         if (existing != null) {
             LOGGER.debug("Replaced existing Authorization header value.");
         }
-        return CompletableFuture.completedFuture(request.withHeaders(HttpHeaders.of(headers, (k, v) -> true)));
+        return CompletableFuture.completedFuture(request.withHeaders(HttpHeaders.of(headers)));
     }
 }

--- a/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/auth/HttpBearerAuthSigner.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/runtime/client/http/auth/HttpBearerAuthSigner.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.client.http.auth;
 
-import java.net.http.HttpHeaders;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -13,12 +12,13 @@ import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
 import software.amazon.smithy.java.runtime.auth.api.identity.TokenIdentity;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 
 final class HttpBearerAuthSigner implements Signer<SmithyHttpRequest, TokenIdentity> {
     static final HttpBearerAuthSigner INSTANCE = new HttpBearerAuthSigner();
     private static final InternalLogger LOGGER = InternalLogger.getLogger(HttpBearerAuthSigner.class);
-    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String AUTHORIZATION_HEADER = "authorization";
     private static final String SCHEME = "Bearer";
 
     private HttpBearerAuthSigner() {}
@@ -34,6 +34,6 @@ final class HttpBearerAuthSigner implements Signer<SmithyHttpRequest, TokenIdent
         if (existing != null) {
             LOGGER.debug("Replaced existing Authorization header value.");
         }
-        return CompletableFuture.completedFuture(request.withHeaders(HttpHeaders.of(headers, (k, v) -> true)));
+        return CompletableFuture.completedFuture(request.withHeaders(HttpHeaders.of(headers)));
     }
 }

--- a/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/AmznErrorHeaderExtractorTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/AmznErrorHeaderExtractorTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.net.http.HttpHeaders;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -19,6 +18,7 @@ import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.TypeRegistry;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.model.shapes.ShapeId;
 
@@ -28,7 +28,7 @@ public class AmznErrorHeaderExtractorTest {
         var extractor = new AmznErrorHeaderExtractor();
 
         var response1 = SmithyHttpResponse.builder()
-            .headers(HttpHeaders.of(Map.of("x-amzn-errortype", List.of("foo")), (k, v) -> true))
+            .headers(HttpHeaders.of(Map.of("x-amzn-errortype", List.of("foo"))))
             .build();
         var response2 = SmithyHttpResponse.builder().build();
 
@@ -48,7 +48,7 @@ public class AmznErrorHeaderExtractorTest {
     public void resolvesAbsoluteShapeIds() {
         var extractor = new AmznErrorHeaderExtractor();
         var response = SmithyHttpResponse.builder()
-            .headers(HttpHeaders.of(Map.of("x-amzn-errortype", List.of("baz#Bam")), (k, v) -> true))
+            .headers(HttpHeaders.of(Map.of("x-amzn-errortype", List.of("baz#Bam"))))
             .build();
         var registry = TypeRegistry.builder()
             .putType(ShapeId.from("baz#Bam"), ModeledApiException.class, ApiExceptionBuilder::new)
@@ -66,8 +66,7 @@ public class AmznErrorHeaderExtractorTest {
                     Map.of(
                         "x-amzn-errortype",
                         List.of("baz#Bam:http://internal.amazon.com/coral/com.amazon.coral.validate/")
-                    ),
-                    (k, v) -> true
+                    )
                 )
             )
             .build();
@@ -87,8 +86,7 @@ public class AmznErrorHeaderExtractorTest {
                     Map.of(
                         "x-amzn-errortype",
                         List.of("Bam:http://internal.amazon.com/coral/com.amazon.coral.validate/")
-                    ),
-                    (k, v) -> true
+                    )
                 )
             )
             .build();
@@ -108,8 +106,7 @@ public class AmznErrorHeaderExtractorTest {
                     Map.of(
                         "x-amzn-errortype",
                         List.of("baz#Bam:http://internal.amazon.com/coral/com.amazon.coral.validate/")
-                    ),
-                    (k, v) -> true
+                    )
                 )
             )
             .build();
@@ -129,8 +126,7 @@ public class AmznErrorHeaderExtractorTest {
                     Map.of(
                         "x-amzn-errortype",
                         List.of("other#Bam:http://internal.amazon.com/coral/com.amazon.coral.validate/")
-                    ),
-                    (k, v) -> true
+                    )
                 )
             )
             .build();
@@ -150,8 +146,7 @@ public class AmznErrorHeaderExtractorTest {
                     Map.of(
                         "x-amzn-errortype",
                         List.of("other#Bam:http://internal.amazon.com/coral/com.amazon.coral.validate/")
-                    ),
-                    (k, v) -> true
+                    )
                 )
             )
             .build();

--- a/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/HttpErrorDeserializerTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/HttpErrorDeserializerTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-import java.net.http.HttpHeaders;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -27,6 +26,7 @@ import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.runtime.core.serde.TypeRegistry;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
 import software.amazon.smithy.java.runtime.json.JsonCodec;
@@ -52,10 +52,7 @@ public class HttpErrorDeserializerTest {
         if (payload != null) {
             responseBuilder.body(DataStream.ofString(payload));
             responseBuilder.headers(
-                HttpHeaders.of(
-                    Map.of("Content-Length", List.of(Integer.toString(payload.length()))),
-                    (k, v) -> true
-                )
+                HttpHeaders.of(Map.of("content-length", List.of(Integer.toString(payload.length()))))
             );
         }
         var response = responseBuilder.build();
@@ -96,12 +93,11 @@ public class HttpErrorDeserializerTest {
             .headers(
                 HttpHeaders.of(
                     Map.of(
-                        "Content-Length",
+                        "content-length",
                         List.of("2"),
                         "x-amzn-errortype",
                         List.of(Baz.SCHEMA.id().toString())
-                    ),
-                    (k, v) -> true
+                    )
                 )
             )
             .body(DataStream.ofString("{}"));
@@ -170,12 +166,11 @@ public class HttpErrorDeserializerTest {
             .headers(
                 HttpHeaders.of(
                     Map.of(
-                        "Content-Length",
+                        "content-length",
                         List.of("2"),
                         "x-amzn-errortype",
                         List.of("com.foo#SomeUnknownError")
-                    ),
-                    (k, v) -> true
+                    )
                 )
             )
             .body(DataStream.ofString("{}"));

--- a/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/auth/HttpApiKeyAuthSignerTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/auth/HttpApiKeyAuthSignerTest.java
@@ -34,9 +34,8 @@ public class HttpApiKeyAuthSignerTest {
             .build();
 
         var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties).get();
-        var authHeader = signedRequest.headers().map().get("x-api-key");
-        assertNotNull(authHeader);
-        assertEquals(authHeader.get(0), API_KEY);
+        var authHeader = signedRequest.headers().firstValue("x-api-key");
+        assertEquals(authHeader, API_KEY);
     }
 
     @Test
@@ -48,9 +47,8 @@ public class HttpApiKeyAuthSignerTest {
             .build();
 
         var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(TEST_REQUEST, TEST_IDENTITY, authProperties).get();
-        var authHeader = signedRequest.headers().map().get("x-api-key");
-        assertNotNull(authHeader);
-        assertEquals(authHeader.get(0), "SCHEME " + API_KEY);
+        var authHeader = signedRequest.headers().firstValue("x-api-key");
+        assertEquals(authHeader, "SCHEME " + API_KEY);
     }
 
     @Test
@@ -62,9 +60,8 @@ public class HttpApiKeyAuthSignerTest {
             .build();
         var updateRequest = TEST_REQUEST.withAddedHeaders("x-api-key", "foo");
         var signedRequest = HttpApiKeyAuthSigner.INSTANCE.sign(updateRequest, TEST_IDENTITY, authProperties).get();
-        var authHeader = signedRequest.headers().map().get("x-api-key");
-        assertNotNull(authHeader);
-        assertEquals(authHeader.get(0), "SCHEME " + API_KEY);
+        var authHeader = signedRequest.headers().firstValue("x-api-key");
+        assertEquals(authHeader, "SCHEME " + API_KEY);
     }
 
     @Test

--- a/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/auth/HttpBasicAuthSignerTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/auth/HttpBasicAuthSignerTest.java
@@ -6,10 +6,8 @@
 package software.amazon.smithy.java.runtime.client.http.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URI;
-import java.net.http.HttpHeaders;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -18,6 +16,7 @@ import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.identity.LoginIdentity;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
 
@@ -36,9 +35,8 @@ public class HttpBasicAuthSignerTest {
         var expectedHeader = "Basic " + Base64.getEncoder()
             .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
         var signedRequest = HttpBasicAuthSigner.INSTANCE.sign(request, testIdentity, AuthProperties.empty()).get();
-        var authHeader = signedRequest.headers().map().get("Authorization");
-        assertNotNull(authHeader);
-        assertEquals(authHeader.get(0), expectedHeader);
+        var authHeader = signedRequest.headers().firstValue("authorization");
+        assertEquals(authHeader, expectedHeader);
     }
 
     @Test
@@ -49,15 +47,14 @@ public class HttpBasicAuthSignerTest {
         var request = SmithyHttpRequest.builder()
             .httpVersion(SmithyHttpVersion.HTTP_1_1)
             .method("PUT")
-            .headers(HttpHeaders.of(Map.of("Authorization", List.of("FOO", "BAR")), (k, v) -> true))
+            .headers(HttpHeaders.of(Map.of("Authorization", List.of("FOO", "BAR"))))
             .uri(URI.create("https://www.example.com"))
             .build();
 
         var expectedHeader = "Basic " + Base64.getEncoder()
             .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
         var signedRequest = HttpBasicAuthSigner.INSTANCE.sign(request, testIdentity, AuthProperties.empty()).get();
-        var authHeader = signedRequest.headers().map().get("Authorization");
-        assertNotNull(authHeader);
-        assertEquals(authHeader.get(0), expectedHeader);
+        var authHeader = signedRequest.headers().firstValue("authorization");
+        assertEquals(authHeader, expectedHeader);
     }
 }

--- a/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/auth/HttpBearerAuthSignerTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/auth/HttpBearerAuthSignerTest.java
@@ -6,16 +6,15 @@
 package software.amazon.smithy.java.runtime.client.http.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URI;
-import java.net.http.HttpHeaders;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.identity.TokenIdentity;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
 
@@ -30,9 +29,8 @@ public class HttpBearerAuthSignerTest {
             .build();
 
         var signedRequest = HttpBearerAuthSigner.INSTANCE.sign(request, tokenIdentity, AuthProperties.empty()).get();
-        var authHeader = signedRequest.headers().map().get("Authorization");
-        assertNotNull(authHeader);
-        assertEquals(authHeader.get(0), "Bearer token");
+        var authHeader = signedRequest.headers().firstValue("authorization");
+        assertEquals(authHeader, "Bearer token");
     }
 
     @Test
@@ -41,13 +39,12 @@ public class HttpBearerAuthSignerTest {
         var request = SmithyHttpRequest.builder()
             .httpVersion(SmithyHttpVersion.HTTP_1_1)
             .method("PUT")
-            .headers(HttpHeaders.of(Map.of("Authorization", List.of("FOO", "BAR")), (k, v) -> true))
+            .headers(HttpHeaders.of(Map.of("Authorization", List.of("FOO", "BAR"))))
             .uri(URI.create("https://www.example.com"))
             .build();
 
         var signedRequest = HttpBearerAuthSigner.INSTANCE.sign(request, tokenIdentity, AuthProperties.empty()).get();
-        var authHeader = signedRequest.headers().map().get("Authorization");
-        assertNotNull(authHeader);
-        assertEquals(authHeader.get(0), "Bearer token");
+        var authHeader = signedRequest.headers().firstValue("authorization");
+        assertEquals(authHeader, "Bearer token");
     }
 }

--- a/codegen/client/src/it/java/software/amazon/smithy/java/codegen/client/AuthSchemeTest.java
+++ b/codegen/client/src/it/java/software/amazon/smithy/java/codegen/client/AuthSchemeTest.java
@@ -6,7 +6,6 @@
 package software.amazon.smithy.java.codegen.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -45,8 +44,7 @@ public class AuthSchemeTest {
             public void readBeforeTransmit(RequestHook<?, ?> hook) {
                 var request = (SmithyHttpRequest) hook.request();
                 var signatureValue = request.headers().firstValue(TestAuthScheme.SIGNATURE_HEADER);
-                assertTrue(signatureValue.isPresent());
-                assertEquals("smithy-test-signature", signatureValue.get());
+                assertEquals("smithy-test-signature", signatureValue);
             }
         };
         var client = TestServiceClient.builder()

--- a/codegen/client/src/it/java/software/amazon/smithy/java/codegen/client/util/EchoServer.java
+++ b/codegen/client/src/it/java/software/amazon/smithy/java/codegen/client/util/EchoServer.java
@@ -51,11 +51,11 @@ public final class EchoServer {
 
     private static class EchoHandler implements HttpHandler {
         private static final Set<String> STANDARD_HEADERS = Set.of(
-            "User-agent",
-            "Content-Type",
-            "Content-Length",
-            "Accept",
-            "Host"
+            "user-agent",
+            "content-type",
+            "content-length",
+            "accept",
+            "host"
         );
 
         @Override
@@ -67,7 +67,7 @@ public final class EchoServer {
                     responseHeaders.set(reqHeader.getKey(), String.valueOf(reqHeader.getValue()));
                 }
             }
-            responseHeaders.set("Content-Type", "application/json");
+            responseHeaders.set("content-type", "application/json");
 
             try (
                 var bos = new ByteArrayOutputStream(); var writer = new BufferedWriter(

--- a/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/HttpHeaders.java
+++ b/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/HttpHeaders.java
@@ -5,28 +5,101 @@
 
 package software.amazon.smithy.java.runtime.http.api;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Contains case-insensitive HTTP headers.
+ */
 public interface HttpHeaders extends Iterable<Map.Entry<String, List<String>>> {
 
-    String getFirstHeader(String name);
+    /**
+     * Create an immutable HttpHeaders.
+     *
+     * @param headers Headers to set.
+     * @return the created headers.
+     */
+    static HttpHeaders of(Map<String, List<String>> headers) {
+        return headers.isEmpty() ? SimpleUnmodifiableHttpHeaders.EMPTY : new SimpleUnmodifiableHttpHeaders(headers);
+    }
 
-    List<String> getHeader(String name);
+    /**
+     * Creates a mutable headers.
+     *
+     * @return the created headers.
+     */
+    static ModifiableHttpHeaders ofModifiable() {
+        return new SimpleModifiableHttpHeaders();
+    }
 
+    /**
+     * Check if the given header is present.
+     *
+     * @param name Header to check.
+     * @return true if the header is present.
+     */
+    default boolean hasHeader(String name) {
+        return !allValues(name).isEmpty();
+    }
+
+    /**
+     * Get the first header value of a specific header by case-insensitive name.
+     *
+     * @param name Name of the header to get.
+     * @return the matching header value, or null if not found.
+     */
+    default String firstValue(String name) {
+        var list = allValues(name);
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    /**
+     * Get the values of a specific header by name.
+     *
+     * @param name Name of the header to get the values of, case-insensitively.
+     * @return the values of the header, or an empty list.
+     */
+    List<String> allValues(String name);
+
+    /**
+     * Get the content-type header, or null if not found.
+     *
+     * @return the content-type header or null.
+     */
+    default String contentType() {
+        return firstValue("content-type");
+    }
+
+    /**
+     * Get the content-length header value, or null if not found.
+     *
+     * @return the parsed content-length or null.
+     */
+    default Long contentLength() {
+        var value = firstValue("content-length");
+        return value == null ? null : Long.parseLong(value);
+    }
+
+    /**
+     * Get the number of header entries (not individual values).
+     *
+     * @return header entries.
+     */
     int size();
 
+    /**
+     * Check if there are no headers.
+     *
+     * @return true if no headers.
+     */
     default boolean isEmpty() {
         return size() == 0;
     }
 
-    default Map<String, List<String>> toMap() {
-        Map<String, List<String>> result = new HashMap<>(size());
-        for (var entry : this) {
-            result.put(entry.getKey(), entry.getValue());
-        }
-        return result;
-    }
-
+    /**
+     * Convert the HttpHeader to an unmodifiable map.
+     *
+     * @return the headers as a map.
+     */
+    Map<String, List<String>> map();
 }

--- a/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/ModifiableHttpHeaders.java
+++ b/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/ModifiableHttpHeaders.java
@@ -8,17 +8,46 @@ package software.amazon.smithy.java.runtime.http.api;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A modifiable version of {@link HttpHeaders}.
+ */
 public interface ModifiableHttpHeaders extends HttpHeaders {
-
-    static ModifiableHttpHeaders create() {
-        return new SimpleModifiableHttpHeaders();
-    }
-
+    /**
+     * Replace a header by name with the given value.
+     *
+     * <p>Any previously set values for this header are replaced.
+     *
+     * @param name Case-insensitive name of the header to set.
+     * @param value Value to set.
+     */
     void putHeader(String name, String value);
 
-    void putHeader(Map<String, List<String>> headers);
-
+    /**
+     * Replace a header by name with the given values.
+     *
+     * <p>Any previously set values for this header are replaced.
+     *
+     * @param name Case-insensitive name of the header to set.
+     * @param values Values to set.
+     */
     void putHeader(String name, List<String> values);
 
+    /**
+     * Put the given {@code headers}, similarly to if {@link #putHeader(String, List)} were to be called for each
+     * entry in the given map.
+     *
+     * @param headers Map of case-insensitive header names to their values.
+     */
+    default void putHeaders(Map<String, List<String>> headers) {
+        for (var entry : headers.entrySet()) {
+            putHeader(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Remove a header and its values by name.
+     *
+     * @param name Case-insensitive name of the header to remove.
+     */
     void removeHeader(String name);
 }

--- a/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SimpleUnmodifiableHttpHeaders.java
+++ b/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SimpleUnmodifiableHttpHeaders.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.http.api;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+final class SimpleUnmodifiableHttpHeaders implements HttpHeaders {
+
+    static final HttpHeaders EMPTY = new SimpleUnmodifiableHttpHeaders(Collections.emptyMap());
+
+    private final Map<String, List<String>> headers;
+
+    SimpleUnmodifiableHttpHeaders(Map<String, List<String>> input) {
+        // Ensure map keys are normalized to use lower-case header names.
+        this.headers = new HashMap<>(input.size());
+        for (var entry : input.entrySet()) {
+            var key = entry.getKey().trim().toLowerCase(Locale.ENGLISH);
+            headers.computeIfAbsent(key, k -> new ArrayList<>()).addAll(trimValues(entry.getValue()));
+        }
+        // Make the value immutable.
+        for (var entry : headers.entrySet()) {
+            entry.setValue(Collections.unmodifiableList(entry.getValue()));
+        }
+    }
+
+    private static List<String> trimValues(List<String> source) {
+        List<String> trimmedValues = new ArrayList<>(source.size());
+        for (var value : source) {
+            trimmedValues.add(value.trim());
+        }
+        return trimmedValues;
+    }
+
+    @Override
+    public List<String> allValues(String name) {
+        return headers.getOrDefault(name.toLowerCase(Locale.ENGLISH), Collections.emptyList());
+    }
+
+    @Override
+    public int size() {
+        return headers.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return headers.isEmpty();
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, List<String>>> iterator() {
+        return headers.entrySet().iterator();
+    }
+
+    @Override
+    public Map<String, List<String>> map() {
+        return Collections.unmodifiableMap(headers);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (!(obj instanceof HttpHeaders)) {
+            return false;
+        }
+
+        // For unmodifiable headers, we treat mutable implementations the same.
+        var other = (HttpHeaders) obj;
+        return headers.equals(other.map());
+    }
+
+    @Override
+    public int hashCode() {
+        return headers.hashCode();
+    }
+}

--- a/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpRequest.java
+++ b/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpRequest.java
@@ -6,7 +6,6 @@
 package software.amazon.smithy.java.runtime.http.api;
 
 import java.net.URI;
-import java.net.http.HttpHeaders;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.Flow;
@@ -55,7 +54,7 @@ public interface SmithyHttpRequest extends SmithyHttpMessage {
         String method;
         URI uri;
         DataStream body;
-        HttpHeaders headers = SmithyHttpRequestImpl.EMPTY_HEADERS;
+        HttpHeaders headers = SimpleUnmodifiableHttpHeaders.EMPTY;
         SmithyHttpVersion httpVersion = SmithyHttpVersion.HTTP_1_1;
 
         private Builder() {

--- a/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpRequestImpl.java
+++ b/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpRequestImpl.java
@@ -6,14 +6,10 @@
 package software.amazon.smithy.java.runtime.http.api;
 
 import java.net.URI;
-import java.net.http.HttpHeaders;
-import java.util.Map;
 import java.util.Objects;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
 
 final class SmithyHttpRequestImpl implements SmithyHttpRequest {
-
-    static final HttpHeaders EMPTY_HEADERS = HttpHeaders.of(Map.of(), (k, v) -> true);
 
     private final SmithyHttpVersion httpVersion;
     private final String method;
@@ -66,7 +62,11 @@ final class SmithyHttpRequestImpl implements SmithyHttpRequest {
 
     @Override
     public SmithyHttpRequest withHeaders(HttpHeaders headers) {
-        return SmithyHttpRequest.builder().with(this).headers(headers).build();
+        if (headers == this.headers) {
+            return this;
+        } else {
+            return SmithyHttpRequest.builder().with(this).headers(headers).build();
+        }
     }
 
     @Override
@@ -95,12 +95,12 @@ final class SmithyHttpRequestImpl implements SmithyHttpRequest {
             .append(httpVersion)
             .append(System.lineSeparator());
         // Append host header if not present.
-        if (headers.firstValue("host").isEmpty()) {
+        if (headers.firstValue("host") == null) {
             String host = uri.getHost();
             if (uri.getPort() != -1) {
                 host += ":" + uri.getPort();
             }
-            result.append("Host: ").append(host).append(System.lineSeparator());
+            result.append("host: ").append(host).append(System.lineSeparator());
         }
         // Add other headers.
         headers.map().forEach((field, values) -> values.forEach(value -> {

--- a/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpResponse.java
+++ b/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpResponse.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.http.api;
 
-import java.net.http.HttpHeaders;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.Flow;
@@ -49,7 +48,7 @@ public interface SmithyHttpResponse extends SmithyHttpMessage {
 
         int statusCode;
         DataStream body;
-        HttpHeaders headers = SmithyHttpRequestImpl.EMPTY_HEADERS;
+        HttpHeaders headers = SimpleUnmodifiableHttpHeaders.EMPTY;
         SmithyHttpVersion httpVersion = SmithyHttpVersion.HTTP_1_1;
 
         private Builder() {

--- a/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpResponseImpl.java
+++ b/http-api/src/main/java/software/amazon/smithy/java/runtime/http/api/SmithyHttpResponseImpl.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.http.api;
 
-import java.net.http.HttpHeaders;
 import java.util.Objects;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
 

--- a/http-api/src/test/java/software/amazon/smithy/java/runtime/http/api/HttpHeadersTest.java
+++ b/http-api/src/test/java/software/amazon/smithy/java/runtime/http/api/HttpHeadersTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.http.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class HttpHeadersTest {
+    @Test
+    public void caseInsensitiveHeaders() {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("hi", List.of("a"));
+        headers.put("BYE", List.of("b", "c"));
+        var httpHeaders = HttpHeaders.of(headers);
+
+        assertThat(httpHeaders.firstValue("hi"), equalTo("a"));
+        assertThat(httpHeaders.firstValue("bye"), equalTo("b"));
+        assertThat(httpHeaders.firstValue("BYE"), equalTo("b"));
+        assertThat(httpHeaders.firstValue("byee"), nullValue());
+    }
+
+    @Test
+    public void mergesHeadersOfDifferentCasing() {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("hi", List.of("a"));
+        headers.put("HI", List.of("b"));
+        headers.put("Hi ", List.of("c"));
+        var httpHeaders = HttpHeaders.of(headers);
+
+        assertThat(httpHeaders.firstValue("hi"), equalTo("a"));
+        assertThat(httpHeaders.allValues("hi"), contains("a", "b", "c"));
+    }
+}

--- a/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/runtime/http/binding/ResponseDeserializer.java
@@ -71,9 +71,9 @@ public final class ResponseDeserializer {
     }
 
     private DataStream bodyDataStream(SmithyHttpResponse response) {
-        var contentType = response.headers().firstValue("content-type").orElse(null);
-        var contentLength = response.headers().firstValue("content-length").map(Long::valueOf).orElse(-1L);
-        return DataStream.ofPublisher(response.body(), contentType, contentLength);
+        var contentType = response.headers().contentType();
+        var contentLength = response.headers().contentLength();
+        return DataStream.ofPublisher(response.body(), contentType, contentLength == null ? -1 : contentLength);
     }
 
     /**

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.protocoltests.harness;
 
-import java.net.http.HttpHeaders;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +20,7 @@ import software.amazon.smithy.java.runtime.client.core.auth.scheme.AuthSchemeOpt
 import software.amazon.smithy.java.runtime.client.core.auth.scheme.AuthSchemeResolver;
 import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
@@ -123,8 +123,8 @@ final class HttpClientResponseProtocolTestProvider extends
             for (var headerEntry : testCase.getHeaders().entrySet()) {
                 headerMap.put(headerEntry.getKey(), List.of(headerEntry.getValue()));
             }
-            testCase.getBodyMediaType().ifPresent(mediaType -> headerMap.put("Content-Type", List.of(mediaType)));
-            builder.headers(HttpHeaders.of(headerMap, (k, v) -> true));
+            testCase.getBodyMediaType().ifPresent(mediaType -> headerMap.put("content-type", List.of(mediaType)));
+            builder.headers(HttpHeaders.of(headerMap));
 
             // Add request body if present;
             testCase.getBody().ifPresent(body -> {

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerRequestProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerRequestProtocolTestProvider.java
@@ -10,8 +10,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.http.HttpHeaders;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Assumptions;
@@ -19,6 +23,7 @@ import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
@@ -171,7 +176,7 @@ public class HttpServerRequestProtocolTestProvider extends
             }
             headerMap.put(key, retVal);
         }
-        return HttpHeaders.of(headerMap, (k, v) -> true);
+        return HttpHeaders.of(headerMap);
     }
 
     private record ServerRequestInvocationContext(

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerResponseProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerResponseProtocolTestProvider.java
@@ -7,15 +7,22 @@ package software.amazon.smithy.java.protocoltests.harness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.net.http.HttpHeaders;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
@@ -55,14 +62,14 @@ public class HttpServerResponseProtocolTestProvider extends
                 headers.put("x-protocol-test-protocol-id", List.of(testCase.getProtocol().toString()));
                 headers.put("x-protocol-test-service", List.of(testOperation.serviceId().toString()));
                 headers.put("x-protocol-test-operation", List.of(testOperation.id().toString()));
-                headers.put("Content-Length", List.of("0"));
-                headers.put("Content-Type", List.of("application/json"));
+                headers.put("content-length", List.of("0"));
+                headers.put("content-type", List.of("application/json"));
 
                 var request = SmithyHttpRequest.builder()
                     .httpVersion(SmithyHttpVersion.HTTP_1_1)
                     .body(DataStream.ofBytes(new byte[0]))
                     .uri(testData.endpoint())
-                    .headers(HttpHeaders.of(headers, (k, v) -> true))
+                    .headers(HttpHeaders.of(headers))
                     .method("POST")
                     .build();
                 invocationContexts.add(

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestProtocolProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestProtocolProvider.java
@@ -65,12 +65,12 @@ public class ProtocolTestProtocolProvider implements ServerProtocolProvider {
             ServiceProtocolResolutionRequest request,
             List<Service> candidates
         ) {
-            String protocolIdHeader = request.headers().getFirstHeader("x-protocol-test-protocol-id");
+            String protocolIdHeader = request.headers().firstValue("x-protocol-test-protocol-id");
             if (protocolIdHeader != null) {
                 ServerProtocol protocol = delegateProtocols.get(ShapeId.from(protocolIdHeader));
                 request.requestContext().put(PROTOCOL_TO_TEST, protocol);
-                ShapeId serviceId = ShapeId.from(request.headers().getFirstHeader("x-protocol-test-service"));
-                ShapeId operationId = ShapeId.from(request.headers().getFirstHeader("x-protocol-test-operation"));
+                ShapeId serviceId = ShapeId.from(request.headers().firstValue("x-protocol-test-service"));
+                ShapeId operationId = ShapeId.from(request.headers().firstValue("x-protocol-test-operation"));
                 for (var service : candidates) {
                     if (service.schema().id().equals(serviceId)) {
                         for (var operation : service.getAllOperations()) {

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ServerTestClient.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ServerTestClient.java
@@ -11,6 +11,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
@@ -42,9 +43,9 @@ final class ServerTestClient {
             .method(request.method(), bodyPublisher)
             .uri(request.uri());
 
-        for (var entry : request.headers().map().entrySet()) {
+        for (var entry : request.headers()) {
             for (var value : entry.getValue()) {
-                if (!entry.getKey().equals("Content-Length")) {
+                if (!entry.getKey().equals("content-length")) {
                     httpRequestBuilder.header(entry.getKey(), value);
                 }
             }
@@ -55,7 +56,7 @@ final class ServerTestClient {
             return SmithyHttpResponse.builder()
                 .statusCode(response.statusCode())
                 .body(DataStream.ofBytes(response.body()))
-                .headers(response.headers())
+                .headers(HttpHeaders.of(response.headers().map()))
                 .build();
 
         } catch (InterruptedException | IOException e) {

--- a/server-aws-rest-json1/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
+++ b/server-aws-rest-json1/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
@@ -43,7 +43,10 @@ public class AwsRestJson1ProtocolTests {
             "RestJsonClientUsesExplicitlyProvidedMemberValuesOverDefaults",
 
             // Header splitting needs work.
-            "RestJsonInputAndOutputWithQuotedStringHeaders"
+            "RestJsonInputAndOutputWithQuotedStringHeaders",
+
+            // TODO: update this test to use lowercase prefix header names.
+            "RestJsonHttpPrefixHeadersArePresent"
         },
         skipOperations = {
             "aws.protocoltests.restjson#DocumentType",

--- a/server-aws-rest-json1/src/main/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1Protocol.java
+++ b/server-aws-rest-json1/src/main/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1Protocol.java
@@ -124,7 +124,7 @@ final class AwsRestJson1Protocol extends ServerProtocol {
             .pathLabelValues(labelValues)
             .request(
                 SmithyHttpRequest.builder()
-                    .headers(convert(headers))
+                    .headers(headers)
                     .uri(httpJob.request().uri())
                     .method(httpJob.request().method())
                     .body(job.request().getDataStream())
@@ -145,11 +145,6 @@ final class AwsRestJson1Protocol extends ServerProtocol {
 
     }
 
-    //TODO remove this when we have migrated Smithy to use HttpHeader's everywhere.
-    private java.net.http.HttpHeaders convert(HttpHeaders headers) {
-        return java.net.http.HttpHeaders.of(headers.toMap(), (k, v) -> true);
-    }
-
     @Override
     public CompletableFuture<Void> serializeOutput(Job job) {
         HttpJob httpJob = (HttpJob) job; //We already check in the deserializeInput method.
@@ -163,7 +158,7 @@ final class AwsRestJson1Protocol extends ServerProtocol {
         SmithyHttpResponse response = serializer.serializeResponse();
         httpJob.response().setSerializedValue(response.body());
         httpJob.response().setStatusCode(response.statusCode());
-        httpJob.response().headers().putHeader(response.headers().map());
+        httpJob.response().headers().putHeaders(response.headers().map());
         return CompletableFuture.completedFuture(null);
     }
 }

--- a/server-netty/src/main/java/software/amazon/smithy/java/server/netty/HttpRequestHandler.java
+++ b/server-netty/src/main/java/software/amazon/smithy/java/server/netty/HttpRequestHandler.java
@@ -86,7 +86,7 @@ final class HttpRequestHandler extends ChannelDuplexHandler {
                 Unpooled.wrappedBuffer(serializedValue.waitForByteBuffer())
             );
             response.headers().set(((NettyHttpHeaders) job.response().headers()).getNettyHeaders());
-            response.headers().set("Content-Length", serializedValue.contentLength());
+            response.headers().set("content-length", serializedValue.contentLength());
         } catch (Throwable e) {
             response = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1,

--- a/server-netty/src/main/java/software/amazon/smithy/java/server/netty/NettyHttpHeaders.java
+++ b/server-netty/src/main/java/software/amazon/smithy/java/server/netty/NettyHttpHeaders.java
@@ -26,25 +26,18 @@ final class NettyHttpHeaders implements ModifiableHttpHeaders {
     }
 
     @Override
-    public String getFirstHeader(String name) {
+    public String firstValue(String name) {
         return nettyHeaders.get(name);
     }
 
     @Override
-    public List<String> getHeader(String name) {
+    public List<String> allValues(String name) {
         return nettyHeaders.getAll(name);
     }
 
     @Override
     public void putHeader(String name, String value) {
         nettyHeaders.add(name, value);
-    }
-
-    @Override
-    public void putHeader(Map<String, List<String>> headers) {
-        for (var entry : headers.entrySet()) {
-            nettyHeaders.add(entry.getKey(), entry.getValue());
-        }
     }
 
     @Override
@@ -70,7 +63,7 @@ final class NettyHttpHeaders implements ModifiableHttpHeaders {
     //TODO implement an efficient toMap and iterator.
 
     @Override
-    public Map<String, List<String>> toMap() {
+    public Map<String, List<String>> map() {
         var map = new HashMap<String, List<String>>();
         for (var name : nettyHeaders.names()) {
             map.put(name, nettyHeaders.getAll(name));
@@ -80,7 +73,7 @@ final class NettyHttpHeaders implements ModifiableHttpHeaders {
 
     @Override
     public Iterator<Map.Entry<String, List<String>>> iterator() {
-        return toMap().entrySet().iterator();
+        return map().entrySet().iterator();
     }
 
     HttpHeaders getNettyHeaders() {


### PR DESCRIPTION
Consolidate the client server parts of the codebase to both rely on an HttpHeaders abstraction that is _not_ the one from the JDK HttpClient. The built-in HttpHeaders uses Optionals and always requires a predicate to create headers. We also wanted a mutable variant for the server side, but immutable for the client side.

I've tweaked the existing interface to look more like the built-in HttpHeaders Java interface to reduce churn.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
