### PR TITLE
Fix Client Response Protocol test runner

### DIFF
--- a/aws/client-awsjson/src/it/java/software/amazon/smithy/java/runtime/client/aws/jsonprotocols/AwsJson1ProtocolTests.java
+++ b/aws/client-awsjson/src/it/java/software/amazon/smithy/java/runtime/client/aws/jsonprotocols/AwsJson1ProtocolTests.java
@@ -50,7 +50,10 @@ public class AwsJson1ProtocolTests {
 
     @HttpClientResponseTests
     @ProtocolTestFilter(
-        skipTests = {}
+        skipTests = {
+            "AwsJson10ClientPopulatesDefaultsValuesWhenMissingInResponse",
+            "AwsJson10ClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse"
+        }
     )
     public void responseTest(Runnable test) throws Exception {
         test.run();

--- a/aws/client-restjson/src/it/java/software/amazon/smithy/java/runtime/client/aws/restjson/RestJson1ProtocolTests.java
+++ b/aws/client-restjson/src/it/java/software/amazon/smithy/java/runtime/client/aws/restjson/RestJson1ProtocolTests.java
@@ -68,6 +68,22 @@ public class RestJson1ProtocolTests {
     }
 
     @HttpClientResponseTests
+    @ProtocolTestFilter(
+        skipTests = {
+            "RestJsonDateTimeWithFractionalSeconds",
+            "RestJsonInputAndOutputWithQuotedStringHeaders",
+            "RestJsonHttpPrefixHeadersArePresent",
+            "HttpPrefixHeadersResponse",
+            "RestJsonHttpPayloadTraitsWithBlob",
+            "RestJsonHttpPayloadTraitsWithMediaTypeWithBlob",
+            "RestJsonEnumPayloadResponse",
+            "RestJsonStringPayloadResponse",
+            "RestJsonHttpPayloadWithUnion",
+            "RestJsonInputAndOutputWithQuotedStringHeaders",
+            "DocumentTypeAsPayloadOutput",
+            "DocumentTypeAsPayloadOutputString"
+        }
+    )
     public void responseTest(Runnable test) {
         test.run();
     }

--- a/aws/client-restxml/src/it/java/software/amazon/smithy/java/runtime/aws/client/restxml/RestXmlProtocolTests.java
+++ b/aws/client-restxml/src/it/java/software/amazon/smithy/java/runtime/aws/client/restxml/RestXmlProtocolTests.java
@@ -64,6 +64,28 @@ public class RestXmlProtocolTests {
     }
 
     @HttpClientResponseTests
+    @ProtocolTestFilter(
+        skipTests = {
+            "XmlEnums",
+            "XmlIntEnums",
+            "XmlLists",
+            "XmlMaps",
+            "XmlMapsXmlName",
+            "FlatNestedXmlMapResponse",
+            "FlattenedXmlMap",
+            "FlattenedXmlMapWithXmlName",
+            "RestXmlFlattenedXmlMapWithXmlNamespace",
+            "RestXmlXmlMapWithXmlNamespace",
+            "RestXmlDateTimeWithFractionalSeconds",
+            "HttpPrefixHeadersArePresent", //failing due to case mismatch in keys
+            "HttpPayloadTraitsWithBlob",
+            "HttpPayloadTraitsWithMediaTypeWithBlob",
+            "RestXmlEnumPayloadResponse",
+            "RestXmlStringPayloadResponse",
+            "RestXmlHttpPayloadWithUnion",
+            "BodyWithXmlName"
+        }
+    )
     public void responseTest(Runnable test) {
         test.run();
     }

--- a/aws/client-rpcv2-cbor-protocol/src/it/java/software/amazon/smithy/java/runtime/client/rpcv2/RpcV2CborProtocolTests.java
+++ b/aws/client-rpcv2-cbor-protocol/src/it/java/software/amazon/smithy/java/runtime/client/rpcv2/RpcV2CborProtocolTests.java
@@ -36,6 +36,12 @@ public class RpcV2CborProtocolTests {
     }
 
     @HttpClientResponseTests
+    @ProtocolTestFilter(
+        skipTests = {
+            "RpcV2CborDateTimeWithFractionalSeconds",
+            "RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse"
+        }
+    )
     public void responseTest(Runnable test) {
         test.run();
     }

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ComparisonUtils.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ComparisonUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.protocoltests.harness;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Comparator;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
+import software.amazon.smithy.java.runtime.core.serde.document.Document;
+import software.amazon.smithy.java.runtime.io.ByteBufferUtils;
+import software.amazon.smithy.java.runtime.io.datastream.DataStream;
+
+final class ComparisonUtils {
+
+    private ComparisonUtils() {}
+
+    static RecursiveComparisonConfiguration getComparisonConfig() {
+        return RecursiveComparisonConfiguration.builder()
+            // Compare data streams by contained data
+            .withComparatorForType(
+                Comparator.comparing(d -> new StringBuildingSubscriber(d).getResult()),
+                DataStream.class
+            )
+            .withComparatorForType(
+                Comparator.comparing(ByteBufferUtils::getBytes, Arrays::compare),
+                ByteBuffer.class
+            )
+            // Compare doubles and floats as longs so NaN's will be equatable
+            .withComparatorForType(nanPermittingDoubleComparator(), Double.class)
+            .withComparatorForType(nanPermittingFloatComparator(), Float.class)
+            .withComparatorForType((a, b) -> Document.equals(a, b) ? 0 : 1, Document.class)
+            .build();
+    }
+
+    private static Comparator<Double> nanPermittingDoubleComparator() {
+        return (d1, d2) -> (Double.isNaN(d1) && Double.isNaN(d2)) ? 0 : Double.compare(d1, d2);
+    }
+
+    private static Comparator<Float> nanPermittingFloatComparator() {
+        return (f1, f2) -> (Float.isNaN(f1) && Float.isNaN(f2)) ? 0 : Float.compare(f1, f2);
+    }
+}

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.java.protocoltests.harness;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -90,7 +92,7 @@ final class HttpClientResponseProtocolTestProvider extends
         MockClient mockClient,
         ApiOperation apiOperation,
         SerializableStruct input,
-        SerializableStruct output,
+        SerializableStruct expectedOutput,
         RequestOverrideConfig overrideConfig,
         boolean shouldSkip
     ) implements TestTemplateInvocationContext {
@@ -104,8 +106,10 @@ final class HttpClientResponseProtocolTestProvider extends
         public List<Extension> getAdditionalExtensions() {
             return List.of((ProtocolTestParameterResolver) () -> {
                 Assumptions.assumeFalse(shouldSkip);
-                mockClient.clientRequest(input, apiOperation, overrideConfig);
-                // No additional assertions are needed if the request successfully completes.
+                var actualOutput = mockClient.clientRequest(input, apiOperation, overrideConfig);
+                assertThat(actualOutput)
+                    .usingRecursiveComparison(ComparisonUtils.getComparisonConfig())
+                    .isEqualTo(expectedOutput);
             });
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently we don't compare the response of the client with the params in the protocol test spec which is incorrect. This causes a bunch of tests to fail which I have filtered out for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
