### PR TITLE
Update getMemberValue to use cast

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCall.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCall.java
@@ -84,7 +84,7 @@ final class ClientCall<I extends SerializableStruct, O extends SerializableStruc
         var inputStream = operation.inputStreamMember();
         if (inputStream != null && inputStream.type() != ShapeType.UNION) {
             // Only tell the call that retries are disallowed if the stream is not replayable.
-            var stream = (DataStream) input.getMemberValue(inputStream);
+            DataStream stream = input.getMemberValue(inputStream);
             return !stream.isReplayable();
         }
         return false;

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientPipeline.java
@@ -214,9 +214,9 @@ final class ClientPipeline<RequestT, ResponseT> {
     private static void setIdemTokenValue(ApiOperation<?, ?> operation, Context context, SerializableStruct input) {
         var tokenMember = operation.idempotencyTokenMember();
         if (tokenMember != null) {
-            var value = input.getMemberValue(tokenMember);
+            String value = input.getMemberValue(tokenMember);
             if (value != null) {
-                context.put(CallContext.IDEMPOTENCY_TOKEN, value.toString());
+                context.put(CallContext.IDEMPOTENCY_TOKEN, value);
             }
         }
     }

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/plugins/InjectIdempotencyTokenPlugin.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/plugins/InjectIdempotencyTokenPlugin.java
@@ -34,10 +34,10 @@ public final class InjectIdempotencyTokenPlugin implements ClientPlugin {
             var tokenMember = operation.idempotencyTokenMember();
 
             if (tokenMember != null) {
-                var value = hook.input().getMemberValue(tokenMember);
+                String value = hook.input().getMemberValue(tokenMember);
 
                 // Treat an empty string, possibly from error correction, as not present and set a default.
-                if (value instanceof String s && s.isEmpty()) {
+                if (value != null && value.isEmpty()) {
                     value = null;
                 }
 

--- a/client-core/src/test/java/software/amazon/smithy/java/client/core/endpoint/EndpointResolverTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/client/core/endpoint/EndpointResolverTest.java
@@ -111,7 +111,7 @@ public class EndpointResolverTest {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             throw new UnsupportedOperationException();
         }
     }

--- a/client-core/src/test/java/software/amazon/smithy/java/client/core/interceptors/TestStructs.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/client/core/interceptors/TestStructs.java
@@ -79,7 +79,7 @@ public final class TestStructs {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             throw new UnsupportedOperationException();
         }
     }
@@ -101,7 +101,7 @@ public final class TestStructs {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             throw new UnsupportedOperationException();
         }
     }

--- a/client-http-binding/src/test/java/software/amazon/smithy/java/client/http/binding/HttpBindingErrorDeserializerTest.java
+++ b/client-http-binding/src/test/java/software/amazon/smithy/java/client/http/binding/HttpBindingErrorDeserializerTest.java
@@ -129,7 +129,7 @@ public class HttpBindingErrorDeserializerTest {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             throw new UnsupportedOperationException();
         }
 

--- a/client-http/src/test/java/software/amazon/smithy/java/client/http/HttpErrorDeserializerTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/client/http/HttpErrorDeserializerTest.java
@@ -197,7 +197,7 @@ public class HttpErrorDeserializerTest {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             throw new UnsupportedOperationException();
         }
 

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/GetMemberValueGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/GetMemberValueGenerator.java
@@ -23,14 +23,16 @@ record GetMemberValueGenerator(JavaWriter writer, SymbolProvider symbolProvider,
         if (shape.members().isEmpty()) {
             template = """
                 @Override
-                public Object getMemberValue(${sdkSchema:N} member) {
+                @SuppressWarnings("unchecked")
+                public <T> T getMemberValue(${sdkSchema:N} member) {
                     throw new ${iae:T}("Attempted to get non-existent member: " + member.id());
                 }
                 """;
         } else {
             template = """
                 @Override
-                public Object getMemberValue(${sdkSchema:N} member) {
+                @SuppressWarnings("unchecked")
+                public <T> T getMemberValue(${sdkSchema:N} member) {
                     return switch (member.memberIndex()) {
                         ${cases:C|}
                         default -> throw new ${iae:T}("Attempted to get non-existent member: " + member.id());
@@ -57,19 +59,19 @@ record GetMemberValueGenerator(JavaWriter writer, SymbolProvider symbolProvider,
             if (shape.getType() == ShapeType.UNION) {
                 // Unions need to access the member value using a getter, since subtypes provide the values.
                 writer.write(
-                    "case $L -> ${schemaUtilsClass:T}.validateSameMember(${memberSchema:L}, member, ${memberName:L}());",
+                    "case $L -> (T) ${schemaUtilsClass:T}.validateSameMember(${memberSchema:L}, member, ${memberName:L}());",
                     idx
                 );
             } else if (isError && member.getMemberName().equalsIgnoreCase("message")) {
                 // Exception message values have to use a special getter.
                 writer.write(
-                    "case $L -> ${schemaUtilsClass:T}.validateSameMember(${memberSchema:L}, member, getMessage());",
+                    "case $L -> (T) ${schemaUtilsClass:T}.validateSameMember(${memberSchema:L}, member, getMessage());",
                     idx
                 );
             } else {
                 // Other values can just skip the getter.
                 writer.write(
-                    "case $L -> ${schemaUtilsClass:T}.validateSameMember(${memberSchema:L}, member, ${memberName:L});",
+                    "case $L -> (T) ${schemaUtilsClass:T}.validateSameMember(${memberSchema:L}, member, ${memberName:L});",
                     idx
                 );
             }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -65,8 +65,8 @@ public final class UnionGenerator
                     }
 
                     @Override
-                    public Object getMemberValue(${sdkSchema:N} member) {
-                        return ${schemaUtils:N}.validateMemberInSchema($$SCHEMA, member, getValue());
+                    public <T> T getMemberValue(${sdkSchema:N} member) {
+                        return (T) ${schemaUtils:N}.validateMemberInSchema($$SCHEMA, member, getValue());
                     }
 
                     public abstract <T> T getValue();

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/SchemaUtils.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/SchemaUtils.java
@@ -43,7 +43,7 @@ public final class SchemaUtils {
             }
 
             @Override
-            public Object getMemberValue(Schema member) {
+            public <T> T getMemberValue(Schema member) {
                 return memberPredicate.test(schema()) ? getMemberValue(member) : null;
             }
         };

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/SerializableStruct.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/SerializableStruct.java
@@ -37,5 +37,5 @@ public interface SerializableStruct extends SerializableShape {
      * @return the value of the member, or null.
      * @throws IllegalArgumentException if the provided schema is not a member of the shape.
      */
-    Object getMemberValue(Schema member);
+    <T> T getMemberValue(Schema member);
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/Unit.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/Unit.java
@@ -42,8 +42,9 @@ public final class Unit implements SerializableStruct {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
-        return SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return (T) SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
     }
 
     public static Builder builder() {

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/document/Documents.java
@@ -279,8 +279,9 @@ final class Documents {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
-            return SchemaUtils.validateMemberInSchema(schema, member, members.get(member.memberName()));
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) SchemaUtils.validateMemberInSchema(schema, member, members.get(member.memberName()));
         }
     }
 
@@ -381,7 +382,7 @@ final class Documents {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             return getDocument().getMemberValue(member);
         }
     }

--- a/core/src/test/java/software/amazon/smithy/java/core/TestHelper.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/TestHelper.java
@@ -27,7 +27,7 @@ public final class TestHelper {
             }
 
             @Override
-            public Object getMemberValue(Schema member) {
+            public <T> T getMemberValue(Schema member) {
                 throw new UnsupportedOperationException("Getting member not supported: " + member);
             }
         };

--- a/core/src/test/java/software/amazon/smithy/java/core/schema/ApiOperationTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/schema/ApiOperationTest.java
@@ -59,7 +59,7 @@ public class ApiOperationTest {
             }
 
             @Override
-            public Object getMemberValue(Schema member) {
+            public <T> T getMemberValue(Schema member) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentMemberTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentMemberTest.java
@@ -53,7 +53,7 @@ public class TypedDocumentMemberTest {
                     }
 
                     @Override
-                    public Object getMemberValue(Schema member) {
+                    public <T> T getMemberValue(Schema member) {
                         return null;
                     }
                 }
@@ -97,7 +97,7 @@ public class TypedDocumentMemberTest {
                     }
 
                     @Override
-                    public Object getMemberValue(Schema member) {
+                    public <T> T getMemberValue(Schema member) {
                         return null;
                     }
                 }
@@ -119,7 +119,7 @@ public class TypedDocumentMemberTest {
                     }
 
                     @Override
-                    public Object getMemberValue(Schema member) {
+                    public <T> T getMemberValue(Schema member) {
                         return null;
                     }
                 }
@@ -169,7 +169,7 @@ public class TypedDocumentMemberTest {
                     }
 
                     @Override
-                    public Object getMemberValue(Schema member) {
+                    public <T> T getMemberValue(Schema member) {
                         return null;
                     }
                 }
@@ -683,7 +683,7 @@ public class TypedDocumentMemberTest {
                             }
 
                             @Override
-                            public Object getMemberValue(Schema member) {
+                            public <T> T getMemberValue(Schema member) {
                                 return null;
                             }
                         }

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentTest.java
@@ -47,7 +47,7 @@ public class TypedDocumentTest {
                     }
 
                     @Override
-                    public Object getMemberValue(Schema member) {
+                    public <T> T getMemberValue(Schema member) {
                         return null;
                     }
                 }

--- a/core/src/test/java/software/amazon/smithy/java/core/testmodels/Bird.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/testmodels/Bird.java
@@ -52,9 +52,10 @@ public final class Bird implements SerializableStruct {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
         if (member.memberName().equals("name")) {
-            return name;
+            return (T) name;
         } else {
             throw new IllegalArgumentException("Unknown member " + member);
         }

--- a/core/src/test/java/software/amazon/smithy/java/core/testmodels/Person.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/testmodels/Person.java
@@ -105,14 +105,15 @@ public final class Person implements SerializableStruct {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
         return switch (member.memberIndex()) {
-            case 0 -> name;
-            case 1 -> favoriteColor;
-            case 2 -> age;
-            case 3 -> birthday;
-            case 4 -> binary;
-            case 5 -> queryParams;
+            case 0 -> (T) name;
+            case 1 -> (T) favoriteColor;
+            case 2 -> (T) (Integer) age;
+            case 3 -> (T) birthday;
+            case 4 -> (T) binary;
+            case 5 -> (T) queryParams;
             default -> throw new IllegalArgumentException("Unknown member index: " + member);
         };
     }

--- a/core/src/test/java/software/amazon/smithy/java/core/testmodels/PojoWithValidatedCollection.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/testmodels/PojoWithValidatedCollection.java
@@ -79,7 +79,7 @@ public final class PojoWithValidatedCollection implements SerializableStruct {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
+    public <T> T getMemberValue(Schema member) {
         throw new UnsupportedOperationException("Member value not supported: " + member);
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/core/testmodels/UnvalidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/testmodels/UnvalidatedPojo.java
@@ -77,7 +77,7 @@ public final class UnvalidatedPojo implements SerializableStruct {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
+    public <T> T getMemberValue(Schema member) {
         throw new UnsupportedOperationException("Member value not supported: " + member);
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/core/testmodels/ValidatedPojo.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/testmodels/ValidatedPojo.java
@@ -88,7 +88,7 @@ public final class ValidatedPojo implements SerializableStruct {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
+    public <T> T getMemberValue(Schema member) {
         throw new UnsupportedOperationException("Member value not supported: " + member);
     }
 

--- a/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DocumentException.java
+++ b/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DocumentException.java
@@ -36,8 +36,9 @@ public final class DocumentException extends ModeledApiException {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
-        return document.getMemberValue(member);
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return (T) document.getMemberValue(member);
     }
 
     /**

--- a/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/WrappedDocument.java
+++ b/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/WrappedDocument.java
@@ -67,7 +67,8 @@ record WrappedDocument(ShapeId service, Schema schema, Document delegate) implem
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
         // Make sure it's part of the schema.
         var value = SchemaUtils.validateMemberInSchema(schema, member, getMember(member.memberName()));
         // If it's a document, unwrap it.
@@ -76,7 +77,7 @@ record WrappedDocument(ShapeId service, Schema schema, Document delegate) implem
         if (value instanceof Document d) {
             value = d.asObject();
         }
-        return value;
+        return (T) value;
     }
 
     @Override

--- a/server/src/main/java/software/amazon/smithy/java/server/exceptions/InternalServerError.java
+++ b/server/src/main/java/software/amazon/smithy/java/server/exceptions/InternalServerError.java
@@ -38,7 +38,8 @@ public final class InternalServerError extends ModeledApiException {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
-        return SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return (T) SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
     }
 }

--- a/server/src/main/java/software/amazon/smithy/java/server/exceptions/MalformedHttpException.java
+++ b/server/src/main/java/software/amazon/smithy/java/server/exceptions/MalformedHttpException.java
@@ -40,7 +40,8 @@ public final class MalformedHttpException extends ModeledApiException {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
-        return SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return (T) SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
     }
 }

--- a/server/src/main/java/software/amazon/smithy/java/server/exceptions/UnknownOperationException.java
+++ b/server/src/main/java/software/amazon/smithy/java/server/exceptions/UnknownOperationException.java
@@ -40,7 +40,8 @@ public final class UnknownOperationException extends ModeledApiException {
     }
 
     @Override
-    public Object getMemberValue(Schema member) {
-        return SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return (T) SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
     }
 }

--- a/xml-codec/src/test/java/software/amazon/smithy/java/xml/XmlCodecTest.java
+++ b/xml-codec/src/test/java/software/amazon/smithy/java/xml/XmlCodecTest.java
@@ -125,7 +125,7 @@ public class XmlCodecTest {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
### Description of changes
While working on updating pagination I noticed that basically all usages of `getMemberValue` require unchecked casting to a type. This PR updates to move the cast into the `getMemberValue` method to make it easier to use in middleware/extensions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
