### PR TITLE
Replace gradle/wrapper-validation-action with gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v4
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlewrapper-validation-action-has-been-replaced-by-gradleactionswrapper-validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
