### PR TITLE
Start to move away from ByteBuffer to Slice

### DIFF
--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/Slice.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/Slice.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.io;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * A wrapper around bytes of data, avoiding state issues with {@link ByteBuffer}.
+ *
+ * @param bytes  The underlying bytes to wrap. These bytes are not copied and are used as-is.
+ * @param offset Starting position of the byte array.
+ * @param length Number of bytes to include in the Slice after offset.
+ */
+public record Slice(byte[] bytes, int offset, int length) {
+
+    public Slice {
+        Objects.requireNonNull(bytes);
+        if (offset < 0 || offset > bytes.length) {
+            throw new IndexOutOfBoundsException("Offset is out of bounds");
+        }
+        if (length < 0 || offset + length > bytes.length) {
+            throw new IndexOutOfBoundsException("Length is out of bounds");
+        }
+    }
+
+    /**
+     * Create a Slice from bytes, assuming all the bytes are part of the Slice.
+     *
+     * @param bytes Bytes to wrap.
+     */
+    public Slice(byte[] bytes) {
+        this(bytes, 0, bytes.length);
+    }
+
+    /**
+     * Create a Slice from a ByteBuffer using the current position of the buffer as the offset.
+     *
+     * @param byteBuffer Buffer to convert from.
+     */
+    public Slice(ByteBuffer byteBuffer) {
+        this(byteBuffer.array(), byteBuffer.position(), byteBuffer.remaining());
+    }
+
+    /**
+     * Get a byte from the slice at the given position relative to the zero-position of the Slice.
+     *
+     * @param pos Position to read from the Slice offset starting at 0.
+     * @return the byte.
+     * @throws IndexOutOfBoundsException if the position is not within the Slice.
+     */
+    public byte at(int pos) {
+        if (pos < length) {
+            return bytes[offset + pos];
+        } else {
+            throw new IndexOutOfBoundsException("Index out of bounds");
+        }
+    }
+
+    /**
+     * Convert the Slice to a ByteBuffer.
+     *
+     * @return the created ByteBuffer.
+     */
+    public ByteBuffer toByteBuffer() {
+        return ByteBuffer.wrap(bytes, offset, length);
+    }
+
+    /**
+     * Copy the bytes contained in the slice into a byte array.
+     *
+     * @return the copied byte array.
+     */
+    public byte[] copyBytes() {
+        byte[] copy = new byte[length];
+        System.arraycopy(bytes, offset, copy, 0, length);
+        return copy;
+    }
+}

--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/ByteBufferDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/ByteBufferDataStream.java
@@ -29,7 +29,7 @@ final class ByteBufferDataStream implements DataStream {
     }
 
     @Override
