### PR TITLE
Add ability to copy context key values

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/CallContext.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/CallContext.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.client.core;
 
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Set;
 import software.amazon.smithy.java.auth.api.identity.Identity;
 import software.amazon.smithy.java.client.core.endpoint.Endpoint;
@@ -69,7 +70,10 @@ public final class CallContext {
      * only ASCII letters, numbers, and hyphens. For example, "P" might be used to indicate that pagination was used
      * with a request.
      */
-    public static final Context.Key<Set<FeatureId>> FEATURE_IDS = Context.key("Feature IDs used with a request");
+    public static final Context.Key<Set<FeatureId>> FEATURE_IDS = Context.key(
+        "Feature IDs used with a request",
+        HashSet::new
+    );
 
     /**
      * The name of the application, used in things like user-agent headers.

--- a/context/src/main/java/software/amazon/smithy/java/context/ArrayStorageContext.java
+++ b/context/src/main/java/software/amazon/smithy/java/context/ArrayStorageContext.java
@@ -62,14 +62,15 @@ final class ArrayStorageContext implements Context {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void copyTo(Context target) {
+    public Context copyTo(Context target) {
         for (var i = 0; i < values.length; i++) {
             var v = values[i];
             if (v != null) {
                 // Grab the key from the shared keyspace when possible.
                 var k = i < Key.MAX_ARRAY_KEY_SPACE ? Key.KEYS[i] : keys.get(i);
-                target.put(k, v);
+                target.put(k, k.copyValue(v));
             }
         }
+        return target;
     }
 }

--- a/context/src/main/java/software/amazon/smithy/java/context/MapStorageContext.java
+++ b/context/src/main/java/software/amazon/smithy/java/context/MapStorageContext.java
@@ -25,9 +25,11 @@ final class MapStorageContext implements Context {
 
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public void copyTo(Context target) {
+    public Context copyTo(Context target) {
         for (var entry : attributes.entrySet()) {
-            target.put((Key) entry.getKey(), entry.getValue());
+            var key = (Key) entry.getKey();
+            target.put(key, key.copyValue(entry.getValue()));
         }
+        return target;
     }
 }

--- a/context/src/main/java/software/amazon/smithy/java/context/UnmodifiableContext.java
+++ b/context/src/main/java/software/amazon/smithy/java/context/UnmodifiableContext.java
@@ -36,7 +36,7 @@ final class UnmodifiableContext implements Context {
     }
 
     @Override
-    public void copyTo(Context target) {
-        delegate.copyTo(target);
+    public Context copyTo(Context target) {
+        return delegate.copyTo(target);
     }
 }


### PR DESCRIPTION
Mutable context keys need to copy their values when the Context is copied. This allows you to pass in a copy function when creating a Context key.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
