### PR TITLE
Add ability to capture/disable capture stacktraces globally and at per exception level

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation(libs.hamcrest)
     testImplementation(libs.assertj.core)
     compileOnly("com.github.spotbugs:spotbugs-annotations:${spotbugs.toolVersion.get()}")
+    testCompileOnly("com.github.spotbugs:spotbugs-annotations:${spotbugs.toolVersion.get()}")
 }
 
 tasks.withType<Test> {

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ReloadClasses.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ReloadClasses.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ReloadClasses {
+}

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ReloadClassesExtension.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ReloadClassesExtension.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.test;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+public class ReloadClassesExtension implements InvocationInterceptor {
+
+    @Override
+    @SuppressFBWarnings("DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED")
+    public void interceptTestMethod(
+        Invocation<Void> invocation,
+        ReflectiveInvocationContext<Method> invocationContext,
+        ExtensionContext extensionContext
+    ) throws Throwable {
+        ReloadClasses annotation = invocationContext.getExecutable().getAnnotation(ReloadClasses.class);
+        if (annotation == null) {
+            InvocationInterceptor.super.interceptTestMethod(invocation, invocationContext, extensionContext);
+            return;
+        }
+        if (invocationContext.getExecutable().isAnnotationPresent(ParameterizedTest.class)) {
+            throw new IllegalStateException("ReloadClasses does not support Parameterized tests, yet");
+        }
+        invocation.skip();
+        URL[] jars;
+        if (ClassLoader.getSystemClassLoader() instanceof URLClassLoader u) {
+            jars = u.getURLs();
+        } else {
+            String classPath = System.getProperty("java.class.path");
+            jars = Arrays.stream(classPath.split(File.pathSeparator))
+                .map(this::getURL)
+                .toArray(URL[]::new);
+        }
+
+        try (URLClassLoader classLoader = new URLClassLoader(jars, null)) {
+            invokeMethodWithModifiedClasspath(invocationContext, classLoader);
+        }
+    }
+
+    private URL getURL(String s) {
+        try {
+            return new File(s).toURI().toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void invokeMethodWithModifiedClasspath(
+        ReflectiveInvocationContext<Method> invocationContext,
+        ClassLoader modifiedClassLoader
+    ) {
+        ClassLoader prev = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(modifiedClassLoader);
+
+        try {
+            invokeMethodWithModifiedClasspath(
+                invocationContext.getExecutable().getDeclaringClass().getName(),
+                invocationContext.getExecutable().getName(),
+                modifiedClassLoader
+            );
+        } finally {
+            Thread.currentThread().setContextClassLoader(prev);
+        }
+    }
+
+    private void invokeMethodWithModifiedClasspath(String className, String methodName, ClassLoader classLoader) {
+        final Class<?> testClass;
+        try {
+            testClass = classLoader.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Cannot load test class [" + className + "] from modified classloader", e);
+        }
+
+        Object testInstance = ReflectionUtils.newInstance(testClass);
+        final Optional<Method> method = ReflectionUtils.findMethod(testClass, methodName);
+        ReflectionUtils.invokeMethod(
+            method.orElseThrow(() -> new IllegalStateException("No test method named " + methodName)),
+            testInstance
+        );
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ApiException.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ApiException.java
@@ -19,6 +19,10 @@ import software.amazon.smithy.java.runtime.retries.api.RetrySafety;
  */
 public class ApiException extends RuntimeException implements RetryInfo {
 
+    private static final boolean GLOBAL_CAPTURE_STACK_TRACE_ENABLED = Boolean.getBoolean(
+        "smithy.java.captureExceptionStackTraces"
+    );
+
     /**
      * The party that is at fault for the error, if any.
      *
@@ -67,20 +71,52 @@ public class ApiException extends RuntimeException implements RetryInfo {
     private Duration retryAfter = null;
 
     public ApiException(String message) {
-        this(message, Fault.OTHER);
+        this(message, Fault.OTHER, null);
+    }
+
+    public ApiException(String message, boolean captureStackTrace) {
+        this(message, Fault.OTHER, captureStackTrace);
     }
 
     public ApiException(String message, Fault errorType) {
-        super(message);
-        this.errorType = Objects.requireNonNull(errorType);
+        this(message, errorType, null);
+    }
+
+    public ApiException(String message, Fault errorType, boolean captureStackTrace) {
+        this(message, null, errorType, captureStackTrace);
+    }
+
+    protected ApiException(String message, Fault errorType, Boolean captureStackTrace) {
+        this(message, null, errorType, captureStackTrace);
     }
 
     public ApiException(String message, Throwable cause) {
-        this(message, cause, Fault.OTHER);
+        this(message, cause, (Boolean) null);
+    }
+
+    public ApiException(String message, Throwable cause, boolean captureStackTrace) {
+        this(message, cause, Fault.OTHER, captureStackTrace);
+    }
+
+    protected ApiException(String message, Throwable cause, Boolean captureStackTrace) {
+        this(message, cause, Fault.OTHER, captureStackTrace);
     }
 
     public ApiException(String message, Throwable cause, Fault errorType) {
-        super(message, cause);
+        this(message, cause, errorType, false);
+    }
+
+    public ApiException(String message, Throwable cause, Fault errorType, boolean captureStackTrace) {
+        this(message, cause, errorType, (Boolean) captureStackTrace);
+    }
+
+    protected ApiException(String message, Throwable cause, Fault errorType, Boolean captureStackTrace) {
+        super(
+            message,
+            cause,
+            false,
+            captureStackTrace != null ? captureStackTrace : GLOBAL_CAPTURE_STACK_TRACE_ENABLED
+        );
         this.errorType = Objects.requireNonNull(errorType);
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ModeledApiException.java
+++ b/core/src/main/java/software/amazon/smithy/java/runtime/core/schema/ModeledApiException.java
@@ -12,23 +12,50 @@ public abstract class ModeledApiException extends ApiException implements Serial
 
     private final Schema schema;
 
-    public ModeledApiException(Schema schema, String message) {
+    protected ModeledApiException(Schema schema, String message) {
         super(message);
         this.schema = schema;
     }
 
-    public ModeledApiException(Schema schema, String message, Fault errorType) {
-        super(message, errorType);
+    protected ModeledApiException(Schema schema, String message, Fault errorType) {
+        super(message, null, errorType, null);
         this.schema = schema;
     }
 
-    public ModeledApiException(Schema schema, String message, Throwable cause) {
-        super(message, cause);
+    protected ModeledApiException(Schema schema, String message, Fault errorType, Throwable cause) {
+        super(message, cause, errorType, null);
         this.schema = schema;
     }
 
-    public ModeledApiException(Schema schema, String message, Throwable cause, Fault errorType) {
-        super(message, cause, errorType);
+    protected ModeledApiException(
+        Schema schema,
+        String message,
+        Fault errorType,
+        Throwable cause,
+        Boolean captureStackTrace
+    ) {
+        super(message, cause, errorType, captureStackTrace);
+        this.schema = schema;
+    }
+
+    protected ModeledApiException(Schema schema, String message, Throwable cause, Boolean captureStackTrace) {
+        super(message, cause, captureStackTrace);
+        this.schema = schema;
+    }
+
+    protected ModeledApiException(Schema schema, String message, Throwable cause) {
+        super(message, cause, (Boolean) null);
+        this.schema = schema;
+    }
+
+    protected ModeledApiException(
+        Schema schema,
+        String message,
+        Throwable cause,
+        Fault errorType,
+        Boolean captureStackTrace
+    ) {
+        super(message, cause, errorType, captureStackTrace);
         this.schema = schema;
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes #459  
Fixes #460 

The generated exception now has has the following new things, (trimmed down for ease of review)


```
@SmithyGenerated
public final class InternalException extends ModeledApiException {

    private InternalException(Builder builder) {
        super($SCHEMA, builder.message, builder.$cause, builder.$captureStackTrace);
    }

    public static final class Builder implements ShapeBuilder<InternalException> {
        private String message;
        private Throwable $cause;
        private Boolean $captureStackTrace;

        public Builder withStackTrace() {
            this.$captureStackTrace = true;
            return this;
        }

        public Builder withoutStackTrace() {
            this.$captureStackTrace = false;
            return this;
        }

        public Builder withCause(Throwable cause) {
            this.$cause = cause;
            return this;
        }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
