### PR TITLE
Skip generating protocol tests entirely if its marked as skipped

### DIFF
--- a/aws/client-awsjson/src/it/java/software/amazon/smithy/java/runtime/client/aws/jsonprotocols/AwsJson1ProtocolTests.java
+++ b/aws/client-awsjson/src/it/java/software/amazon/smithy/java/runtime/client/aws/jsonprotocols/AwsJson1ProtocolTests.java
@@ -34,7 +34,8 @@ public class AwsJson1ProtocolTests {
 
             // Like above, but in smithy-java we populate the defaults but don't change the nullability.
             "AwsJson10ClientIgnoresNonTopLevelDefaultsOnMembersWithClientOptional",
-        }
+        },
+        skipOperations = "aws.protocoltests.json10#OperationWithRequiredMembersWithDefaults"
     )
     public void requestTest(DataStream expected, DataStream actual) {
         String expectedJson = "{}";
@@ -53,7 +54,8 @@ public class AwsJson1ProtocolTests {
         skipTests = {
             "AwsJson10ClientPopulatesDefaultsValuesWhenMissingInResponse",
             "AwsJson10ClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse"
-        }
+        },
+        skipOperations = "aws.protocoltests.json10#OperationWithRequiredMembersWithDefaults"
     )
     public void responseTest(Runnable test) throws Exception {
         test.run();

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/IgnoredTestCase.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/IgnoredTestCase.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.protocoltests.harness;
+
+import java.util.List;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase;
+
+record IgnoredTestCase(HttpMessageTestCase testCase) implements TestTemplateInvocationContext {
+
+    @Override
+    public String getDisplayName(int invocationIndex) {
+        return testCase.getId();
+    }
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        return List.of((ExecutionCondition) context -> ConditionEvaluationResult.disabled(""));
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is required to suppress tests where the creation of the test itself fails, like the ones in AwsJson10 where the outputBuilder init fails because of invalid Base64 default blob.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
