### PR TITLE
Prevent early signer closure

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientPipeline.java
@@ -292,9 +292,10 @@ final class ClientPipeline<RequestT, ResponseT> {
             return identity.thenCompose(identity -> {
                 // Throws when no identity is found.
                 var resolvedIdentity = identity.unwrap();
-                try (var signer = authScheme.signer()) {
-                    return signer.sign(request, resolvedIdentity, signerProperties);
-                }
+                var signer = authScheme.signer();
+                var result = signer.sign(request, resolvedIdentity, signerProperties);
+                result.whenComplete((res, err) -> signer.close());
+                return result;
             });
         }
     }


### PR DESCRIPTION
`Signer::sign` returns a CompletableFuture. Looking at the implementation for the SigV4 signer, we can see that the actual signing logic happens in the completion handler for the future its `sign` method returns. This means our try-with-resources statement may return and `close()` the signer before it's actually signed anything.

---

More generally, we have a problem with resource lifetimes. `try-with-resources` statements are nice, but they cannot be used anywhere we have a potentially asynchronous callback that uses the resource whose lifetime is bounded by the `try` statement's lexical scope.