### PR TITLE
Add a timeout to protocol tests

### DIFF
--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientRequestTests.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientRequestTests.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.annotation.Testable;
 
@@ -17,5 +18,6 @@ import org.junit.platform.commons.annotation.Testable;
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate
 @Testable
+@Timeout(5)
 @ExtendWith(HttpClientRequestProtocolTestProvider.class)
 public @interface HttpClientRequestTests {}

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseTests.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseTests.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.annotation.Testable;
 
@@ -17,5 +18,6 @@ import org.junit.platform.commons.annotation.Testable;
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate
 @Testable
+@Timeout(5)
 @ExtendWith(HttpClientResponseProtocolTestProvider.class)
 public @interface HttpClientResponseTests {}

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerRequestTests.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerRequestTests.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.annotation.Testable;
 
@@ -17,6 +18,7 @@ import org.junit.platform.commons.annotation.Testable;
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate
 @Testable
+@Timeout(5)
 @ExtendWith(HttpServerRequestProtocolTestProvider.class)
 public @interface HttpServerRequestTests {
 

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerResponseTests.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerResponseTests.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.annotation.Testable;
 
@@ -17,6 +18,7 @@ import org.junit.platform.commons.annotation.Testable;
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate
 @Testable
+@Timeout(5)
 @ExtendWith(HttpServerResponseProtocolTestProvider.class)
 public @interface HttpServerResponseTests {
 }

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ServerTestClient.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ServerTestClient.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 import software.amazon.smithy.java.runtime.http.api.HttpHeaders;
 import software.amazon.smithy.java.runtime.http.api.SmithyHttpRequest;
@@ -24,7 +25,7 @@ final class ServerTestClient {
 
     private ServerTestClient(URI endpoint) {
         this.endpoint = endpoint;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(4)).build();
     }
 
     public static ServerTestClient get(URI endpoint) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a blanket 5 second timeout to all protocol tests. Also use a 4 second timeout in the client used for server tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
