### PR TITLE
Add MockPlugin

### DIFF
--- a/aws/aws-client-http/build.gradle.kts
+++ b/aws/aws-client-http/build.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
     api(project(":http-api"))
 
     testImplementation(project(":dynamic-client"))
+    testImplementation(project(":mock-client-plugin"))
     testImplementation(project(":aws:client-awsjson"))
 }

--- a/aws/client-awsjson/src/main/java/software/amazon/smithy/java/aws/client/awsjson/AwsJsonProtocol.java
+++ b/aws/client-awsjson/src/main/java/software/amazon/smithy/java/aws/client/awsjson/AwsJsonProtocol.java
@@ -40,7 +40,7 @@ abstract sealed class AwsJsonProtocol extends HttpClientProtocol permits AwsJson
      *                discriminator of documents that use relative shape IDs.
      */
     public AwsJsonProtocol(ShapeId trait, ShapeId service) {
-        super(trait.toString());
+        super(trait);
         this.service = service;
         this.codec = JsonCodec.builder().defaultNamespace(service.getNamespace()).build();
 

--- a/aws/client-restjson/src/main/java/software/amazon/smithy/java/aws/client/restjson/RestJsonClientProtocol.java
+++ b/aws/client-restjson/src/main/java/software/amazon/smithy/java/aws/client/restjson/RestJsonClientProtocol.java
@@ -39,7 +39,7 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
      *                relative shape IDs.
      */
     public RestJsonClientProtocol(ShapeId service) {
-        super(RestJson1Trait.ID.toString());
+        super(RestJson1Trait.ID);
 
         this.codec = JsonCodec.builder()
             .useJsonName(true)

--- a/aws/client-restxml/src/main/java/software/amazon/smithy/java/aws/client/restxml/RestXmlClientProtocol.java
+++ b/aws/client-restxml/src/main/java/software/amazon/smithy/java/aws/client/restxml/RestXmlClientProtocol.java
@@ -39,7 +39,7 @@ public final class RestXmlClientProtocol extends HttpBindingClientProtocol<AwsEv
      *                relative shape IDs.
      */
     public RestXmlClientProtocol(ShapeId service) {
-        super(RestXmlTrait.ID.toString());
+        super(RestXmlTrait.ID);
 
         this.codec = XmlCodec.builder().build();
         this.errorDeserializer = HttpErrorDeserializer.builder()

--- a/aws/client-rpcv2-cbor-protocol/src/main/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocol.java
+++ b/aws/client-rpcv2-cbor-protocol/src/main/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocol.java
@@ -39,7 +39,7 @@ public final class RpcV2CborProtocol extends HttpClientProtocol {
     private final HttpErrorDeserializer errorDeserializer;
 
     public RpcV2CborProtocol(ShapeId service) {
-        super(Rpcv2CborTrait.ID.toString());
+        super(Rpcv2CborTrait.ID);
         this.service = service;
         this.errorDeserializer = HttpErrorDeserializer.builder()
             .codec(CBOR_CODEC)

--- a/client-core/build.gradle.kts
+++ b/client-core/build.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
 
     testImplementation(project(":dynamic-client"))
     testImplementation(project(":aws:client-restjson"))
+    testImplementation(project(":mock-client-plugin"))
 }

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
@@ -40,7 +40,7 @@ public abstract class Client {
 
         // Resolve the transport and apply it as a plugin before user-defined plugins, allowing user-defined plugins
         // to supersede and functionality of plugins applied by transports.
-        configBuilder.resolveTransport().applyPlugin(configBuilder.transport());
+        configBuilder.resolveTransport();
 
         for (ClientPlugin plugin : builder.plugins) {
             configBuilder.applyPlugin(plugin);

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientConfig.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientConfig.java
@@ -351,6 +351,7 @@ public final class ClientConfig {
          */
         public Builder transport(ClientTransport<?, ?> transport) {
             this.transport = transport;
+            applyPlugin(transport);
             return this;
         }
 
@@ -366,10 +367,6 @@ public final class ClientConfig {
             Objects.requireNonNull(protocol, "protocol must be set to resolve a transport");
             if (transport == null) {
                 transport(discoverTransport(protocol));
-            }
-            // If the transport has not yet been applied as a plugin, apply it now.
-            if (!appliedPlugins.contains(transport.getClass())) {
-                applyPlugin(transport);
             }
             return this;
         }

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientProtocol.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientProtocol.java
@@ -13,6 +13,7 @@ import software.amazon.smithy.java.core.schema.ApiException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
  * Handles request and response serialization.
@@ -26,7 +27,7 @@ public interface ClientProtocol<RequestT, ResponseT> {
      *
      * @return the protocol ID.
      */
-    String id();
+    ShapeId id();
 
     /**
      * Get the message exchange.

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/auth/scheme/AuthSchemeResolverParams.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/auth/scheme/AuthSchemeResolverParams.java
@@ -8,13 +8,14 @@ package software.amazon.smithy.java.client.core.auth.scheme;
 import java.util.Objects;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
  * AuthSchemeResolver parameters.
  */
 public final class AuthSchemeResolverParams {
 
-    private final String protocolId;
+    private final ShapeId protocolId;
     private final ApiOperation<?, ?> operation;
     private final Context context;
 
@@ -38,7 +39,7 @@ public final class AuthSchemeResolverParams {
      *
      * @return the protocol ID.
      */
-    public String protocolId() {
+    public ShapeId protocolId() {
         return protocolId;
     }
 
@@ -84,7 +85,7 @@ public final class AuthSchemeResolverParams {
      */
     public static final class Builder {
 
-        private String protocolId;
+        private ShapeId protocolId;
         private ApiOperation<?, ?> operation;
         private Context context;
 
@@ -105,7 +106,7 @@ public final class AuthSchemeResolverParams {
          * @param protocolId The protocol ID.
          * @return the builder.
          */
-        public Builder protocolId(String protocolId) {
+        public Builder protocolId(ShapeId protocolId) {
             this.protocolId = protocolId;
             return this;
         }

--- a/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
+++ b/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
@@ -26,6 +26,7 @@ import software.amazon.smithy.java.http.binding.HttpBinding;
 import software.amazon.smithy.java.http.binding.RequestSerializer;
 import software.amazon.smithy.java.http.binding.ResponseDeserializer;
 import software.amazon.smithy.java.logging.InternalLogger;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
  * An HTTP-based protocol that uses HTTP binding traits.
@@ -37,7 +38,7 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
     private static final InternalLogger LOGGER = InternalLogger.getLogger(HttpBindingClientProtocol.class);
     private final HttpBinding httpBinding = new HttpBinding();
 
-    public HttpBindingClientProtocol(String id) {
+    public HttpBindingClientProtocol(ShapeId id) {
         super(id);
     }
 

--- a/client-http/build.gradle.kts
+++ b/client-http/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 description = "This module provides client HTTP functionality"
 
 extra["displayName"] = "Smithy :: Java :: Client Http"
-extra["moduleName"] = "software.amazon.smithy.java.client-http"
+extra["moduleName"] = "software.amazon.smithy.java.client.http"
 
 dependencies {
     api(project(":client-core"))

--- a/client-http/src/main/java/software/amazon/smithy/java/client/http/HttpClientProtocol.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/client/http/HttpClientProtocol.java
@@ -11,20 +11,21 @@ import software.amazon.smithy.java.client.core.endpoint.Endpoint;
 import software.amazon.smithy.java.http.api.HttpRequest;
 import software.amazon.smithy.java.http.api.HttpResponse;
 import software.amazon.smithy.java.io.uri.URIBuilder;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
  * An abstract class for implementing HTTP-Based protocol.
  */
 public abstract class HttpClientProtocol implements ClientProtocol<HttpRequest, HttpResponse> {
 
-    private final String id;
+    private final ShapeId id;
 
-    public HttpClientProtocol(String id) {
+    public HttpClientProtocol(ShapeId id) {
         this.id = id;
     }
 
     @Override
-    public final String id() {
+    public final ShapeId id() {
         return id;
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ModeledApiException.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ModeledApiException.java
@@ -63,4 +63,22 @@ public abstract class ModeledApiException extends ApiException implements Serial
     public final Schema schema() {
         return schema;
     }
+
+    /**
+     * Get the status code of an error from its schema.
+     *
+     * @param schema Schema to check for the httpError and error trait.
+     * @return the resolved status code, or 500.
+     */
+    public static int getHttpStatusCode(Schema schema) {
+        var httpError = schema.getTrait(TraitKey.HTTP_ERROR_TRAIT);
+        if (httpError != null) {
+            return httpError.getCode();
+        }
+        var errorTrait = schema.getTrait(TraitKey.ERROR_TRAIT);
+        if (errorTrait != null) {
+            return errorTrait.getDefaultHttpStatusCode();
+        }
+        return 500;
+    }
 }

--- a/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSerializer.java
@@ -14,6 +14,7 @@ import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.concurrent.Flow;
 import java.util.function.BiConsumer;
+import software.amazon.smithy.java.core.schema.ModeledApiException;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
@@ -105,6 +106,7 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
         }
 
         if (isFailure) {
+            responseStatus = ModeledApiException.getHttpStatusCode(schema);
             headers.put("X-Amzn-Errortype", List.of(schema.id().getName()));
         }
 

--- a/mock-client-plugin/build.gradle.kts
+++ b/mock-client-plugin/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("smithy-java.module-conventions")
+}
+
+description = "This module provides mocking functionality for HTTP clients"
+
+extra["displayName"] = "Smithy :: Java :: JSON"
+extra["moduleName"] = "software.amazon.smithy.java.client.http.mock"
+
+dependencies {
+    implementation(project(":logging"))
+    implementation(project(":core"))
+    implementation(project(":client-core"))
+    implementation(project(":client-http"))
+
+    // Included to allow mocking responses based on shapes.
+    implementation(project(":server-core"))
+
+    testImplementation(project(":dynamic-client"))
+    testImplementation(project(":aws:client-restjson"))
+    testImplementation(project(":server-aws-rest-json1"))
+}

--- a/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/CurrentRequest.java
+++ b/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/CurrentRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http.mock;
+
+import software.amazon.smithy.java.client.core.ClientProtocol;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.http.api.HttpRequest;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.server.Operation;
+
+/**
+ * Package-private request placeholder.
+ *
+ * @param operation Server operation being sent.
+ * @param request
+ * @param protocol
+ */
+record CurrentRequest(
+    Operation<? extends SerializableStruct, ? extends SerializableStruct> operation,
+    MockedRequest request,
+    ClientProtocol<HttpRequest, HttpResponse> protocol
+) {
+    /**
+     * Create a new CurrentRequest using the provided request.
+     *
+     * @param request request to use.
+     * @return the new CurrentRequest.
+     */
+    CurrentRequest withMessage(HttpRequest request) {
+        return new CurrentRequest(operation, request().withRequest(request), protocol);
+    }
+}

--- a/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockPlugin.java
+++ b/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockPlugin.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http.mock;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.ServiceLoader;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.ClientPlugin;
+import software.amazon.smithy.java.client.core.ClientProtocol;
+import software.amazon.smithy.java.client.core.ClientTransport;
+import software.amazon.smithy.java.client.core.MessageExchange;
+import software.amazon.smithy.java.client.core.endpoint.Endpoint;
+import software.amazon.smithy.java.client.http.HttpMessageExchange;
+import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.java.http.api.HttpHeaders;
+import software.amazon.smithy.java.http.api.HttpRequest;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.server.Operation;
+import software.amazon.smithy.java.server.Service;
+import software.amazon.smithy.java.server.core.HttpJob;
+import software.amazon.smithy.java.server.core.ProtocolResolver;
+import software.amazon.smithy.java.server.core.ServerProtocol;
+import software.amazon.smithy.java.server.core.ServerProtocolProvider;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Provides mocking support for clients by overriding the transport entirely and wrapping and delegating to the
+ * underlying protocol of the client.
+ *
+ * <p>The client must use an HTTP protocol that uses {@link HttpMessageExchange}.
+ *
+ * <p>The client is mocked at both the protocol and transport layer to allow for mocking HTTP responses and to
+ * translate pre-made output shapes into HTTP responses using a {@link ServerProtocol} found on the classpath.
+ * To use this automatic translation feature, each ServerProtocol must be on the classpath.
+ *
+ * <p>The requests that were sent and their corresponding inputs can be queried using {@link #getRequests()}, and
+ * later cleared using {@link #clearRequests()}.
+ */
+public final class MockPlugin implements ClientPlugin {
+
+    // Used to pass the required context from the wrapped protocol to the wrapped transport.
+    private static final Context.Key<CurrentRequest> CURRENT_REQUEST = Context.key("CURRENT_REQUEST");
+
+    private static final Map<ShapeId, ServerProtocolProvider> SERVER_PROTOCOL_HANDLERS = ServiceLoader.load(
+        ServerProtocolProvider.class,
+        ProtocolResolver.class.getClassLoader()
+    )
+        .stream()
+        .map(ServiceLoader.Provider::get)
+        .collect(Collectors.toMap(ServerProtocolProvider::getProtocolId, Function.identity()));
+
+    private final List<BiFunction<Context, SerializableStruct, MockedResult>> matchers = new ArrayList<>();
+    private final List<MockedRequest> requests = Collections.synchronizedList(new ArrayList<>());
+    private final Service mockService;
+
+    private MockPlugin(Builder builder) {
+        this.mockService = new MockService();
+        this.matchers.addAll(builder.matchers);
+    }
+
+    /**
+     * Create a new MockPlugin using a builder.
+     *
+     * @return the builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void configureClient(ClientConfig.Builder config) {
+        config.protocol(new MockProtocol((ClientProtocol<HttpRequest, HttpResponse>) config.protocol()));
+        config.transport(new MockTransport());
+    }
+
+    /**
+     * Get the requests that have been intercepted by the plugin.
+     *
+     * @return the intercepted requests.
+     */
+    public List<MockedRequest> getRequests() {
+        return List.copyOf(requests);
+    }
+
+    /**
+     * Clear the received request list.
+     */
+    public void clearRequests() {
+        requests.clear();
+    }
+
+    /**
+     * Creates a MockPlugin.
+     */
+    public static final class Builder {
+        private final List<BiFunction<Context, SerializableStruct, MockedResult>> matchers = new ArrayList<>();
+
+        private Builder() {}
+
+        /**
+         * Create the plugin.
+         *
+         * @return the created MockPlugin.
+         */
+        public MockPlugin build() {
+            return new MockPlugin(this);
+        }
+
+        /**
+         * Add a matcher that mocks the response if the matcher returns a non-null value.
+         *
+         * <p>If null is returned, then subsequent matchers will attempt to match and intercept the request. If no
+         * matcher intercepts the request, {@link NoSuchElementException} is thrown.
+         *
+         * @param matcher Matcher that receives the context and input shape, and returns a result or null.
+         * @return the builder.
+         */
+        public Builder addMatcher(BiFunction<Context, SerializableStruct, MockedResult> matcher) {
+            matchers.add(matcher);
+            return this;
+        }
+
+        /**
+         * Add a queue of mocked results to the plugin.
+         *
+         * <p>This will add a matcher that unconditionally attempts to return a result from the queue. It is added in
+         * order relative to other matchers, meaning it can be used after more specific matchers, or even used one
+         * queue after the other to drain multiple queues.
+         *
+         * @param resultQueue Queue to add.
+         * @return the builder.
+         */
+        public Builder addQueue(MockQueue resultQueue) {
+            matchers.add((context, input) -> resultQueue.poll());
+            return this;
+        }
+    }
+
+    private final class MockProtocol implements ClientProtocol<HttpRequest, HttpResponse> {
+        private final ClientProtocol<HttpRequest, HttpResponse> delegate;
+
+        MockProtocol(ClientProtocol<HttpRequest, HttpResponse> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ShapeId id() {
+            return delegate.id();
+        }
+
+        @Override
+        public MessageExchange<HttpRequest, HttpResponse> messageExchange() {
+            return delegate.messageExchange();
+        }
+
+        @Override
+        public <I extends SerializableStruct, O extends SerializableStruct> HttpRequest createRequest(
+            ApiOperation<I, O> operation,
+            I input,
+            Context context,
+            URI endpoint
+        ) {
+            var serviceOperation = Operation.of(
+                operation.schema().id().getName(),
+                (i, c) -> {
+                    throw new UnsupportedOperationException();
+                },
+                operation,
+                mockService
+            );
+            var currentRequest = new CurrentRequest(serviceOperation, new MockedRequest(input, null), delegate);
+            context.put(CURRENT_REQUEST, currentRequest);
+            return delegate.createRequest(operation, input, context, endpoint);
+        }
+
+        @Override
+        public HttpRequest setServiceEndpoint(HttpRequest request, Endpoint endpoint) {
+            return delegate.setServiceEndpoint(request, endpoint);
+        }
+
+        @Override
+        public <I extends SerializableStruct, O extends SerializableStruct> CompletableFuture<O> deserializeResponse(
+            ApiOperation<I, O> operation,
+            Context context,
+            TypeRegistry typeRegistry,
+            HttpRequest request,
+            HttpResponse response
+        ) {
+            return delegate.deserializeResponse(operation, context, typeRegistry, request, response);
+        }
+    }
+
+    private final class MockTransport implements ClientTransport<HttpRequest, HttpResponse> {
+        @Override
+        public MessageExchange<HttpRequest, HttpResponse> messageExchange() {
+            return HttpMessageExchange.INSTANCE;
+        }
+
+        @Override
+        public CompletableFuture<HttpResponse> send(Context context, HttpRequest request) {
+            var currentRequest = context.expect(CURRENT_REQUEST);
+
+            // Update the current context value with the potentially changed request.
+            currentRequest = currentRequest.withMessage(request);
+            context.put(CURRENT_REQUEST, currentRequest);
+
+            // Track the request here rather than when the request is created because this method is called
+            // more often than the request creation method when retries happen.
+            requests.add(currentRequest.request());
+
+            MockedResult result = null;
+            for (var matcher : matchers) {
+                result = matcher.apply(context, currentRequest.request().input());
+                if (result != null) {
+                    break;
+                }
+            }
+
+            if (result == null) {
+                throw new NoSuchElementException("No matcher matched input: " + currentRequest.request().input());
+            }
+
+            if (result instanceof MockedResult.Response res) {
+                return CompletableFuture.completedFuture(res.response());
+            } else if (result instanceof MockedResult.Error err) {
+                return CompletableFuture.failedFuture(err.e());
+            } else if (result instanceof MockedResult.Output o) {
+                return replyWithMockOutput(currentRequest, o);
+            } else {
+                throw new IllegalStateException("Unknown result type: " + result.getClass().getName());
+            }
+        }
+    }
+
+    private CompletableFuture<HttpResponse> replyWithMockOutput(
+        CurrentRequest currentRequest,
+        MockedResult.Output output
+    ) {
+        var cRequest = currentRequest.request().request();
+        var serverRequest = new software.amazon.smithy.java.server.core.HttpRequest(
+            cRequest.headers(),
+            cRequest.uri(),
+            cRequest.method()
+        );
+
+        // Use the explicitly provided protocol if set, otherwise try to find the matching server protocol.
+        var protocol = output.protocol();
+        if (protocol == null) {
+            protocol = detectServerProtocol(currentRequest.protocol().id());
+        }
+
+        serverRequest.setDataStream(cRequest.body());
+        var response = new software.amazon.smithy.java.server.core.HttpResponse(HttpHeaders.ofModifiable());
+        var job = new HttpJob(currentRequest.operation(), protocol, serverRequest, response);
+
+        CompletableFuture<Void> future;
+        if (output.output() instanceof RuntimeException e) {
+            future = protocol.serializeError(job, e);
+        } else {
+            future = protocol.serializeOutput(job, output.output());
+        }
+
+        return future.thenApply(ignored -> {
+            return HttpResponse.builder()
+                .statusCode(response.getStatusCode())
+                .headers(response.headers())
+                .body(response.getSerializedValue())
+                .build();
+        });
+    }
+
+    private static ServerProtocol detectServerProtocol(ShapeId id) {
+        var provider = SERVER_PROTOCOL_HANDLERS.get(id);
+        if (provider == null) {
+            throw new IllegalArgumentException("No server protocol could be found for " + id);
+        }
+        return provider.provideProtocolHandler(List.of());
+    }
+}

--- a/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockQueue.java
+++ b/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockQueue.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http.mock;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.server.core.ServerProtocol;
+
+/**
+ * A thread-safe mutable queue of {@link MockedResult} values to return from a {@link MockPlugin}.
+ */
+public final class MockQueue {
+
+    private final Queue<MockedResult> queue = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Dequeue a result from the queue.
+     *
+     * @return the result or null if no results are available.
+     */
+    public MockedResult poll() {
+        return queue.poll();
+    }
+
+    /**
+     * Get the remaining number of results in the queue.
+     *
+     * @return the remaining result count.
+     */
+    public int remaining() {
+        return queue.size();
+    }
+
+    /**
+     * Clear the result queue.
+     */
+    public MockQueue clear() {
+        queue.clear();
+        return this;
+    }
+
+    /**
+     * Enqueue a mock HTTP response.
+     *
+     * @param response Response to enqueue.
+     */
+    public MockQueue enqueue(HttpResponse response) {
+        queue.offer(new MockedResult.Response(response));
+        return this;
+    }
+
+    /**
+     * Enqueue a mocked output shape, relying on on-demand server protocol resolution in the mock transport.
+     *
+     * <p>If a corresponding protocol can't be found, an exception is thrown at that point.
+     *
+     * <p>Exceptions that implement {@link SerializableStruct} can be enqueued here too if you want the entire
+     * serialization process to occur. Other exceptions should be given explicitly to {@link #enqueueError}.
+     *
+     * @param output the output to enqueue.
+     */
+    public MockQueue enqueue(SerializableStruct output) {
+        enqueue(null, output);
+        return this;
+    }
+
+    /**
+     * Enqueue a mocked output shape using a specific server protocol.
+     *
+     * @param protocol Protocol to use when serializing the output shape.
+     * @param output Output shape to enqueue.
+     */
+    public MockQueue enqueue(ServerProtocol protocol, SerializableStruct output) {
+        queue.offer(new MockedResult.Output(output, protocol));
+        return this;
+    }
+
+    /**
+     * Enqueue a specific exception to be thrown by the transport.
+     *
+     * @param e Exception to throw.
+     */
+    public MockQueue enqueueError(RuntimeException e) {
+        queue.offer(new MockedResult.Error(e));
+        return this;
+    }
+}

--- a/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockService.java
+++ b/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http.mock;
+
+import java.util.List;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.server.Operation;
+import software.amazon.smithy.java.server.Service;
+
+/**
+ * Package-private MockService.
+ *
+ * <p>It just throws and does nothing.
+ */
+final class MockService implements Service {
+    @Override
+    public <I extends SerializableStruct, O extends SerializableStruct> Operation<I, O> getOperation(
+        String operationName
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Operation<? extends SerializableStruct, ? extends SerializableStruct>> getAllOperations() {
+        return List.of();
+    }
+
+    @Override
+    public Schema schema() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockedRequest.java
+++ b/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockedRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http.mock;
+
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.http.api.HttpRequest;
+
+/**
+ * A mocked request received by the {@link MockPlugin}.
+ *
+ * @param input The input shape.
+ * @param request The HTTP request that was sent.
+ */
+public record MockedRequest(SerializableStruct input, HttpRequest request) {
+    /**
+     * Create an updated mocked request using the given request.
+     *
+     * @param request HTTP request to set.
+     * @return a new mocked request.
+     */
+    public MockedRequest withRequest(HttpRequest request) {
+        return new MockedRequest(input(), request);
+    }
+}

--- a/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockedResult.java
+++ b/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockedResult.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http.mock;
+
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.server.core.ServerProtocol;
+
+/**
+ * A mocked result to return from a {@link MockPlugin}.
+ */
+public sealed interface MockedResult {
+    /**
+     * Return a serialized output shape using the given protocol.
+     *
+     * @param output   Shape to serialize.
+     * @param protocol Custom and optional protocol used to serialize the shape.
+     */
+    record Output(SerializableStruct output, ServerProtocol protocol) implements MockedResult {
+        /**
+         * Serializes the output by dynamically detecting the protocol used when a call is made.
+         *
+         * <p>If a corresponding server protocol cannot be found for the dynamically detected client protocol, then
+         * a {@link IllegalArgumentException} is thrown at that time.
+         *
+         * @param output Output to serialize.
+         */
+        public Output(SerializableStruct output) {
+            this(output, null);
+        }
+    }
+
+    /**
+     * Returns a specific HTTP response.
+     *
+     * @param response Response to return.
+     */
+    record Response(HttpResponse response) implements MockedResult {}
+
+    /**
+     * Throws a specific exception directly rather than serializing it.
+     *
+     * <p>To serialize and then throw an exception, create the modeled exception and create an {@link Output} result.
+     *
+     * @param e The error to throw.
+     */
+    record Error(RuntimeException e) implements MockedResult {}
+}

--- a/mock-client-plugin/src/test/java/software/amazon/smithy/java/client/http/mock/MockPluginTest.java
+++ b/mock-client-plugin/src/test/java/software/amazon/smithy/java/client/http/mock/MockPluginTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http.mock;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
+import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
+import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
+import software.amazon.smithy.java.client.core.interceptors.OutputHook;
+import software.amazon.smithy.java.core.schema.ApiException;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.dynamicclient.DynamicClient;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.retries.api.RetrySafety;
+import software.amazon.smithy.java.server.exceptions.InternalServerError;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public class MockPluginTest {
+
+    private static final ShapeId SERVICE = ShapeId.from("smithy.example#Sprockets");
+
+    private static final Model MODEL = Model.assembler()
+        .addUnparsedModel("test.smithy", """
+            $version: "2"
+            namespace smithy.example
+
+            @aws.protocols#restJson1
+            service Sprockets {
+                operations: [GetSprocket]
+                errors: [ServiceFooError]
+            }
+
+            @http(method: "POST", uri: "/s")
+            operation GetSprocket {
+                input := {
+                    id: String
+                }
+                output := {
+                    id: String
+                }
+                errors: [InvalidSprocketId]
+            }
+
+            @error("client")
+            @httpError(429)
+            @retryable
+            structure InvalidSprocketId {}
+
+            @error("server")
+            @httpError(500)
+            structure ServiceFooError {}
+            """)
+        .discoverModels()
+        .assemble()
+        .unwrap();
+
+    @Test
+    public void returnsMockedOutput() throws URISyntaxException {
+        var mockQueue = new MockQueue();
+        var mock = MockPlugin.builder().addQueue(mockQueue).build();
+
+        var client = DynamicClient.builder()
+            .service(SERVICE)
+            .model(MODEL)
+            .addPlugin(mock)
+            .endpointResolver(EndpointResolver.staticEndpoint(new URI("http://localhost")))
+            .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+            .build();
+
+        mockQueue.enqueue(
+            client.createStruct(
+                ShapeId.from("smithy.example#GetSprocketOutput"),
+                Document.createStringMap(Map.of("id", Document.createString("a")))
+            )
+        );
+        mockQueue.enqueue(
+            client.createStruct(
+                ShapeId.from("smithy.example#GetSprocketOutput"),
+                Document.createStringMap(Map.of("id", Document.createString("b")))
+            )
+        );
+
+        var result1 = client.call("GetSprocket");
+        assertThat(result1.getMember("id").asString(), equalTo("a"));
+
+        var result2 = client.call("GetSprocket");
+        assertThat(result2.getMember("id").asString(), equalTo("b"));
+
+        assertThat(mock.getRequests(), hasSize(2));
+    }
+
+    @Test
+    public void returnsMockedInternalError() throws URISyntaxException {
+        var mockQueue = new MockQueue().enqueue(new InternalServerError("Oh no"));
+        var mock = MockPlugin.builder().addQueue(mockQueue).build();
+
+        var client = DynamicClient.builder()
+            .service(SERVICE)
+            .model(MODEL)
+            .addPlugin(mock)
+            .endpointResolver(EndpointResolver.staticEndpoint(new URI("http://localhost")))
+            .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+            .build();
+
+        var e = Assertions.assertThrows(ApiException.class, () -> client.call("GetSprocket"));
+        assertThat(e.getFault(), equalTo(ApiException.Fault.SERVER));
+        assertThat(e.isRetrySafe(), equalTo(RetrySafety.MAYBE));
+
+        assertThat(mock.getRequests(), hasSize(1));
+    }
+
+    @Test
+    public void returnsMockedExceptionsDirectly() throws URISyntaxException {
+        var mockQueue = new MockQueue().enqueueError(new InternalServerError("Oh no"));
+        var mock = MockPlugin.builder().addQueue(mockQueue).build();
+
+        var client = DynamicClient.builder()
+            .service(SERVICE)
+            .model(MODEL)
+            .addPlugin(mock)
+            .endpointResolver(EndpointResolver.staticEndpoint(new URI("http://localhost")))
+            .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+            .build();
+
+        Assertions.assertThrows(InternalServerError.class, () -> client.call("GetSprocket"));
+        assertThat(mock.getRequests(), hasSize(1));
+    }
+
+    @Test
+    public void returnsMockedHttpResponses() throws URISyntaxException {
+        AtomicReference<Boolean> ref = new AtomicReference<>();
+
+        var mockQueue = new MockQueue()
+            .enqueue(HttpResponse.builder().statusCode(404).withAddedHeader("a", "b").build());
+        var mock = MockPlugin.builder().addQueue(mockQueue).build();
+
+        var client = DynamicClient.builder()
+            .service(SERVICE)
+            .model(MODEL)
+            .addPlugin(mock)
+            .endpointResolver(EndpointResolver.staticEndpoint(new URI("http://localhost")))
+            .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+            .addInterceptor(new ClientInterceptor() {
+                @Override
+                public void readAfterExecution(OutputHook<?, ?, ?, ?> hook, RuntimeException error) {
+                    assertThat(error, not(nullValue()));
+                    assertThat(hook.response(), not(nullValue()));
+                    assertThat(hook.response(), instanceOf(HttpResponse.class));
+                    var res = (HttpResponse) hook.response();
+                    assertThat(res.headers().firstValue("a"), equalTo("b"));
+                    ref.set(true);
+                }
+            })
+            .build();
+
+        var e = Assertions.assertThrows(ApiException.class, () -> client.call("GetSprocket"));
+        assertThat(e.getFault(), is(ApiException.Fault.CLIENT));
+
+        assertThat(mock.getRequests(), hasSize(1));
+
+        // Make sure the interceptor was called.
+        assertThat(ref.get(), is(true));
+    }
+
+    @Test
+    public void returnsResultsBasedOnPredicates() throws URISyntaxException {
+        var aQueue = new MockQueue();
+        var bQueue = new MockQueue();
+
+        var mock = MockPlugin.builder()
+            .addMatcher((ctx, i) -> {
+                if (i instanceof Document d) {
+                    if (d.getMember("id").asString().equals("a")) {
+                        return aQueue.poll();
+                    }
+                }
+                return null;
+            })
+            .addMatcher((ctx, i) -> {
+                if (i instanceof Document d) {
+                    if (d.getMember("id").asString().equals("b")) {
+                        return bQueue.poll();
+                    }
+                }
+                return null;
+            })
+            .build();
+
+        var client = DynamicClient.builder()
+            .service(SERVICE)
+            .model(MODEL)
+            .addPlugin(mock)
+            .endpointResolver(EndpointResolver.staticEndpoint(new URI("http://localhost")))
+            .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+            .build();
+
+        // Because we need to use the dynamic client itself to enqueue these responses, we have to defer queueing them
+        // instead of returning them directly from the matcher.
+        aQueue.enqueue(
+            client.createStruct(
+                ShapeId.from("smithy.example#GetSprocketOutput"),
+                Document.createStringMap(Map.of("id", Document.createString("a")))
+            )
+        );
+
+        bQueue.enqueue(
+            client.createStruct(
+                ShapeId.from("smithy.example#GetSprocketOutput"),
+                Document.createStringMap(Map.of("id", Document.createString("b")))
+            )
+        );
+
+        var aresult = client.call("GetSprocket", Document.createStringMap(Map.of("id", Document.createString("a"))));
+        assertThat(aresult.getMember("id").asString(), equalTo("a"));
+
+        var bresult = client.call("GetSprocket", Document.createStringMap(Map.of("id", Document.createString("b"))));
+        assertThat(bresult.getMember("id").asString(), equalTo("b"));
+
+        assertThat(mock.getRequests(), hasSize(2));
+    }
+}

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
@@ -21,9 +21,11 @@ import software.amazon.smithy.java.client.http.HttpMessageExchange;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.java.logging.InternalLogger;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
  * A mock client used to execute protocol tests.
@@ -82,8 +84,8 @@ final class MockClient extends Client {
     private record PlaceHolderProtocol<Req, Res>(MessageExchange<Req, Res> messageExchange) implements
         ClientProtocol<Req, Res> {
         @Override
-        public String id() {
-            return "placeholder";
+        public ShapeId id() {
+            return PreludeSchemas.DOCUMENT.id();
         }
 
         @Override

--- a/server-aws-rest-json1/src/main/java/software/amazon/smithy/java/server/protocols/restjson/router/UriTreeMatcherMapBuilder.java
+++ b/server-aws-rest-json1/src/main/java/software/amazon/smithy/java/server/protocols/restjson/router/UriTreeMatcherMapBuilder.java
@@ -44,7 +44,7 @@ final class UriTreeMatcherMapBuilder<T> implements UriMatcherMapBuilder<T> {
      */
     @Override
     public UriMatcherMap<T> build() {
-        return new UriTreeMatcherMap<>(root.seal(), allowEmptyPathSegments);
+        return new UriTreeMatcherMap<>(root.seal(), allowEmptyPathSegments != null && allowEmptyPathSegments);
     }
 
     /**

--- a/server-rpcv2-cbor/src/main/java/software/amazon/smithy/java/server/protocols/rpcv2/RpcV2CborProtocol.java
+++ b/server-rpcv2-cbor/src/main/java/software/amazon/smithy/java/server/protocols/rpcv2/RpcV2CborProtocol.java
@@ -8,8 +8,8 @@ package software.amazon.smithy.java.server.protocols.rpcv2;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.cbor.Rpcv2CborCodec;
+import software.amazon.smithy.java.core.schema.ModeledApiException;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
-import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.io.ByteBufferOutputStream;
 import software.amazon.smithy.java.io.datastream.DataStream;
 import software.amazon.smithy.java.server.Service;
@@ -97,17 +97,7 @@ final class RpcV2CborProtocol extends ServerProtocol {
         var httpJob = job.asHttpJob();
         final int statusCode;
         if (isError) {
-            var httpError = output.schema().getTrait(TraitKey.HTTP_ERROR_TRAIT);
-            if (httpError != null) {
-                statusCode = httpError.getCode();
-            } else {
-                var errorTrait = output.schema().getTrait(TraitKey.ERROR_TRAIT);
-                if (errorTrait != null && errorTrait.isClientError()) {
-                    statusCode = 400;
-                } else {
-                    statusCode = 500;
-                }
-            }
+            statusCode = ModeledApiException.getHttpStatusCode(output.schema());
         } else {
             statusCode = 200;
         }

--- a/server/src/main/java/software/amazon/smithy/java/server/exceptions/InternalServerError.java
+++ b/server/src/main/java/software/amazon/smithy/java/server/exceptions/InternalServerError.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.server.exceptions;
 
 import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
@@ -17,7 +18,9 @@ public final class InternalServerError extends ModeledApiException {
         "software.amazon.smithy.exceptions#InternalServerError"
     );
 
-    private static final Schema SCHEMA = Schema.structureBuilder(ID).build();
+    private static final Schema SCHEMA = Schema.structureBuilder(ID)
+        .putMember("message", PreludeSchemas.STRING)
+        .build();
     private static final Schema SCHEMA_MESSAGE = SCHEMA.member("message");
 
     public InternalServerError(String message) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,9 +13,9 @@ include(":codegen:plugins:client")
 include(":codegen:plugins:server")
 include(":codegen:plugins:types")
 
-
-// Protocol tests
+// Testing
 include(":protocol-tests")
+include(":mock-client-plugin")
 
 include("tracing-api")
 


### PR DESCRIPTION
The MockPlugin is used to intercept requests and return canned responses, shapes, or exceptions. Various tests that previously did something similar to this have been updated to use it.

Other minor fixes were made to make this happen:
1. ClientTransport is not needed to be applied manually in Client.
2. ClientTransport is applied eagerly as a plugin when applied to the ClientConfig.Builder.
3. Changed a Boolean to boolean in UriTreeMatcherMapBuilder to avoid an NPE.
4. ClientProtocol now uses a ShapeId instead of a String.
5. Added a method to DynamicClient to create a SerializableStruct from the converted model.
6. Added a helper method to detect the correct HTTP status of an error.
7. Fixed a bug in the HttpBindingSerializer where the status code wasn't being properly set for errors (was always 200).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
