### PR TITLE
Fix interop issues with dynamic client

### DIFF
--- a/dynamic-client/src/test/java/software/amazon/smithy/java/runtime/dynamicclient/WrappedDocumentTest.java
+++ b/dynamic-client/src/test/java/software/amazon/smithy/java/runtime/dynamicclient/WrappedDocumentTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -48,6 +49,29 @@ public class WrappedDocumentTest {
         assertThat(sd.type(), is(ShapeType.STRUCTURE));
         assertThat(sd.discriminator().toString(), equalTo("foo#Bar"));
         assertThat(sd.size(), equalTo(2));
+    }
+
+    @Test
+    public void unwrapsValuesWhenGettingMemberValue() {
+        var schema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
+            .putMember("foo", PreludeSchemas.STRING)
+            .build();
+        var document = Document.createFromObject(Map.of("__type", "foo#Bar", "foo", "bar"));
+        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+
+        assertThat(sd.getMemberValue(schema.member("foo")), equalTo("bar"));
+    }
+
+    @Test
+    public void returnsNullWhenMemberDoesNotExist() {
+        var schema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
+            .putMember("foo", PreludeSchemas.STRING)
+            .build();
+        var document = Document.createFromObject(Map.of());
+        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+
+        assertThat(sd.getMemberValue(schema.member("foo")), nullValue());
+        assertThat(sd.getMember("foo"), nullValue());
     }
 
     @Test


### PR DESCRIPTION
DynamicClient should return unwrapped objects when getMemberValue is called, and it should wrap objects provided to setMemberValue.

Adds support for setMemberValue in dynamic client.

Ensures that null is returned from a dynamic client document when the member is not set.

Ensures that you can build up a dynamic client document value in multiple sets (deserialize calls, setMemberValue, etc), and adds validation to ensure incomplete values can't be built.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
