### PR TITLE
Treat clientOptional as present

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/plugins/InjectIdempotencyTokenPlugin.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/runtime/client/core/plugins/InjectIdempotencyTokenPlugin.java
@@ -35,6 +35,12 @@ public final class InjectIdempotencyTokenPlugin implements ClientPlugin {
 
             if (tokenMember != null) {
                 var value = hook.input().getMemberValue(tokenMember);
+
+                // Treat an empty string, possibly from error correction, as not present and set a default.
+                if (value instanceof String s && s.isEmpty()) {
+                    value = null;
+                }
+
                 if (value == null) {
                     var builder = operation.inputBuilder();
                     SchemaUtils.copyShape(hook.input(), builder);

--- a/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/plugins/InjectIdempotencyTokenPluginTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/plugins/InjectIdempotencyTokenPluginTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.util.List;
@@ -136,5 +137,13 @@ public class InjectIdempotencyTokenPluginTest {
         var token = callAndGetToken("CreateSprocket", Document.createFromObject(Map.of("id", "1", "token", "xyz")));
 
         assertThat(token, equalTo("xyz"));
+    }
+
+    @Test
+    public void ignoresEmptyStringToken() {
+        var token = callAndGetToken("CreateSprocket", Document.createFromObject(Map.of("id", "1", "token", "")));
+
+        assertThat(token, notNullValue());
+        assertThat(token, not(equalTo("")));
     }
 }

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/IdempotencyTokenRequiredTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/IdempotencyTokenRequiredTest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.test;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.codegen.test.model.IdempotencyTokenRequiredInput;
+
+public class IdempotencyTokenRequiredTest {
+    @Test
+    void makesRequiredTokensClientOptional() {
+        // Will not fail to build because the token was made client optional.
+        IdempotencyTokenRequiredInput.builder().build();
+    }
+}

--- a/codegen/core/src/it/resources/META-INF/smithy/idempotencytoken/idempotency-token.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/idempotencytoken/idempotency-token.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace smithy.java.codegen.test.idempotencytoken
+
+operation IdempotencyTokenRequired {
+    input := {
+        @idempotencyToken
+        @required
+        token: String
+    }
+}

--- a/codegen/core/src/it/resources/META-INF/smithy/main.smithy
+++ b/codegen/core/src/it/resources/META-INF/smithy/main.smithy
@@ -4,6 +4,7 @@ namespace smithy.java.codegen.test
 
 use smithy.java.codegen.test.enums#EnumTests
 use smithy.java.codegen.test.exceptions#ExceptionTests
+use smithy.java.codegen.test.idempotencytoken#IdempotencyTokenRequired
 use smithy.java.codegen.test.lists#ListTests
 use smithy.java.codegen.test.maps#MapTests
 use smithy.java.codegen.test.naming#Naming
@@ -31,5 +32,6 @@ service TestService {
         AllAuth
         ScopedAuth
         NoAuth
+        IdempotencyTokenRequired
     ]
 }

--- a/codegen/core/src/it/resources/META-INF/smithy/manifest
+++ b/codegen/core/src/it/resources/META-INF/smithy/manifest
@@ -1,3 +1,4 @@
+idempotencytoken/idempotency-token.smithy
 enums/enum-tests.smithy
 enums/non-sequential.smithy
 enums/unsafe-value-name.smithy

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/BuilderGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/BuilderGenerator.java
@@ -62,7 +62,7 @@ abstract class BuilderGenerator implements Runnable {
             public static final class Builder implements ${sdkShapeBuilder:T}<${shape:T}>${?isStaged}, ${#stages}${value:L}${^key.last}, ${/key.last}${/stages}${/isStaged} {
                 ${builderProperties:C|}
 
-                private Builder() {}
+                ${builderConstructor:C|}
 
                 @Override
                 public ${schema:T} schema() {
@@ -82,6 +82,7 @@ abstract class BuilderGenerator implements Runnable {
         writer.putContext("schema", Schema.class);
         writer.putContext("sdkShapeBuilder", ShapeBuilder.class);
         writer.putContext("builderProperties", writer.consumer(this::generateProperties));
+        writer.putContext("builderConstructor", writer.consumer(this::generateConstructor));
         writer.putContext("builderSetters", writer.consumer(this::generateSetters));
         writer.putContext("buildMethod", writer.consumer(this::generateBuild));
         writer.putContext("errorCorrection", writer.consumer(this::generateErrorCorrection));
@@ -111,6 +112,10 @@ abstract class BuilderGenerator implements Runnable {
     }
 
     protected abstract void generateProperties(JavaWriter writer);
+
+    protected void generateConstructor(JavaWriter writer) {
+        writer.write("private Builder() {}");
+    }
 
     protected abstract void generateSetters(JavaWriter writer);
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -64,6 +65,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
 import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
@@ -510,6 +512,32 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
             super(writer, shape, symbolProvider, model, service);
         }
 
+        // Required shapes marked with clientOptional should not be required to create the type. For these shapes,
+        // tell the tracker they're always set. Validation can detect later that they're provided.
+        @Override
+        protected void generateConstructor(JavaWriter writer) {
+            List<MemberShape> requiredClientOptional = new ArrayList<>();
+            for (var member : shape.members()) {
+                if (CodegenUtils.isRequiredWithNoDefault(member) && member.hasTrait(ClientOptionalTrait.class)) {
+                    requiredClientOptional.add(member);
+                }
+            }
+            if (requiredClientOptional.isEmpty()) {
+                // Make the default empty constructor.
+                super.generateConstructor(writer);
+            } else {
+                // Make the constructor set the tracker members.
+                writer.openBlock("private Builder() {", "}", () -> {
+                    writer.write("// Tell the tracker to assume clientOptional members are present.");
+                    for (var member : requiredClientOptional) {
+                        var memberName = symbolProvider.toMemberName(member);
+                        var schemaName = CodegenUtils.toMemberSchemaName(memberName);
+                        writer.write("tracker.setMember($L);", schemaName);
+                    }
+                });
+            }
+        }
+
         @Override
         protected void generateErrorCorrection(JavaWriter writer) {
             if (shape.members().stream().noneMatch(CodegenUtils::isRequiredWithNoDefault)) {
@@ -684,7 +712,7 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
                 }
             }
 
-            // Add presence tracker
+            // Add presence tracker if any members are required by validation.
             if (shape.members().stream().anyMatch(CodegenUtils::isRequiredWithNoDefault)) {
                 writer.putContext("tracker", PresenceTracker.class);
                 writer.write("private final ${tracker:T} tracker = ${tracker:T}.of($$SCHEMA);");

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/transforms/DefaultTransforms.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/transforms/DefaultTransforms.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.transforms;
+
+import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.model.Model;
+
+/**
+ * Default transformations applied to Smithy models before code generation.
+ */
+public final class DefaultTransforms {
+    public static Model transform(Model model, JavaCodegenSettings settings) {
+        model = RemoveDeprecatedShapesTransformer.transform(model, settings);
+        model = MakeIdempotencyTokenClientOptional.transform(model);
+        return model;
+    }
+}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/transforms/MakeIdempotencyTokenClientOptional.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/transforms/MakeIdempotencyTokenClientOptional.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.transforms;
+
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
+import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
+import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Idempotency tokens that are required should fail validation, but shouldn't be required to create a type, allowing
+ * for a default value to get injected when missing.
+ */
+@SmithyInternalApi
+public final class MakeIdempotencyTokenClientOptional {
+    public static Model transform(Model model) {
+        return ModelTransformer.create().mapShapes(model, shape -> {
+            if (shape.isMemberShape()
+                && shape.hasTrait(RequiredTrait.class)
+                && shape.hasTrait(IdempotencyTokenTrait.class)
+                && !shape.hasTrait(ClientOptionalTrait.class)) {
+                return Shape.shapeToBuilder(shape).addTrait(new ClientOptionalTrait()).build();
+            }
+            return shape;
+        });
+    }
+}

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenPlugin.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/utils/TestJavaCodegenPlugin.java
@@ -11,7 +11,7 @@ import software.amazon.smithy.codegen.core.directed.CodegenDirector;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
-import software.amazon.smithy.java.codegen.transforms.RemoveDeprecatedShapesTransformer;
+import software.amazon.smithy.java.codegen.transforms.DefaultTransforms;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 
 public class TestJavaCodegenPlugin implements SmithyBuildPlugin {
@@ -29,8 +29,9 @@ public class TestJavaCodegenPlugin implements SmithyBuildPlugin {
         runner.directedCodegen(new TestJavaCodegen());
         runner.fileManifest(context.getFileManifest());
         runner.service(settings.service());
-        // Filter out any deprecated shapes
-        var model = RemoveDeprecatedShapesTransformer.transform(context.getModel(), settings);
+
+        var model = DefaultTransforms.transform(context.getModel(), settings);
+
         runner.model(model);
         runner.integrationClass(JavaCodegenIntegration.class);
         runner.performDefaultCodegenTransforms();

--- a/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/JavaClientCodegenPlugin.java
+++ b/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/JavaClientCodegenPlugin.java
@@ -11,7 +11,7 @@ import software.amazon.smithy.codegen.core.directed.CodegenDirector;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
-import software.amazon.smithy.java.codegen.transforms.RemoveDeprecatedShapesTransformer;
+import software.amazon.smithy.java.codegen.transforms.DefaultTransforms;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -38,8 +38,9 @@ public final class JavaClientCodegenPlugin implements SmithyBuildPlugin {
         runner.fileManifest(context.getFileManifest());
         runner.service(settings.service());
         runner.changeStringEnumsToEnumShapes(true);
-        // Filter out any deprecated shapes
-        var model = RemoveDeprecatedShapesTransformer.transform(context.getModel(), settings);
+
+        var model = DefaultTransforms.transform(context.getModel(), settings);
+
         runner.model(model);
         runner.integrationClass(JavaCodegenIntegration.class);
         runner.performDefaultCodegenTransforms();

--- a/codegen/plugins/types/src/main/java/software/amazon/smithy/java/codegen/types/JavaTypeCodegenPlugin.java
+++ b/codegen/plugins/types/src/main/java/software/amazon/smithy/java/codegen/types/JavaTypeCodegenPlugin.java
@@ -15,7 +15,7 @@ import software.amazon.smithy.codegen.core.directed.CodegenDirector;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
-import software.amazon.smithy.java.codegen.transforms.RemoveDeprecatedShapesTransformer;
+import software.amazon.smithy.java.codegen.transforms.DefaultTransforms;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.model.Model;
@@ -49,8 +49,8 @@ public final class JavaTypeCodegenPlugin implements SmithyBuildPlugin {
         runner.service(codegenSettings.service());
         runner.changeStringEnumsToEnumShapes(true);
 
-        // Filter out any deprecated shapes
-        var model = RemoveDeprecatedShapesTransformer.transform(context.getModel(), codegenSettings);
+        var model = DefaultTransforms.transform(context.getModel(), codegenSettings);
+
         // Add the synthetic service to the model
         var closure = getClosure(model, settings);
         LOGGER.info("Found {} shapes in generation closure", closure.size());


### PR DESCRIPTION
ClientOptional required members not being present won't block the creation of a POJO, but will still fail validation. We achieve this by just telling the tracker that the member is present in the builder ctor.

The idempotency token injector now works with required tokens, and it will now treat an empty string token value as not set and replace it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
