### PR TITLE
Add ApiOperation to interceptor hooks

### DIFF
--- a/aws/client-restxml/src/it/java/software/amazon/smithy/java/runtime/aws/client/restxml/RestXmlProtocolTests.java
+++ b/aws/client-restxml/src/it/java/software/amazon/smithy/java/runtime/aws/client/restxml/RestXmlProtocolTests.java
@@ -83,7 +83,7 @@ public class RestXmlProtocolTests {
             "RestXmlEnumPayloadResponse",
             "RestXmlStringPayloadResponse",
             "RestXmlHttpPayloadWithUnion",
-            "BodyWithXmlName", 
+            "BodyWithXmlName",
             "NestedXmlMapWithXmlNameDeserializes"
         }
     )

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptor.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptor.java
@@ -61,7 +61,7 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      */
-    default void readBeforeExecution(InputHook<?> hook) {}
+    default void readBeforeExecution(InputHook<?, ?> hook) {}
 
     /**
      * A hook called before the input message is serialized into a transport message.
@@ -85,7 +85,7 @@ public interface ClientInterceptor {
      * @return the updated input.
      * @param <I> Input type.
      */
-    default <I extends SerializableStruct> I modifyBeforeSerialization(InputHook<I> hook) {
+    default <I extends SerializableStruct> I modifyBeforeSerialization(InputHook<I, ?> hook) {
         return hook.input();
     }
 
@@ -103,7 +103,7 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      */
-    default void readBeforeSerialization(InputHook<?> hook) {}
+    default void readBeforeSerialization(InputHook<?, ?> hook) {}
 
     /**
      * A hook called after the input message is marshalled into a protocol-specific request.
@@ -120,7 +120,7 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      */
-    default void readAfterSerialization(RequestHook<?, ?> hook) {}
+    default void readAfterSerialization(RequestHook<?, ?, ?> hook) {}
 
     /**
      * A hook called before the retry loop is entered that can be used to modify and return a new request.
@@ -140,7 +140,7 @@ public interface ClientInterceptor {
      * @return the updated protocol-specific request entry to send.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <RequestT> RequestT modifyBeforeRetryLoop(RequestHook<?, RequestT> hook) {
+    default <RequestT> RequestT modifyBeforeRetryLoop(RequestHook<?, ?, RequestT> hook) {
         return hook.request();
     }
 
@@ -160,7 +160,7 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      */
-    default void readBeforeAttempt(RequestHook<?, ?> hook) {}
+    default void readBeforeAttempt(RequestHook<?, ?, ?> hook) {}
 
     /**
      * A hook called before the request is signed; this method can modify and return a new request.
@@ -182,7 +182,7 @@ public interface ClientInterceptor {
      * @return the protocol-specific request.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <RequestT> RequestT modifyBeforeSigning(RequestHook<?, RequestT> hook) {
+    default <RequestT> RequestT modifyBeforeSigning(RequestHook<?, ?, RequestT> hook) {
         return hook.request();
     }
 
@@ -200,7 +200,7 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      */
-    default void readBeforeSigning(RequestHook<?, ?> hook) {}
+    default void readBeforeSigning(RequestHook<?, ?, ?> hook) {}
 
     /**
      * A hook called after the transport request message is signed.
@@ -216,7 +216,7 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      */
-    default void readAfterSigning(RequestHook<?, ?> hook) {}
+    default void readAfterSigning(RequestHook<?, ?, ?> hook) {}
 
     /**
      * A hook called before the transport request message is sent to the service.
@@ -240,7 +240,7 @@ public interface ClientInterceptor {
      * @return the protocol-specific request.
      * @param <RequestT> Protocol-specific request type.
      */
-    default <RequestT> RequestT modifyBeforeTransmit(RequestHook<?, RequestT> hook) {
+    default <RequestT> RequestT modifyBeforeTransmit(RequestHook<?, ?, RequestT> hook) {
         return hook.request();
     }
 
@@ -259,7 +259,7 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      */
-    default void readBeforeTransmit(RequestHook<?, ?> hook) {}
+    default void readBeforeTransmit(RequestHook<?, ?, ?> hook) {}
 
     /**
      * A hook called after the transport request message is sent to the service and a transport response message is
@@ -278,7 +278,7 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      */
-    default void readAfterTransmit(ResponseHook<?, ?, ?> hook) {}
+    default void readAfterTransmit(ResponseHook<?, ?, ?, ?> hook) {}
 
     /**
      * A hook called before the response is deserialized.
@@ -302,7 +302,7 @@ public interface ClientInterceptor {
      * @return the protocol-specific response.
      * @param <ResponseT> Protocol-specific response type.
      */
-    default <ResponseT> ResponseT modifyBeforeDeserialization(ResponseHook<?, ?, ResponseT> hook) {
+    default <ResponseT> ResponseT modifyBeforeDeserialization(ResponseHook<?, ?, ?, ResponseT> hook) {
         return hook.response();
     }
 
@@ -322,7 +322,7 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      */
-    default void readBeforeDeserialization(ResponseHook<?, ?, ?> hook) {}
+    default void readBeforeDeserialization(ResponseHook<?, ?, ?, ?> hook) {}
 
     /**
      * A hook called after the transport response message is deserialized.
@@ -367,7 +367,7 @@ public interface ClientInterceptor {
      * @param <O> Output type.
      */
     default <O extends SerializableStruct> O modifyBeforeAttemptCompletion(
-        OutputHook<?, ?, ?, O> hook,
+        OutputHook<?, O, ?, ?> hook,
         RuntimeException error
     ) {
         return hook.forward(error);
@@ -418,7 +418,7 @@ public interface ClientInterceptor {
      * @param <O> Output type.
      */
     default <O extends SerializableStruct> O modifyBeforeCompletion(
-        OutputHook<?, ?, ?, O> hook,
+        OutputHook<?, O, ?, ?> hook,
         RuntimeException error
     ) {
         return hook.forward(error);

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptorChain.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ClientInterceptorChain.java
@@ -25,7 +25,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public void readBeforeExecution(InputHook<?> hook) {
+    public void readBeforeExecution(InputHook<?, ?> hook) {
         applyToEachThrowLastError(ClientInterceptor::readBeforeExecution, hook);
     }
 
@@ -49,7 +49,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public <I extends SerializableStruct> I modifyBeforeSerialization(InputHook<I> hook) {
+    public <I extends SerializableStruct> I modifyBeforeSerialization(InputHook<I, ?> hook) {
         var input = hook.input();
         for (var interceptor : interceptors) {
             input = interceptor.modifyBeforeSerialization(hook.withInput(input));
@@ -58,27 +58,27 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public void readBeforeSerialization(InputHook<?> hook) {
+    public void readBeforeSerialization(InputHook<?, ?> hook) {
         for (var interceptor : interceptors) {
             interceptor.readBeforeSerialization(hook);
         }
     }
 
     @Override
-    public void readAfterSerialization(RequestHook<?, ?> hook) {
+    public void readAfterSerialization(RequestHook<?, ?, ?> hook) {
         for (var interceptor : interceptors) {
             interceptor.readAfterSerialization(hook);
         }
     }
 
     @Override
-    public <RequestT> RequestT modifyBeforeRetryLoop(RequestHook<?, RequestT> hook) {
+    public <RequestT> RequestT modifyBeforeRetryLoop(RequestHook<?, ?, RequestT> hook) {
         return modifyRequestHook(ClientInterceptor::modifyBeforeRetryLoop, hook);
     }
 
     private <I extends SerializableStruct, RequestT> RequestT modifyRequestHook(
-        BiFunction<ClientInterceptor, RequestHook<I, RequestT>, RequestT> mapper,
-        RequestHook<I, RequestT> hook
+        BiFunction<ClientInterceptor, RequestHook<I, ?, RequestT>, RequestT> mapper,
+        RequestHook<I, ?, RequestT> hook
     ) {
         var request = hook.request();
         for (var interceptor : interceptors) {
@@ -88,50 +88,50 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public void readBeforeAttempt(RequestHook<?, ?> hook) {
+    public void readBeforeAttempt(RequestHook<?, ?, ?> hook) {
         applyToEachThrowLastError(ClientInterceptor::readBeforeAttempt, hook);
     }
 
     @Override
-    public <RequestT> RequestT modifyBeforeSigning(RequestHook<?, RequestT> hook) {
+    public <RequestT> RequestT modifyBeforeSigning(RequestHook<?, ?, RequestT> hook) {
         return modifyRequestHook(ClientInterceptor::modifyBeforeSigning, hook);
     }
 
     @Override
-    public void readBeforeSigning(RequestHook<?, ?> hook) {
+    public void readBeforeSigning(RequestHook<?, ?, ?> hook) {
         for (var interceptor : interceptors) {
             interceptor.readBeforeSigning(hook);
         }
     }
 
     @Override
-    public void readAfterSigning(RequestHook<?, ?> hook) {
+    public void readAfterSigning(RequestHook<?, ?, ?> hook) {
         for (var interceptor : interceptors) {
             interceptor.readAfterSigning(hook);
         }
     }
 
     @Override
-    public <RequestT> RequestT modifyBeforeTransmit(RequestHook<?, RequestT> hook) {
+    public <RequestT> RequestT modifyBeforeTransmit(RequestHook<?, ?, RequestT> hook) {
         return modifyRequestHook(ClientInterceptor::modifyBeforeTransmit, hook);
     }
 
     @Override
-    public void readBeforeTransmit(RequestHook<?, ?> hook) {
+    public void readBeforeTransmit(RequestHook<?, ?, ?> hook) {
         for (var interceptor : interceptors) {
             interceptor.readBeforeTransmit(hook);
         }
     }
 
     @Override
-    public void readAfterTransmit(ResponseHook<?, ?, ?> hook) {
+    public void readAfterTransmit(ResponseHook<?, ?, ?, ?> hook) {
         for (var interceptor : interceptors) {
             interceptor.readAfterTransmit(hook);
         }
     }
 
     @Override
-    public <ResponseT> ResponseT modifyBeforeDeserialization(ResponseHook<?, ?, ResponseT> hook) {
+    public <ResponseT> ResponseT modifyBeforeDeserialization(ResponseHook<?, ?, ?, ResponseT> hook) {
         var response = hook.response();
         for (var interceptor : interceptors) {
             response = interceptor.modifyBeforeDeserialization(hook.withResponse(response));
@@ -140,7 +140,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
     }
 
     @Override
-    public void readBeforeDeserialization(ResponseHook<?, ?, ?> hook) {
+    public void readBeforeDeserialization(ResponseHook<?, ?, ?, ?> hook) {
         for (var interceptor : interceptors) {
             interceptor.readBeforeDeserialization(hook);
         }
@@ -155,7 +155,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
 
     @Override
     public <O extends SerializableStruct> O modifyBeforeAttemptCompletion(
-        OutputHook<?, ?, ?, O> hook,
+        OutputHook<?, O, ?, ?> hook,
         RuntimeException error
     ) {
         var output = hook.output();
@@ -193,7 +193,7 @@ final class ClientInterceptorChain implements ClientInterceptor {
 
     @Override
     public <O extends SerializableStruct> O modifyBeforeCompletion(
-        OutputHook<?, ?, ?, O> hook,
+        OutputHook<?, O, ?, ?> hook,
         RuntimeException error
     ) {
         var output = hook.output();

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/InputHook.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/InputHook.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
@@ -16,14 +17,25 @@ import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
  *
  * @param <I> Input shape.
  */
-public sealed class InputHook<I extends SerializableStruct> permits RequestHook {
+public sealed class InputHook<I extends SerializableStruct, O extends SerializableStruct> permits RequestHook {
 
     private final Context context;
     private final I input;
+    private final ApiOperation<I, O> operation;
 
-    public InputHook(Context context, I input) {
+    public InputHook(ApiOperation<I, O> operation, Context context, I input) {
+        this.operation = Objects.requireNonNull(operation);
         this.context = Objects.requireNonNull(context);
         this.input = Objects.requireNonNull(input);
+    }
+
+    /**
+     * Get the API operation being called.
+     *
+     * @return the operation being called.
+     */
+    public ApiOperation<I, O> operation() {
+        return operation;
     }
 
     /**
@@ -50,8 +62,8 @@ public sealed class InputHook<I extends SerializableStruct> permits RequestHook 
      * @param input Input to use.
      * @return the hook.
      */
-    public InputHook<I> withInput(I input) {
-        return this.input.equals(input) ? this : new InputHook<>(context, input);
+    public InputHook<I, O> withInput(I input) {
+        return this.input.equals(input) ? this : new InputHook<>(operation, context, input);
     }
 
     /**

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/OutputHook.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/OutputHook.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
@@ -19,13 +20,20 @@ import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
  * @param <ResponseT> Protocol specific response.
  * @param <O> Output shape.
  */
-public final class OutputHook<I extends SerializableStruct, RequestT, ResponseT, O extends SerializableStruct> extends
-    ResponseHook<I, RequestT, ResponseT> {
+public final class OutputHook<I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT> extends
+    ResponseHook<I, O, RequestT, ResponseT> {
 
     private final O output;
 
-    public OutputHook(Context context, I input, RequestT request, ResponseT response, O output) {
-        super(context, input, request, response);
+    public OutputHook(
+        ApiOperation<I, O> operation,
+        Context context,
+        I input,
+        RequestT request,
+        ResponseT response,
+        O output
+    ) {
+        super(operation, context, input, request, response);
         this.output = output;
     }
 
@@ -44,10 +52,10 @@ public final class OutputHook<I extends SerializableStruct, RequestT, ResponseT,
      * @param output Output to use.
      * @return the hook.
      */
-    public OutputHook<I, RequestT, ResponseT, O> withOutput(O output) {
+    public OutputHook<I, O, RequestT, ResponseT> withOutput(O output) {
         return Objects.equals(output, this.output)
             ? this
-            : new OutputHook<>(context(), input(), request(), response(), output);
+            : new OutputHook<>(operation(), context(), input(), request(), response(), output);
     }
 
     /**

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/RequestHook.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/RequestHook.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
@@ -17,12 +18,13 @@ import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
  * @param <I> Input shape.
  * @param <RequestT> Protocol specific request.
  */
-public sealed class RequestHook<I extends SerializableStruct, RequestT> extends InputHook<I> permits ResponseHook {
+public sealed class RequestHook<I extends SerializableStruct, O extends SerializableStruct, RequestT> extends
+    InputHook<I, O> permits ResponseHook {
 
     private final RequestT request;
 
-    public RequestHook(Context context, I input, RequestT request) {
-        super(context, input);
+    public RequestHook(ApiOperation<I, O> operation, Context context, I input, RequestT request) {
+        super(operation, context, input);
         this.request = request;
     }
 
@@ -41,8 +43,10 @@ public sealed class RequestHook<I extends SerializableStruct, RequestT> extends 
      * @param request Request to use.
      * @return the hook.
      */
-    public RequestHook<I, RequestT> withRequest(RequestT request) {
-        return Objects.equals(request, this.request) ? this : new RequestHook<>(context(), input(), request);
+    public RequestHook<I, O, RequestT> withRequest(RequestT request) {
+        return Objects.equals(request, this.request)
+            ? this
+            : new RequestHook<>(operation(), context(), input(), request);
     }
 
     /**

--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ResponseHook.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/interceptors/ResponseHook.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
 
 /**
@@ -18,13 +19,14 @@ import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
  * @param <RequestT> Protocol specific request.
  * @param <ResponseT> Protocol specific response.
  */
-public sealed class ResponseHook<I extends SerializableStruct, RequestT, ResponseT> extends RequestHook<I, RequestT>
+public sealed class ResponseHook<I extends SerializableStruct, O extends SerializableStruct, RequestT, ResponseT>
+    extends RequestHook<I, O, RequestT>
     permits OutputHook {
 
     private final ResponseT response;
 
-    public ResponseHook(Context context, I input, RequestT request, ResponseT response) {
-        super(context, input, request);
+    public ResponseHook(ApiOperation<I, O> operation, Context context, I input, RequestT request, ResponseT response) {
+        super(operation, context, input, request);
         this.response = response;
     }
 
@@ -43,10 +45,10 @@ public sealed class ResponseHook<I extends SerializableStruct, RequestT, Respons
      * @param response Response to use.
      * @return the hook.
      */
-    public ResponseHook<I, RequestT, ResponseT> withResponse(ResponseT response) {
+    public ResponseHook<I, O, RequestT, ResponseT> withResponse(ResponseT response) {
         return Objects.equals(response, this.response)
             ? this
-            : new ResponseHook<>(context(), input(), request(), response);
+            : new ResponseHook<>(operation(), context(), input(), request(), response);
     }
 
     /**

--- a/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/InputHookTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/InputHookTest.java
@@ -17,7 +17,7 @@ public class InputHookTest {
     public void usesSameInstanceIfValueUnchanged() {
         var foo = new TestStructs.Foo();
         var context = Context.create();
-        var hook = new InputHook<>(context, foo);
+        var hook = new InputHook<>(TestStructs.OPERATION, context, foo);
 
         assertThat(hook.withInput(foo), sameInstance(hook));
         assertThat(hook.withInput(new TestStructs.Foo()), not(sameInstance(hook)));
@@ -27,7 +27,7 @@ public class InputHookTest {
     public void mapsValueIfExpectedType() {
         var foo = new TestStructs.Foo();
         var context = Context.create();
-        var hook = new InputHook<>(context, foo);
+        var hook = new InputHook<>(TestStructs.OPERATION, context, foo);
 
         assertThat(hook.mapInput(TestStructs.Bar.class, bar -> bar), sameInstance(foo));
         assertThat(hook.mapInput(TestStructs.Foo.class, f -> new TestStructs.Foo()), not(sameInstance(foo)));

--- a/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/OutputHookTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/OutputHookTest.java
@@ -17,7 +17,7 @@ public class OutputHookTest {
     public void usesSameInstanceIfValueUnchanged() {
         var foo = new TestStructs.Foo();
         var context = Context.create();
-        var hook = new OutputHook<>(context, foo, null, null, foo);
+        var hook = new OutputHook<>(TestStructs.OPERATION, context, foo, null, null, foo);
 
         assertThat(hook.withOutput(foo), sameInstance(hook));
         assertThat(hook.withOutput(new TestStructs.Foo()), not(sameInstance(hook)));
@@ -27,7 +27,7 @@ public class OutputHookTest {
     public void mapsValueIfExpectedType() {
         var foo = new TestStructs.Foo();
         var context = Context.create();
-        var hook = new OutputHook<>(context, foo, null, null, foo);
+        var hook = new OutputHook<>(TestStructs.OPERATION, context, foo, null, null, foo);
 
         assertThat(hook.mapOutput(TestStructs.Bar.class, bar -> bar), sameInstance(foo));
         assertThat(hook.mapOutput(TestStructs.Foo.class, f -> new TestStructs.Foo()), not(sameInstance(foo)));

--- a/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/RequestHookTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/RequestHookTest.java
@@ -18,7 +18,7 @@ public class RequestHookTest {
         var foo = new TestStructs.Foo();
         var context = Context.create();
         var request = new MyRequest();
-        var hook = new RequestHook<>(context, foo, request);
+        var hook = new RequestHook<>(TestStructs.OPERATION, context, foo, request);
 
         assertThat(hook.withRequest(request), sameInstance(hook));
         assertThat(hook.withRequest(new MyRequest()), not(sameInstance(hook)));
@@ -29,7 +29,7 @@ public class RequestHookTest {
         var foo = new TestStructs.Foo();
         var context = Context.create();
         var request = new MyRequest();
-        var hook = new RequestHook<>(context, foo, request);
+        var hook = new RequestHook<>(TestStructs.OPERATION, context, foo, request);
 
         assertThat(hook.mapRequest(TestStructs.Bar.class, bar -> bar), sameInstance(request));
         assertThat(hook.mapRequest(MyRequest.class, f -> new MyRequest()), not(sameInstance(request)));

--- a/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/ResponseHookTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/ResponseHookTest.java
@@ -19,7 +19,7 @@ public class ResponseHookTest {
         var context = Context.create();
         var request = new MyRequest();
         var response = new MyResponse();
-        var hook = new ResponseHook<>(context, foo, request, response);
+        var hook = new ResponseHook<>(TestStructs.OPERATION, context, foo, request, response);
 
         assertThat(hook.withResponse(response), sameInstance(hook));
         assertThat(hook.withResponse(new MyResponse()), not(sameInstance(hook)));
@@ -31,7 +31,7 @@ public class ResponseHookTest {
         var context = Context.create();
         var request = new MyRequest();
         var response = new MyResponse();
-        var hook = new ResponseHook<>(context, foo, request, response);
+        var hook = new ResponseHook<>(TestStructs.OPERATION, context, foo, request, response);
 
         assertThat(hook.mapResponse(TestStructs.Bar.class, bar -> bar), sameInstance(response));
         assertThat(hook.mapResponse(MyResponse.class, f -> new MyResponse()), not(sameInstance(response)));

--- a/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/TestStructs.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/interceptors/TestStructs.java
@@ -5,14 +5,62 @@
 
 package software.amazon.smithy.java.runtime.client.core.interceptors;
 
+import java.util.List;
+import java.util.Set;
+import software.amazon.smithy.java.runtime.core.schema.ApiOperation;
 import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.runtime.core.schema.Schema;
 import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.runtime.core.serde.TypeRegistry;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 public final class TestStructs {
 
     private TestStructs() {}
+
+    static final ApiOperation<Foo, Foo> OPERATION = new ApiOperation<>() {
+        @Override
+        public ShapeBuilder<Foo> inputBuilder() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ShapeBuilder<Foo> outputBuilder() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Schema schema() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Schema inputSchema() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Schema outputSchema() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<Schema> errorSchemas() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TypeRegistry typeRegistry() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<ShapeId> effectiveAuthSchemes() {
+            return List.of();
+        }
+    };
 
     static final class Foo implements SerializableStruct {
         @Override

--- a/codegen/plugins/client/src/it/java/software/amazon/smithy/java/codegen/client/AuthSchemeTest.java
+++ b/codegen/plugins/client/src/it/java/software/amazon/smithy/java/codegen/client/AuthSchemeTest.java
@@ -41,7 +41,7 @@ public class AuthSchemeTest {
     void defaultAuthSchemesAdded() {
         var interceptor = new ClientInterceptor() {
             @Override
-            public void readBeforeTransmit(RequestHook<?, ?> hook) {
+            public void readBeforeTransmit(RequestHook<?, ?, ?> hook) {
                 var request = (SmithyHttpRequest) hook.request();
                 var signatureValue = request.headers().firstValue(TestAuthScheme.SIGNATURE_HEADER);
                 assertEquals("smithy-test-signature", signatureValue);

--- a/codegen/plugins/client/src/it/java/software/amazon/smithy/java/codegen/client/GenericClientTest.java
+++ b/codegen/plugins/client/src/it/java/software/amazon/smithy/java/codegen/client/GenericClientTest.java
@@ -62,7 +62,7 @@ public class GenericClientTest {
         var header = "x-foo";
         var interceptor = new ClientInterceptor() {
             @Override
-            public <RequestT> RequestT modifyBeforeTransmit(RequestHook<?, RequestT> hook) {
+            public <RequestT> RequestT modifyBeforeTransmit(RequestHook<?, ?, RequestT> hook) {
                 return hook.mapRequest(SmithyHttpRequest.class, request -> request.withAddedHeaders("X-Foo", "Bar"));
             }
 
@@ -93,7 +93,7 @@ public class GenericClientTest {
     public void customerOverrideWorksCorrectly() {
         var interceptor = new ClientInterceptor() {
             @Override
-            public void readBeforeExecution(InputHook<?> hook) {
+            public void readBeforeExecution(InputHook<?, ?> hook) {
                 var constant = hook.context().get(TestClientPlugin.CONSTANT_KEY);
                 assertEquals(constant, "CONSTANT");
                 var value = hook.context().get(TestSettings.VALUE_KEY);

--- a/dynamic-client/src/test/java/software/amazon/smithy/java/runtime/dynamicclient/DynamicClientTest.java
+++ b/dynamic-client/src/test/java/software/amazon/smithy/java/runtime/dynamicclient/DynamicClientTest.java
@@ -139,7 +139,7 @@ public class DynamicClientTest {
             .endpointResolver(EndpointResolver.staticEndpoint("https://foo.com"))
             .addInterceptor(new ClientInterceptor() {
                 @Override
-                public void readBeforeTransmit(RequestHook<?, ?> hook) {
+                public void readBeforeTransmit(RequestHook<?, ?, ?> hook) {
                     var input = hook.input();
                     assertThat(input, instanceOf(Document.class));
                     assertThat(((Document) input).getMember("id").asString(), equalTo("1"));

--- a/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/ClientConfigTest.java
+++ b/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/ClientConfigTest.java
@@ -221,7 +221,7 @@ public class ClientConfigTest {
         }
 
         @Override
-        public void readBeforeTransmit(RequestHook<?, ?> hook) {
+        public void readBeforeTransmit(RequestHook<?, ?, ?> hook) {
             request = (SmithyHttpRequest) hook.request();
         }
     }

--- a/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
+++ b/examples/restjson-example/src/it/java/software/amazon/smithy/java/runtime/example/GenericTest.java
@@ -126,12 +126,12 @@ public class GenericTest {
     public void supportsInterceptors() throws Exception {
         var interceptor = new ClientInterceptor() {
             @Override
-            public void readBeforeTransmit(RequestHook<?, ?> hook) {
+            public void readBeforeTransmit(RequestHook<?, ?, ?> hook) {
                 System.out.println("Sending request: " + hook.input());
             }
 
             @Override
-            public <RequestT> RequestT modifyBeforeTransmit(RequestHook<?, RequestT> hook) {
+            public <RequestT> RequestT modifyBeforeTransmit(RequestHook<?, ?, RequestT> hook) {
                 return hook.mapRequest(SmithyHttpRequest.class, request -> request.withAddedHeaders("X-Foo", "Bar"));
             }
         };

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerRequestProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpServerRequestProtocolTestProvider.java
@@ -12,7 +12,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
This allows access to operation schemas, input builders, output builders and type registries.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
