### PR TITLE
Sanitize problematic characters

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocFormatterInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocFormatterInterceptor.java
@@ -152,15 +152,16 @@ final class JavadocFormatterInterceptor implements CodeInterceptor<JavadocSectio
     private void writeDocstringLine(JavaWriter writer, String string, int nestingLevel) {
         for (Scanner it = new Scanner(string); it.hasNextLine();) {
             var s = it.nextLine();
-            // If we are outs of an HTML tag, wrap the string. Otherwise, ignore wrapping.
-            var str = nestingLevel == 0
-                ? StringUtils.wrap(s, MAX_LINE_LENGTH, writer.getNewline() + " * ", false)
-                : s;
 
             // Sanitize string
             for (var entry : REPLACEMENTS.entrySet()) {
-                str = str.replace(entry.getKey(), entry.getValue());
+                s = s.replace(entry.getKey(), entry.getValue());
             }
+
+            // If we are out of an HTML tag, wrap the string. Otherwise, ignore wrapping.
+            var str = nestingLevel == 0
+                ? StringUtils.wrap(s, MAX_LINE_LENGTH, writer.getNewline() + " * ", false)
+                : s;
 
             writer.writeInlineWithNoFormatting(str);
 


### PR DESCRIPTION
### Description of changes
Sanitizes the documentation input for javadocs by converting problematic characters to their HTML escape codes. 

At the moment this is just `*` which can cause javadocs to be treated as completed, breaking compilation, but I left it open as we may want to clean out additional characters in the future.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
