### PR TITLE
Add toBuilder to RetryStrategy

### DIFF
--- a/aws/aws-client-http/src/test/java/software/amazon/smithy/java/aws/client/http/AmzSdkRequestPluginTest.java
+++ b/aws/aws-client-http/src/test/java/software/amazon/smithy/java/aws/client/http/AmzSdkRequestPluginTest.java
@@ -132,6 +132,11 @@ public class AmzSdkRequestPluginTest {
                 public int maxAttempts() {
                     return 3;
                 }
+
+                @Override
+                public Builder toBuilder() {
+                    throw new UnsupportedOperationException();
+                }
             })
             .build();
 

--- a/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/ClientPipelineTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/runtime/client/core/ClientPipelineTest.java
@@ -105,6 +105,11 @@ public class ClientPipelineTest {
                 public int maxAttempts() {
                     return 1;
                 }
+
+                @Override
+                public Builder toBuilder() {
+                    throw new UnsupportedOperationException();
+                }
             })
             .build();
 
@@ -188,6 +193,11 @@ public class ClientPipelineTest {
                 @Override
                 public int maxAttempts() {
                     return 3;
+                }
+
+                @Override
+                public Builder toBuilder() {
+                    throw new UnsupportedOperationException();
                 }
             })
             .build();

--- a/retries-api/src/main/java/software/amazon/smithy/java/runtime/retries/api/NoRetryImpl.java
+++ b/retries-api/src/main/java/software/amazon/smithy/java/runtime/retries/api/NoRetryImpl.java
@@ -33,4 +33,25 @@ final class NoRetryImpl implements RetryStrategy {
     public int maxAttempts() {
         return 1;
     }
+
+    @Override
+    public Builder toBuilder() {
+        return new Builder() {
+            @Override
+            public RetryStrategy build() {
+                return INSTANCE;
+            }
+
+            @Override
+            public Builder maxAttempts(int maxAttempts) {
+                if (maxAttempts != 1) {
+                    throw new UnsupportedOperationException(
+                        "Cannot set maxAttempts to anything other than 1 with a "
+                            + "no-retry strategy"
+                    );
+                }
+                return this;
+            }
+        };
+    }
 }

--- a/retries-api/src/main/java/software/amazon/smithy/java/runtime/retries/api/RetryStrategy.java
+++ b/retries-api/src/main/java/software/amazon/smithy/java/runtime/retries/api/RetryStrategy.java
@@ -61,11 +61,39 @@ public interface RetryStrategy {
     int maxAttempts();
 
     /**
+     * Create a builder for this strategy, allowing things like {@link #maxAttempts()} to be customized.
+     *
+     * @return the builder.
+     */
+    Builder toBuilder();
+
+    /**
      * Create a RetryStrategy that only allows the first request, but does not allow retries.
      *
      * @return the created strategy.
      */
     static RetryStrategy noRetries() {
         return NoRetryImpl.INSTANCE;
+    }
+
+    /**
+     * A builder used to create or modify a RetryStrategy.
+     */
+    interface Builder {
+        /**
+         * Create the retry strategy.
+         *
+         * @return the created strategy.
+         */
+        RetryStrategy build();
+
+        /**
+         * Set the max attempts of the strategy.
+         *
+         * @param maxAttempts Max attempts to use before giving up (1 means one attempt and no retries, 2 is a single
+         *                    retry if the first call fails, etc).
+         * @return the builder.
+         */
+        Builder maxAttempts(int maxAttempts);
     }
 }

--- a/retries-sdk-adapter/src/main/java/software/amazon/smithy/java/runtime/retries/sdkadapter/SdkRetryStrategy.java
+++ b/retries-sdk-adapter/src/main/java/software/amazon/smithy/java/runtime/retries/sdkadapter/SdkRetryStrategy.java
@@ -125,4 +125,21 @@ public class SdkRetryStrategy implements RetryStrategy {
     public int maxAttempts() {
         return delegate.maxAttempts();
     }
+
+    @Override
+    public Builder toBuilder() {
+        var rebuild = delegate.toBuilder();
+        return new Builder() {
+            @Override
+            public RetryStrategy build() {
+                return new SdkRetryStrategy(rebuild.build());
+            }
+
+            @Override
+            public Builder maxAttempts(int maxAttempts) {
+                rebuild.maxAttempts(maxAttempts);
+                return this;
+            }
+        };
+    }
 }


### PR DESCRIPTION
This allows for changing things like maxAttempts on an existing strategy, including the SDK adapters.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
