### PR TITLE
Fix skipping logic of protocol tests

### DIFF
--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientRequestProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientRequestProtocolTestProvider.java
@@ -79,7 +79,7 @@ final class HttpClientRequestProtocolTestProvider extends
                             inputBuilder.build(),
                             overrideBuilder.build(),
                             testTransport::getCapturedRequest,
-                            filter.skipOperation(operation.id()) || filter.skipTestCase(testCase, TestType.CLIENT)
+                            filter.skipOperation(operation.id()) || filter.skipTestCase(testCase)
                         );
                     })
             );

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
@@ -78,7 +78,7 @@ final class HttpClientResponseProtocolTestProvider extends
                             input,
                             outputBuilder.build(),
                             overrideBuilder.build(),
-                            filter.skipOperation(operation.id()) || filter.skipTestCase(testCase, TestType.CLIENT)
+                            filter.skipOperation(operation.id()) || filter.skipTestCase(testCase)
 
                         );
                     })

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerRequestProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerRequestProtocolTestProvider.java
@@ -27,7 +27,6 @@ import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
-import software.amazon.smithy.protocoltests.traits.AppliesTo;
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase;
 
 public class HttpServerRequestProtocolTestProvider extends
@@ -56,9 +55,6 @@ public class HttpServerRequestProtocolTestProvider extends
             var testOperation = serverTestOperation.operation();
             boolean shouldSkip = testFilter.skipOperation(testOperation.id());
             for (var testCase : testOperation.requestTestCases()) {
-                if (testCase.getAppliesTo().filter(t -> t == AppliesTo.SERVER).isPresent()) {
-                    continue;
-                }
                 var createUri = createUri(testData.endpoint(), testCase.getUri(), testCase.getQueryParams());
                 var headers = createHeaders(testCase.getHeaders());
                 var request = SmithyHttpRequest.builder()

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerResponseProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerResponseProtocolTestProvider.java
@@ -27,7 +27,6 @@ import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpResponse;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpVersion;
 import software.amazon.smithy.java.runtime.io.datastream.DataStream;
-import software.amazon.smithy.protocoltests.traits.AppliesTo;
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestCase;
 
 public class HttpServerResponseProtocolTestProvider extends
@@ -55,9 +54,6 @@ public class HttpServerResponseProtocolTestProvider extends
             var testOperation = serverTestOperation.operation();
             boolean shouldSkip = filter.skipOperation(testOperation.id());
             for (var testCase : testOperation.responseTestCases()) {
-                if (testCase.getAppliesTo().filter(t -> t == AppliesTo.SERVER).isPresent()) {
-                    continue;
-                }
                 Map<String, List<String>> headers = new HashMap<>();
                 headers.put("x-protocol-test-protocol-id", List.of(testCase.getProtocol().toString()));
                 headers.put("x-protocol-test-service", List.of(testOperation.serviceId().toString()));

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/TestFilter.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/TestFilter.java
@@ -26,11 +26,7 @@ sealed interface TestFilter {
     /**
      * Filters test cases
      */
-    boolean skipTestCase(HttpMessageTestCase testCase, TestType testType);
-
-    default boolean skipTestCase(HttpMessageTestCase testCase) {
-        return skipTestCase(testCase, null);
-    }
+    boolean skipTestCase(HttpMessageTestCase testCase);
 
     default TestFilter combine(TestFilter other) {
         return new CombinedTestFilter(this, other);
@@ -76,12 +72,9 @@ sealed interface TestFilter {
         }
 
         @Override
-        public boolean skipTestCase(HttpMessageTestCase testCase, TestType testType) {
+        public boolean skipTestCase(HttpMessageTestCase testCase) {
             return skippedTests.contains(testCase.getId())
-                || (!tests.isEmpty() && !tests.contains(testCase.getId()))
-                || (testType != null
-                    && testCase.getAppliesTo().isPresent()
-                    && !testCase.getAppliesTo().get().equals(testType.appliesTo));
+                || (!tests.isEmpty() && !tests.contains(testCase.getId()));
         }
     }
 
@@ -93,7 +86,7 @@ sealed interface TestFilter {
         }
 
         @Override
-        public boolean skipTestCase(HttpMessageTestCase testCase, TestType testType) {
+        public boolean skipTestCase(HttpMessageTestCase testCase) {
             return false;
         }
     }
@@ -114,8 +107,8 @@ sealed interface TestFilter {
         }
 
         @Override
-        public boolean skipTestCase(HttpMessageTestCase testCase, TestType testType) {
-            return first.skipTestCase(testCase, testType) || second.skipTestCase(testCase, testType);
+        public boolean skipTestCase(HttpMessageTestCase testCase) {
+            return first.skipTestCase(testCase) || second.skipTestCase(testCase);
         }
     }
 }

--- a/server-aws-rest-json1/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
+++ b/server-aws-rest-json1/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
@@ -41,6 +41,8 @@ public class AwsRestJson1ProtocolTests {
             "SDKAppendedGzipAfterProvidedEncoding_restJson1",
             "RestJsonClientPopulatesDefaultValuesInInput",
             "RestJsonClientUsesExplicitlyProvidedMemberValuesOverDefaults",
+            "RestJsonMustSupportParametersInContentType", //hangs on the client side some reason
+            "RestJsonServerPopulatesDefaultsWhenMissingInRequestBody",
 
             // Header splitting needs work.
             "RestJsonInputAndOutputWithQuotedStringHeaders",
@@ -75,7 +77,8 @@ public class AwsRestJson1ProtocolTests {
             "RestJsonEnumPayloadResponse",
             "RestJsonStreamingTraitsWithBlob",
             "RestJsonStreamingTraitsWithMediaTypeWithBlob",
-            "RestJsonDeserializesDenseSetMapAndSkipsNull"
+            "RestJsonDeserializesDenseSetMapAndSkipsNull",
+            "RestJsonServerPopulatesDefaultsInResponseWhenMissingInParams"
         }
     )
     public void responseTest(DataStream expected, DataStream actual) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There we two issues in the Protocol Tests skipping tests logic,

1. For Client tests, all appliesTo(Server) tests were being shown as skipped. This is unnecessarily verbose, since for client tests I want to only show those tests to be skipped which are added in the ProtocolTestFilter.
2. For Server tests we were incorrectly skipping all tests which were only applied to server. This led to adding some more tests which need to be skipped for now, will fix them when we start fixing all broken tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
