### PR TITLE
Prevent naming conflicts for ID

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/IdStringGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/IdStringGenerator.java
@@ -26,7 +26,7 @@ public record IdStringGenerator(JavaWriter writer, Shape shape) implements Runna
         // Use the original shape ID here instead of any potentially renamed input or output shapes.
         // This is critical for shape serialization in protocols like XML.
         writer.write(
-            "public static final ${shapeId:T} ID = ${shapeId:T}.from($S);",
+            "static final ${shapeId:T} $$ID = ${shapeId:T}.from($S);",
             CodegenUtils.getOriginalId(shape)
         );
         writer.popState();

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
@@ -211,7 +211,7 @@ public class OperationGenerator
             writer.indent();
             for (var errorId : shape.getErrors(service)) {
                 var errorShape = model.expectShape(errorId);
-                writer.write(".putType($1T.ID, $1T.class, $1T::builder)", symbolProvider.toSymbol(errorShape));
+                writer.write(".putType($1T.$$ID, $1T.class, $1T::builder)", symbolProvider.toSymbol(errorShape));
             }
             writer.writeWithNoFormatting(".build();");
             writer.dedent();

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaBuilderGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaBuilderGenerator.java
@@ -79,7 +79,7 @@ final class SchemaBuilderGenerator extends ShapeVisitor.Default<Void> implements
     @Override
     public Void structureShape(StructureShape shape) {
         writer.write(
-            "static final ${schemaBuilder:T} ${name:L}_BUILDER = ${schemaClass:T}.structureBuilder(ID${traits:C});"
+            "static final ${schemaBuilder:T} ${name:L}_BUILDER = ${schemaClass:T}.structureBuilder($$ID${traits:C});"
         );
         return null;
     }
@@ -87,7 +87,7 @@ final class SchemaBuilderGenerator extends ShapeVisitor.Default<Void> implements
     @Override
     public Void unionShape(UnionShape shape) {
         writer.write(
-            "static final ${schemaBuilder:T} ${name:L}_BUILDER = ${schemaClass:T}.structureBuilder(ID${traits:C});"
+            "static final ${schemaBuilder:T} ${name:L}_BUILDER = ${schemaClass:T}.structureBuilder($$ID${traits:C});"
         );
         return null;
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaGenerator.java
@@ -157,7 +157,7 @@ public final class SchemaGenerator implements ShapeVisitor<Void>, Runnable {
         writer.putContext("variants", shape.members().stream().map(symbolProvider::toMemberName).toList());
         writer.putContext("set", Set.class);
         writer.write("""
-            static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createIntEnum(ID,
+            static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createIntEnum($$ID,
                 ${set:T}.of(${#variants}${value:L}.value${^key.last}, ${/key.last}${/variants})${traits:C}
             );
             """);
@@ -217,7 +217,7 @@ public final class SchemaGenerator implements ShapeVisitor<Void>, Runnable {
         writer.putContext("variants", shape.members().stream().map(symbolProvider::toMemberName).toList());
         writer.putContext("set", Set.class);
         writer.write("""
-            static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createEnum(ID,
+            static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createEnum($$ID,
                 ${set:T}.of(${#variants}${value:L}.value${^key.last}, ${/key.last}${/variants})${traits:C}
             );
             """);
@@ -243,7 +243,7 @@ public final class SchemaGenerator implements ShapeVisitor<Void>, Runnable {
         writer.write(
             """
                 ${?recursive}${C}
-                ${/recursive}static final ${schemaClass:T} ${name:L} = ${?recursive}${name:L}_BUILDER${/recursive}${^recursive}${schemaClass:T}.${builderMethod:L}(ID${traits:C})${/recursive}${?hasMembers}
+                ${/recursive}static final ${schemaClass:T} ${name:L} = ${?recursive}${name:L}_BUILDER${/recursive}${^recursive}${schemaClass:T}.${builderMethod:L}($$ID${traits:C})${/recursive}${?hasMembers}
                     ${C|}
                     ${/hasMembers}.build();
                 """,
@@ -298,7 +298,7 @@ public final class SchemaGenerator implements ShapeVisitor<Void>, Runnable {
 
     @Override
     public Void operationShape(OperationShape shape) {
-        writer.write("static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createOperation(ID${traits:C});");
+        writer.write("static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createOperation($$ID${traits:C});");
         return null;
     }
 
@@ -309,7 +309,7 @@ public final class SchemaGenerator implements ShapeVisitor<Void>, Runnable {
 
     @Override
     public Void serviceShape(ServiceShape serviceShape) {
-        writer.write("static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createService(ID${traits:C});");
+        writer.write("static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createService($$ID${traits:C});");
         return null;
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -203,9 +203,9 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
                 () -> {
                     if (shape.hasTrait(ErrorTrait.class)) {
                         if (shape.getMember("message").isPresent()) {
-                            writer.write("super(ID, builder.message);");
+                            writer.write("super($$ID, builder.message);");
                         } else {
-                            writer.write("super(ID, null);");
+                            writer.write("super($$ID, null);");
                         }
                     }
 

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -199,7 +199,6 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
             fileContents,
             containsString(
                 """
-                        public static final ShapeId ID = ShapeId.from("smithy.java.codegen#EnumWithDocs");
                         /**
                          * @deprecated As of the past.
                          */


### PR DESCRIPTION
### Description of changes
Renames the shapeId `ID` field to `$ID` to prevent any chance of conflicts with enum variants.

Also updates the `$ID` property to be package-private as it is only ever used directly by other class in the same package. Users can still get the ID via the schema.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
