### PR TITLE
Add RPCv2 CBOR client support

### DIFF
--- a/aws/client-rpcv2-cbor-protocol/build.gradle.kts
+++ b/aws/client-rpcv2-cbor-protocol/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("smithy-java.module-conventions")
+    id("smithy-java.protocol-testing-conventions")
+}
+
+description = "This module provides the implementation of the client RpcV2 CBOR protocol"
+
+extra["displayName"] = "Smithy :: Java :: Client RpcV2 CBOR"
+extra["moduleName"] = "software.amazon.smithy.java.aws.client-rpcv2-cbor-protocol"
+
+dependencies {
+    api(project(":client-http"))
+    api(project(":rpcv2-cbor-codec"))
+    api(libs.smithy.aws.traits)
+
+    implementation(libs.smithy.protocol.traits)
+
+    // Protocol test dependencies
+    testImplementation(libs.smithy.protocol.tests)
+}
+
+val generator = "software.amazon.smithy.java.protocoltests.generators.ProtocolTestGenerator"
+addGenerateSrcsTask(generator, "rpcv2Cbor", "smithy.protocoltests.rpcv2Cbor#RpcV2Protocol")

--- a/aws/client-rpcv2-cbor-protocol/src/it/java/software/amazon/smithy/java/runtime/client/rpcv2/RpcV2CborProtocolTests.java
+++ b/aws/client-rpcv2-cbor-protocol/src/it/java/software/amazon/smithy/java/runtime/client/rpcv2/RpcV2CborProtocolTests.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.client.rpcv2;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static software.amazon.smithy.java.runtime.cbor.CborReadUtil.readTextString;
+import static software.amazon.smithy.java.runtime.io.ByteBufferUtils.getBytes;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import software.amazon.smithy.java.protocoltests.harness.HttpClientRequestTests;
+import software.amazon.smithy.java.protocoltests.harness.HttpClientResponseTests;
+import software.amazon.smithy.java.protocoltests.harness.ProtocolTest;
+import software.amazon.smithy.java.protocoltests.harness.ProtocolTestFilter;
+import software.amazon.smithy.java.protocoltests.harness.TestType;
+import software.amazon.smithy.java.runtime.cbor.CborParser;
+import software.amazon.smithy.java.runtime.cbor.CborParser.Token;
+import software.amazon.smithy.java.runtime.cbor.CborReadUtil;
+import software.amazon.smithy.java.runtime.io.datastream.DataStream;
+
+@ProtocolTest(
+    service = "smithy.protocoltests.rpcv2Cbor#RpcV2Protocol",
+    testType = TestType.CLIENT
+)
+@ProtocolTestFilter(skipOperations = {})
+public class RpcV2CborProtocolTests {
+    @HttpClientRequestTests
+    @ProtocolTestFilter(
+        skipTests = {
+            // this test is broken and needs to be fixed in smithy
+            "RpcV2CborClientPopulatesDefaultValuesInInput",
+            // clientOptional is not respected for client-generated shapes yet
+            "RpcV2CborClientSkipsTopLevelDefaultValuesInInput",
+            "RpcV2CborClientUsesExplicitlyProvidedMemberValues",
+            "RpcV2CborClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional",
+            "RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults",
+        }
+    )
+    public void requestTest(DataStream expected, DataStream actual) {
+        var ex = parse(getBytes(expected.waitForByteBuffer()));
+        var ac = parse(getBytes(actual.waitForByteBuffer()));
+        assertEquals(ex, ac);
+    }
+
+    @HttpClientResponseTests
+    public void responseTest(Runnable test) {
+        test.run();
+    }
+
+    private static CborValue parse(byte[] buf) {
+        try {
+            return parse0(buf);
+        } catch (Exception e) {
+            // to ensure a stack trace is gathered
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static CborValue parse0(byte[] buf) {
+        var parser = new CborParser(buf);
+        var context = new ArrayDeque<CborValue>();
+        var keys = new ArrayDeque<String>();
+        CborValue root = null;
+        byte token;
+        while ((token = parser.advance()) != Token.FINISHED) {
+            switch (token) {
+                case Token.KEY -> keys.addLast(readTextString(buf, parser.getPosition(), parser.getItemLength()));
+                case Token.START_OBJECT -> context.addLast(new MapValue());
+                case Token.START_ARRAY -> context.addLast(new ListValue());
+                case Token.END_ARRAY, Token.END_OBJECT -> {
+                    var top = Objects.requireNonNull(context.pollLast());
+                    if (context.isEmpty()) {
+                        root = top;
+                    } else {
+                        add(keys, context, top);
+                    }
+                }
+                case Token.NULL -> add(keys, context, new NullValue());
+                case Token.TEXT_STRING -> add(keys, context, new StringValue(buf, parser));
+                case Token.POS_INT, Token.NEG_INT -> add(keys, context, new IntValue(buf, token, parser));
+                case Token.FLOAT -> add(keys, context, new FloatValue(buf, token, parser));
+                case Token.TRUE, Token.FALSE -> add(keys, context, new BooleanValue(token));
+                case Token.EPOCH_F, Token.EPOCH_INEG, Token.EPOCH_IPOS -> add(
+                    keys,
+                    context,
+                    new TimeValue(buf, token, parser)
+                );
+                case Token.BYTE_STRING -> add(keys, context, new BlobValue(buf, parser));
+                default -> throw new RuntimeException("can't handle " + Token.name(token));
+            }
+        }
+        return root;
+    }
+
+    private static void add(Deque<String> keys, Deque<CborValue> context, CborValue value) {
+        var top = context.peekLast();
+        if (top instanceof MapValue v) {
+            v.put(Objects.requireNonNull(keys.pollLast()), value);
+        } else if (top instanceof ListValue v) {
+            v.add(value);
+        } else {
+            throw new RuntimeException("Can't add to a " + top.getClass());
+        }
+    }
+
+    sealed static abstract class CborValue<T extends CborValue<T>> permits BooleanValue, BlobValue, FloatValue,
+        IntValue, ListValue, MapValue, NullValue, StringValue, TimeValue {
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public boolean equals(Object o) {
+            assertEquals(this.getClass(), o.getClass());
+            compare((T) o);
+            return true;
+        }
+
+        abstract void compare(T v);
+    }
+
+    private static final class MapValue extends CborValue<MapValue> {
+        private final Map<String, CborValue<?>> map;
+
+        private MapValue() {
+            this.map = new HashMap<>();
+        }
+
+        public void put(String Key, CborValue<?> value) {
+            map.put(Key, value);
+        }
+
+        @Override
+        public void compare(MapValue value) {
+            assertEquals(map, value.map);
+        }
+
+        @Override
+        public String toString() {
+            return "Map{" + map + "}";
+        }
+    }
+
+    private static final class ListValue extends CborValue<ListValue> {
+        private final List<CborValue<?>> values = new ArrayList<>();
+
+        public void add(CborValue<?> value) {
+            values.add(value);
+        }
+
+        @Override
+        public void compare(ListValue value) {
+            assertEquals(values, value.values);
+        }
+
+        @Override
+        public String toString() {
+            return "List{" + values + "}";
+        }
+    }
+
+    private static final class NullValue extends CborValue<NullValue> {
+        @Override
+        void compare(NullValue v) {}
+
+        @Override
+        public String toString() {
+            return "Null";
+        }
+    }
+
+    private static final class StringValue extends CborValue<StringValue> {
+        private final String value;
+
+        private StringValue(byte[] buf, CborParser parser) {
+            this.value = CborReadUtil.readTextString(buf, parser.getPosition(), parser.getItemLength());
+        }
+
+        @Override
+        public void compare(StringValue value) {
+            assertEquals(this.value, value.value);
+        }
+
+        @Override
+        public String toString() {
+            return "String{" + value + "}";
+        }
+    }
+
+    private static final class IntValue extends CborValue<IntValue> {
+        private final long value;
+
+        IntValue(byte[] buf, byte type, CborParser parser) {
+            if (type > Token.NEG_INT) {
+                throw new RuntimeException("can't read " + Token.name(type) + " as long");
+            }
+
+            int pos = parser.getPosition();
+            int len = parser.getItemLength();
+            long val = CborReadUtil.readLong(buf, type, pos, len);
+            if (len < 8) {
+                this.value = val;
+            } else if (type == Token.POS_INT) {
+                this.value = val < 0 ? Long.MAX_VALUE : val;
+            } else {
+                this.value = val < 0 ? val : Long.MIN_VALUE;
+            }
+        }
+
+        @Override
+        public void compare(IntValue value) {
+            assertEquals(this.value, value.value);
+        }
+
+        @Override
+        public String toString() {
+            return "Int{" + value + "}";
+        }
+    }
+
+    private static final class FloatValue extends CborValue<FloatValue> {
+        private final double value;
+
+        FloatValue(byte[] buf, byte type, CborParser parser) {
+            int len = parser.getItemLength();
+            long raw = CborReadUtil.readLong(buf, type, parser.getPosition(), parser.getItemLength());
+            if (len == 8) {
+                value = Double.longBitsToDouble(raw);
+            } else if (len == 4) {
+                value = Float.intBitsToFloat((int) raw);
+            } else {
+                throw new RuntimeException("Can't handle fp of len " + len);
+            }
+        }
+
+        @Override
+        void compare(FloatValue v) {
+            assertEquals(value, v.value);
+        }
+
+        @Override
+        public String toString() {
+            return "Float{" + value + "}";
+        }
+    }
+
+    private static final class BooleanValue extends CborValue<BooleanValue> {
+        private final boolean bool;
+
+        BooleanValue(byte type) {
+            this.bool = type == Token.TRUE;
+        }
+
+        @Override
+        public void compare(BooleanValue value) {
+            assertEquals(bool, value.bool);
+        }
+
+        @Override
+        public String toString() {
+            return "Boolean{" + bool + "}";
+        }
+    }
+
+    private static final class TimeValue extends CborValue<TimeValue> {
+        private final long time;
+
+        TimeValue(byte[] buf, byte type, CborParser parser) {
+            byte actual = (byte) (type ^ Token.TAG_FLAG);
+            if (actual <= Token.NEG_INT) {
+                time = new IntValue(buf, actual, parser).value * 1000;
+            } else if (actual == Token.FLOAT) {
+                time = Math.round(new FloatValue(buf, actual, parser).value * 1000d);
+            } else {
+                throw new RuntimeException("not a timestamp: " + Token.name(type));
+            }
+        }
+
+        @Override
+        void compare(TimeValue v) {
+            assertEquals(time, v.time);
+        }
+
+        @Override
+        public String toString() {
+            return "Time{" + time + "}";
+        }
+    }
+
+    private static final class BlobValue extends CborValue<BlobValue> {
+        private final byte[] bytes;
+
+        BlobValue(byte[] buf, CborParser parser) {
+            this.bytes = CborReadUtil.readByteString(buf, parser.getPosition(), parser.getItemLength());
+        }
+
+        @Override
+        public void compare(BlobValue value) {
+            assertArrayEquals(bytes, value.bytes);
+        }
+
+        @Override
+        public String toString() {
+            return "Blob{" + HexFormat.of().formatHex(bytes) + "}";
+        }
+    }
+}

--- a/aws/client-rpcv2-cbor-protocol/src/main/java/software/amazon/smithy/java/runtime/client/rpcv2/RpcV2CborProtocol.java
+++ b/aws/client-rpcv2-cbor-protocol/src/main/java/software/amazon/smithy/java/runtime/client/rpcv2/RpcV2CborProtocol.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.client.rpcv2;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.runtime.cbor.Rpcv2CborCodec;
+import software.amazon.smithy.java.runtime.client.core.ClientProtocol;
+import software.amazon.smithy.java.runtime.client.core.ClientProtocolFactory;
+import software.amazon.smithy.java.runtime.client.core.ProtocolSettings;
+import software.amazon.smithy.java.runtime.client.http.HttpClientProtocol;
+import software.amazon.smithy.java.runtime.client.http.HttpErrorDeserializer;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.Unit;
+import software.amazon.smithy.java.runtime.core.serde.Codec;
+import software.amazon.smithy.java.runtime.core.serde.TypeRegistry;
+import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
+import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
+import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
+import software.amazon.smithy.java.runtime.io.ByteBufferOutputStream;
+import software.amazon.smithy.java.runtime.io.datastream.DataStream;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.protocol.traits.Rpcv2CborTrait;
+
+public final class RpcV2CborProtocol extends HttpClientProtocol {
+    private static final Codec CBOR_CODEC = Rpcv2CborCodec.builder().build();
+    private static final List<String> CONTENT_TYPE = List.of("application/cbor");
+    private static final List<String> SMITHY_PROTOCOL = List.of("rpc-v2-cbor");
+
+    private final ShapeId service;
+    private final HttpErrorDeserializer errorDeserializer;
+
+    public RpcV2CborProtocol(ShapeId service) {
+        super(Rpcv2CborTrait.ID.toString());
+        this.service = service;
+        this.errorDeserializer = HttpErrorDeserializer.builder()
+            .codec(CBOR_CODEC)
+            .serviceId(service)
+            .build();
+    }
+
+    @Override
+    public <I extends SerializableStruct, O extends SerializableStruct> SmithyHttpRequest createRequest(
+        ApiOperation<I, O> operation,
+        I input,
+        Context context,
+        URI endpoint
+    ) {
+        var target = "/service/" + service.getName() + "/operation/" + operation.schema().id().getName();
+
+        Map<String, List<String>> headers;
+        DataStream body;
+        if (Unit.ID.equals(operation.inputSchema().id())) {
+            // Top-level Unit types do not get serialized
+            headers = Map.of(
+                "smithy-protocol",
+                SMITHY_PROTOCOL,
+                "Accept",
+                CONTENT_TYPE
+            );
+            body = DataStream.ofEmpty();
+        } else {
+            var sink = new ByteBufferOutputStream();
+            try (var serializer = CBOR_CODEC.createSerializer(sink)) {
+                input.serialize(serializer);
+                serializer.flush();
+            }
+            headers = Map.of(
+                "Content-Type",
+                CONTENT_TYPE,
+                "smithy-protocol",
+                SMITHY_PROTOCOL,
+                "Accept",
+                CONTENT_TYPE
+            );
+            body = DataStream.ofByteBuffer(sink.toByteBuffer(), "application/cbor");
+        }
+
+        return SmithyHttpRequest.builder()
+            .method("POST")
+            .uri(endpoint.resolve(target))
+            .headers(HttpHeaders.of(headers))
+            .body(body)
+            .build();
+    }
+
+    @Override
+    public <I extends SerializableStruct, O extends SerializableStruct> CompletableFuture<O> deserializeResponse(
+        ApiOperation<I, O> operation,
+        Context context,
+        TypeRegistry typeRegistry,
+        SmithyHttpRequest request,
+        SmithyHttpResponse response
+    ) {
+        if (response.statusCode() != 200) {
+            return errorDeserializer.createError(context, operation.schema().id(), typeRegistry, response)
+                .thenApply(e -> {
+                    throw e;
+                });
+        }
+
+        var builder = operation.outputBuilder();
+        var content = response.body();
+        if (content.contentLength() == 0) {
+            return CompletableFuture.completedFuture(builder.build());
+        }
+
+        return content.asByteBuffer()
+            .thenApply(bytes -> CBOR_CODEC.deserializeShape(bytes, builder))
+            .toCompletableFuture();
+    }
+
+    public static final class Factory implements ClientProtocolFactory<Rpcv2CborTrait> {
+        @Override
+        public ShapeId id() {
+            return Rpcv2CborTrait.ID;
+        }
+
+        @Override
+        public ClientProtocol<?, ?> createProtocol(ProtocolSettings settings, Rpcv2CborTrait trait) {
+            return new RpcV2CborProtocol(
+                Objects.requireNonNull(
+                    settings.service(),
+                    "service is a required protocol setting"
+                )
+            );
+        }
+    }
+}

--- a/aws/client-rpcv2-cbor-protocol/src/main/resources/META-INF/services/software.amazon.smithy.java.runtime.client.core.ClientProtocolFactory
+++ b/aws/client-rpcv2-cbor-protocol/src/main/resources/META-INF/services/software.amazon.smithy.java.runtime.client.core.ClientProtocolFactory
@@ -1,0 +1,1 @@
+software.amazon.smithy.java.runtime.client.rpcv2.RpcV2CborProtocol$Factory

--- a/examples/restjson-example/build.gradle.kts
+++ b/examples/restjson-example/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     api(project(":aws:client-restjson"))
+    api(project(":rpcv2-cbor-codec"))
     api(libs.smithy.aws.traits)
 }
 

--- a/examples/restjson-example/src/jmh/java/software/amazon/smithy/java/runtime/SmithyJavaTrials.java
+++ b/examples/restjson-example/src/jmh/java/software/amazon/smithy/java/runtime/SmithyJavaTrials.java
@@ -5,7 +5,9 @@
 
 package software.amazon.smithy.java.runtime;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -19,9 +21,10 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
+import software.amazon.smithy.java.runtime.cbor.Rpcv2CborCodec;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.runtime.core.serde.Codec;
 import software.amazon.smithy.java.runtime.example.model.AllFieldsOptional;
 import software.amazon.smithy.java.runtime.example.model.AttributeUpdates;
 import software.amazon.smithy.java.runtime.example.model.CodegenStruct;
@@ -44,9 +47,6 @@ import software.amazon.smithy.utils.IoUtils;
 )
 @Fork(1)
 public class SmithyJavaTrials {
-
-    private static final JsonCodec CODEC = JsonCodec.builder().build();
-
     private static final Map<String, Class<? extends ShapeBuilder<?>>> CASES = Map.ofEntries(
         Map.entry("all_fields_optional_0", AllFieldsOptional.Builder.class),
         Map.entry("all_fields_optional_1", AllFieldsOptional.Builder.class),
@@ -62,6 +62,30 @@ public class SmithyJavaTrials {
         Map.entry("struct_4", CodegenStruct.Builder.class),
         Map.entry("send_message_request_1", SendMessageRequest.Builder.class)
     );
+
+    public enum Protocol {
+        RestJson(JsonCodec.builder().build()),
+        RpcV2(Rpcv2CborCodec.builder().build()),
+        ;
+
+        private final Codec codec;
+
+        Protocol(Codec codec) {
+            this.codec = codec;
+        }
+
+        public <T extends SerializableStruct> ByteBuffer serialize(T obj) {
+            return codec.serialize(obj);
+        }
+    }
+
+    @Param(
+        {
+            "RestJson",
+            "RpcV2",
+        }
+    )
+    private Protocol type;
 
     @Param(
         {
@@ -81,7 +105,8 @@ public class SmithyJavaTrials {
         }
     )
     private String testName;
-    private byte[] jsonBytes;
+
+    private ByteBuffer bytes;
     private SerializableStruct shape;
     private ShapeBuilder<?> cleanBuilder;
 
@@ -112,19 +137,56 @@ public class SmithyJavaTrials {
         shape = (SerializableStruct) preparationCodec.deserializeShape(originalBytes, builder);
 
         // These are the bytes that the CODEC under test expects (in case it ever is different from serialized tests).
-        jsonBytes = CODEC.serializeToString(shape).getBytes(StandardCharsets.UTF_8);
+        bytes = type.serialize(shape);
 
         // Where we'll later deserialize into during the deserialization benchmark.
         cleanBuilder = builderConstructor.newInstance();
     }
 
     @Benchmark
-    public Object serialize(Blackhole bh) {
-        return CODEC.serialize(shape);
+    public Object serialize() {
+        return type.codec.serialize(shape);
     }
 
     @Benchmark
     public Object deserialize() {
-        return CODEC.deserializeShape(jsonBytes, cleanBuilder);
+        return type.codec.deserializeShape(bytes, cleanBuilder);
+    }
+
+    public static final class Runner {
+        public static void main(String[] args) throws Exception {
+            run(Protocol.RpcV2, "struct_4");
+        }
+
+        private void runAll() throws Exception {
+            for (var testName : Arrays.asList(
+                new String[]{
+                    "all_fields_optional_0",
+                    "all_fields_optional_1",
+                    "all_fields_optional_3",
+                    "all_fields_optional_5",
+                    "all_fields_optional_6",
+                    "attribute_updates_1",
+                    "attribute_updates_2",
+                    "attribute_updates_3",
+                    "struct_1",
+                    "struct_2",
+                    "struct_3",
+                    "struct_4",
+                    "send_message_request_1"
+                }
+            )) {
+                run(Protocol.RpcV2, testName);
+            }
+        }
+
+        private static void run(Protocol type, String testName) throws Exception {
+            var trial = new SmithyJavaTrials();
+            trial.type = Protocol.RpcV2;
+            trial.testName = testName;
+            trial.setup();
+            trial.serialize();
+            trial.deserialize();
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ smithy-aws-traits = { module = "software.amazon.smithy:smithy-aws-traits", versi
 smithy-protocol-traits = { module = "software.amazon.smithy:smithy-protocol-traits", version.ref = "smithy" }
 smithy-protocol-test-traits = { module = "software.amazon.smithy:smithy-protocol-test-traits", version.ref = "smithy"}
 smithy-aws-protocol-tests = { module = "software.amazon.smithy:smithy-aws-protocol-tests", version.ref = "smithy" }
+smithy-protocol-tests = { module = "software.amazon.smithy:smithy-protocol-tests", version.ref = "smithy" }
 
 # AWS SDK for Java V2 retries bridge dependencies.
 aws-sdk-retries-spi = {module = "software.amazon.awssdk:retries-spi", version.ref = "aws-sdk"}

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/Assertions.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/Assertions.java
@@ -56,7 +56,11 @@ final class Assertions {
             var headerValues = message.headers().allValues(headerEntry.getKey());
             assertNotNull(headerValues);
             var converted = convertHeaderToString(headerEntry.getKey(), headerValues);
-            assertEquals(headerEntry.getValue(), converted);
+            assertEquals(
+                headerEntry.getValue(),
+                converted,
+                "Mismatch for header \"%s\"".formatted(headerEntry.getKey())
+            );
         }
     }
 

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientRequestProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientRequestProtocolTestProvider.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.protocoltests.harness;
 
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -122,6 +123,10 @@ final class HttpClientRequestProtocolTestProvider extends
                     ) throws ParameterResolutionException {
                         if (testCase.getBody().isEmpty()) {
                             return DataStream.ofEmpty();
+                        }
+                        // an `isBinary` property would be nice
+                        if (ProtocolTestProvider.isBinaryMediaType(testCase.getBodyMediaType())) {
+                            return DataStream.ofBytes(Base64.getDecoder().decode(testCase.getBody().get()));
                         }
                         return DataStream.ofString(testCase.getBody().get(), testCase.getBodyMediaType().orElse(null));
                     }

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.protocoltests.harness;
 
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -129,7 +130,12 @@ final class HttpClientResponseProtocolTestProvider extends
             // Add request body if present;
             testCase.getBody().ifPresent(body -> {
                 if (testCase.getBodyMediaType().isPresent()) {
-                    builder.body(DataStream.ofString(body, testCase.getBodyMediaType().get()));
+                    var type = testCase.getBodyMediaType().get();
+                    if (ProtocolTestProvider.isBinaryMediaType(type)) {
+                        builder.body(DataStream.ofBytes(Base64.getDecoder().decode(body), type));
+                    } else {
+                        builder.body(DataStream.ofString(body, type));
+                    }
                 } else {
                     builder.body(DataStream.ofString(body));
                 }

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestProvider.java
@@ -6,6 +6,9 @@
 package software.amazon.smithy.java.protocoltests.harness;
 
 import java.lang.annotation.Annotation;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
@@ -17,6 +20,15 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
  * @param <T> Annotation used to trigger and configure the test template provider.
  */
 abstract class ProtocolTestProvider<T extends Annotation, D> implements TestTemplateInvocationContextProvider {
+    private static final Set<String> BINARY_MEDIA_TYPES = Set.of("application/cbor");
+
+    protected static boolean isBinaryMediaType(Optional<String> mediaType) {
+        return mediaType.isPresent() && isBinaryMediaType(mediaType.get());
+    }
+
+    protected static boolean isBinaryMediaType(String mediaType) {
+        return BINARY_MEDIA_TYPES.contains(mediaType.toLowerCase(Locale.ROOT));
+    }
 
     @Override
     public boolean supportsTestTemplate(ExtensionContext context) {

--- a/rpcv2-cbor-codec/build.gradle.kts
+++ b/rpcv2-cbor-codec/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("smithy-java.module-conventions")
+}
+
+description = "This module provides CBOR functionality"
+
+extra["displayName"] = "Smithy :: Java :: RPCv2 CBOR"
+extra["moduleName"] = "software.amazon.smithy.java.cbor"
+
+dependencies {
+    api(project(":core"))
+    implementation(libs.jackson.core)
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/BadCborException.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/BadCborException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
+
+final class BadCborException extends SerializationException {
+    BadCborException(String message) {
+        this(message, false);
+    }
+
+    BadCborException(String message, boolean includeTrace) {
+        super(message);
+        if (includeTrace) {
+            super.fillInStackTrace();
+        }
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborConstants.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborConstants.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+final class CborConstants {
+    static final int MAJOR_TYPE_SHIFT = 5;
+
+    static final byte MAJOR_TYPE_POSINT = 0,
+        MAJOR_TYPE_NEGINT = 1,
+        MAJOR_TYPE_BYTESTRING = 2,
+        MAJOR_TYPE_TEXTSTRING = 3,
+        MAJOR_TYPE_ARRAY = 4,
+        MAJOR_TYPE_MAP = 5,
+        MAJOR_TYPE_TAG = 6,
+        MAJOR_TYPE_SIMPLE = 7;
+
+    static final int TYPE_POSINT = MAJOR_TYPE_POSINT << MAJOR_TYPE_SHIFT,
+        TYPE_NEGINT = MAJOR_TYPE_NEGINT << MAJOR_TYPE_SHIFT,
+        TYPE_BYTESTRING = MAJOR_TYPE_BYTESTRING << MAJOR_TYPE_SHIFT,
+        TYPE_TEXTSTRING = MAJOR_TYPE_TEXTSTRING << MAJOR_TYPE_SHIFT,
+        TYPE_ARRAY = MAJOR_TYPE_ARRAY << MAJOR_TYPE_SHIFT,
+        TYPE_MAP = MAJOR_TYPE_MAP << MAJOR_TYPE_SHIFT,
+        TYPE_TAG = MAJOR_TYPE_TAG << MAJOR_TYPE_SHIFT,
+        TYPE_SIMPLE = MAJOR_TYPE_SIMPLE << MAJOR_TYPE_SHIFT;
+
+    static final int ONE_BYTE = 24,
+        TWO_BYTES = 25,
+        FOUR_BYTES = 26,
+        EIGHT_BYTES = 27,
+        INDEFINITE = 31;
+
+    static final int SIMPLE_FALSE = 20,
+        SIMPLE_TRUE = 21,
+        SIMPLE_NULL = 22,
+        SIMPLE_FLOAT = 26,
+        SIMPLE_DOUBLE = 27;
+
+    static final int TYPE_SIMPLE_FALSE = TYPE_SIMPLE | SIMPLE_FALSE,
+        TYPE_SIMPLE_TRUE = TYPE_SIMPLE | SIMPLE_TRUE,
+        TYPE_SIMPLE_NULL = TYPE_SIMPLE | SIMPLE_NULL,
+        TYPE_SIMPLE_FLOAT = TYPE_SIMPLE | SIMPLE_FLOAT,
+        TYPE_SIMPLE_DOUBLE = TYPE_SIMPLE | SIMPLE_DOUBLE,
+        TYPE_SIMPLE_BREAK_STREAM = TYPE_SIMPLE | INDEFINITE;
+
+    static final byte TAG_TIME_EPOCH = 1; // expect integer or float
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborDeserializer.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborDeserializer.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import static software.amazon.smithy.java.runtime.cbor.CborReadUtil.readByteString;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.smithy.java.runtime.cbor.CborParser.Token;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
+import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.runtime.core.serde.document.Document;
+
+final class CborDeserializer implements ShapeDeserializer {
+    private static final class Canonicalizer {
+        private record Canonical(Schema member, byte[] utf8) implements Comparable<Canonical> {
+            @Override
+            public int compareTo(Canonical o) {
+                return Arrays.compare(utf8, o.utf8);
+            }
+
+            private Schema isSame(byte[] bytes, int off, int len) {
+                if (Arrays.compare(utf8, 0, utf8.length, bytes, off, off + len) == 0) {
+                    return member;
+                }
+                return null;
+            }
+        }
+
+        private final Object[][] canonicals;
+
+        Canonicalizer(Schema schema) {
+            int biggest = 0;
+            Map<Integer, List<Canonical>> bySize = new HashMap<>();
+            for (var member : schema.members()) {
+                byte[] utf8 = member.memberName().getBytes(StandardCharsets.UTF_8);
+                biggest = Math.max(biggest, utf8.length);
+                bySize.computeIfAbsent(utf8.length, $ -> new ArrayList<>())
+                    .add(new Canonical(member, utf8));
+            }
+
+            canonicals = new Object[biggest + 1][];
+            for (var entry : bySize.entrySet()) {
+                int len = entry.getKey();
+                var canonsForLen = entry.getValue().toArray(new Canonical[0]);
+                Arrays.sort(canonsForLen);
+                canonicals[len] = canonsForLen;
+            }
+        }
+
+        Schema resolve(byte[] payload, int off, int len) {
+            if (len >= canonicals.length) {
+                return null;
+            }
+
+            Object[] canonicals = this.canonicals[len];
+            if (canonicals == null) {
+                return null;
+            }
+
+            if (canonicals.length == 1) {
+                return getMemberIfSame(canonicals[0], payload, off, len);
+            } else {
+                for (int i = 0; i < canonicals.length; i++) {
+                    var member = getMemberIfSame(canonicals[i], payload, off, len);
+                    if (member != null) {
+                        return member;
+                    }
+                }
+                return null;
+            }
+        }
+
+        private Schema getMemberIfSame(Object o, byte[] bytes, int off, int len) {
+            return ((Canonical) o).isSame(bytes, off, len);
+        }
+    }
+
+    private static final Map<Schema, Canonicalizer> CANONICALIZERS = new ConcurrentHashMap<>();
+
+    private final CborParser parser;
+    private final byte[] payload;
+
+    CborDeserializer(byte[] payload) {
+        this.parser = new CborParser(payload);
+        this.payload = payload;
+        parser.advance();
+    }
+
+    CborDeserializer(ByteBuffer byteBuffer) {
+        if (byteBuffer.hasArray()) {
+            byte[] payload = byteBuffer.array();
+            this.payload = payload;
+            this.parser = new CborParser(
+                payload,
+                byteBuffer.arrayOffset() + byteBuffer.position(),
+                byteBuffer.remaining()
+            );
+        } else {
+            this.payload = new byte[byteBuffer.remaining()];
+            byteBuffer.get(this.payload);
+            this.parser = new CborParser(this.payload);
+        }
+        parser.advance();
+    }
+
+    @Override
+    public void close() {
+        if (parser.currentToken() != Token.FINISHED) {
+            throw new SerializationException("Unexpected CBOR content at end of object");
+        }
+    }
+
+    @Override
+    public boolean readBoolean(Schema schema) {
+        byte token = parser.currentToken();
+        if (token == Token.TRUE) {
+            return true;
+        } else if (token == Token.FALSE) {
+            return false;
+        }
+        throw badType("boolean", token);
+    }
+
+    private static SerializationException badType(String type, byte token) {
+        return new SerializationException("Can't read " + Token.name(token) + " as a " + type);
+    }
+
+    @Override
+    public ByteBuffer readBlob(Schema schema) {
+        byte token = parser.currentToken();
+        if (token == Token.BYTE_STRING) {
+            int pos = parser.getPosition();
+            int len = parser.getItemLength();
+            ByteBuffer buffer;
+            if (CborParser.isIndefinite(len)) {
+                buffer = ByteBuffer.wrap(readByteString(payload, pos, len));
+            } else {
+                buffer = ByteBuffer.wrap(payload, pos, len).slice();
+            }
+            return buffer;
+        }
+        throw badType("blob", token);
+    }
+
+    @Override
+    public byte readByte(Schema schema) {
+        return (byte) readLong("byte", parser.currentToken());
+    }
+
+    @Override
+    public short readShort(Schema schema) {
+        return (short) readLong("short", parser.currentToken());
+    }
+
+    @Override
+    public int readInteger(Schema schema) {
+        return (int) readLong("integer", parser.currentToken());
+    }
+
+    @Override
+    public long readLong(Schema schema) {
+        return readLong("long", parser.currentToken());
+    }
+
+    private long readLong(String type, byte token) {
+        int off = parser.getPosition();
+        int len = parser.getItemLength();
+        if (token > Token.NEG_INT) throw badType(type, token);
+        long val = CborReadUtil.readLong(payload, token, off, len);
+        if (len < 8) {
+            return val;
+        }
+        if (token == Token.POS_INT) {
+            return val < 0 ? Long.MAX_VALUE : val;
+        } else {
+            return val < 0 ? val : Long.MIN_VALUE;
+        }
+    }
+
+    @Override
+    public float readFloat(Schema schema) {
+        return (float) readDouble("float", parser.currentToken());
+    }
+
+    @Override
+    public double readDouble(Schema schema) {
+        return readDouble("double", parser.currentToken());
+    }
+
+    private double readDouble(String type, byte token) {
+        if (token != Token.FLOAT) {
+            throw badType(type, token);
+        }
+
+        int pos = parser.getPosition();
+        int len = parser.getItemLength();
+        long fp = CborReadUtil.readLong(payload, token, pos, len);
+        // ordered by how likely it is we'll encounter each case
+        if (len == 8) { // double
+            return Double.longBitsToDouble(fp);
+        } else if (len == 4) { // float
+            return Float.intBitsToFloat((int) fp);
+        } else { // b == 2  - half-precision float
+            return float16((int) fp);
+        }
+    }
+
+    // https://stackoverflow.com/questions/6162651/half-precision-floating-point-in-java/6162687
+    private static float float16(int hbits) {
+        int mant = hbits & 0x03ff;          // 10 bits mantissa
+        int exp = hbits & 0x7c00;          // 5 bits exponent
+        if (exp == 0x7c00) {                // NaN/Inf
+            exp = 0x3fc00;                  // -> NaN/Inf
+        } else if (exp != 0) {              // normalized value
+            exp += 0x1c000;                 // exp - 15 + 127
+            if (mant == 0 && exp > 0x1c400) // smooth transition
+                return Float.intBitsToFloat((hbits & 0x8000) << 16 | exp << 13);
+        } else if (mant != 0) {             // && exp==0 -> subnormal
+            exp = 0x1c400;                  // make it normal
+            do {
+                mant <<= 1;                 // mantissa * 2
+                exp -= 0x400;               // decrease exp by 1
+            } while ((mant & 0x400) == 0);  // while not normal
+            mant &= 0x3ff;                  // discard subnormal bit
+        }                                   // else +/-0 -> +/-0
+        return Float.intBitsToFloat(
+            // combine all parts
+            (hbits & 0x8000) << 16          // sign  << ( 31 - 15 )
+                | (exp | mant) << 13        // value << ( 23 - 10 )
+        );
+    }
+
+    @Override
+    public BigInteger readBigInteger(Schema schema) {
+        return null;
+    }
+
+    @Override
+    public BigDecimal readBigDecimal(Schema schema) {
+        return null;
+    }
+
+    @Override
+    public String readString(Schema schema) {
+        byte token = parser.currentToken();
+        if (token != Token.TEXT_STRING) {
+            throw badType("string", token);
+        }
+        return CborReadUtil.readTextString(payload, parser.getPosition(), parser.getItemLength());
+    }
+
+    @Override
+    public Document readDocument() {
+        throw new UnsupportedOperationException("RPCv2 does not support Documents");
+    }
+
+    @Override
+    public Instant readTimestamp(Schema schema) {
+        byte token = parser.currentToken();
+        byte actual = (byte) (token ^ Token.TAG_FLAG);
+        if (actual <= Token.NEG_INT) {
+            return Instant.ofEpochMilli(readLong("timestamp", token) * 1000);
+        } else if (actual == Token.FLOAT) {
+            double d = readDouble("timestamp", actual);
+            return Instant.ofEpochMilli(Math.round(d * 1000d));
+        }
+        throw badType("timestamp", token);
+    }
+
+    @Override
+    public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> consumer) {
+        byte token = parser.currentToken();
+        if (token != Token.START_OBJECT) {
+            throw badType("struct", token);
+        }
+
+        var canonicalizer = getCanonicalizer(schema);
+        for (token = parser.advance(); token != Token.END_OBJECT; token = parser.advance()) {
+            if (token != Token.KEY) {
+                throw badType("struct member", token);
+            }
+
+            int memberPos = parser.getPosition();
+            int memberLen = parser.getItemLength();
+            // don't dispatch any events for explicit nulls
+            if (parser.advance() == Token.NULL) {
+                continue;
+            }
+
+            // wait to resolve the member until we know an event will be dispatched
+            Object member = resolveMember(schema, canonicalizer, payload, memberPos, memberLen);
+            if (member.getClass() == String.class) {
+                consumer.unknownMember(state, (String) member);
+                skipUnknownMember();
+            } else {
+                consumer.accept(state, (Schema) member, this);
+            }
+        }
+    }
+
+    private void skipUnknownMember() {
+        byte current = parser.currentToken();
+        if (current != Token.START_OBJECT && current != Token.START_ARRAY) {
+            return;
+        }
+
+        int depth = 0;
+        while (true) {
+            if (current == Token.START_OBJECT || current == Token.START_ARRAY) {
+                depth++;
+            } else if ((current == Token.END_OBJECT || current == Token.END_ARRAY) && --depth == 0) {
+                return;
+            }
+            current = parser.advance();
+        }
+    }
+
+    private static Object resolveMember(Schema host, Canonicalizer canonicalizer, byte[] payload, int pos, int len) {
+        // this method is static for safety. the parser has already advanced past the member field by the time
+        // resolveMember is called, so don't touch the parser or any other instance state.
+        if (CborParser.isIndefinite(len)) {
+            return resolveSlow(host, payload, pos, len);
+        }
+
+        var schema = canonicalizer.resolve(payload, pos, len);
+        if (schema != null) {
+            return schema;
+        }
+        return CborReadUtil.readTextString(payload, pos, len);
+    }
+
+    private static Object resolveSlow(Schema host, byte[] payload, int pos, int len) {
+        var name = CborReadUtil.readTextString(payload, pos, len);
+        var schema = host.member(name);
+        return schema != null ? schema : host;
+    }
+
+    private Canonicalizer getCanonicalizer(Schema schema) {
+        var canonicalizer = CANONICALIZERS.get(schema);
+        if (canonicalizer == null) {
+            canonicalizer = new Canonicalizer(schema);
+            CANONICALIZERS.put(schema, canonicalizer);
+        }
+
+        return canonicalizer;
+    }
+
+    @Override
+    public <T> void readList(Schema schema, T state, ListMemberConsumer<T> consumer) {
+        byte token = parser.currentToken();
+        if (token != Token.START_ARRAY) {
+            throw badType("list", token);
+        }
+
+        for (token = parser.advance(); token != Token.END_ARRAY; token = parser.advance()) {
+            consumer.accept(state, this);
+        }
+    }
+
+    @Override
+    public int containerSize() {
+        return parser.collectionSize();
+    }
+
+    @Override
+    public <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> consumer) {
+        byte token = parser.currentToken();
+        if (token != Token.START_OBJECT) {
+            throw badType("struct", token);
+        }
+
+        for (token = parser.advance(); token != Token.END_OBJECT; token = parser.advance()) {
+            if (token != Token.KEY) {
+                throw badType("key", token);
+            }
+            var key = CborReadUtil.readTextString(payload, parser.getPosition(), parser.getItemLength());
+            parser.advance();
+            consumer.accept(state, key, this);
+        }
+    }
+
+    @Override
+    public boolean isNull() {
+        return parser.currentToken() == Token.NULL;
+    }
+
+    @Override
+    public <T> T readNull() {
+        return null;
+    }
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborParser.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborParser.java
@@ -1,0 +1,531 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import static software.amazon.smithy.java.runtime.cbor.CborParser.Token.name;
+import static software.amazon.smithy.java.runtime.cbor.CborReadUtil.argLength;
+import static software.amazon.smithy.java.runtime.cbor.CborReadUtil.readPosInt;
+import static software.amazon.smithy.java.runtime.cbor.CborReadUtil.readStrLen;
+
+import java.util.Arrays;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class CborParser {
+    public static final class Token {
+        public static int version() { return 1; }
+
+        // high bit toggle to indicate a tagged item
+        public static final byte TAG_FLAG = 1 << 4;
+
+        // the first group of simple types directly map to their cbor major types for simpler reading routines
+        public static final byte POS_INT = TYPE_POSINT;            // 0b00000
+        public static final byte NEG_INT = TYPE_NEGINT;            // 0b00001
+        public static final byte BYTE_STRING = TYPE_BYTESTRING;        // 0b00010
+        public static final byte TEXT_STRING = TYPE_TEXTSTRING;        // 0b00011
+
+        // types that require explicit method invocations on ReadTranslator
+        // these values must be contiguous for efficient lookup table generation
+        public static final byte NULL = 4;                      // 0b00100
+        public static final byte KEY = 5;                      // 0b00101
+        public static final byte START_OBJECT = 6;                      // 0b00110
+        public static final byte START_ARRAY = 7;                      // 0b00111
+        public static final byte END_OBJECT = 8;                      // 0b01000
+        public static final byte END_ARRAY = 9;                      // 0b01001
+
+        // the second group of simple types have arbitrary values and can pretty much be anything
+        public static final byte POS_BIGINT = 10;                     // 0b01010
+        public static final byte NEG_BIGINT = 11;                     // 0b01011
+        public static final byte FLOAT = 12;                     // 0b01100
+        // gap: we used to have a bigfloat token, but we never supported that type
+        public static final byte BIG_DECIMAL = 14;                     // 0b01110
+        public static final byte TRUE = 15;                     // 0b01111
+        public static final byte FALSE = TRUE | TAG_FLAG; // 0b11111 (31)
+
+        // tag types are the type of the tagged data with the high bit set
+        // these do not need to be contiguous
+        public static final byte EPOCH_IPOS = POS_INT | TAG_FLAG; // 0b10000 (16)
+        public static final byte EPOCH_INEG = NEG_INT | TAG_FLAG; // 0b10001 (17)
+        public static final byte EPOCH_F = FLOAT | TAG_FLAG; // 0b11100 (28)
+
+        public static final byte FINISHED = -1;
+
+        public static String name(byte token) {
+            switch (token) {
+                case POS_INT:
+                    return "POS_INT";
+                case NEG_INT:
+                    return "NEG_INT";
+                case BYTE_STRING:
+                    return "BYTE_STRING";
+                case TEXT_STRING:
+                    return "TEXT_STRING";
+                case POS_BIGINT:
+                    return "POS_BIGINT";
+                case NEG_BIGINT:
+                    return "NEG_BIGINT";
+                case FLOAT:
+                    return "FLOAT";
+                case BIG_DECIMAL:
+                    return "BIG_DECIMAL";
+                case TRUE:
+                    return "TRUE";
+                case FALSE:
+                    return "FALSE";
+                case EPOCH_IPOS:
+                    return "EPOCH_IPOS";
+                case EPOCH_INEG:
+                    return "EPOCH_INEG";
+                case EPOCH_F:
+                    return "EPOCH_F";
+                case NULL:
+                    return "NULL";
+                case KEY:
+                    return "KEY";
+                case START_OBJECT:
+                    return "START_OBJECT";
+                case START_ARRAY:
+                    return "START_ARRAY";
+                case END_ARRAY:
+                    return "END_ARRAY";
+                case END_OBJECT:
+                    return "END_OBJECT";
+            }
+            if (token == FINISHED) return "FINISHED";
+            throw new BadCborException("unknown token " + token);
+        }
+    }
+
+    static final int MAJOR_TYPE_SHIFT = 5,
+        MAJOR_TYPE_MASK = 0b111_00000,
+        MINOR_TYPE_MASK = 0b0001_1111;
+
+    static final byte TYPE_POSINT = 0,
+        TYPE_NEGINT = 1,
+        TYPE_BYTESTRING = 2,
+        TYPE_TEXTSTRING = 3,
+        TYPE_ARRAY = 4,
+        TYPE_MAP = 5,
+        TYPE_TAG = 6,
+        TYPE_SIMPLE = 7;
+
+    static final int ZERO_BYTES = 23,
+        ONE_BYTE = 24,
+        EIGHT_BYTES = 27,
+        INDEFINITE = 31;
+
+    static final int SIMPLE_FALSE = 20,
+        SIMPLE_TRUE = 21,
+        SIMPLE_NULL = 22,
+        SIMPLE_UNDEFINED = 23,
+        SIMPLE_VALUE_1 = 24, // value follows in next 1 byte, currently reserved and unused
+        SIMPLE_HALF_FLOAT = 25,
+        SIMPLE_FLOAT = 26,
+        SIMPLE_DOUBLE = 27;
+
+    static final byte SIMPLE_STREAM_BREAK = (byte) ((TYPE_SIMPLE << MAJOR_TYPE_SHIFT) | INDEFINITE);
+
+    static final byte TAG_TIME_RFC3339 = 0, // expect text string
+        TAG_TIME_EPOCH = 1, // expect integer or float
+        TAG_POS_BIGNUM = 2, // expect byte string
+        TAG_NEG_BIGNUM = 3, // expect byte string
+        TAG_DECIMAL = 4; // expect two-element integer array
+
+    private static final int FLAG_INDEFINITE_LEN = 1 << 31;
+    private static final int MASK_LEN = ~FLAG_INDEFINITE_LEN;
+
+    public static boolean isIndefinite(int itemLength) {
+        return itemLength < 0;
+    }
+
+    public static int itemLength(int itemLength) {
+        return itemLength & MASK_LEN;
+    }
+
+    private final byte[] buffer;
+    private final int len;
+    private int idx;
+    private byte token;
+
+    // Definite sizes shrink to zero, indefinite sizes start at -1 and decrement meaninglessly towards Long.MIN_VALUE.
+    // Must be long because we need to store 2 * size for maps, and a map can have up to Integer.MAX_VALUE elements.
+    // Count is left shifted one. Low bit is collection type: 0 == map, 1 == array.
+    private long currentState = 0;
+    private long[] previousStates = new long[4];
+    private boolean inCollection = false;
+    private int historyDepth = 0;
+    private int itemLength = 0;
+    private int overhead = 0; // overhead is [0,8]
+    private boolean readingTag = false;
+
+    public CborParser(byte[] buffer) {
+        this(buffer, 0, buffer.length);
+    }
+
+    public CborParser(byte[] buffer, int off, int len) {
+        this.buffer = buffer;
+        this.idx = off;
+        this.len = len;
+    }
+
+    /**
+     * @return the starting position of the current data item
+     */
+    public int getPosition() {
+        return idx;
+    }
+
+    /**
+     * If the last token returned by {@link #advance()} is a single data item (e.g. a numeric type),
+     * this indicates the number of bytes from {@link #getPosition()} to read to retrieve it.
+     *
+     * <p>This method does not return a defined result for collection types like strings, arrays, or maps.
+     *
+     * @return number of bytes encoding the current single-element data item, or undefined
+     */
+    public int getItemLength() {
+        return itemLength;
+    }
+
+    public int collectionSize() {
+        long s = currentState >> 2;
+        return s >= 0 ? (int) s : -1;
+    }
+
+    public byte currentToken() {
+        return token;
+    }
+
+    /**
+     * Gets the next {@link Token} in the payload. The data for this token begins at {@link #getPosition()}. The data's
+     * length is determined by {@link #getItemLength()} if the token is <b>not</b> one of these types:
+     *
+     * <ul>
+     *     <li>{@link Token#NULL}</li>
+     *     <li>{@link Token#START_ARRAY}</li>
+     *     <li>{@link Token#END_ARRAY}</li>
+     *     <li>{@link Token#START_OBJECT}</li>
+     *     <li>{@link Token#END_OBJECT}</li>
+     * </ul>
+     *
+     * @return the next {@link Token} in the payload
+     */
+    public byte advance() {
+        return (token = nextToken0());
+    }
+
+    private byte nextToken0() {
+        if (inCollection) {
+            long state = currentState;
+            if (state >> 1 == 0) {
+                // count is 0, so the only remaining value is the collection type in the low bit
+                return getEndToken(state);
+            } else if ((state & 3) == 0) {
+                // mask is 0b11: low bit is collection type (map == 0), high bit is 0 if the count is even
+                int i = (idx += itemLength(itemLength) + overhead);
+                if (i >= len) {
+                    throwIncompleteCollectionException();
+                }
+                return dispatchKey(buffer[i]);
+            }
+        }
+
+        int i = (idx += itemLength(itemLength) + overhead);
+        if (i >= len) {
+            return endOfBuffer(i);
+        }
+
+        return dispatch(buffer[i]);
+    }
+
+    private byte dispatchKey(byte b) {
+        byte major = (byte) ((b & MAJOR_TYPE_MASK) >> MAJOR_TYPE_SHIFT);
+        if (major == TYPE_TEXTSTRING) {
+            byte minor = (byte) (b & MINOR_TYPE_MASK);
+            string(major, minor);
+            return Token.KEY;
+        } else if (b == SIMPLE_STREAM_BREAK) {
+            return endStreamCollection();
+        } else {
+            throw new BadCborException("map keys must be strings");
+        }
+    }
+
+    private byte endOfBuffer(int i) {
+        itemLength = 0;
+        overhead = 0;
+        if (i > len) {
+            throw new BadCborException("unexpected end of payload");
+        }
+        if (inCollection) {
+            throwIncompleteCollectionException();
+        }
+        return Token.FINISHED;
+    }
+
+    private byte getEndToken(long state) {
+        byte retVal = state == 0 ? Token.END_OBJECT : Token.END_ARRAY;
+        if (historyDepth > 0) {
+            currentState = previousStates[--historyDepth];
+        } else {
+            inCollection = false;
+            currentState = 0;
+        }
+        return retVal;
+    }
+
+    private byte dispatch(byte b) {
+        byte major = (byte) ((b & MAJOR_TYPE_MASK) >> MAJOR_TYPE_SHIFT);
+        byte minor = (byte) (b & MINOR_TYPE_MASK);
+        // major is guaranteed in range [0,7] by the mask-and-shift operation
+        switch (major) {
+            case TYPE_POSINT:
+            case TYPE_NEGINT:
+                return integer(major, minor);
+            case TYPE_BYTESTRING:
+            case TYPE_TEXTSTRING:
+                return string(major, minor);
+            case TYPE_ARRAY:
+            case TYPE_MAP:
+                return collection(major, minor);
+            case TYPE_TAG:
+                return tag(minor);
+            case TYPE_SIMPLE:
+                return simple(major, minor);
+            default:
+                throw new BadCborException("unknown major type: " + major);
+        }
+    }
+
+    private byte tag(byte minor) {
+        // RFC8949 3.4 permits nested tags, but I see no need to support anything beyond the simple
+        // tags that are relevant to the Smithy object model.
+        if (readingTag) throw new BadCborException("nested tags not permitted");
+        // reset increments before calling nextToken. 1 overhead for this tag /immediate value
+        overhead = 1;
+        itemLength = 0;
+        readingTag = true;
+        byte next = advance();
+        readingTag = false;
+        switch (minor) {
+            case TAG_TIME_EPOCH:
+                if (next != Token.FLOAT && next > Token.NEG_INT)
+                    throw new BadCborException("malformed instant: got " + name(next));
+                return (byte) (next | Token.TAG_FLAG);
+            case TAG_POS_BIGNUM:
+                if (next != Token.BYTE_STRING)
+                    throw new BadCborException("malformed +bignum: got " + name(next));
+                return Token.POS_BIGINT;
+            case TAG_NEG_BIGNUM:
+                if (next != Token.BYTE_STRING)
+                    throw new BadCborException("malformed -bignum: got " + name(next));
+                return Token.NEG_BIGINT;
+            case TAG_DECIMAL:
+                tagDecimalFp(next);
+                return Token.BIG_DECIMAL;
+            default:
+                throw new BadCborException("unsupported tag minor " + minor);
+        }
+    }
+
+    private void tagDecimalFp(byte next) {
+        // A decimal fraction or a bigfloat is represented as a tagged array that contains
+        // exactly an integer and a bignum/integer
+        if (next != Token.START_ARRAY)
+            badDecimalInitialType(next);
+        int start = idx;
+        byte token;
+        if ((token = advance()) > Token.NEG_INT)
+            badDecimalArgument1(token);
+        token = advance();
+        int tmp = token & 0b11110;
+        if (tmp != Token.POS_INT && tmp != Token.POS_BIGINT)
+            badDecimalArgument2(token);
+        if ((token = advance()) != Token.END_ARRAY)
+            badDecimalFinalToken(token);
+        itemLength = idx - start + itemLength(itemLength) + overhead - 1;
+        overhead = 1;
+        idx = start;
+    }
+
+    private static void badDecimalInitialType(byte next) {
+        throw new BadCborException("malformed BIG_DECIMAL: got " + name(next));
+    }
+
+    private static void badDecimalArgument1(byte token) {
+        throw new BadCborException("malformed BIG_DECIMAL: expected int 1, got " + name(token));
+    }
+
+    private static void badDecimalArgument2(byte token) {
+        throw new BadCborException("malformed BIG_DECIMAL: expected int 2, got " + name(token));
+    }
+
+    private static void badDecimalFinalToken(byte token) {
+        throw new BadCborException("malformed BIG_DECIMAL: expected END_ARRAY, got " + name(token));
+    }
+
+    private byte integer(byte major, byte minor) {
+        if (minor == INDEFINITE) throw new BadCborException("numeric type has indefinite length");
+        int argLength = argLength(minor);
+        if (argLength > 0) {
+            overhead = 0;
+            idx++;
+        } else {
+            overhead = 1;
+        }
+        itemLength = argLength;
+        // 2 because the count is left-shifted one (2 == 1 << 1)
+        currentState -= 2;
+        return major;
+    }
+
+    private byte simple(byte major, byte minor) {
+        if (minor <= SIMPLE_VALUE_1) {
+            currentState -= 2;
+            itemLength = 1;
+            overhead = 0;
+            switch (minor) {
+                case SIMPLE_FALSE:
+                    return Token.FALSE;
+                case SIMPLE_TRUE:
+                    return Token.TRUE;
+                case SIMPLE_NULL:
+                case SIMPLE_UNDEFINED:
+                    return Token.NULL;
+                default:
+                    throw new BadCborException("bad simple minor type " + minor);
+            }
+        } else if (minor <= SIMPLE_DOUBLE) {
+            // collectionSize is decremented in integer if necessary
+            integer(major, minor);
+            return Token.FLOAT;
+        } else if (minor == INDEFINITE) {
+            return endStreamCollection();
+        }
+        throw new BadCborException("illegal simple minor type " + minor);
+    }
+
+    private byte endStreamCollection() {
+        // no need to decrement collectionSize in this branch since we're in an indefinite collection
+        itemLength = 0;
+        overhead = 1;
+        // note that we can leave the collection type in the low bit. all that matters is that
+        // the number is negative, and the low bit will only make a positive number more positive
+        // and a negative number more negative.
+        if (!inCollection || currentState >= 0)
+            throw new BadCborException("unexpected indefinite terminator");
+        long state = currentState;
+        if (historyDepth > 0) {
+            currentState = previousStates[--historyDepth];
+        } else {
+            inCollection = false;
+            currentState = 0;
+        }
+        return (state & 1) == 0 ? Token.END_OBJECT : Token.END_ARRAY;
+    }
+
+    /**
+     * Reads a {@linkplain #TYPE_TEXTSTRING text string} or {@linkplain #TYPE_BYTESTRING bytestring}
+     * from the buffer.
+     *
+     * <p>Definite length strings have no overhead. {@code idx} will point to the start of the string
+     * data and {@code itemLength} will be the number of bytes in the string. The next data item begins
+     * at {@code idx + itemLength}.
+     *
+     * <p>Indefinite length strings are a bit trickier. {@code idx} will point to the start of the first
+     * string in the sequence and {@code itemLength} will be the number of bytes in the final assembled
+     * string. However, this is <b>not</b> the number of bytes that this string spans in the CBOR payload.
+     * We use a separate count, {@linkplain #overhead}, to factor in the additional overhead of encoding
+     * non-data tags. We add all opening tag bytes, length operands, and the final closing {@link #INDEFINITE}
+     * byte to this value.
+     */
+    private byte string(byte major, byte minor) {
+        overhead = 0;
+        if (minor == INDEFINITE) {
+            readIndefiniteLength(major);
+        } else {
+            int argLen = argLength(minor);
+            itemLength = readImm(minor, argLen);
+        }
+        currentState -= 2;
+        return major;
+    }
+
+    private int readImm(int minor, int argLen) {
+        if (argLen == 0) {
+            // minor is the collection/string length, data begins on next byte
+            idx++;
+            return minor;
+        } else {
+            // minor is the number of bytes following this one that encode the collection/string length
+            int ret = readPosInt(buffer, ++idx, argLen);
+            idx += argLen;
+            return ret;
+        }
+    }
+
+    private byte collection(byte major, byte minor) {
+        // collection length is tracked in collectionSizes
+        itemLength = 0;
+        long size;
+        if (minor == INDEFINITE) {
+            overhead = 1;
+            size = -1;
+        } else {
+            int argLen = argLength(minor);
+            overhead = 0;
+            size = readImm(minor, argLen);
+        }
+        if (inCollection) {
+            currentState -= 2;
+            if (historyDepth == previousStates.length) {
+                previousStates = Arrays.copyOf(previousStates, previousStates.length * 2);
+            }
+            previousStates[historyDepth++] = currentState;
+        }
+        inCollection = true;
+        if (major == TYPE_ARRAY) {
+            currentState = (size << 1) | 1;
+            return Token.START_ARRAY;
+        } else { //major == TYPE_MAP
+            currentState = size << 2;
+            return Token.START_OBJECT;
+        }
+    }
+
+    // idx = start of string, itemLength = byte count, overhead = tag bytes
+    private void readIndefiniteLength(byte type) {
+        itemLength = 0;
+        int scan = ++idx;
+        while (true) {
+            if (scan >= len) throw new BadCborException("non-terminating string");
+            byte b = buffer[scan];
+            if (b == SIMPLE_STREAM_BREAK) {
+                overhead++;
+                break;
+            }
+            int major = (b & MAJOR_TYPE_MASK) >> MAJOR_TYPE_SHIFT;
+            int minor = b & MINOR_TYPE_MASK;
+            if (major != type) {
+                throw new BadCborException("major type misalign: " + type + " " + major);
+            }
+            if (minor == INDEFINITE) throw new BadCborException("expected finite length");
+            int argLen = argLength(minor);
+            int strLen = readStrLen(buffer, scan, minor, argLen);
+            int totalOverhead = argLen + 1;
+            overhead += totalOverhead;
+            itemLength += strLen;
+            scan += totalOverhead + strLen;
+        }
+        itemLength |= FLAG_INDEFINITE_LEN;
+    }
+
+    private void throwIncompleteCollectionException() {
+        String type = (currentState & 1L) == 0 ? "map" : "array";
+        String msg = currentState < 0 ? "stream break" : ((currentState >> 1) + " more elements");
+        throw new BadCborException("incomplete " + type + ": expecting " + msg);
+    }
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborReadUtil.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborReadUtil.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import static software.amazon.smithy.java.runtime.cbor.CborParser.EIGHT_BYTES;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.MAJOR_TYPE_MASK;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.MAJOR_TYPE_SHIFT;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.MINOR_TYPE_MASK;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.ONE_BYTE;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.TAG_NEG_BIGNUM;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.TAG_POS_BIGNUM;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.TYPE_NEGINT;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.TYPE_POSINT;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.TYPE_TAG;
+import static software.amazon.smithy.java.runtime.cbor.CborParser.ZERO_BYTES;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class CborReadUtil {
+    public static int argLength(int minorType) {
+        if (minorType <= ZERO_BYTES) return 0;
+        if (minorType > EIGHT_BYTES) throw new BadCborException("illegal arg length type: " + minorType);
+        int shift = minorType - ONE_BYTE;
+        return 1 << shift;
+    }
+
+    public static int readPosInt(byte[] buffer, int off, int len) {
+        if (len == 0) {
+            return buffer[off] & MINOR_TYPE_MASK;
+        }
+        long val = readLong0(buffer, off, len);
+        if (val > Integer.MAX_VALUE) throw new BadCborException("value cannot fit into an int");
+        if (val < 0) throw new BadCborException("expected positive int");
+        return (int) val;
+    }
+
+    public static int readStrLen(byte[] buffer, int off, int minor, int argLen) {
+        if (argLen == 0) {
+            return minor;
+        }
+        return readPosInt(buffer, off + 1, argLen);
+    }
+
+    /**
+     * Flips all the bits of the given byte[] using the bitwise negation operator (~)
+     *
+     */
+    private static void flipBytes(final byte[] src) {
+        for (int i = 0; i < src.length; i++) {
+            src[i] = (byte) ~src[i];
+        }
+    }
+
+    public static long readLong(byte[] buffer, byte type, int off, int len) {
+        long val = len == 0 ? buffer[off] & MINOR_TYPE_MASK : readLong0(buffer, off, len);
+        if (type == TYPE_NEGINT) return -val - 1;
+        else return val;
+    }
+
+    @SuppressFBWarnings("SF_SWITCH_FALLTHROUGH")
+    private static long readLong0(byte[] buffer, int off, int len) {
+        long acc = 0;
+        // case order is important here, do not reorder
+        switch (len) {
+            case 8:
+                acc = ((long) buffer[off++] & 0xff) << 56
+                    | ((long) buffer[off++] & 0xff) << 48
+                    | ((long) buffer[off++] & 0xff) << 40
+                    | ((long) buffer[off++] & 0xff) << 32;
+            case 4:
+                acc |= ((long) buffer[off++] & 0xff) << 24
+                    | ((long) buffer[off++] & 0xff) << 16;
+            case 2:
+                acc |= ((long) buffer[off++] & 0xff) << 8;
+            case 1:
+                return acc | ((long) buffer[off] & 0xff);
+            default:
+                return invalidLength(len);
+        }
+    }
+
+    private static long invalidLength(int len) {
+        throw new BadCborException("invalid length: " + len, true);
+    }
+
+    public static BigInteger readBigInteger(byte[] buffer, byte context, int off, int len) {
+        //If the value fits inside a long
+        boolean isPosInt = context == CborParser.Token.POS_INT;
+        if (isPosInt || context == CborParser.Token.NEG_INT) {
+            return readSmallBigInteger(buffer, context, off, len, isPosInt);
+        }
+        final byte[] buff;
+        if (len >= 0) {
+            final int desOff;
+            if (buffer[off] >= 0) {
+                buff = new byte[len];
+                desOff = 0;
+            } else {
+                buff = new byte[len + 1];
+                desOff = 1;
+            }
+            CborReadUtil.readByteString(buffer, off, buff, desOff, len);
+        } else {
+            //Handle indefinite length string
+            byte[] indefBuf = CborReadUtil.readByteString(buffer, off, len);
+            if (indefBuf.length == 0 || indefBuf[0] < 0) {
+                buff = new byte[indefBuf.length + 1];
+                System.arraycopy(indefBuf, 0, buff, 1, indefBuf.length);
+            } else {
+                buff = indefBuf;
+            }
+        }
+        if (context == CborParser.Token.NEG_BIGINT) {
+            CborReadUtil.flipBytes(buff);
+        }
+        return new BigInteger(buff);
+    }
+
+    private static BigInteger readSmallBigInteger(byte[] buffer, byte context, int off, int len, boolean isPosInt) {
+        //If its exactly 64 bits, we write a negative number.
+        if (len == 8 && buffer[off] >> 8 == -1) {
+            byte[] val = new byte[9];
+            CborReadUtil.readByteString(buffer, off, val, 1, len);
+            if (!isPosInt) {
+                CborReadUtil.flipBytes(val);
+            }
+            return new BigInteger(val);
+        }
+        return BigInteger.valueOf(readLong(buffer, context, off, len));
+    }
+
+    public static BigDecimal readBigDecimal(byte[] buffer, int originalOff) {
+        int cur = originalOff;
+        int exponentLength = argLength(getMinor(buffer[cur]));
+        long exponent = readLong(buffer, getMajor(buffer[cur]), exponentLength > 0 ? cur + 1 : cur, exponentLength);
+        int intExponent = (int) exponent;
+        if (intExponent != exponent) {
+            throw new BadCborException("exponent cannot fit into an int");
+        }
+        cur += exponentLength + 1;
+        byte major = getMajor(buffer[cur]);
+        byte minor = getMinor(buffer[cur]);
+        byte context;
+        int mantissaLength;
+        switch (major) {
+            case TYPE_TAG:
+                if (minor == TAG_POS_BIGNUM) {
+                    context = CborParser.Token.POS_BIGINT;
+                } else if (minor == TAG_NEG_BIGNUM) {
+                    context = CborParser.Token.NEG_BIGINT;
+                } else {
+                    throw new BadCborException("Unexpected minor " + minor, true);
+                }
+                cur++;
+                byte mantissaLengthMinor = getMinor(buffer[cur]);
+                int argLen = argLength(mantissaLengthMinor);
+                if (argLen == 0) {
+                    mantissaLength = mantissaLengthMinor;
+                    cur++;
+                } else {
+                    mantissaLength = readPosInt(buffer, ++cur, argLen);
+                    cur += argLen;
+                }
+                break;
+            case TYPE_POSINT:
+            case TYPE_NEGINT:
+                mantissaLength = argLength(minor);
+                if (mantissaLength > 0) {
+                    cur++;
+                }
+                context = major;
+                break;
+            default:
+                throw new BadCborException("Unexpected major " + major, true);
+        }
+        BigInteger unscaled = readBigInteger(buffer, context, cur, mantissaLength);
+        return new BigDecimal(unscaled, -intExponent);
+    }
+
+    public static String readTextString(byte[] buffer, int off, int len) {
+        if (CborParser.isIndefinite(len)) {
+            return new String(readBytesIndefinite(buffer, off, CborParser.itemLength(len)), StandardCharsets.UTF_8);
+        } else {
+            return new String(buffer, off, len, StandardCharsets.UTF_8);
+        }
+    }
+
+    public static byte[] readByteString(byte[] buffer, int off, int len) {
+        if (CborParser.isIndefinite(len)) {
+            return readBytesIndefinite(buffer, off, CborParser.itemLength(len));
+        } else {
+            return readBytesFinite(buffer, off, len);
+        }
+    }
+
+    public static void readByteString(byte[] buffer, int off, byte[] dest, int destOff, int len) {
+        if (CborParser.isIndefinite(len)) {
+            readBytesIndefinite(buffer, off, dest, destOff, CborParser.itemLength(len));
+        } else {
+            readBytesFinite(buffer, off, dest, destOff, len);
+        }
+    }
+
+    private static byte[] readBytesFinite(byte[] b, int off, int len) {
+        byte[] dest = new byte[len];
+        readBytesFinite(b, off, dest, 0, len);
+        return dest;
+    }
+
+    private static void readBytesFinite(byte[] b, int off, byte[] dest, int destOff, int len) {
+        if (off + len > b.length) throw new BadCborException("out-of-bounds finite string read operands", true);
+        System.arraycopy(b, off, dest, destOff, len);
+    }
+
+    private static byte[] readBytesIndefinite(byte[] buffer, int off, int len) {
+        byte[] dest = new byte[len];
+        readBytesIndefinite(buffer, off, dest, 0, len);
+        return dest;
+    }
+
+    private static void readBytesIndefinite(byte[] buffer, int off, byte[] dest, int destOff, int len) {
+        int strPos = 0;
+        while (strPos < len) {
+            byte b = buffer[off];
+            int minor = b & MINOR_TYPE_MASK;
+            int argLen = argLength(minor);
+            int strLen = readStrLen(buffer, off, minor, argLen);
+            off += argLen + 1;
+            System.arraycopy(buffer, off, dest, destOff + strPos, strLen);
+            off += strLen;
+            strPos += strLen;
+        }
+        if (strPos != len) throw new BadCborException("cannot read unclosed indefinite length string");
+    }
+
+    /**
+     * Compares a byte sequence within the CBOR payload to an arbitrary byte sequence. It is assumed that the second
+     * sequence (argument {@code str}) is a freestanding byte sequence and does not contain CBOR indefinite length
+     * coding.
+     *
+     * @param buf  the CBOR payload
+     * @param bOff offset in {@code buf} where the byte sequence to compare begins
+     * @param bLen length of the byte sequence in {@code buf}
+     * @param str  the byte sequence to compare against
+     * @param sOff the offset in {@code str} where the sequence begins
+     * @param sLen the length of the sequence in {@code str} to compare against
+     * @return true if they match
+     */
+    public static boolean compareStringExternal(byte[] buf, int bOff, int bLen, byte[] str, int sOff, int sLen) {
+        if (CborParser.isIndefinite(bLen)) {
+            return compareIndefinite(buf, bOff, CborParser.itemLength(bLen), str, sOff, sLen);
+        } else {
+            return compareFinite(buf, bOff, bLen, str, sOff, sLen);
+        }
+    }
+
+    public static boolean compareStringsInPayload(byte[] buf, int off1, int len1, int off2, int len2) {
+        boolean indefinite1 = CborParser.isIndefinite(len1);
+        boolean indefinite2 = CborParser.isIndefinite(len2);
+        if (!indefinite1 && !indefinite2) {
+            return compareFinite(buf, off1, len1, buf, off2, len2);
+        } else {
+            // TODO: don't read one up front, or at least try to make sure we always use `compareFinite` when possible
+            byte[] one = CborReadUtil.readByteString(buf, off1, len1);
+            return compareStringExternal(buf, off2, len2, one, 0, one.length);
+        }
+    }
+
+    private static boolean compareIndefinite(byte[] buf, int bOff, int bLen, byte[] s, int sOff, int sLen) {
+        if (bLen != sLen) return false;
+        int lim = sOff + sLen;
+        while (sOff < lim) {
+            byte b = buf[bOff];
+            int minor = b & MINOR_TYPE_MASK;
+            int argLen = argLength(minor);
+            int chunkLen = readStrLen(buf, bOff, minor, argLen);
+            bOff += argLen + 1;
+            if (!compareFinite(buf, bOff, chunkLen, s, sOff, chunkLen)) return false;
+            bOff += chunkLen;
+            sOff += chunkLen;
+        }
+        if (sOff != lim) throw new BadCborException("cannot compare unclosed indefinite length string");
+        return true;
+    }
+
+    private static boolean compareFinite(byte[] buf, int bOff, int bLen, byte[] s, int sOff, int sLen) {
+        return Arrays.compare(buf, bOff, bLen, s, sOff, sLen) == 0;
+    }
+
+    private static byte getMajor(byte b) {
+        return (byte) ((b & MAJOR_TYPE_MASK) >> MAJOR_TYPE_SHIFT);
+    }
+
+    private static byte getMinor(byte b) {
+        return (byte) (b & MINOR_TYPE_MASK);
+    }
+
+    private CborReadUtil() {}
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborSerdeProvider.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborSerdeProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+
+public interface CborSerdeProvider {
+    int getPriority();
+
+    String getName();
+
+    ShapeDeserializer newDeserializer(byte[] source, Rpcv2CborCodec.Settings settings);
+
+    ShapeDeserializer newDeserializer(ByteBuffer source, Rpcv2CborCodec.Settings settings);
+
+    ShapeSerializer newSerializer(OutputStream sink, Rpcv2CborCodec.Settings settings);
+
+    ByteBuffer serialize(SerializableStruct struct, Rpcv2CborCodec.Settings settings);
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborSerializer.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/CborSerializer.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.EIGHT_BYTES;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.FOUR_BYTES;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.INDEFINITE;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.ONE_BYTE;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TAG_TIME_EPOCH;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TWO_BYTES;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_ARRAY;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_BYTESTRING;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_MAP;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_NEGINT;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_POSINT;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_SIMPLE_BREAK_STREAM;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_SIMPLE_DOUBLE;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_SIMPLE_FALSE;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_SIMPLE_FLOAT;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_SIMPLE_NULL;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_SIMPLE_TRUE;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_TAG;
+import static software.amazon.smithy.java.runtime.cbor.CborConstants.TYPE_TEXTSTRING;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.function.BiConsumer;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.serde.InterceptingSerializer;
+import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
+import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.runtime.core.serde.document.Document;
+
+final class CborSerializer implements ShapeSerializer {
+    private static final int MAP_STREAM = TYPE_MAP | INDEFINITE;
+    private static final int ARRAY_STREAM = TYPE_ARRAY | INDEFINITE;
+
+    private boolean[] collection = new boolean[4];
+    private int collectionIdx = -1;
+    private final Sink sink;
+    private final CborMapSerializer mapSerializer = new CborMapSerializer();
+    private final CborStructSerializer structSerializer = new CborStructSerializer();
+
+    public CborSerializer(Sink sink) {
+        this.sink = sink;
+    }
+
+    private void startMap(int size) {
+        boolean indefinite = size < 0;
+        if (indefinite) {
+            sink.write(MAP_STREAM);
+        } else {
+            tagAndLength(TYPE_MAP, size);
+        }
+        startCollection(indefinite);
+    }
+
+    private void startArray(int size) {
+        boolean indefinite = size < 0;
+        if (indefinite) {
+            sink.write(ARRAY_STREAM);
+        } else {
+            tagAndLength(TYPE_ARRAY, size);
+        }
+        startCollection(indefinite);
+    }
+
+    private void startCollection(boolean indefinite) {
+        int idx = ++collectionIdx;
+        boolean[] coll = collection;
+        int l = coll.length;
+        if (idx == l) {
+            collection = (coll = Arrays.copyOf(coll, l + (l >> 1)));
+        }
+        coll[idx] = indefinite;
+    }
+
+    private void endMap() {
+        if (collection[collectionIdx--]) {
+            sink.write(TYPE_SIMPLE_BREAK_STREAM);
+        }
+    }
+
+    private void endArray() {
+        if (collection[collectionIdx--]) {
+            sink.write(TYPE_SIMPLE_BREAK_STREAM);
+        }
+    }
+
+    private void tagAndLength(int type, int len) {
+        if (len < ONE_BYTE) {
+            sink.write(type | len);
+        } else if (len <= 0xFF) {
+            sink.write(type | ONE_BYTE);
+            sink.write(len);
+        } else if (len <= 0xFFFF) {
+            sink.write(type | TWO_BYTES);
+            write2Nonnegative(len);
+        } else {
+            sink.write(type | FOUR_BYTES);
+            write4Nonnegative(len);
+        }
+    }
+
+    private void write8Nonnegative(long l) {
+        sink.write((int) ((l >> 56) & 0xFF));
+        sink.write((int) ((l >> 48) & 0xFF));
+        sink.write((int) ((l >> 40) & 0xFF));
+        sink.write((int) ((l >> 32) & 0xFF));
+        sink.write((int) ((l >> 24) & 0xFF));
+        sink.write((int) ((l >> 16) & 0xFF));
+        sink.write((int) ((l >> 8) & 0xFF));
+        sink.write((int) ((l) & 0xFF));
+    }
+
+    private void write4Nonnegative(int i) {
+        sink.write((i >> 24) & 0xFF);
+        sink.write((i >> 16) & 0xFF);
+        sink.write((i >> 8) & 0xFF);
+        sink.write((i) & 0xFF);
+    }
+
+    private void write2Nonnegative(int i) {
+        sink.write((i >> 8) & 0xFF);
+        sink.write((i) & 0xFF);
+    }
+
+    private void writeLong(long l) {
+        byte type;
+        if (l < 0) {
+            l = -l - 1;
+            type = TYPE_NEGINT;
+        } else {
+            type = TYPE_POSINT;
+        }
+
+        if (l < ONE_BYTE) {
+            sink.write(type | (int) l);
+        } else if (l <= 0xFFL) {
+            sink.write(type | ONE_BYTE);
+            sink.write((int) l);
+        } else if (l <= 0xFFFFL) {
+            sink.write(type | TWO_BYTES);
+            write2Nonnegative((int) l);
+        } else if (l <= 0xFFFF_FFFFL) {
+            sink.write(type | FOUR_BYTES);
+            write4Nonnegative((int) l);
+        } else {
+            sink.write(type | EIGHT_BYTES);
+            write8Nonnegative(l);
+        }
+    }
+
+    private void writeBytes0(int type, byte[] b, int off, int len) {
+        tagAndLength(type, len);
+        sink.write(b, off, len);
+    }
+
+    @Override
+    public void writeStruct(Schema schema, SerializableStruct struct) {
+        sink.write(MAP_STREAM);
+        startCollection(true);
+        struct.serializeMembers(structSerializer);
+        endMap();
+    }
+
+    @Override
+    public <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {
+        startArray(size);
+        consumer.accept(listState, this);
+        endArray();
+    }
+
+    @Override
+    public <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer) {
+        startMap(size);
+        consumer.accept(mapState, mapSerializer);
+        endMap();
+    }
+
+    @Override
+    public void writeBoolean(Schema schema, boolean value) {
+        sink.write(value ? TYPE_SIMPLE_TRUE : TYPE_SIMPLE_FALSE);
+    }
+
+    @Override
+    public void writeByte(Schema schema, byte value) {
+        writeLong(value);
+    }
+
+    @Override
+    public void writeShort(Schema schema, short value) {
+        writeLong(value);
+    }
+
+    @Override
+    public void writeInteger(Schema schema, int value) {
+        writeLong(value);
+    }
+
+    @Override
+    public void writeLong(Schema schema, long value) {
+        writeLong(value);
+    }
+
+    @Override
+    public void writeFloat(Schema schema, float value) {
+        sink.write(TYPE_SIMPLE_FLOAT);
+        write4Nonnegative(Float.floatToRawIntBits(value));
+    }
+
+    @Override
+    public void writeDouble(Schema schema, double value) {
+        sink.write(TYPE_SIMPLE_DOUBLE);
+        write8Nonnegative(Double.doubleToRawLongBits(value));
+    }
+
+    @Override
+    public void writeString(Schema schema, String value) {
+        byte[] str = value.getBytes(StandardCharsets.UTF_8);
+        writeBytes0(TYPE_TEXTSTRING, str, 0, str.length);
+    }
+
+    @Override
+    public void writeBlob(Schema schema, ByteBuffer value) {
+        tagAndLength(TYPE_BYTESTRING, value.remaining());
+        sink.write(value);
+    }
+
+    @Override
+    public void writeBlob(Schema schema, byte[] value) {
+        writeBytes0(TYPE_BYTESTRING, value, 0, value.length);
+    }
+
+    @Override
+    public void writeTimestamp(Schema schema, Instant value) {
+        double epochSeconds = value.toEpochMilli() / 1000D;
+        sink.write(TYPE_TAG | TAG_TIME_EPOCH);
+        writeDouble(schema, epochSeconds);
+    }
+
+    @Override
+    public void writeNull(Schema schema) {
+        sink.write(TYPE_SIMPLE_NULL);
+    }
+
+    @Override
+    public void writeBigInteger(Schema schema, BigInteger value) {
+        // TODO: Add BigInteger support
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
+        // TODO: Add BigDecimal support
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeDocument(Schema schema, Document value) {
+        throw new UnsupportedOperationException();
+    }
+
+    private final class CborStructSerializer extends InterceptingSerializer {
+        @Override
+        protected ShapeSerializer before(Schema schema) {
+            String name = schema.memberName();
+            tagAndLength(TYPE_TEXTSTRING, name.length());
+            sink.writeAscii(name);
+            return CborSerializer.this;
+        }
+    }
+
+    private final class CborMapSerializer implements MapSerializer {
+        @Override
+        public <T> void writeEntry(
+            Schema keySchema,
+            String key,
+            T state,
+            BiConsumer<T, ShapeSerializer> valueSerializer
+        ) {
+            byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+            writeBytes0(TYPE_TEXTSTRING, keyBytes, 0, keyBytes.length);
+            valueSerializer.accept(state, CborSerializer.this);
+        }
+    }
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/DefaultCborSerdeProvider.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/DefaultCborSerdeProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+
+final class DefaultCborSerdeProvider implements CborSerdeProvider {
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+    @Override
+    public String getName() {
+        return "cbor";
+    }
+
+    @Override
+    public ShapeDeserializer newDeserializer(byte[] source, Rpcv2CborCodec.Settings settings) {
+        return new CborDeserializer(source);
+    }
+
+    @Override
+    public ShapeDeserializer newDeserializer(ByteBuffer source, Rpcv2CborCodec.Settings settings) {
+        return new CborDeserializer(source);
+    }
+
+    @Override
+    public ShapeSerializer newSerializer(OutputStream sink, Rpcv2CborCodec.Settings settings) {
+        return new CborSerializer(new Sink.OutputStreamSink(sink));
+    }
+
+    @Override
+    public ByteBuffer serialize(SerializableStruct struct, Rpcv2CborCodec.Settings settings) {
+        var sink = new Sink.ResizingSink();
+        var serializer = new CborSerializer(sink);
+        struct.serialize(serializer);
+        return sink.finish();
+    }
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/Rpcv2CborCodec.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/Rpcv2CborCodec.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.ServiceLoader;
+import software.amazon.smithy.java.runtime.core.serde.Codec;
+import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+
+public final class Rpcv2CborCodec implements Codec {
+    private static final CborSerdeProvider PROVIDER;
+
+    static {
+        final String preferredName = System.getProperty("smithy-java.cbor-provider");
+        CborSerdeProvider selected = null;
+        for (var provider : ServiceLoader.load(CborSerdeProvider.class)) {
+            if (preferredName != null) {
+                if (provider.getName().equals(preferredName)) {
+                    selected = provider;
+                    break;
+                }
+            }
+            if (selected == null) {
+                selected = provider;
+            } else if (provider.getPriority() > selected.getPriority()) {
+                selected = provider;
+            }
+        }
+        if (selected == null) {
+            selected = new DefaultCborSerdeProvider();
+        }
+        PROVIDER = selected;
+    }
+
+    private Rpcv2CborCodec() {
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public ShapeSerializer createSerializer(OutputStream sink) {
+        return PROVIDER.newSerializer(sink, new Rpcv2CborCodec.Settings());
+    }
+
+    @Override
+    public ShapeDeserializer createDeserializer(byte[] source) {
+        return PROVIDER.newDeserializer(source, new Rpcv2CborCodec.Settings());
+    }
+
+    @Override
+    public ShapeDeserializer createDeserializer(ByteBuffer source) {
+        return PROVIDER.newDeserializer(source, new Rpcv2CborCodec.Settings());
+    }
+
+    public record Settings() {}
+
+    public static final class Builder {
+        public Rpcv2CborCodec build() {
+            return new Rpcv2CborCodec();
+        }
+    }
+}

--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/Sink.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/Sink.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import software.amazon.smithy.java.runtime.core.serde.SerializationException;
+
+sealed interface Sink permits Sink.OutputStreamSink, Sink.ResizingSink, Sink.NullSink {
+    void write(byte[] b, int off, int len);
+
+    void write(byte[] b);
+
+    void write(int b);
+
+    void write(ByteBuffer b);
+
+    void writeAscii(String s);
+
+    default ByteBuffer finish() { return null; }
+
+    final class OutputStreamSink implements Sink {
+        private final OutputStream os;
+
+        public OutputStreamSink(OutputStream os) {
+            this.os = os;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            try {
+                os.write(b, off, len);
+            } catch (Exception e) {
+                throw new SerializationException(e);
+            }
+        }
+
+        @Override
+        public void write(byte[] b) {
+            try {
+                os.write(b);
+            } catch (Exception e) {
+                throw new SerializationException(e);
+            }
+        }
+
+        @Override
+        public void write(int b) {
+            try {
+                os.write(b);
+            } catch (Exception e) {
+                throw new SerializationException(e);
+            }
+        }
+
+        @Override
+        public void write(ByteBuffer b) {
+            try {
+                if (b.hasArray()) {
+                    os.write(b.array(), b.arrayOffset() + b.position(), b.remaining());
+                } else {
+                    copyNonArrayBB(b);
+                }
+            } catch (Exception e) {
+                throw new SerializationException(e);
+            }
+        }
+
+        @Override
+        public void writeAscii(String s) {
+            try {
+                os.write(s.getBytes(StandardCharsets.UTF_8));
+            } catch (Exception e) {
+                throw new SerializationException(e);
+            }
+        }
+
+        private void copyNonArrayBB(ByteBuffer b) throws Exception {
+            b = b.duplicate();
+            int rem = b.remaining();
+            byte[] copy = new byte[rem];
+            b.get(copy);
+            os.write(copy);
+        }
+    }
+
+    final class ResizingSink implements Sink {
+        private byte[] bytes = new byte[128];
+        private int pos;
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            ensureCapacity(len);
+            System.arraycopy(b, off, bytes, pos, len);
+            pos += len;
+        }
+
+        @Override
+        public void write(byte[] b) {
+            write(b, 0, b.length);
+        }
+
+        @Override
+        public void write(int b) {
+            bytes[pos++] = (byte) b;
+        }
+
+        @Override
+        public void write(ByteBuffer b) {
+            if (b.hasArray()) {
+                write(b.array(), b.position() + b.arrayOffset(), b.limit());
+            } else {
+                copyNonArrayBB(b);
+            }
+        }
+
+        @Override
+        public void writeAscii(String s) {
+            int len = s.length();
+            ensureCapacity(len);
+            s.getBytes(0, s.length(), bytes, pos);
+            pos += len;
+        }
+
+        private void copyNonArrayBB(ByteBuffer b) {
+            int rem = b.remaining();
+            ensureCapacity(rem);
+            b.duplicate().get(bytes);
+            pos += rem;
+        }
+
+        @Override
+        public ByteBuffer finish() {
+            return ByteBuffer.wrap(bytes, 0, pos);
+        }
+
+        private void ensureCapacity(int len) {
+            int cap = bytes.length;
+            if (pos + len > cap) {
+                bytes = Arrays.copyOf(bytes, cap + (cap >> 1));
+            }
+        }
+    }
+
+    final class NullSink implements Sink {
+        @Override
+        public void write(byte[] b, int off, int len) {
+
+        }
+
+        @Override
+        public void write(byte[] b) {
+
+        }
+
+        @Override
+        public void write(int b) {
+
+        }
+
+        @Override
+        public void write(ByteBuffer b) {
+
+        }
+
+        @Override
+        public void writeAscii(String s) {
+
+        }
+
+        @Override
+        public ByteBuffer finish() {
+            return ByteBuffer.wrap(new byte[0]);
+        }
+    }
+}

--- a/rpcv2-cbor-codec/src/test/java/software/amazon/smithy/java/runtime/cbor/CborParserTest.java
+++ b/rpcv2-cbor-codec/src/test/java/software/amazon/smithy/java/runtime/cbor/CborParserTest.java
@@ -1,0 +1,571 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static software.amazon.smithy.java.runtime.cbor.CborReadUtil.readByteString;
+import static software.amazon.smithy.java.runtime.cbor.CborReadUtil.readLong;
+import static software.amazon.smithy.java.runtime.cbor.CborReadUtil.readTextString;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.smithy.java.runtime.cbor.CborParser.Token;
+import software.amazon.smithy.java.runtime.core.serde.MapSerializer;
+import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.runtime.io.ByteBufferOutputStream;
+import software.amazon.smithy.java.runtime.io.ByteBufferUtils;
+
+public class CborParserTest {
+    private byte[] cbor;
+    private CborParser parser;
+
+    private static byte[] write(Consumer<CborSerializer> consumer) {
+        try (
+            var stream = new ByteBufferOutputStream(); var ser = new CborSerializer(new Sink.OutputStreamSink(stream))
+        ) {
+            try {
+                consumer.accept(ser);
+            } catch (StopWritingException ignored) {}
+            return ByteBufferUtils.getBytes(stream.toByteBuffer());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final class StopWritingException extends RuntimeException {
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
+        }
+    }
+
+    private void stopWriting(ShapeSerializer ser) {
+        throw new StopWritingException();
+    }
+
+    @Test
+    public void simple() {
+        cbor = write(os -> {
+            os.writeInteger(null, 1);
+            os.writeInteger(null, 1048576);
+            os.writeInteger(null, -1);
+        });
+
+        parser = new CborParser(cbor);
+
+        token(Token.POS_INT, 0, 0);
+        num(1);
+
+        token(Token.POS_INT, 2, 4);
+        num(1048576);
+
+        token(Token.NEG_INT, 6, 0);
+        num(-1);
+
+        finished();
+    }
+
+    @Test
+    public void incompleteImmediate() {
+        cbor = write(os -> {
+            writeList(os, Integer.MAX_VALUE, this::stopWriting);
+        });
+
+        parser = new CborParser(cbor);
+        token(Token.START_ARRAY);
+        Exception e = assertThrows(BadCborException.class, this::finished);
+        assertEquals("incomplete array: expecting " + Integer.MAX_VALUE + " more elements", e.getMessage());
+    }
+
+    @Test
+    public void bytestring() {
+        byte[] bigString = new byte[10];
+        Arrays.fill(bigString, (byte) 'A');
+        String s = "well howdy there";
+        cbor = write(io -> {
+            io.writeBlob(null, "hello".getBytes(StandardCharsets.UTF_8));
+            io.writeBlob(null, bigString);
+            io.writeString(null, s);
+        });
+        parser = new CborParser(cbor);
+
+        token(Token.BYTE_STRING, 1, 5);
+        string("hello");
+
+        token(Token.BYTE_STRING, 7, bigString.length);
+        string(bigString);
+
+        token(Token.TEXT_STRING, 18, s.length());
+        string(s);
+
+        finished();
+    }
+
+    @Test
+    public void nestedIndefiniteArrays() {
+        cbor = write(os -> {
+            writeList(os, -1, list -> {
+                list.writeInteger(null, 1);
+                writeList(list, -1, nested1 -> {
+                    nested1.writeInteger(null, 2);
+                    nested1.writeLong(null, Long.MIN_VALUE);
+                    writeList(nested1, -1, nested2 -> {
+                        nested2.writeString(null, "hello");
+                    });
+                });
+            });
+        });
+
+        parser = new CborParser(cbor);
+        token(Token.START_ARRAY, 0);
+
+        token(Token.POS_INT, 1, 0);
+        num(1);
+
+        token(Token.START_ARRAY, 2);
+
+        token(Token.POS_INT, 3, 0);
+        num(2);
+        token(Token.NEG_INT, 5, 8);
+        num(Long.MIN_VALUE);
+
+        token(Token.START_ARRAY, 13);
+        token(Token.TEXT_STRING, 15, 5);
+        string("hello");
+        token(Token.END_ARRAY, 20);
+
+        token(Token.END_ARRAY, 21);
+
+        token(Token.END_ARRAY, 22);
+
+        finished();
+    }
+
+    @Test
+    public void map() {
+        cbor = write(os -> {
+            writeMap(os, 1, map -> {
+                map.entry("key", e -> e.writeInteger(null, -1));
+            });
+            os.writeString(null, "not a key");
+        });
+        parser = new CborParser(cbor);
+
+        token(Token.START_OBJECT);
+        token(Token.KEY, 2, 3);
+
+        token(Token.NEG_INT, 5, 0);
+        num(-1);
+
+        token(Token.END_OBJECT);
+        token(Token.TEXT_STRING, 7, "not a key".length());
+
+        finished();
+    }
+
+    @ValueSource(ints = {1, 1024, 1040000, 19100100})
+    @ParameterizedTest
+    public void longList(int elements) {
+        cbor = write(os -> {
+            writeList(os, elements, list -> {
+                for (int i = 0; i < elements; i++) {
+                    os.writeInteger(null, i);
+                }
+            });
+        });
+        parser = new CborParser(cbor);
+
+        token(Token.START_ARRAY);
+        for (int i = 0; i < elements; i++) {
+            token(Token.POS_INT);
+            num(i);
+        }
+        token(Token.END_ARRAY);
+    }
+
+    @ValueSource(ints = {1, 1024, 1040000})
+    @ParameterizedTest
+    public void longMap(int elements) {
+        cbor = write(os -> {
+            writeMap(os, elements, map -> {
+                for (int i = 0; i < elements; i++) {
+                    os.writeString(null, Integer.toString(i));
+                    os.writeInteger(null, i);
+                }
+            });
+        });
+        parser = new CborParser(cbor);
+
+        token(Token.START_OBJECT);
+        for (int i = 0; i < elements; i++) {
+            token(Token.KEY);
+            string(Integer.toString(i));
+            token(Token.POS_INT);
+            num(i);
+        }
+        token(Token.END_OBJECT);
+    }
+
+    @Test
+    public void collectionsWithIndefiniteMembers() {
+        cbor = write(os -> {
+            writeMap(os, 1, map -> {
+                map.entry("key", e -> {
+                    writeList(e, -1, list -> {
+                        list.writeString(null, "value1");
+                        list.writeString(null, "value2");
+                    });
+                });
+            });
+
+            writeList(os, -1, list -> {
+                writeList(list, -1, nested -> {
+                    nested.writeString(null, "s");
+                });
+            });
+
+            writeList(os, 1, list -> {
+                writeList(list, -1, nested -> {
+                    nested.writeString(null, "s2");
+                });
+            });
+
+            writeList(os, -1, list -> {
+                writeList(list, 3, nested -> {
+                    nested.writeInteger(null, 1);
+                    nested.writeInteger(null, 2);
+                    nested.writeString(null, "three");
+                });
+
+                writeMap(list, -1, map -> {
+                    map.entry("it's my key!", v -> {
+                        writeMap(v, -1, nested -> {
+                            nested.entry("it's another nested key", nestedValue -> {
+                                nestedValue.writeInteger(null, 91919191);
+                            });
+                        });
+                    });
+
+                    map.entry("still just a key", value -> {
+                        writeList(value, -1, nested -> {
+                            nested.writeString(null, "array");
+                        });
+                    });
+                });
+            });
+        });
+        parser = new CborParser(cbor);
+
+        token(Token.START_OBJECT);
+        token(Token.KEY, 2, 3);
+        string("key");
+        token(Token.START_ARRAY);
+        token(Token.TEXT_STRING);
+        string("value1");
+        token(Token.TEXT_STRING);
+        string("value2");
+        token(Token.END_ARRAY);
+        token(Token.END_OBJECT);
+
+        token(Token.START_ARRAY);
+        token(Token.START_ARRAY);
+        token(Token.TEXT_STRING);
+        string("s");
+        token(Token.END_ARRAY);
+        token(Token.END_ARRAY);
+
+        token(Token.START_ARRAY);
+        token(Token.START_ARRAY);
+        token(Token.TEXT_STRING);
+        string("s2");
+        token(Token.END_ARRAY);
+        token(Token.END_ARRAY);
+
+        token(Token.START_ARRAY);
+        token(Token.START_ARRAY);
+        token(Token.POS_INT);
+        num(1);
+        token(Token.POS_INT);
+        num(2);
+        token(Token.TEXT_STRING);
+        string("three");
+        token(Token.END_ARRAY);
+
+        token(Token.START_OBJECT);
+        token(Token.KEY);
+        string("it's my key!");
+        token(Token.START_OBJECT);
+        token(Token.KEY);
+        string("it's another nested key");
+        token(Token.POS_INT);
+        num(91919191);
+        token(Token.END_OBJECT);
+        token(Token.KEY);
+        string("still just a key");
+        token(Token.START_ARRAY);
+        token(Token.TEXT_STRING);
+        string("array");
+        token(Token.END_ARRAY);
+        token(Token.END_OBJECT);
+
+        token(Token.END_ARRAY);
+        token(Token.FINISHED);
+    }
+
+    @Test
+    public void nestedCollections() {
+        cbor = write(os -> {
+            writeMap(os, 2, map -> {
+                map.entry("AAA", value -> value.writeInteger(null, 1));
+                map.entry("BBB", value -> writeMap(value, 1, nested -> {
+                    nested.entry("CCC", nestedValue -> {
+                        nestedValue.writeString(null, "DDDDD");
+                    });
+                }));
+            });
+        });
+
+        parser = new CborParser(cbor);
+
+        token(Token.START_OBJECT);
+        token(Token.KEY, 2, 3);
+        string("AAA");
+        token(Token.POS_INT, 5, 0);
+        num(1);
+        token(Token.KEY, 7, 3);
+        string("BBB");
+        token(Token.START_OBJECT);
+        token(Token.KEY, 12, 3);
+        string("CCC");
+        token(Token.TEXT_STRING, 16, 5);
+        string("DDDDD");
+        token(Token.END_OBJECT);
+        token(Token.END_OBJECT);
+        token(Token.FINISHED);
+    }
+
+    @Test
+    public void array() {
+        cbor = write(os -> {
+            List<Integer> ints = Arrays.asList(1, 2, 3, 31);
+            writeList(os, ints.size(), list -> {
+                ints.forEach(i -> list.writeInteger(null, i));
+            });
+        });
+
+        parser = new CborParser(cbor);
+        token(Token.START_ARRAY);
+        assertEquals(1, parser.getPosition());
+
+        token(Token.POS_INT);
+        num(1);
+        token(Token.POS_INT);
+        num(2);
+        token(Token.POS_INT);
+        num(3);
+        token(Token.POS_INT);
+        num(31);
+
+        token(Token.END_ARRAY);
+
+        token(Token.FINISHED);
+    }
+
+    @Test
+    public void booleans() {
+        cbor = write(os -> {
+            os.writeBoolean(null, false);
+            os.writeBoolean(null, true);
+        });
+
+        parser = new CborParser(cbor);
+        token(Token.FALSE);
+        token(Token.TRUE);
+        token(Token.FINISHED);
+    }
+
+    @Test
+    public void floats() {
+        cbor = write(os -> {
+            os.writeDouble(null, 1);
+            os.writeFloat(null, 0.1f);
+        });
+
+        parser = new CborParser(cbor);
+        token(Token.FLOAT);
+        token(Token.FLOAT);
+        token(Token.FINISHED);
+    }
+
+    @Test
+    public void bigDecimalLongExponent() {
+        byte[][] payloads = new byte[][]{
+            new byte[]{-60, -126, 27, 0, 0, 0, 7, -1, -1, -1, -1, 1},
+            new byte[]{-60, -126, 59, 0, 0, 0, 7, -1, -1, -1, -1, 1},
+        };
+        for (byte[] payload : payloads) {
+            cbor = payload;
+            parser = new CborParser(cbor);
+            token(Token.BIG_DECIMAL);
+            assertThrows(BadCborException.class, () -> CborReadUtil.readBigDecimal(cbor, parser.getPosition()));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void incompleteCollection(boolean map) {
+        cbor = write(os -> {
+            if (map) {
+                writeMap(os, 2, c -> {
+                    c.entry("hi", value -> value.writeString(null, "hi"));
+                });
+            } else {
+                writeList(os, 2, c -> {
+                    c.writeString(null, "hi");
+                });
+            }
+        });
+        parser = new CborParser(cbor);
+
+        token(map ? Token.START_OBJECT : Token.START_ARRAY);
+        token(map ? Token.KEY : Token.TEXT_STRING);
+        string("hi");
+        if (map) {
+            token(Token.TEXT_STRING);
+            string("hi");
+        }
+        expectFailure("incomplete " + (map ? "map" : "array"));
+    }
+
+    @Test
+    public void missingMapValue() {
+        cbor = write(os -> {
+            writeMap(os, 1, map -> {
+                map.entry("hi", this::stopWriting);
+            });
+        });
+        parser = new CborParser(cbor);
+
+        token(Token.START_OBJECT);
+        token(Token.KEY);
+        string("hi");
+        expectFailure("incomplete map");
+    }
+
+    @Test
+    public void date() {
+        Date time = new Date();
+        cbor = write(os -> {
+            os.writeTimestamp(null, time.toInstant());
+        });
+
+        parser = new CborParser(cbor);
+        token(Token.EPOCH_F);
+        num(Double.doubleToRawLongBits(time.getTime() / 1000d));
+        finished();
+    }
+
+    @Test
+    public void negativeDate() {
+        Date d = new Date(-1000);
+        cbor = write(os -> {
+            os.writeTimestamp(null, d.toInstant());
+        });
+
+        parser = new CborParser(cbor);
+        token(Token.EPOCH_F);
+        num(d.getTime() / 1000d);
+        finished();
+    }
+
+    private void token(byte token) {
+        byte next = parser.advance();
+        assertEquals(token, next, "expected " + Token.name(token) + " but got " + Token.name(next));
+    }
+
+    private void token(byte token, int position) {
+        token(token);
+        assertEquals(position, parser.getPosition(), "expected pos " + position + " but was " + parser.getPosition());
+    }
+
+    private void token(byte token, int position, int itemLength) {
+        token(token, position);
+        assertEquals(
+            itemLength,
+            CborParser.itemLength(parser.getItemLength()),
+            "expected len " + itemLength
+                + " but was " + CborParser.itemLength(parser.getItemLength())
+        );
+    }
+
+    private void num(double d) {
+        num(Double.doubleToRawLongBits(d), Token.POS_INT);
+    }
+
+    private void num(long n) {
+        num(n, n < 0 ? Token.NEG_INT : Token.POS_INT);
+    }
+
+    private void num(long n, byte token) {
+        assertEquals(n, readLong(cbor, token, parser.getPosition(), parser.getItemLength()));
+    }
+
+    private void string(String s) {
+        assertEquals(s, readTextString(cbor, parser.getPosition(), parser.getItemLength()));
+    }
+
+    private void string(byte[] b) {
+        assertArrayEquals(b, readByteString(cbor, parser.getPosition(), parser.getItemLength()));
+    }
+
+    private void finished() {
+        token(Token.FINISHED, cbor.length, 0);
+    }
+
+    private void lengthIsFinite() {
+        assertFalse(CborParser.isIndefinite(parser.getItemLength()));
+    }
+
+    private void lengthIsIndefinite() {
+        assertTrue(CborParser.isIndefinite(parser.getItemLength()));
+    }
+
+    private void expectFailure(String msg) {
+        BadCborException e = assertThrows(BadCborException.class, parser::advance);
+        assertTrue(e.getMessage().contains(msg), e.getMessage());
+    }
+
+    private static void writeList(ShapeSerializer s, int len, Consumer<ShapeSerializer> listHandler) {
+        s.writeList(null, null, len, ($, l) -> listHandler.accept(l));
+    }
+
+    private static void writeMap(ShapeSerializer s, int len, Consumer<WriteEntry> mapHandler) {
+        s.writeMap(null, null, len, ($, l) -> mapHandler.accept(new WriteEntry(l)));
+    }
+
+    private static final class WriteEntry {
+        private final MapSerializer m;
+
+        private WriteEntry(MapSerializer m) {
+            this.m = m;
+        }
+
+        void entry(String key, Consumer<ShapeSerializer> val) {
+            m.writeEntry(null, key, null, ($, s) -> val.accept(s));
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ include(":http-binding")
 
 include(":json-codec")
 include(":xml-codec")
+include(":rpcv2-cbor-codec")
 
 include(":client-core")
 include(":client-http")
@@ -53,3 +54,4 @@ include(":aws:sigv4")
 include(":aws:client-awsjson")
 include(":aws:client-restjson")
 include(":aws:client-restxml")
+include(":aws:client-rpcv2-cbor-protocol")


### PR DESCRIPTION
This commit adds basic client-side support for RPCv2. Tests that check for `@clientOptional` behavior are ignored.