### PR TITLE
Implicit duplicate symbols

### DIFF
--- a/codegen/core/src/it/resources/META-INF/smithy/naming/naming-collision.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/naming/naming-collision.smithy
@@ -15,6 +15,9 @@ operation Naming {
 
         type: Type
     }
+    errors: [
+        IllegalArgumentException
+    ]
 }
 
 @private
@@ -25,3 +28,9 @@ structure InnerDeserializer {}
 
 @private
 structure Type {}
+
+/// This will clash with built in `java.lang` exception used a number
+/// of places such as in enums and unions
+@private
+@error("client")
+structure IllegalArgumentException {}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
@@ -8,9 +8,13 @@ package software.amazon.smithy.java.codegen;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.java.logging.InternalLogger;
@@ -18,6 +22,7 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -40,7 +45,6 @@ public final class JavaCodegenSettings {
     private static final String RELATIVE_DATE = "relativeDate";
     private static final String RELATIVE_VERSION = "relativeVersion";
     private static final String EDITION = "edition";
-
     private static final List<String> PROPERTIES = List.of(
         SERVICE,
         NAME,
@@ -69,6 +73,7 @@ public final class JavaCodegenSettings {
     private final String relativeDate;
     private final String relativeVersion;
     private final SmithyJavaCodegenEdition edition;
+    private final Map<String, Set<Symbol>> generatedSymbols = new HashMap<>();
 
     private JavaCodegenSettings(Builder builder) {
         this.service = Objects.requireNonNull(builder.service);
@@ -163,6 +168,17 @@ public final class JavaCodegenSettings {
 
     public SmithyJavaCodegenEdition edition() {
         return edition;
+    }
+
+    @SmithyInternalApi
+    public void addSymbol(Symbol symbol) {
+        var symbols = generatedSymbols.computeIfAbsent(symbol.getNamespace(), k -> new HashSet<>());
+        symbols.add(symbol);
+    }
+
+    @SmithyInternalApi
+    public Set<Symbol> getGeneratedSymbolsPackage(String packageNamespace) {
+        return generatedSymbols.get(packageNamespace);
     }
 
     private static Symbol buildSymbolFromFullyQualifiedName(String fullyQualifiedName) {

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/CoreIntegration.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/CoreIntegration.java
@@ -6,8 +6,14 @@
 package software.amazon.smithy.java.codegen.integrations.core;
 
 import java.util.List;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
+import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.TraitInitializer;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -29,6 +35,32 @@ public class CoreIntegration implements JavaCodegenIntegration {
     @Override
     public byte priority() {
         return -1;
+    }
+
+    @Override
+    public SymbolProvider decorateSymbolProvider(
+        Model model,
+        JavaCodegenSettings settings,
+        SymbolProvider symbolProvider
+    ) {
+        return new SymbolProvider() {
+            @Override
+            public Symbol toSymbol(Shape shape) {
+                // Add symbols to generated symbol map, so we can resolve any implicit usages
+                // from symbols in the same package.
+                var symbol = symbolProvider.toSymbol(shape);
+                if (symbol != null) {
+                    settings.addSymbol(symbol);
+                }
+                return symbol;
+            }
+
+            // Necessary to ensure initial toMemberName is not squashed by decorating
+            @Override
+            public String toMemberName(MemberShape shape) {
+                return symbolProvider.toMemberName(shape);
+            }
+        };
     }
 
     @Override

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/writer/DeferredSymbolWriter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/writer/DeferredSymbolWriter.java
@@ -36,7 +36,6 @@ public abstract class DeferredSymbolWriter<W extends SymbolWriter<W, I>, I exten
      */
     protected void addToSymbolTable(Symbol symbol) {
         Set<Symbol> nameSet = symbolTable.computeIfAbsent(symbol.getName(), n -> new HashSet<>());
-
         nameSet.add(symbol);
     }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/writer/JavaWriter.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/writer/JavaWriter.java
@@ -79,6 +79,9 @@ public class JavaWriter extends DeferredSymbolWriter<JavaWriter, JavaImportConta
     }
 
     private void putNameContext() {
+        // Add any implicit usages from classes in the same package
+        var packageSymbols = settings.getGeneratedSymbolsPackage(packageNamespace);
+        packageSymbols.forEach(this::addToSymbolTable);
         for (final Set<Symbol> duplicates : symbolTable.values()) {
             // If the duplicates list has more than one entry
             // then duplicates are present, and we need to de-duplicate the names

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -59,7 +59,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
 
     @Test
     void addsDeprecated() {
-        var fileContents = getFileStringForClass("DeprecatedInput");
+        var fileContents = getFileStringForClass("DeprecatedAnnotationInput");
 
         // Check that class header is added
         assertThat(fileContents, containsString("""
@@ -68,7 +68,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
              */
             @Deprecated(since = "1.3")
             @SmithyGenerated
-            public final class DeprecatedInput implements SerializableStruct {
+            public final class DeprecatedAnnotationInput implements SerializableStruct {
             """));
 
         // Check that member headers match expected
@@ -102,10 +102,10 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
 
     @Test
     void hasGeneratedAnnotationIfNoOtherDocs() {
-        var fileContents = getFileStringForClass("SmithyGeneratedInput");
+        var fileContents = getFileStringForClass("SmithyGeneratedAnnotationInput");
         assertThat(fileContents, containsString("""
             @SmithyGenerated
-            public final class SmithyGeneratedInput implements SerializableStruct {
+            public final class SmithyGeneratedAnnotationInput implements SerializableStruct {
             """));
     }
 

--- a/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
+++ b/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
@@ -6,8 +6,8 @@ service TestService {
     version: "today"
     operations: [
         DocStringWrapping
-        SmithyGenerated
-        Deprecated
+        SmithyGeneratedAnnotation
+        DeprecatedAnnotation
         Since
         ExternalDocumentation
         Unstable
@@ -37,11 +37,11 @@ operation DocStringWrapping {
     }
 }
 
-operation SmithyGenerated {
+operation SmithyGeneratedAnnotation {
     input := {}
 }
 
-operation Deprecated {
+operation DeprecatedAnnotation {
     input: DeprecatedInput
 }
 


### PR DESCRIPTION
### Description of changes
Previously we were not checking for potential implicit name duplication between a generated type in the same package and a base type. For example `IllegalArgumentException`'s are used within the generated code (in enums and unions), but will conflict with any generated type named `IllegalArgumentException`, so we need to use the fully qualified name for the java.lang illegal arg exception.

Uses the Settings to store the generated symbols as that is available to both writers and integrations. Using the core integration to check for allows us to handle correctly for all symbols across all future generators based on this core implementation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
