### PR TITLE
Remove no longer needed TODOs

### DIFF
--- a/aws/client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
+++ b/aws/client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
@@ -72,7 +72,6 @@ public class RestJson1ProtocolTests {
         skipTests = {
             "RestJsonDateTimeWithFractionalSeconds",
             "RestJsonInputAndOutputWithQuotedStringHeaders",
-            "RestJsonHttpPrefixHeadersArePresent",
             "HttpPrefixHeadersResponse",
             "RestJsonHttpPayloadTraitsWithBlob",
             "RestJsonHttpPayloadTraitsWithMediaTypeWithBlob",

--- a/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
+++ b/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
@@ -116,10 +116,7 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
             .deserialize()
             .thenApply(ignore -> {
                 O output = outputBuilder.errorCorrection().build();
-
-                // TODO: error handling from the builder.
                 LOGGER.trace("Successfully built {} from HTTP response with {}", output, getClass().getName());
-
                 return output;
             });
     }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
@@ -33,8 +33,6 @@ import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
-// TODO: for streaming schemas and idempotency token schemas, can we use the member index rather than member name?
-// this would require that the symbol provider could provide the index position, which requires a pre-sort of members.
 @SmithyInternalApi
 public class OperationGenerator
     implements Consumer<GenerateOperationDirective<CodeGenerationContext, JavaCodegenSettings>> {

--- a/server-aws-rest-json1/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
+++ b/server-aws-rest-json1/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
@@ -46,9 +46,6 @@ public class AwsRestJson1ProtocolTests {
 
             // Header splitting needs work.
             "RestJsonInputAndOutputWithQuotedStringHeaders",
-
-            // TODO: update this test to use lowercase prefix header names.
-            "RestJsonHttpPrefixHeadersArePresent"
         },
         skipOperations = {
             "aws.protocoltests.restjson#DocumentType",


### PR DESCRIPTION
1. Response deserialization already accounts for errors and throws the appropriate error when values are incorrect types. Error correction also ensure that require validation passes.
2. OperationGenerator already uses the appropriate generated SCHEMA to refer to idempotency tokens and streaming members.
3. RestJsonHttpPrefixHeadersArePresent protocol test was updated to use lowercase names, allowing us to pass in client and server.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
