### PR TITLE
Add option to use external type definitions for clients and servers

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
@@ -45,6 +45,7 @@ public final class JavaCodegenSettings {
     private static final String RELATIVE_DATE = "relativeDate";
     private static final String RELATIVE_VERSION = "relativeVersion";
     private static final String EDITION = "edition";
+    private static final String USE_EXTERNAL_TYPES = "useExternalTypes";
     private static final List<String> PROPERTIES = List.of(
         SERVICE,
         NAME,
@@ -57,7 +58,8 @@ public final class JavaCodegenSettings {
         DEFAULT_SETTINGS,
         RELATIVE_DATE,
         RELATIVE_VERSION,
-        EDITION
+        EDITION,
+        USE_EXTERNAL_TYPES
     );
 
     private final ShapeId service;
@@ -73,6 +75,7 @@ public final class JavaCodegenSettings {
     private final String relativeDate;
     private final String relativeVersion;
     private final SmithyJavaCodegenEdition edition;
+    private final boolean useExternalTypes;
     private final Map<String, Set<Symbol>> generatedSymbols = new HashMap<>();
 
     private JavaCodegenSettings(Builder builder) {
@@ -89,6 +92,7 @@ public final class JavaCodegenSettings {
         this.relativeDate = builder.relativeDate;
         this.relativeVersion = builder.relativeVersion;
         this.edition = Objects.requireNonNullElse(builder.edition, SmithyJavaCodegenEdition.LATEST);
+        this.useExternalTypes = builder.useExternalTypes;
     }
 
     /**
@@ -111,7 +115,8 @@ public final class JavaCodegenSettings {
             .getArrayMember(DEFAULT_SETTINGS, n -> n.expectStringNode().getValue(), builder::defaultSettings)
             .getStringMember(RELATIVE_DATE, builder::relativeDate)
             .getStringMember(RELATIVE_VERSION, builder::relativeVersion)
-            .getStringMember(EDITION, builder::edition);
+            .getStringMember(EDITION, builder::edition)
+            .getBooleanMember(USE_EXTERNAL_TYPES, builder::useExternalTypes);
 
         builder.sourceLocation(settingsNode.getSourceLocation().getFilename());
 
@@ -170,6 +175,10 @@ public final class JavaCodegenSettings {
         return edition;
     }
 
+    public boolean useExternalTypes() {
+        return useExternalTypes;
+    }
+
     @SmithyInternalApi
     public void addSymbol(Symbol symbol) {
         var symbols = generatedSymbols.computeIfAbsent(symbol.getNamespace(), k -> new HashSet<>());
@@ -226,6 +235,7 @@ public final class JavaCodegenSettings {
         private String relativeDate;
         private String relativeVersion;
         private SmithyJavaCodegenEdition edition;
+        private boolean useExternalTypes;
 
         public Builder service(String string) {
             this.service = ShapeId.from(string);
@@ -315,6 +325,11 @@ public final class JavaCodegenSettings {
 
         public Builder edition(String string) {
             this.edition = SmithyJavaCodegenEdition.valueOf(string.toUpperCase(Locale.ENGLISH));
+            return this;
+        }
+
+        public Builder useExternalTypes(boolean useExternalTypes) {
+            this.useExternalTypes = useExternalTypes;
             return this;
         }
 

--- a/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/DirectedJavaClientCodegen.java
+++ b/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/DirectedJavaClientCodegen.java
@@ -53,42 +53,58 @@ final class DirectedJavaClientCodegen
 
     @Override
     public void generateStructure(GenerateStructureDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new StructureGenerator<>().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new StructureGenerator<>().accept(directive);
+        }
     }
 
     @Override
     public void generateError(GenerateErrorDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new StructureGenerator<>().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new StructureGenerator<>().accept(directive);
+        }
     }
 
     @Override
     public void generateUnion(GenerateUnionDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new UnionGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new UnionGenerator().accept(directive);
+        }
     }
 
     @Override
     public void generateList(GenerateListDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new ListGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new ListGenerator().accept(directive);
+        }
     }
 
     @Override
     public void generateMap(GenerateMapDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new MapGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new MapGenerator().accept(directive);
+        }
     }
 
     @Override
     public void generateEnumShape(GenerateEnumDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new EnumGenerator<>().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new EnumGenerator<>().accept(directive);
+        }
     }
 
     @Override
     public void generateIntEnumShape(GenerateIntEnumDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new EnumGenerator<>().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new EnumGenerator<>().accept(directive);
+        }
     }
 
     @Override
     public void generateOperation(GenerateOperationDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new OperationGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new OperationGenerator().accept(directive);
+        }
     }
 
     @Override
@@ -99,7 +115,9 @@ final class DirectedJavaClientCodegen
 
     @Override
     public void customizeBeforeIntegrations(CustomizeDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new SharedSchemasGenerator().accept(directive);
-        new SharedSerdeGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new SharedSchemasGenerator().accept(directive);
+            new SharedSerdeGenerator().accept(directive);
+        }
     }
 }

--- a/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/DirectedJavaServerCodegen.java
+++ b/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/DirectedJavaServerCodegen.java
@@ -63,37 +63,51 @@ final class DirectedJavaServerCodegen
 
     @Override
     public void generateStructure(GenerateStructureDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new StructureGenerator<>().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new StructureGenerator<>().accept(directive);
+        }
     }
 
     @Override
     public void generateError(GenerateErrorDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new StructureGenerator<>().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new StructureGenerator<>().accept(directive);
+        }
     }
 
     @Override
     public void generateUnion(GenerateUnionDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new UnionGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new UnionGenerator().accept(directive);
+        }
     }
 
     @Override
     public void generateList(GenerateListDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new ListGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new ListGenerator().accept(directive);
+        }
     }
 
     @Override
     public void generateMap(GenerateMapDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new MapGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new MapGenerator().accept(directive);
+        }
     }
 
     @Override
     public void generateEnumShape(GenerateEnumDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new EnumGenerator<>().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new EnumGenerator<>().accept(directive);
+        }
     }
 
     @Override
     public void generateIntEnumShape(GenerateIntEnumDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new EnumGenerator<>().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new EnumGenerator<>().accept(directive);
+        }
     }
 
     @Override
@@ -104,12 +118,16 @@ final class DirectedJavaServerCodegen
     @Override
     public void generateOperation(GenerateOperationDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
         new OperationInterfaceGenerator().accept(directive);
-        new OperationGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new OperationGenerator().accept(directive);
+        }
     }
 
     @Override
     public void customizeBeforeIntegrations(CustomizeDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        new SharedSchemasGenerator().accept(directive);
-        new SharedSerdeGenerator().accept(directive);
+        if (!directive.settings().useExternalTypes()) {
+            new SharedSchemasGenerator().accept(directive);
+            new SharedSerdeGenerator().accept(directive);
+        }
     }
 }

--- a/examples/end-to-end-example/smithy-build.json
+++ b/examples/end-to-end-example/smithy-build.json
@@ -3,18 +3,15 @@
   "plugins": {
     "java-client-codegen": {
       "service": "com.example#CoffeeShop",
-      // TODO: Make plugin aware of existing?
-      "namespace": "software.amazon.smithy.java.client.example",
+      "namespace": "software.amazon.smithy.java.example",
       "headerFile": "license.txt",
-      "protocol": "aws.protocols#restJson1",
-      "transport": {
-        "http-java": {}
-      }
+      "protocol": "aws.protocols#restJson1"
     },
     "java-server-codegen": {
       "service": "com.example#CoffeeShop",
-      "namespace": "software.amazon.smithy.java.server.example",
-      "headerFile": "license.txt"
+      "namespace": "software.amazon.smithy.java.example",
+      "headerFile": "license.txt",
+      "useExternalTypes": true
     }
   }
 }

--- a/examples/end-to-end-example/src/it/java/software/amazon/smithy/java/server/example/RoundTripTests.java
+++ b/examples/end-to-end-example/src/it/java/software/amazon/smithy/java/server/example/RoundTripTests.java
@@ -18,13 +18,13 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.java.client.example.client.CoffeeShopClient;
-import software.amazon.smithy.java.client.example.model.CoffeeType;
-import software.amazon.smithy.java.client.example.model.CreateOrderInput;
-import software.amazon.smithy.java.client.example.model.GetMenuInput;
-import software.amazon.smithy.java.client.example.model.GetOrderInput;
-import software.amazon.smithy.java.client.example.model.OrderNotFound;
-import software.amazon.smithy.java.client.example.model.OrderStatus;
+import software.amazon.smithy.java.example.client.CoffeeShopClient;
+import software.amazon.smithy.java.example.model.CoffeeType;
+import software.amazon.smithy.java.example.model.CreateOrderInput;
+import software.amazon.smithy.java.example.model.GetMenuInput;
+import software.amazon.smithy.java.example.model.GetOrderInput;
+import software.amazon.smithy.java.example.model.OrderNotFound;
+import software.amazon.smithy.java.example.model.OrderStatus;
 import software.amazon.smithy.java.runtime.client.core.endpoint.EndpointResolver;
 
 public class RoundTripTests {

--- a/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/BasicServerExample.java
+++ b/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/BasicServerExample.java
@@ -7,8 +7,8 @@ package software.amazon.smithy.java.server.example;
 
 import java.net.URI;
 import java.util.concurrent.ExecutionException;
+import software.amazon.smithy.java.example.service.CoffeeShop;
 import software.amazon.smithy.java.server.Server;
-import software.amazon.smithy.java.server.example.service.CoffeeShop;
 
 public class BasicServerExample implements Runnable {
     static final URI endpoint = URI.create("http://localhost:8888");

--- a/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/CreateOrder.java
+++ b/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/CreateOrder.java
@@ -6,11 +6,11 @@
 package software.amazon.smithy.java.server.example;
 
 import java.util.UUID;
+import software.amazon.smithy.java.example.model.CreateOrderInput;
+import software.amazon.smithy.java.example.model.CreateOrderOutput;
+import software.amazon.smithy.java.example.model.OrderStatus;
+import software.amazon.smithy.java.example.service.CreateOrderOperation;
 import software.amazon.smithy.java.server.RequestContext;
-import software.amazon.smithy.java.server.example.model.CreateOrderInput;
-import software.amazon.smithy.java.server.example.model.CreateOrderOutput;
-import software.amazon.smithy.java.server.example.model.OrderStatus;
-import software.amazon.smithy.java.server.example.service.CreateOrderOperation;
 
 /**
  * Create an order for a coffee.

--- a/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/GetMenu.java
+++ b/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/GetMenu.java
@@ -6,12 +6,12 @@
 package software.amazon.smithy.java.server.example;
 
 import java.util.List;
+import software.amazon.smithy.java.example.model.CoffeeItem;
+import software.amazon.smithy.java.example.model.CoffeeType;
+import software.amazon.smithy.java.example.model.GetMenuInput;
+import software.amazon.smithy.java.example.model.GetMenuOutput;
+import software.amazon.smithy.java.example.service.GetMenuOperation;
 import software.amazon.smithy.java.server.RequestContext;
-import software.amazon.smithy.java.server.example.model.CoffeeItem;
-import software.amazon.smithy.java.server.example.model.CoffeeType;
-import software.amazon.smithy.java.server.example.model.GetMenuInput;
-import software.amazon.smithy.java.server.example.model.GetMenuOutput;
-import software.amazon.smithy.java.server.example.service.GetMenuOperation;
 
 /**
  * Returns the menu for the coffee shop

--- a/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/GetOrder.java
+++ b/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/GetOrder.java
@@ -6,11 +6,11 @@
 package software.amazon.smithy.java.server.example;
 
 import java.util.UUID;
+import software.amazon.smithy.java.example.model.GetOrderInput;
+import software.amazon.smithy.java.example.model.GetOrderOutput;
+import software.amazon.smithy.java.example.model.OrderNotFound;
+import software.amazon.smithy.java.example.service.GetOrderOperation;
 import software.amazon.smithy.java.server.RequestContext;
-import software.amazon.smithy.java.server.example.model.GetOrderInput;
-import software.amazon.smithy.java.server.example.model.GetOrderOutput;
-import software.amazon.smithy.java.server.example.model.OrderNotFound;
-import software.amazon.smithy.java.server.example.service.GetOrderOperation;
 
 final class GetOrder implements GetOrderOperation {
     @Override

--- a/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/Order.java
+++ b/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/Order.java
@@ -6,8 +6,8 @@
 package software.amazon.smithy.java.server.example;
 
 import java.util.UUID;
-import software.amazon.smithy.java.server.example.model.CoffeeType;
-import software.amazon.smithy.java.server.example.model.OrderStatus;
+import software.amazon.smithy.java.example.model.CoffeeType;
+import software.amazon.smithy.java.example.model.OrderStatus;
 
 /**
  * A coffee drink order.

--- a/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/OrderTracker.java
+++ b/examples/end-to-end-example/src/main/java/software/amazon/smithy/java/server/example/OrderTracker.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import software.amazon.smithy.java.server.example.model.OrderStatus;
+import software.amazon.smithy.java.example.model.OrderStatus;
 
 /**
  * This class is a stand-in for a database.


### PR DESCRIPTION
### Description of changes
Adds a `useExternalTypes` option to client and server code generators to disable the creation of types in those code generators. This allows clients and server and type code generators to be used in the same project, with the same namespace without creating clashing files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
