### PR TITLE
Remove unnecessary application of transport

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
@@ -40,7 +40,7 @@ public abstract class Client {
 
         // Resolve the transport and apply it as a plugin before user-defined plugins, allowing user-defined plugins
         // to supersede and functionality of plugins applied by transports.
-        configBuilder.resolveTransport().applyPlugin(configBuilder.transport());
+        configBuilder.resolveTransport();
 
         for (ClientPlugin plugin : builder.plugins) {
             configBuilder.applyPlugin(plugin);


### PR DESCRIPTION
The transport is automatically applied as a plugin when resolveTransport is called.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
