### PR TITLE
Remove need to rethrow in read hooks and improve

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/ClientInterceptor.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/ClientInterceptor.java
@@ -339,11 +339,8 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      * @param error Error to be thrown, present.
-     * @throws RuntimeException on error or to forward the given {@code error}.
      */
-    default void readAfterDeserialization(OutputHook<?, ?, ?, ?> hook, RuntimeException error) {
-        hook.forward(error);
-    }
+    default void readAfterDeserialization(OutputHook<?, ?, ?, ?> hook, RuntimeException error) {}
 
     /**
      * A hook called when an attempt is completed. This method can modify and return a new output or error matching
@@ -389,11 +386,8 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      * @param error Error to be thrown, present.
-     * @throws RuntimeException on error or to forward the given {@code error}.
      */
-    default void readAfterAttempt(OutputHook<?, ?, ?, ?> hook, RuntimeException error) {
-        hook.forward(error);
-    }
+    default void readAfterAttempt(OutputHook<?, ?, ?, ?> hook, RuntimeException error) {}
 
     /**
      * A hook called when an execution is completed.
@@ -440,9 +434,6 @@ public interface ClientInterceptor {
      *
      * @param hook Hook data.
      * @param error Error to be thrown, present.
-     * @throws RuntimeException on error or to forward the given {@code error}.
      */
-    default void readAfterExecution(OutputHook<?, ?, ?, ?> hook, RuntimeException error) {
-        hook.forward(error);
-    }
+    default void readAfterExecution(OutputHook<?, ?, ?, ?> hook, RuntimeException error) {}
 }

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/OutputHook.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/OutputHook.java
@@ -74,6 +74,7 @@ public final class OutputHook<I extends SerializableStruct, O extends Serializab
     /**
      * Provides a type-safe convenience method to modify the output if it is of a specific class.
      *
+     * @param e Error to throw if not null.
      * @param predicateType Type to map over.
      * @param mapper Mapper that accepts the value if it matches the expected class.
      * @return the updated value.
@@ -81,10 +82,13 @@ public final class OutputHook<I extends SerializableStruct, O extends Serializab
      */
     @SuppressWarnings("unchecked")
     public <R extends SerializableStruct> O mapOutput(
+        RuntimeException e,
         Class<R> predicateType,
         Function<OutputHook<?, R, ?, ?>, R> mapper
     ) {
-        if (predicateType.isInstance(output)) {
+        if (e != null) {
+            throw e;
+        } else if (predicateType.isInstance(output)) {
             return (O) mapper.apply((OutputHook<?, R, ?, ?>) this);
         } else {
             return output;
@@ -94,6 +98,7 @@ public final class OutputHook<I extends SerializableStruct, O extends Serializab
     /**
      * Provides a type-safe convenience method to modify the output if it is of a specific class.
      *
+     * @param e Error to throw if not null.
      * @param predicateType Type to map over.
      * @param state State to provide to the mapper.
      * @param mapper Mapper that accepts the value if it matches the expected class.
@@ -102,11 +107,14 @@ public final class OutputHook<I extends SerializableStruct, O extends Serializab
      */
     @SuppressWarnings("unchecked")
     public <R extends SerializableStruct, T> O mapOutput(
+        RuntimeException e,
         Class<R> predicateType,
         T state,
         BiFunction<OutputHook<?, R, ?, ?>, T, R> mapper
     ) {
-        if (predicateType.isInstance(output)) {
+        if (e != null) {
+            throw e;
+        } else if (predicateType.isInstance(output)) {
             return (O) mapper.apply((OutputHook<?, R, ?, ?>) this, state);
         } else {
             return output;

--- a/client-core/src/test/java/software/amazon/smithy/java/client/core/interceptors/OutputHookTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/client/core/interceptors/OutputHookTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.context.Context;
 
@@ -29,7 +30,21 @@ public class OutputHookTest {
         var context = Context.create();
         var hook = new OutputHook<>(TestStructs.OPERATION, context, foo, null, null, foo);
 
-        assertThat(hook.mapOutput(TestStructs.Bar.class, OutputHook::output), sameInstance(foo));
-        assertThat(hook.mapOutput(TestStructs.Foo.class, f -> new TestStructs.Foo()), not(sameInstance(foo)));
+        assertThat(hook.mapOutput(null, TestStructs.Bar.class, OutputHook::output), sameInstance(foo));
+        assertThat(hook.mapOutput(null, TestStructs.Foo.class, f -> new TestStructs.Foo()), not(sameInstance(foo)));
+    }
+
+    @Test
+    public void throwsErrorIfNotNull() {
+        var foo = new TestStructs.Foo();
+        var context = Context.create();
+        var hook = new OutputHook<>(TestStructs.OPERATION, context, foo, null, null, foo);
+        var err = new RuntimeException("a");
+
+        var e = Assertions.assertThrows(RuntimeException.class, () -> {
+            hook.mapOutput(err, TestStructs.Bar.class, OutputHook::output);
+        });
+
+        assertThat(e, sameInstance(err));
     }
 }


### PR DESCRIPTION
Read only hooks no longer need to rethrow errors.
- They can rethrow, but it's not necessary

OutputHook map functions now accept an error and rethrow if present.
- this should help avoid bugs where people forget to check errors

Log when an error supersedes another error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
