### PR TITLE
Add schema() to SerializableStruct

### DIFF
--- a/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/endpoint/EndpointResolverTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/endpoint/EndpointResolverTest.java
@@ -96,8 +96,8 @@ public class EndpointResolverTest {
         }
 
         @Override
-        public void serialize(ShapeSerializer encoder) {
-            encoder.writeStruct(SCHEMA, this);
+        public Schema schema() {
+            return SCHEMA;
         }
 
         @Override

--- a/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/TestStructs.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/TestStructs.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.java.runtime.client.core.interceptors;
 
+import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 
@@ -13,6 +15,11 @@ public final class TestStructs {
     private TestStructs() {}
 
     static final class Foo implements SerializableStruct {
+        @Override
+        public Schema schema() {
+            return PreludeSchemas.DOCUMENT;
+        }
+
         @Override
         public void serialize(ShapeSerializer encoder) {
             throw new UnsupportedOperationException();
@@ -25,6 +32,11 @@ public final class TestStructs {
     }
 
     static final class Bar implements SerializableStruct {
+        @Override
+        public Schema schema() {
+            return PreludeSchemas.DOCUMENT;
+        }
+
         @Override
         public void serialize(ShapeSerializer encoder) {
             throw new UnsupportedOperationException();

--- a/client-http-binding/src/test/java/software/amazon/smithy/java/runtime/client/http/binding/HttpBindingErrorDeserializerTest.java
+++ b/client-http-binding/src/test/java/software/amazon/smithy/java/runtime/client/http/binding/HttpBindingErrorDeserializerTest.java
@@ -124,12 +124,14 @@ public class HttpBindingErrorDeserializerTest {
         }
 
         @Override
-        public void serializeMembers(ShapeSerializer serializer) {
-            serializer.writeStruct(SCHEMA, this);
+        public Schema schema() {
+            return SCHEMA;
         }
 
         @Override
-        public void serialize(ShapeSerializer encoder) {}
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeStruct(SCHEMA, this);
+        }
 
         static final class Builder implements ShapeBuilder<Baz> {
             private String message;

--- a/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/HttpErrorDeserializerTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/runtime/client/http/HttpErrorDeserializerTest.java
@@ -192,12 +192,14 @@ public class HttpErrorDeserializerTest {
         }
 
         @Override
-        public void serializeMembers(ShapeSerializer serializer) {
-            serializer.writeStruct(SCHEMA, this);
+        public Schema schema() {
+            return SCHEMA;
         }
 
         @Override
-        public void serialize(ShapeSerializer encoder) {}
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeStruct(SCHEMA, this);
+        }
 
         static final class Builder implements ShapeBuilder<Baz> {
             private String message;

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.codegen.generators;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -32,8 +33,8 @@ record StructureSerializerGenerator(
         writer.pushState();
         var template = """
             @Override
-            public void serialize(${shapeSerializer:N} serializer) {
-                serializer.writeStruct($$SCHEMA, this);
+            public ${schemaClass:N} schema() {
+                return $$SCHEMA;
             }
 
             @Override
@@ -43,6 +44,7 @@ record StructureSerializerGenerator(
             """;
         writer.putContext("shapeSerializer", ShapeSerializer.class);
         writer.putContext("writeMemberSerialization", writer.consumer(this::writeMemberSerialization));
+        writer.putContext("schemaClass", Schema.class);
         writer.write(template);
         writer.popState();
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -17,6 +17,7 @@ import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.serde.SerializationException;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
@@ -58,8 +59,8 @@ public final class UnionGenerator
                     ${toString:C|}
 
                     @Override
-                    public void serialize(${shapeSerializer:N} serializer) {
-                        serializer.writeStruct($$SCHEMA, this);
+                    public ${schemaClass:N} schema() {
+                        return $$SCHEMA;
                     }
 
                     ${valueCasters:C|}
@@ -91,6 +92,7 @@ public final class UnionGenerator
             writer.putContext("type", CodegenUtils.getInnerTypeEnumSymbol(directive.symbol()));
             writer.putContext("serializableStruct", SerializableStruct.class);
             writer.putContext("shapeSerializer", ShapeSerializer.class);
+            writer.putContext("schemaClass", Schema.class);
             writer.putContext("object", Object.class);
             writer.putContext("objects", Objects.class);
             writer.putContext("document", Document.class);

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SerializableStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/SerializableStruct.java
@@ -15,6 +15,18 @@ import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
  */
 public interface SerializableStruct extends SerializableShape {
     /**
+     * Get the schema of the shape.
+     *
+     * @return the schema of the shape.
+     */
+    Schema schema();
+
+    @Override
+    default void serialize(ShapeSerializer encoder) {
+        encoder.writeStruct(schema(), this);
+    }
+
+    /**
      * Serializes the members of the structure or union.
      *
      * @param serializer Serializer to write to.
@@ -31,8 +43,8 @@ public interface SerializableStruct extends SerializableShape {
     static SerializableStruct create(Schema schema, BiConsumer<Schema, ShapeSerializer> memberWriter) {
         return new SerializableStruct() {
             @Override
-            public void serialize(ShapeSerializer encoder) {
-                encoder.writeStruct(schema, this);
+            public Schema schema() {
+                return schema;
             }
 
             @Override
@@ -57,8 +69,8 @@ public interface SerializableStruct extends SerializableShape {
     ) {
         return new SerializableStruct() {
             @Override
-            public void serialize(ShapeSerializer encoder) {
-                encoder.writeStruct(schema, this);
+            public Schema schema() {
+                return schema;
             }
 
             @Override

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Unit.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/Unit.java
@@ -32,8 +32,8 @@ public final class Unit implements SerializableStruct {
     }
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
-        encoder.writeStruct(SCHEMA, this);
+    public Schema schema() {
+        return SCHEMA;
     }
 
     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Bird.java
@@ -37,13 +37,13 @@ public final class Bird implements SerializableStruct {
     }
 
     @Override
-    public String toString() {
-        return ToStringSerializer.serialize(this);
+    public Schema schema() {
+        return SCHEMA;
     }
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
-        encoder.writeStruct(SCHEMA, this);
+    public String toString() {
+        return ToStringSerializer.serialize(this);
     }
 
     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/Person.java
@@ -100,8 +100,8 @@ public final class Person implements SerializableStruct {
     }
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
-        encoder.writeStruct(SCHEMA, this);
+    public Schema schema() {
+        return SCHEMA;
     }
 
     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/PojoWithValidatedCollection.java
@@ -68,8 +68,8 @@ public final class PojoWithValidatedCollection implements SerializableStruct {
     }
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
-        encoder.writeStruct(SCHEMA, this);
+    public Schema schema() {
+        return SCHEMA;
     }
 
     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/UnvalidatedPojo.java
@@ -61,8 +61,8 @@ public final class UnvalidatedPojo implements SerializableStruct {
     }
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
-        encoder.writeStruct(SCHEMA, this);
+    public Schema schema() {
+        return SCHEMA;
     }
 
     @Override

--- a/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/runtime/core/testmodels/ValidatedPojo.java
@@ -72,8 +72,8 @@ public final class ValidatedPojo implements SerializableStruct {
     }
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
-        encoder.writeStruct(SCHEMA, this);
+    public Schema schema() {
+        return SCHEMA;
     }
 
     @Override

--- a/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonSerializerTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/runtime/json/JsonSerializerTest.java
@@ -244,8 +244,8 @@ public class JsonSerializerTest {
 
     private static final class NestedStruct implements SerializableStruct {
         @Override
-        public void serialize(ShapeSerializer encoder) {
-            encoder.writeStruct(JsonTestData.NESTED, this);
+        public Schema schema() {
+            return JsonTestData.NESTED;
         }
 
         @Override
@@ -256,8 +256,8 @@ public class JsonSerializerTest {
 
     private static final class EmptyStruct implements SerializableStruct {
         @Override
-        public void serialize(ShapeSerializer encoder) {
-            encoder.writeStruct(JsonTestData.NESTED, this);
+        public Schema schema() {
+            return JsonTestData.NESTED;
         }
 
         @Override

--- a/server/src/main/java/software/amazon/smithy/java/server/exceptions/InternalServerError.java
+++ b/server/src/main/java/software/amazon/smithy/java/server/exceptions/InternalServerError.java
@@ -32,12 +32,12 @@ public class InternalServerError extends ModeledApiException {
     }
 
     @Override
-    public void serializeMembers(ShapeSerializer serializer) {
-        serializer.writeString(SCHEMA_MESSAGE, getMessage());
+    public Schema schema() {
+        return SCHEMA;
     }
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
-        encoder.writeStruct(SCHEMA, this);
+    public void serializeMembers(ShapeSerializer serializer) {
+        serializer.writeString(SCHEMA_MESSAGE, getMessage());
     }
 }

--- a/server/src/main/java/software/amazon/smithy/java/server/exceptions/UnknownOperationException.java
+++ b/server/src/main/java/software/amazon/smithy/java/server/exceptions/UnknownOperationException.java
@@ -23,13 +23,11 @@ public class UnknownOperationException extends ModeledApiException {
     }
 
     @Override
-    public void serializeMembers(ShapeSerializer serializer) {
-
-    }
+    public void serializeMembers(ShapeSerializer serializer) {}
 
     @Override
-    public void serialize(ShapeSerializer encoder) {
-        encoder.writeStruct(SCHEMA, this);
+    public Schema schema() {
+        return SCHEMA;
     }
 
     @Override

--- a/xml-codec/src/test/java/software/amazon/smithy/java/runtime/xml/XmlCodecTest.java
+++ b/xml-codec/src/test/java/software/amazon/smithy/java/runtime/xml/XmlCodecTest.java
@@ -100,8 +100,8 @@ public class XmlCodecTest {
         }
 
         @Override
-        public void serialize(ShapeSerializer encoder) {
-            encoder.writeStruct(SCHEMA, this);
+        public Schema schema() {
+            return SCHEMA;
         }
 
         @Override


### PR DESCRIPTION
We already need this to support use cases in retries and server-side exceptions. Given that the serialize method already exposes the schema anyways, there's no reason to continue to hid it on SerializableStruct.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