-    public boolean hasByteBuffer() {
+    public boolean hasBytes() {
         return true;
     }
 

--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/EmptyDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/EmptyDataStream.java
@@ -28,7 +28,7 @@ final class EmptyDataStream implements DataStream {
     }
 
     @Override
-    public boolean hasByteBuffer() {
+    public boolean hasBytes() {
         return true;
     }
 

--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/SliceDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/SliceDataStream.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.io.datastream;
+
+import java.io.InputStream;
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import software.amazon.smithy.java.runtime.io.ByteBufferUtils;
+import software.amazon.smithy.java.runtime.io.Slice;
+
+final class SliceDataStream implements DataStream {
+
+    private final Slice slice;
+    private final String contentType;
+    private Flow.Publisher<ByteBuffer> publisher;
+
+    SliceDataStream(Slice slice, String contentType) {
+        this.slice = slice;
+        this.contentType = contentType;
+    }
+
+    @Override
+    public long contentLength() {
+        return slice.length();
+    }
+
+    @Override
+    public boolean hasKnownLength() {
+        return true;
+    }
+
+    @Override
+    public String contentType() {
+        return contentType;
+    }
+
+    @Override
+    public Slice waitForSlice() {
+        return slice;
+    }
+
+    @Override
+    public ByteBuffer waitForByteBuffer() {
+        return slice.toByteBuffer();
+    }
+
+    @Override
+    public boolean hasBytes() {
+        return true;
+    }
+
+    @Override
+    public boolean isReplayable() {
+        return true;
+    }
+
+    @Override
+    public CompletableFuture<Slice> asSlice() {
+        return CompletableFuture.completedFuture(slice);
+    }
+
+    @Override
+    public CompletableFuture<ByteBuffer> asByteBuffer() {
+        return CompletableFuture.completedFuture(slice.toByteBuffer());
+    }
+
+    @Override
+    public CompletableFuture<InputStream> asInputStream() {
+        return CompletableFuture.completedFuture(ByteBufferUtils.byteBufferInputStream(slice.toByteBuffer()));
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
+        var p = publisher;
+        if (p == null) {
+            publisher = p = HttpRequest.BodyPublishers.ofByteArray(slice.bytes(), slice.offset(), slice.length());
+        }
+        p.subscribe(subscriber);
+    }
+}

--- a/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/WrappedDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/runtime/io/datastream/WrappedDataStream.java
@@ -50,8 +50,8 @@ final class WrappedDataStream implements DataStream {
     }
 
     @Override
-    public boolean hasByteBuffer() {
-        return delegate.hasByteBuffer();
+    public boolean hasBytes() {
+        return delegate.hasBytes();
     }
 
     @Override

--- a/io/src/test/java/software/amazon/smithy/java/runtime/io/SliceTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/runtime/io/SliceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.io;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SliceTest {
+    @Test
+    public void wrapsBytes() {
+        var bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        var slice = new Slice(bytes);
+
+        assertThat(slice.bytes(), sameInstance(bytes));
+        assertThat(slice.offset(), is(0));
+        assertThat(slice.length(), is(bytes.length));
+    }
+
+    @Test
+    public void wrapsByteBuffer() {
+        var bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        var bb = ByteBuffer.wrap(bytes);
+        var slice = new Slice(bb);
+
+        assertThat(slice.bytes(), sameInstance(bytes));
+        assertThat(slice.offset(), is(0));
+        assertThat(slice.length(), is(bytes.length));
+    }
+
+    @Test
+    public void wrapsByteBufferAtOffset() {
+        var bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        var bb = ByteBuffer.wrap(bytes, 1, 3);
+        var slice = new Slice(bb);
+
+        assertThat(bb.position(), is(1));
+        assertThat(bb.remaining(), is(3));
+
+        assertThat(slice.bytes(), sameInstance(bytes));
+        assertThat(slice.offset(), is(1));
+        assertThat(slice.length(), is(3));
+
+        assertThat(slice.at(0), equalTo((byte) 'e'));
+        assertThat(slice.at(1), equalTo((byte) 'l'));
+        assertThat(slice.at(2), equalTo((byte) 'l'));
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> slice.at(3));
+    }
+
+    @Test
+    public void doesNotAllowOobAccess() {
+        var bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        var bb = ByteBuffer.wrap(bytes, 1, 2);
+        var slice = new Slice(bb);
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> slice.at(3));
+    }
+
+    @Test
+    public void convertsToBbWithNoOffset() {
+        var bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        var bb = ByteBuffer.wrap(bytes);
+        var slice = new Slice(bb);
+        var roundTrip = slice.toByteBuffer();
+
+        System.out.println(bb.limit());
+
+        assertThat(roundTrip.position(), equalTo(bb.position()));
+        assertThat(roundTrip.limit(), equalTo(bb.limit()));
+        assertThat(roundTrip.array(), is(bytes));
+        assertThat(roundTrip.array(), is(bb.array()));
+    }
+
+    @Test
+    public void convertsToBbWithOffset() {
+        var bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        var bb = ByteBuffer.wrap(bytes, 1, 3);
+        var slice = new Slice(bb);
+        var roundTrip = slice.toByteBuffer();
+
+        assertThat(roundTrip.position(), equalTo(bb.position()));
+        assertThat(roundTrip.limit(), equalTo(bb.limit()));
+        assertThat(roundTrip.array(), is(bytes));
+        assertThat(roundTrip.array(), is(bb.array()));
+    }
+
+    @Test
+    public void copiesSlice() {
+        var bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        var slice = new Slice(bytes);
+
+        assertThat(Arrays.equals(bytes, slice.copyBytes()), is(true));
+    }
+
+    @Test
+    public void copiesSliceSubset() {
+        var bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        var slice = new Slice(bytes, 1, 3);
+        var copy = slice.copyBytes();
+
+        assertThat(copy.length, is(3));
+        assertThat(copy[0], equalTo((byte) 'e'));
+        assertThat(copy[1], equalTo((byte) 'l'));
+        assertThat(copy[2], equalTo((byte) 'l'));
+    }
+}

--- a/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/ByteBufferDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/ByteBufferDataStreamTest.java
@@ -19,7 +19,7 @@ public class ByteBufferDataStreamTest {
         var bytes = "foo".getBytes(StandardCharsets.UTF_8);
         var ds = DataStream.ofBytes(bytes);
 
-        assertThat(ds.hasByteBuffer(), is(true));
+        assertThat(ds.hasBytes(), is(true));
         assertThat(ds.waitForByteBuffer(), equalTo(ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8))));
         assertThat(ds.isReplayable(), is(true));
     }

--- a/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/SliceDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/SliceDataStreamTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.runtime.io.datastream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.runtime.io.Slice;
+
+public class SliceDataStreamTest {
+    @Test
+    public void createsDataStream() throws Exception {
+        var bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        var slice = new Slice(bytes, 1, 3);
+        var ds = DataStream.ofSlice(slice);
+
+        assertThat(ds.waitForSlice(), sameInstance(slice));
+        assertThat(ds.asSlice().get(), sameInstance(slice));
+        assertThat(ds.contentLength(), is(3L));
+        assertThat(new Slice(ds.waitForByteBuffer()).bytes(), is(bytes));
+        assertThat(ds.waitForByteBuffer().remaining(), is(3));
+    }
+}

--- a/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/WrappedDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/runtime/io/datastream/WrappedDataStreamTest.java
@@ -20,7 +20,7 @@ public class WrappedDataStreamTest {
         var ds = DataStream.ofBytes(bytes);
         var wrapped = DataStream.ofPublisher(ds, "text/plain", 3);
 
-        assertThat(wrapped.hasByteBuffer(), is(true));
+        assertThat(wrapped.hasBytes(), is(true));
         assertThat(wrapped.waitForByteBuffer(), equalTo(ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8))));
     }
 }


### PR DESCRIPTION
ByteBuffer has tricky state in it's position and cursor functionality. We don't use any of that in smithy-java, so we often forget to account for moving or not moving the position. This commit introduces Slice, which is basically a lighter ByteBuffer with no state. We'll add more commits that migrate other abstractions to Slice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
