### PR TITLE
Fix RPCv2's ResizingSink::copyNonArrayBB

### DIFF
--- a/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/Sink.java
+++ b/rpcv2-cbor-codec/src/main/java/software/amazon/smithy/java/runtime/cbor/Sink.java
@@ -120,6 +120,7 @@ sealed interface Sink permits Sink.OutputStreamSink, Sink.ResizingSink, Sink.Nul
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public void writeAscii(String s) {
             int len = s.length();
             ensureCapacity(len);
@@ -130,7 +131,7 @@ sealed interface Sink permits Sink.OutputStreamSink, Sink.ResizingSink, Sink.Nul
         private void copyNonArrayBB(ByteBuffer b) {
             int rem = b.remaining();
             ensureCapacity(rem);
-            b.duplicate().get(bytes);
+            b.duplicate().get(bytes, pos, rem);
             pos += rem;
         }
 

--- a/rpcv2-cbor-codec/src/test/java/software/amazon/smithy/java/runtime/cbor/CborSerializerTest.java
+++ b/rpcv2-cbor-codec/src/test/java/software/amazon/smithy/java/runtime/cbor/CborSerializerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.runtime.io.ByteBufferUtils;
+
+public class CborSerializerTest {
+    private static final Rpcv2CborCodec.Settings SETTINGS = new Rpcv2CborCodec.Settings();
+    private static final DefaultCborSerdeProvider CODEC = new DefaultCborSerdeProvider();
+
+    @Test
+    public void birdSerialization() {
+        var name = "kestrel";
+        var bytes = ByteBuffer.wrap(" li'l guy".getBytes(StandardCharsets.UTF_8)).position(1).asReadOnlyBuffer();
+        var bird = new CborTestData.BirdBuilder()
+            .name(name)
+            .bytes(bytes.duplicate())
+            .build();
+
+        var ser = CODEC.serialize(bird, SETTINGS);
+        var de = new CborTestData.BirdBuilder().deserialize(CODEC.newDeserializer(ser, SETTINGS)).build();
+
+        assertEquals(name, de.name);
+        assertBuffersEqual(bytes, de.bytes);
+        assertEquals("li'l guy", new String(ByteBufferUtils.getBytes(de.bytes)));
+    }
+
+    private static void assertBuffersEqual(ByteBuffer expected, ByteBuffer actual) {
+        byte[] expectedBytes = ByteBufferUtils.getBytes(expected);
+        byte[] actualBytes = ByteBufferUtils.getBytes(actual);
+        assertArrayEquals(expectedBytes, actualBytes);
+    }
+}

--- a/rpcv2-cbor-codec/src/test/java/software/amazon/smithy/java/runtime/cbor/CborTestData.java
+++ b/rpcv2-cbor-codec/src/test/java/software/amazon/smithy/java/runtime/cbor/CborTestData.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.cbor;
+
+import java.nio.ByteBuffer;
+import software.amazon.smithy.java.runtime.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.runtime.core.schema.Schema;
+import software.amazon.smithy.java.runtime.core.schema.SerializableStruct;
+import software.amazon.smithy.java.runtime.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.runtime.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.runtime.core.serde.ShapeSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+final class CborTestData {
+    static final ShapeId BIRD_ID = ShapeId.from("smithy.example#Bird");
+    static final Schema BIRD = Schema.structureBuilder(BIRD_ID)
+        .putMember("name", PreludeSchemas.STRING)
+        .putMember("bytes", PreludeSchemas.BLOB)
+        .build();
+    static final Schema BIRD_NAME = BIRD.member("name");
+    static final Schema BIRD_BYTES = BIRD.member("bytes");
+
+    static final class Bird implements SerializableStruct {
+        String name;
+        ByteBuffer bytes;
+
+        private Bird(BirdBuilder builder) {
+            name = builder.name;
+            bytes = builder.bytes;
+        }
+
+        @Override
+        public Schema schema() {
+            return CborTestData.BIRD;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (name != null) {
+                serializer.writeString(BIRD_NAME, name);
+            }
+            if (bytes != null) {
+                serializer.writeBlob(BIRD_BYTES, bytes);
+            }
+        }
+
+        @Override
+        public Object getMemberValue(Schema member) {
+            return null;
+        }
+    }
+
+    static final class BirdBuilder implements ShapeBuilder<Bird> {
+        private String name;
+        private ByteBuffer bytes;
+
+        @Override
+        public Bird build() {
+            return new Bird(this);
+        }
+
+        @Override
+        public ShapeBuilder<Bird> deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct(schema(), this, (builder, member, de) -> {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.name(de.readString(member));
+                    case 1 -> builder.bytes(de.readBlob(member));
+                }
+            });
+            return this;
+        }
+
+        BirdBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        BirdBuilder bytes(ByteBuffer bytes) {
+            this.bytes = bytes;
+            return this;
+        }
+
+        @Override
+        public Schema schema() {
+            return CborTestData.BIRD;
+        }
+    }
+}


### PR DESCRIPTION
We should probably remove ResizingSink altogether in favor of focusing on ByteBufferArrayOutputStream