### PR TITLE
Remove optionals from auth, support expiration

### DIFF
--- a/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/identity/Identity.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/runtime/auth/api/identity/Identity.java
@@ -6,17 +6,18 @@
 package software.amazon.smithy.java.runtime.auth.api.identity;
 
 import java.time.Instant;
-import java.util.Optional;
 
 /**
  * Interface to represent the identity of the caller, used for authentication.
  */
 public interface Identity {
     /**
-     * The time after which this identity will no longer be valid. If this is empty, an expiration time is not known
+     * The time after which this identity will no longer be valid. If this is null, an expiration time is not known
      * (but the identity may still expire at some time in the future).
+     *
+     * @return the expiration time, if known, or null.
      */
-    default Optional<Instant> expirationTime() {
-        return Optional.empty();
+    default Instant expirationTime() {
+        return null;
     }
 }

--- a/aws/aws-client-core/src/main/java/software/amazon/smithy/java/aws/runtime/client/core/identity/AwsCredentialsIdentity.java
+++ b/aws/aws-client-core/src/main/java/software/amazon/smithy/java/aws/runtime/client/core/identity/AwsCredentialsIdentity.java
@@ -5,8 +5,8 @@
 
 package software.amazon.smithy.java.aws.runtime.client.core.identity;
 
+import java.time.Instant;
 import java.util.Objects;
-import java.util.Optional;
 import software.amazon.smithy.java.runtime.auth.api.identity.Identity;
 
 /**
@@ -33,12 +33,12 @@ public interface AwsCredentialsIdentity extends Identity {
     String secretAccessKey();
 
     /**
-     * Retrieve the AWS session token. This token is retrieved from an AWS token service, and is used for authenticating that this
-     * user has received temporary permission to access some resource.
+     * Retrieve the AWS session token. This token is retrieved from an AWS token service, and is used for
+     * authenticating that this user has received temporary permission to access some resource.
      *
-     * @return the optional session token.
+     * @return the session token, or null if there is no session token.
      */
-    Optional<String> sessionToken();
+    String sessionToken();
 
     /**
      * Constructs a new credentials object, with the specified AWS access key and secret key.
@@ -60,10 +60,29 @@ public interface AwsCredentialsIdentity extends Identity {
      * @return the created identity.
      */
     static AwsCredentialsIdentity create(String accessKeyId, String secretAccessKey, String sessionToken) {
+        return create(accessKeyId, secretAccessKey, sessionToken, null);
+    }
+
+    /**
+     * Constructs a new credentials object, with the specified AWS access key, secret key, and session token.
+     *
+     * @param accessKeyId The AWS access key, used to identify the user interacting with services.
+     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with services.
+     * @param sessionToken The AWS session token, used for authenticating temporary access some resource.
+     * @param expirationTime When the credentials expire, or null if no expiration or unknown.
+     * @return the created identity.
+     */
+    static AwsCredentialsIdentity create(
+        String accessKeyId,
+        String secretAccessKey,
+        String sessionToken,
+        Instant expirationTime
+    ) {
         return new AwsCredentialsIdentityRecord(
             Objects.requireNonNull(accessKeyId, "accessKeyId is null"),
             Objects.requireNonNull(secretAccessKey, "secretAccessKey is null"),
-            Optional.ofNullable(sessionToken)
+            sessionToken,
+            expirationTime
         );
     }
 }

--- a/aws/aws-client-core/src/main/java/software/amazon/smithy/java/aws/runtime/client/core/identity/AwsCredentialsIdentityRecord.java
+++ b/aws/aws-client-core/src/main/java/software/amazon/smithy/java/aws/runtime/client/core/identity/AwsCredentialsIdentityRecord.java
@@ -5,10 +5,11 @@
 
 package software.amazon.smithy.java.aws.runtime.client.core.identity;
 
-import java.util.Optional;
+import java.time.Instant;
 
 record AwsCredentialsIdentityRecord(
-    String accessKeyId, String secretAccessKey,
-    Optional<String> sessionToken
-) implements AwsCredentialsIdentity {
-}
+    String accessKeyId,
+    String secretAccessKey,
+    String sessionToken,
+    Instant expirationTime
+) implements AwsCredentialsIdentity {}

--- a/aws/sigv4/src/main/java/software/amazon/smithy/java/aws/runtime/client/auth/scheme/sigv4/SigV4Signer.java
+++ b/aws/sigv4/src/main/java/software/amazon/smithy/java/aws/runtime/client/auth/scheme/sigv4/SigV4Signer.java
@@ -93,7 +93,7 @@ final class SigV4Signer implements Signer<SmithyHttpRequest, AwsCredentialsIdent
                     clock.instant(),
                     identity.accessKeyId(),
                     identity.secretAccessKey(),
-                    identity.sessionToken().orElse(null),
+                    identity.sessionToken(),
                     !request.body().hasKnownLength()
                 );
                 return request.withHeaders(HttpHeaders.of(signedHeaders));


### PR DESCRIPTION
Use nullable values for auth, like the rest of the project. Also add support for expiration time to AWS credentials.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
