### PR TITLE
Make mock matcher take a record

### DIFF
--- a/client-core/src/test/java/software/amazon/smithy/java/client/core/plugins/InjectIdempotencyTokenPluginTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/client/core/plugins/InjectIdempotencyTokenPluginTest.java
@@ -81,7 +81,7 @@ public class InjectIdempotencyTokenPluginTest {
     private String callAndGetToken(String operation, Document input) {
         var mock = MockPlugin.builder()
             .addMatcher(
-                (ctx, i) -> new MockedResult.Response(
+                request -> new MockedResult.Response(
                     HttpResponse.builder()
                         .statusCode(200)
                         .headers(HttpHeaders.of(Map.of("content-type", List.of("application/json"))))

--- a/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MatcherRequest.java
+++ b/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MatcherRequest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http.mock;
+
+import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+
+/**
+ * The input to a {@link MockPlugin.Builder#addMatcher} function.
+ *
+ * @param context Context of the call.
+ * @param operation Operation being called.
+ * @param input Input of the call.
+ */
+public record MatcherRequest(Context context, ApiOperation<?, ?> operation, SerializableStruct input) {}

--- a/mock-client-plugin/src/test/java/software/amazon/smithy/java/client/http/mock/MockPluginTest.java
+++ b/mock-client-plugin/src/test/java/software/amazon/smithy/java/client/http/mock/MockPluginTest.java
@@ -185,16 +185,16 @@ public class MockPluginTest {
         var bQueue = new MockQueue();
 
         var mock = MockPlugin.builder()
-            .addMatcher((ctx, i) -> {
-                if (i instanceof Document d) {
+            .addMatcher(request -> {
+                if (request.input() instanceof Document d) {
                     if (d.getMember("id").asString().equals("a")) {
                         return aQueue.poll();
                     }
                 }
                 return null;
             })
-            .addMatcher((ctx, i) -> {
-                if (i instanceof Document d) {
+            .addMatcher(request -> {
+                if (request.input() instanceof Document d) {
                     if (d.getMember("id").asString().equals("b")) {
                         return bQueue.poll();
                     }


### PR DESCRIPTION
This record makes matching more extensible, and also no provides the ApiOperation being invoked, allowing for more operation-specific mocking.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
