### PR TITLE
Allow clients to return clientConfiguration

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/Client.java
@@ -97,6 +97,13 @@ public abstract class Client {
     }
 
     /**
+     * @return the configuration in use by this client.
+     */
+    public ClientConfig config() {
+        return config;
+    }
+
+    /**
      * Builder for Clients and request overrides.
      *
      * <p><strong>Note:</strong> this class is implemented by code generated builders, but should not
@@ -121,6 +128,25 @@ public abstract class Client {
 
         List<ClientPlugin> plugins() {
             return Collections.unmodifiableList(plugins);
+        }
+
+        /**
+         * Specify overrides to the configuration that should be used for clients created by this builder.
+         *
+         * @param config Client config to use for updated values.
+         * @return Returns the builder.
+         */
+        @SuppressWarnings("unchecked")
+        public B withConfiguration(ClientConfig config) {
+            configBuilder.transport(config.transport())
+                .protocol(config.protocol())
+                .endpointResolver(config.endpointResolver())
+                .authSchemeResolver(config.authSchemeResolver())
+                .identityResolvers(config.identityResolvers());
+            config.interceptors().forEach(configBuilder::addInterceptor);
+            config.supportedAuthSchemes().forEach(configBuilder::putSupportedAuthSchemes);
+            configBuilder.putAllConfig(config.context());
+            return (B) this;
         }
 
         /**

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientConfig.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/ClientConfig.java
@@ -58,36 +58,59 @@ public final class ClientConfig {
         this.context = Context.unmodifiableCopy(builder.context);
     }
 
-    // Note: Making all the accessors package-private for now as they are only needed by Client, but could be public.
-    ClientTransport<?, ?> transport() {
+    /**
+     * @return Transport for client to use to send data to an endpoint.
+     */
+    public ClientTransport<?, ?> transport() {
         return transport;
     }
 
-    ClientProtocol<?, ?> protocol() {
+    /**
+     * @return Protocol for client to use for request and response serialization and deserialization.
+     */
+    public ClientProtocol<?, ?> protocol() {
         return protocol;
     }
 
-    EndpointResolver endpointResolver() {
+    /**
+     * @return EndpointResolver to use to resolve an endpoint for an operation.
+     */
+    public EndpointResolver endpointResolver() {
         return endpointResolver;
     }
 
-    List<ClientInterceptor> interceptors() {
+    /**
+     * @return Interceptors configured to hook into the client's request execution pipeline.
+     */
+    public List<ClientInterceptor> interceptors() {
         return interceptors;
     }
 
-    List<AuthScheme<?, ?>> supportedAuthSchemes() {
+    /**
+     * @return Authentication schemes supported by the client.
+     */
+    public List<AuthScheme<?, ?>> supportedAuthSchemes() {
         return supportedAuthSchemes;
     }
 
-    AuthSchemeResolver authSchemeResolver() {
+    /**
+     * @return Resolver to use to resolve the authentication scheme that should be used to sign a request.
+     */
+    public AuthSchemeResolver authSchemeResolver() {
         return authSchemeResolver;
     }
 
-    List<IdentityResolver<?>> identityResolvers() {
+    /**
+     * @return Resolvers to use to resolve an identity for authentication.
+     */
+    public List<IdentityResolver<?>> identityResolvers() {
         return identityResolvers;
     }
 
-    Context context() {
+    /**
+     * @return Context to use
+     */
+    public Context context() {
         return context;
     }
 
@@ -325,7 +348,7 @@ public final class ClientConfig {
          * @param context Context containing all the configuration to put.
          * @return the builder.
          */
-        private Builder putAllConfig(Context context) {
+        Builder putAllConfig(Context context) {
             context.copyTo(this.context);
             return this;
         }

--- a/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
+++ b/codegen/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.java.codegen.sections.OperationSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.runtime.client.core.Client;
+import software.amazon.smithy.java.runtime.client.core.ClientConfig;
 import software.amazon.smithy.java.runtime.client.core.ClientPlugin;
 import software.amazon.smithy.java.runtime.client.core.ClientProtocolFactory;
 import software.amazon.smithy.java.runtime.client.core.ClientSetting;
@@ -80,6 +81,11 @@ public final class ClientInterfaceGenerator
                     public interface ${interface:T} {
 
                         ${operations:C|}
+
+                        /**
+                         * @return Configuration in use by client.
+                         */
+                         ${clientConfig:T} config();
 
                         /**
                          * Create a Builder for {@link ${interface:T}}.
@@ -140,6 +146,7 @@ public final class ClientInterfaceGenerator
                 writer.putContext("clientPlugin", ClientPlugin.class);
                 writer.putContext("client", Client.class);
                 writer.putContext("requestOverride", RequestOverrideConfig.class);
+                writer.putContext("clientConfig", ClientConfig.class);
                 writer.putContext("interface", symbol);
                 writer.putContext("impl", symbol.expectProperty(ClientSymbolProperties.CLIENT_IMPL));
                 writer.putContext("transport", getTransportClass(directive.settings()));

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
@@ -30,8 +30,6 @@ public final class PojoWithValidatedCollection implements SerializableStruct {
         .putMember("value", ValidatedPojo.SCHEMA)
         .build();
     private static final Schema MAP_OF_VALIDATED_POJO_KEY = MAP_OF_VALIDATED_POJO.member("key");
-    // TODO: why is this unused.
-    private static final Schema MAP_OF_VALIDATED_POJO_VALUE = MAP_OF_VALIDATED_POJO.member("value");
     private static final Schema LIST_OF_VALIDATED_POJO = Schema
         .listBuilder(ShapeId.from("smithy.example#ListOfValidatedPojo"))
         .putMember("member", ValidatedPojo.SCHEMA)

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/Assertions.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/Assertions.java
@@ -61,7 +61,6 @@ final class Assertions {
     }
 
     private static String convertHeaderToString(String key, List<String> values) {
-        // TODO: Is this needed for all protocol tests?
         if (!key.equalsIgnoreCase("x-stringlist")) {
             return String.join(", ", values);
         }

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
@@ -98,7 +98,6 @@ public final class ProtocolTestExtension implements BeforeAllCallback, AfterAllC
         switch (testType.appliesTo) {
             case CLIENT -> {
                 // instantiate a mock client for use by test runners
-                // TODO: allow customization of client builder
                 var mockClientBuilder = MockClient.builder();
 
                 // Discover all client auth scheme implementations that could be used for tests


### PR DESCRIPTION
### Description of changes
Updates Clients to return their ClientConfig. 

This client config can be helpful for debugging clients and can also be used to help configure other clients.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
