### PR TITLE
Escape serializer member name

### DIFF
--- a/codegen/core/src/it/resources/META-INF/smithy/naming/naming-collision.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/naming/naming-collision.smithy
@@ -14,6 +14,9 @@ operation Naming {
         inner: InnerDeserializer
 
         type: Type
+
+        // Collides with `serializer` input to serializeMembers
+        serializer: String
     }
 }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -52,6 +52,7 @@ public final class CodegenUtils {
         .build();
     public static final ReservedWords MEMBER_ESCAPER = new ReservedWordsBuilder()
         .loadCaseInsensitiveWords(RESERVED_WORDS_FILE, word -> word + "Member")
+        .put("serializer", "serializerMember")
         .build();
 
     private static final String SCHEMA_STATIC_NAME = "$SCHEMA";


### PR DESCRIPTION
### Description of changes
Escapes any members named `serializer` to prevent collision in the `serializeMembers` method on serializable structs.

Note, this name is only a problem for members, not for struct names.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
