### PR TITLE
Rename schema property to avoid naming conflicts

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/model/TraitsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/model/TraitsTest.java
@@ -40,14 +40,14 @@ public class TraitsTest {
     @ParameterizedTest
     @MethodSource("memberSchemaSource")
     void testStructureMemberSchemaTraitsSet(String memberName, Class<? extends Trait> traitClass, Trait expected) {
-        var memberSchema = TraitsInput.SCHEMA.member(memberName);
+        var memberSchema = TraitsInput.$SCHEMA.member(memberName);
         var traitValue = memberSchema.expectTrait(TraitKey.get(traitClass));
         assertEquals(traitValue, expected);
     }
 
     @Test
     void testErrorTraitsSet() {
-        var retryableTrait = RetryableError.SCHEMA.expectTrait(TraitKey.get(RetryableTrait.class));
+        var retryableTrait = RetryableError.$SCHEMA.expectTrait(TraitKey.get(RetryableTrait.class));
         assertEquals(retryableTrait, RetryableTrait.builder().build());
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -54,7 +54,7 @@ public final class CodegenUtils {
         .loadCaseInsensitiveWords(RESERVED_WORDS_FILE, word -> word + "Member")
         .build();
 
-    private static final String SCHEMA_STATIC_NAME = "SCHEMA";
+    private static final String SCHEMA_STATIC_NAME = "$SCHEMA";
     private static final EnumSet<ShapeType> SHAPES_WITH_INNER_SCHEMA = EnumSet.of(
         ShapeType.OPERATION,
         ShapeType.SERVICE,
@@ -229,7 +229,11 @@ public final class CodegenUtils {
             return writer.format("$T.$L", PreludeSchemas.class, shape.getType().name());
         } else if (SHAPES_WITH_INNER_SCHEMA.contains(shape.getType())) {
             // Shapes that generate a class have their schemas as static properties on that class
-            return writer.format("$T.SCHEMA", provider.toSymbol(shape));
+            return writer.format(
+                "$T.$L",
+                provider.toSymbol(shape),
+                shape.hasTrait(UnitTypeTrait.class) ? "SCHEMA" : "$SCHEMA"
+            );
         }
         return writer.format("SharedSchemas.$L", toSchemaName(shape));
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/BuilderGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/BuilderGenerator.java
@@ -62,7 +62,7 @@ abstract class BuilderGenerator implements Runnable {
 
                 @Override
                 public Schema schema() {
-                    return SCHEMA;
+                    return $$SCHEMA;
                 }
 
                 ${builderSetters:C|}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
@@ -296,7 +296,7 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
                 """
                     @Override
                     public Builder deserialize(${shapeDeserializer:N} de) {
-                        return value(de.${?string}readString${/string}${^string}readInteger${/string}(SCHEMA));
+                        return value(de.${?string}readString${/string}${^string}readInteger${/string}($$SCHEMA));
                     }"""
             );
             writer.popState();

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
@@ -85,31 +85,31 @@ public class OperationGenerator
 
                         @Override
                         public ${sdkSchema:N} schema() {
-                            return SCHEMA;
+                            return $$SCHEMA;
                         }
 
                         @Override
                         public ${sdkSchema:N} inputSchema() {
-                            return ${inputType:T}.SCHEMA;
+                            return ${inputType:T}.$$SCHEMA;
                         }
 
                         ${?hasInputEventStream}
                         @Override
                         public ${sdkSchema:T} inputEventSchema() {
-                            return ${inputEventType:T}.SCHEMA;
+                            return ${inputEventType:T}.$$SCHEMA;
                         }
                         ${/hasInputEventStream}
 
                         ${?hasOutputEventStream}
                         @Override
                         public ${sdkSchema:T} outputEventSchema() {
-                            return ${outputEventType:T}.SCHEMA;
+                            return ${outputEventType:T}.$$SCHEMA;
                         }
                         ${/hasOutputEventStream}
 
                         @Override
                         public ${sdkSchema:N} outputSchema() {
-                            return ${outputType:T}.SCHEMA;
+                            return ${outputType:T}.$$SCHEMA;
                         }
 
                         @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
@@ -66,7 +66,7 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
     public void run() {
         writer.pushState();
         writer.putContext("state", state);
-        writer.putContext("schema", "SCHEMA");
+        writer.putContext("schema", "$SCHEMA");
         shape.accept(this);
         writer.popState();
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
@@ -24,13 +24,13 @@ record StructureDeserializerGenerator(
         var template = """
             @Override
             public Builder deserialize(${shapeDeserializer:N} decoder) {
-                decoder.readStruct(SCHEMA, this, InnerDeserializer.INSTANCE);
+                decoder.readStruct($$SCHEMA, this, InnerDeserializer.INSTANCE);
                 return this;
             }
 
             @Override
             public Builder deserializeMember(${shapeDeserializer:N} decoder, ${sdkSchema:N} schema) {
-                decoder.readStruct(schema.assertMemberTargetIs(SCHEMA), this, InnerDeserializer.INSTANCE);
+                decoder.readStruct(schema.assertMemberTargetIs($$SCHEMA), this, InnerDeserializer.INSTANCE);
                 return this;
             }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -684,7 +684,7 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
             // Add presence tracker
             if (shape.members().stream().anyMatch(CodegenUtils::isRequiredWithNoDefault)) {
                 writer.putContext("tracker", PresenceTracker.class);
-                writer.write("private final ${tracker:T} tracker = ${tracker:T}.of(SCHEMA);");
+                writer.write("private final ${tracker:T} tracker = ${tracker:T}.of($$SCHEMA);");
             }
 
             // Add non-static builder properties

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
@@ -33,7 +33,7 @@ record StructureSerializerGenerator(
         var template = """
             @Override
             public void serialize(${shapeSerializer:N} serializer) {
-                serializer.writeStruct(SCHEMA, this);
+                serializer.writeStruct($$SCHEMA, this);
             }
 
             @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -59,7 +59,7 @@ public final class UnionGenerator
 
                     @Override
                     public void serialize(${shapeSerializer:N} serializer) {
-                        serializer.writeStruct(SCHEMA, this);
+                        serializer.writeStruct($$SCHEMA, this);
                     }
 
                     ${valueCasters:C|}

--- a/codegen/server/src/main/java/software/amazon/smithy/java/codegen/server/generators/ServiceGenerator.java
+++ b/codegen/server/src/main/java/software/amazon/smithy/java/codegen/server/generators/ServiceGenerator.java
@@ -76,7 +76,7 @@ public final class ServiceGenerator implements
 
                     @Override
                     public ${schemaClass:T} schema() {
-                         return SCHEMA;
+                         return $$SCHEMA;
                     }
                 }
                 """;


### PR DESCRIPTION
### Description of changes
Rename SCHEMA property in generated shapes to `$SCHEMA` to avoid same naming conflicts as in: https://github.com/smithy-lang/smithy-java/pull/403


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
