### PR TITLE
Run spotlessApply before spotlessCheck

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
@@ -117,6 +117,10 @@ tasks.named("spotbugsTest") {
     enabled = false
 }
 
+tasks.spotlessCheck {
+    dependsOn(tasks.spotlessApply)
+}
+
 /*
  * Repositories
  * ================================


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Its kind of annoying that spotless keeps failing in the test change repeat cycle because we keep forgetting to format the code. This change runs the formatter before running the format check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
