### PR TITLE
Correct member-order comparator

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -249,13 +249,9 @@ public final class CodegenUtils {
             .stream()
             .sorted(
                 (a, b) -> {
-                    if (isRequiredWithNoDefault(a) && !isRequiredWithNoDefault(b)) {
-                        return -1;
-                    } else if (isRequiredWithNoDefault(a)) {
-                        return 1;
-                    } else {
-                        return 0;
-                    }
+                    int aRequiredWithNoDefault = isRequiredWithNoDefault(a) ? 1 : 0;
+                    int bRequiredWithNoDefault = isRequiredWithNoDefault(b) ? 1 : 0;
+                    return bRequiredWithNoDefault - aRequiredWithNoDefault;
                 }
             )
             .collect(Collectors.toList());


### PR DESCRIPTION
### Description of changes
Corrects previously incorrect comparator that could cause: `Comparison method violates its general contract!`
errors for some models.

note: member ordering method is verified in unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
