### PR TITLE
Avoid naming clashes on schema and InnerDeserializer

### DIFF
--- a/codegen/core/src/it/resources/META-INF/smithy/naming/naming-collision.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/naming/naming-collision.smithy
@@ -16,9 +16,11 @@ operation Naming {
         type: Type
 
         object: Object
-        
+
         // Collides with `serializer` input to serializeMembers
         serializer: String
+
+        innerDeserializer: ShapeSerializer
     }
     errors: [
         IllegalArgumentException
@@ -46,6 +48,11 @@ structure Object {
     notifyAll: String
     wait: String
     finalize: String
+}
+
+@private
+structure ShapeSerializer {
+    schema: String
 }
 
 /// This will clash with built in `java.lang` exception used a number

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -49,6 +49,9 @@ public final class CodegenUtils {
     private static final URL OBJECT_RESERVED_MEMBERS_FILE = Objects.requireNonNull(
         CodegenUtils.class.getResource("object-reserved-members.txt")
     );
+    private static final URL SMITHY_RESERVED_MEMBERS_FILE = Objects.requireNonNull(
+        CodegenUtils.class.getResource("smithy-reserved-members.txt")
+    );
 
     public static final ReservedWords SHAPE_ESCAPER = new ReservedWordsBuilder()
         .loadCaseInsensitiveWords(RESERVED_WORDS_FILE, word -> word + "Shape")
@@ -56,7 +59,7 @@ public final class CodegenUtils {
     public static final ReservedWords MEMBER_ESCAPER = new ReservedWordsBuilder()
         .loadCaseInsensitiveWords(RESERVED_WORDS_FILE, word -> word + "Member")
         .loadCaseInsensitiveWords(OBJECT_RESERVED_MEMBERS_FILE, word -> word + "Member")
-        .put("serializer", "serializerMember")
+        .loadCaseInsensitiveWords(SMITHY_RESERVED_MEMBERS_FILE, word -> word + "Member")
         .build();
 
     private static final String SCHEMA_STATIC_NAME = "$SCHEMA";

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureDeserializerGenerator.java
@@ -24,18 +24,18 @@ record StructureDeserializerGenerator(
         var template = """
             @Override
             public Builder deserialize(${shapeDeserializer:N} decoder) {
-                decoder.readStruct($$SCHEMA, this, InnerDeserializer.INSTANCE);
+                decoder.readStruct($$SCHEMA, this, $$InnerDeserializer.INSTANCE);
                 return this;
             }
 
             @Override
             public Builder deserializeMember(${shapeDeserializer:N} decoder, ${sdkSchema:N} schema) {
-                decoder.readStruct(schema.assertMemberTargetIs($$SCHEMA), this, InnerDeserializer.INSTANCE);
+                decoder.readStruct(schema.assertMemberTargetIs($$SCHEMA), this, $$InnerDeserializer.INSTANCE);
                 return this;
             }
 
-            private static final class InnerDeserializer implements ${shapeDeserializer:T}.StructMemberConsumer<Builder> {
-                private static final InnerDeserializer INSTANCE = new InnerDeserializer();
+            private static final class $$InnerDeserializer implements ${shapeDeserializer:T}.StructMemberConsumer<Builder> {
+                private static final $$InnerDeserializer INSTANCE = new $$InnerDeserializer();
 
                 @Override
                 public void accept(Builder builder, ${sdkSchema:T} member, ${shapeDeserializer:T} de) {${?hasMembers}

--- a/codegen/core/src/main/resources/software/amazon/smithy/java/codegen/reserved-words.txt
+++ b/codegen/core/src/main/resources/software/amazon/smithy/java/codegen/reserved-words.txt
@@ -33,7 +33,6 @@ goto
 if
 implements
 import
-innerDeserializer
 type
 instanceof
 int

--- a/codegen/core/src/main/resources/software/amazon/smithy/java/codegen/smithy-reserved-members.txt
+++ b/codegen/core/src/main/resources/software/amazon/smithy/java/codegen/smithy-reserved-members.txt
@@ -1,0 +1,12 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Member names reserved for Smithy interfaces or fields that are generated into
+# customer-defined objects. Member getters with any of these names will attempt
+# to override APIs reserved for Smithy's use unless escaped.
+#
+# Note: Only zero-args methods are a problem here.
+innerDeserializer
+schema
+serializer


### PR DESCRIPTION
I don't love that we have to reserve `schema` for ourselves.