### PR TITLE
Reduce build noise, fix or suppress compiler warnings

### DIFF
--- a/buildSrc/src/main/kotlin/CodegenExtension.kt
+++ b/buildSrc/src/main/kotlin/CodegenExtension.kt
@@ -28,6 +28,7 @@ fun Project.addGenerateSrcsTask(
         environment("output", output)
         service?.let { environment("service", it) }
         environment("mode", mode)
+        systemProperty("java.util.logging.config.file", "${project.rootDir}/config/logging/logging.properties")
     }
     tasks.getByName("integ").dependsOn(task)
     tasks.getByName("compileItJava").dependsOn(task)

--- a/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
@@ -53,16 +53,16 @@ testlogger {
     showStackTraces = true
     showFullStackTraces = false
     showCauses = true
-    showSummary = true
-    showPassed = true
-    showSkipped = true
+    showSummary = false
+    showPassed = false
+    showSkipped = false
     showFailed = true
     showOnlySlow = false
     showStandardStreams = true
     showPassedStandardStreams = false
     showSkippedStandardStreams = false
     showFailedStandardStreams = true
-    logLevel = LogLevel.LIFECYCLE
+    logLevel = LogLevel.WARN
 }
 
 /*

--- a/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
@@ -37,6 +37,10 @@ tasks.withType<Javadoc>() {
     (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:-html", "-quiet")
 }
 
+//tasks.withType<JavaCompile> {
+//    options.compilerArgs = listOf("-Xlint:unchecked")
+//}
+
 // Include an Automatic-Module-Name in all JARs.
 afterEvaluate {
     val moduleName: String by extra

--- a/client-http/src/test/java/software/amazon/smithy/java/client/http/useragent/UserAgentPluginTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/client/http/useragent/UserAgentPluginTest.java
@@ -91,7 +91,7 @@ public class UserAgentPluginTest {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             return null;
         }
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/BuilderGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/BuilderGenerator.java
@@ -137,6 +137,7 @@ abstract class BuilderGenerator implements Runnable {
 
         var template = """
             @Override
+            @SuppressWarnings("unchecked")
             public void setMemberValue(Schema member, Object value) {
                 switch (member.memberIndex()) {
                     ${memberSetters:C|}

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -65,6 +65,7 @@ public final class UnionGenerator
                     }
 
                     @Override
+                    @SuppressWarnings("unchecked")
                     public <T> T getMemberValue(${sdkSchema:N} member) {
                         return (T) ${schemaUtils:N}.validateMemberInSchema($$SCHEMA, member, getValue());
                     }

--- a/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/generators/ServiceGenerator.java
+++ b/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/generators/ServiceGenerator.java
@@ -65,6 +65,7 @@ public final class ServiceGenerator implements
                     ${builder:C|}
 
                     @Override
+                    @SuppressWarnings("unchecked")
                     public <I extends ${serializableStruct:T}, O extends ${serializableStruct:T}> ${operationHolder:T}<I, O> getOperation(String operationName) {
                         ${getOperation:C|}
                     }

--- a/config/logging/logging.properties
+++ b/config/logging/logging.properties
@@ -1,0 +1,1 @@
+.level = WARNING

--- a/core/src/jmh/java/software/amazon/smithy/java/core/schema/TraitMapBench.java
+++ b/core/src/jmh/java/software/amazon/smithy/java/core/schema/TraitMapBench.java
@@ -48,7 +48,7 @@ import software.amazon.smithy.model.traits.Trait;
 @Fork(2)
 public class TraitMapBench {
     @Benchmark
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void getTrait(Blackhole bh, TraitState s) {
         Class[] t = s.traitClasses;
         ThreadLocalRandom random = ThreadLocalRandom.current();
@@ -59,7 +59,7 @@ public class TraitMapBench {
     }
 
     @Benchmark
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void getTraitWithKey(Blackhole bh, TraitState s) {
         TraitKey[] keys = s.traitKeys;
         ThreadLocalRandom random = ThreadLocalRandom.current();
@@ -90,6 +90,7 @@ public class TraitMapBench {
             }
         }
 
+        @SuppressWarnings("unchecked")
         private void setupConfig(String config, int i) {
             String[] split = config.split("-");
             int size = Integer.parseInt(split[0]);

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/TraitKey.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/TraitKey.java
@@ -77,6 +77,7 @@ public final class TraitKey<T extends Trait> {
     public static final TraitKey<EndpointTrait> ENDPOINT_TRAIT = TraitKey.get(EndpointTrait.class);
     public static final TraitKey<HostLabelTrait> HOST_LABEL_TRAIT = TraitKey.get(HostLabelTrait.class);
     public static final TraitKey<MediaTypeTrait> MEDIA_TYPE_TRAIT = TraitKey.get(MediaTypeTrait.class);
+    @SuppressWarnings("deprecation")
     public static final TraitKey<EnumTrait> ENUM_TRAIT = TraitKey.get(EnumTrait.class);
     public static final TraitKey<HttpTrait> HTTP_TRAIT = TraitKey.get(HttpTrait.class);
     public static final TraitKey<HttpErrorTrait> HTTP_ERROR_TRAIT = TraitKey.get(HttpErrorTrait.class);

--- a/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
@@ -170,7 +170,7 @@ public class JsonSerializerTest {
                         }
 
                         @Override
-                        public Object getMemberValue(Schema member) {
+                        public <T> T getMemberValue(Schema member) {
                             return null;
                         }
                     }
@@ -206,7 +206,7 @@ public class JsonSerializerTest {
                         }
 
                         @Override
-                        public Object getMemberValue(Schema member) {
+                        public <T> T getMemberValue(Schema member) {
                             return null;
                         }
                     }
@@ -280,7 +280,7 @@ public class JsonSerializerTest {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             return null;
         }
     }
@@ -295,7 +295,7 @@ public class JsonSerializerTest {
         public void serializeMembers(ShapeSerializer serializer) {}
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             return null;
         }
     }

--- a/protocol-tests/src/test/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestDocumentTest.java
+++ b/protocol-tests/src/test/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestDocumentTest.java
@@ -45,7 +45,7 @@ public class ProtocolTestDocumentTest {
                     }
 
                     @Override
-                    public Object getMemberValue(Schema member) {
+                    public <T> T getMemberValue(Schema member) {
                         return null;
                     }
                 }

--- a/rpcv2-cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborTestData.java
+++ b/rpcv2-cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborTestData.java
@@ -48,7 +48,7 @@ final class CborTestData {
         }
 
         @Override
-        public Object getMemberValue(Schema member) {
+        public <T> T getMemberValue(Schema member) {
             return null;
         }
     }

--- a/server/src/main/java/software/amazon/smithy/java/server/ServerBuilder.java
+++ b/server/src/main/java/software/amazon/smithy/java/server/ServerBuilder.java
@@ -76,6 +76,7 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
 
     protected abstract Server buildServer();
 
+    @SuppressWarnings("unchecked")
     protected final T self() {
         return (T) this;
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A full clean build generates a lot of unnecessary noise and warnings. I cleaned up all compiler warnings and we don't need a list of all passed tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
