### PR TITLE
Make identity resolver result nullable

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/scheme/AuthScheme.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/scheme/AuthScheme.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.client.core.auth.scheme;
 
-import java.util.Optional;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
@@ -63,10 +62,10 @@ public interface AuthScheme<RequestT, IdentityT extends Identity> {
      * provided {@link IdentityResolvers}.
      *
      * @param resolvers Resolver repository.
-     * @return the optionally located identity resolver.
+     * @return the located identity resolver, or null if no resolver is found.
      */
-    default Optional<IdentityResolver<IdentityT>> identityResolver(IdentityResolvers resolvers) {
-        return Optional.ofNullable(resolvers.identityResolver(identityClass()));
+    default IdentityResolver<IdentityT> identityResolver(IdentityResolvers resolvers) {
+        return resolvers.identityResolver(identityClass());
     }
 
     /**

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/scheme/NoAuthAuthScheme.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/auth/scheme/NoAuthAuthScheme.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.runtime.client.core.auth.scheme;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
@@ -44,12 +43,11 @@ final class NoAuthAuthScheme implements AuthScheme<Object, Identity> {
      * Retrieve an identity resolver associated with this authentication scheme, that unconditionally returns an empty
      * {@link Identity}, independent of what resolvers are provided.
      *
-     * @param resolvers Resolver repository.
-     * @return An identity resolver that unconditionally returns an empty identity.
+     * <p>{@inheritDoc}
      */
     @Override
-    public Optional<IdentityResolver<Identity>> identityResolver(IdentityResolvers resolvers) {
-        return Optional.of(NULL_IDENTITY_RESOLVER);
+    public IdentityResolver<Identity> identityResolver(IdentityResolvers resolvers) {
+        return NULL_IDENTITY_RESOLVER;
     }
 
     @Override

--- a/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestAuthScheme.java
+++ b/codegen/client/src/test/java/software/amazon/smithy/java/codegen/client/TestAuthScheme.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.codegen.client;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.runtime.auth.api.AuthProperties;
 import software.amazon.smithy.java.runtime.auth.api.Signer;
@@ -43,7 +42,7 @@ public final class TestAuthScheme implements AuthScheme<SmithyHttpRequest, Ident
     }
 
     @Override
-    public Optional<IdentityResolver<Identity>> identityResolver(IdentityResolvers resolvers) {
+    public IdentityResolver<Identity> identityResolver(IdentityResolvers resolvers) {
         return AuthScheme.noAuthAuthScheme().identityResolver(resolvers);
     }
 


### PR DESCRIPTION
The rest of the library doesn't use Optional. Also closes a previous TODO item by adding more information for when a resolver can't be found.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
