### PR TITLE
Convert Document.create* to Document.of

### DIFF
--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientTransportFactory.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientTransportFactory.java
@@ -52,7 +52,7 @@ public interface ClientTransportFactory<RequestT, ResponseT> {
      * <p>Transports must be able to be instantiated without any arguments for use in dynamic clients.
      */
     default ClientTransport<RequestT, ResponseT> createTransport() {
-        return createTransport(Document.createStringMap(Collections.emptyMap()));
+        return createTransport(Document.of(Collections.emptyMap()));
     }
 
     /**

--- a/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientPipelineTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientPipelineTest.java
@@ -182,7 +182,7 @@ public class ClientPipelineTest {
             })
             .build();
 
-        var response = client.call("GetSprocket", Document.createFromObject(Map.of("id", "1")));
+        var response = client.call("GetSprocket", Document.ofObject(Map.of("id", "1")));
 
         assertThat(mockQueue.remaining(), is(0));
         assertThat(response.getMember("id").asString(), equalTo("1"));

--- a/client-core/src/test/java/software/amazon/smithy/java/client/core/plugins/InjectIdempotencyTokenPluginTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/client/core/plugins/InjectIdempotencyTokenPluginTest.java
@@ -72,7 +72,7 @@ public class InjectIdempotencyTokenPluginTest {
 
     @Test
     public void injectsToken() {
-        var token = callAndGetToken("CreateSprocket", Document.createFromObject(Map.of("id", "1")));
+        var token = callAndGetToken("CreateSprocket", Document.ofObject(Map.of("id", "1")));
 
         assertThat(token, not(nullValue()));
         assertThat(token.length(), greaterThan(0));
@@ -101,28 +101,28 @@ public class InjectIdempotencyTokenPluginTest {
             .addPlugin(mock)
             .build();
 
-        client.call(operation, Document.createFromObject(input));
+        client.call(operation, Document.of(input));
         assertThat(mock.getRequests(), not(empty()));
         return mock.getRequests().get(0).request().headers().firstValue("x-token");
     }
 
     @Test
     public void doesNotInjectToken() {
-        var token = callAndGetToken("CreateSprocketNoToken", Document.createFromObject(Map.of("id", "1")));
+        var token = callAndGetToken("CreateSprocketNoToken", Document.ofObject(Map.of("id", "1")));
 
         assertThat(token, nullValue());
     }
 
     @Test
     public void usesProvidedToken() {
-        var token = callAndGetToken("CreateSprocket", Document.createFromObject(Map.of("id", "1", "token", "xyz")));
+        var token = callAndGetToken("CreateSprocket", Document.ofObject(Map.of("id", "1", "token", "xyz")));
 
         assertThat(token, equalTo("xyz"));
     }
 
     @Test
     public void ignoresEmptyStringToken() {
-        var token = callAndGetToken("CreateSprocket", Document.createFromObject(Map.of("id", "1", "token", "")));
+        var token = callAndGetToken("CreateSprocket", Document.ofObject(Map.of("id", "1", "token", "")));
 
         assertThat(token, notNullValue());
         assertThat(token, not(equalTo("")));

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
@@ -40,12 +40,12 @@ public class DefaultsTest {
         defaults.streamingBlob()
             .asByteBuffer()
             .thenAccept(b -> assertEquals(b, ByteBuffer.wrap(Base64.getDecoder().decode("c3RyZWFtaW5n"))));
-        assertEquals(defaults.boolDoc(), Document.createBoolean(true));
-        assertEquals(defaults.stringDoc(), Document.createString("string"));
-        assertEquals(defaults.numberDoc(), Document.createInteger(1));
-        assertEquals(defaults.floatingPointnumberDoc(), Document.createDouble(1.2));
-        assertEquals(defaults.listDoc(), Document.createList(Collections.emptyList()));
-        assertEquals(defaults.mapDoc(), Document.createStringMap(Collections.emptyMap()));
+        assertEquals(defaults.boolDoc(), Document.of(true));
+        assertEquals(defaults.stringDoc(), Document.of("string"));
+        assertEquals(defaults.numberDoc(), Document.of(1));
+        assertEquals(defaults.floatingPointnumberDoc(), Document.of(1.2));
+        assertEquals(defaults.listDoc(), Document.of(Collections.emptyList()));
+        assertEquals(defaults.mapDoc(), Document.of(Collections.emptyMap()));
         assertEquals(defaults.list(), List.of());
         assertEquals(defaults.map(), Map.of());
         assertEquals(defaults.timestamp(), Instant.parse("1985-04-12T23:20:50.52Z"));

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ListsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ListsTest.java
@@ -126,7 +126,7 @@ public class ListsTest {
                 .build(),
             ListAllTypesInput.builder()
                 .listOfDocuments(
-                    List.of(Document.createDouble(2.0), Document.createString("string"))
+                    List.of(Document.of(2.0), Document.of("string"))
                 )
                 .build()
         );
@@ -240,7 +240,7 @@ public class ListsTest {
                 .build(),
             SparseListsInput.builder()
                 .listOfDocuments(
-                    ListUtils.of(Document.createDouble(2.0), null, Document.createString("string"))
+                    ListUtils.of(Document.of(2.0), null, Document.of("string"))
                 )
                 .build()
         );
@@ -264,8 +264,8 @@ public class ListsTest {
         // Collections should return empty collections for access
         assertEquals(emptyInput.listOfBoolean(), Collections.emptyList());
         assertEquals(emptyInput.listOfBoolean(), nullInput.listOfBoolean());
-        var emptyDocument = Document.createTyped(emptyInput);
-        var nullDocument = Document.createTyped(nullInput);
+        var emptyDocument = Document.of(emptyInput);
+        var nullDocument = Document.of(nullInput);
         assertNotNull(emptyDocument.getMember("listOfBoolean"));
         assertNull(nullDocument.getMember("listOfBoolean"));
     }

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/MapsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/MapsTest.java
@@ -288,8 +288,8 @@ public class MapsTest {
         assertEquals(emptyInput.stringBooleanMap(), Collections.emptyMap());
         assertEquals(emptyInput.stringBooleanMap(), nullInput.stringBooleanMap());
 
-        var emptyDocument = Document.createTyped(emptyInput);
-        var nullDocument = Document.createTyped(nullInput);
+        var emptyDocument = Document.of(emptyInput);
+        var nullDocument = Document.of(nullInput);
         assertNotNull(emptyDocument.getMember("stringBooleanMap"));
         assertNull(nullDocument.getMember("stringBooleanMap"));
     }

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/RecursionTests.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/RecursionTests.java
@@ -114,7 +114,7 @@ public class RecursionTests {
                 )
             )
         );
-        var document = Document.createTyped(recursive);
+        var document = Document.of(recursive);
         var builder = AttributeValue.builder();
         document.deserializeInto(builder);
         var output = builder.build();

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/StructuresTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/StructuresTest.java
@@ -45,7 +45,7 @@ public class StructuresTest {
     static Stream<SerializableShape> memberTypes() {
         return Stream.of(
             BooleanMembersInput.builder().requiredBoolean(true).build(),
-            DocumentMembersInput.builder().requiredDoc(Document.createString("str")).build(),
+            DocumentMembersInput.builder().requiredDoc(Document.of("str")).build(),
             ListMembersInput.builder().requiredList(List.of("a", "b", "c")).build(),
             MapMembersInput.builder().requiredMap(Map.of("a", "b")).build(),
             BigDecimalMembersInput.builder().requiredBigDecimal(BigDecimal.valueOf(1.0)).build(),

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/UnionTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/UnionTest.java
@@ -60,7 +60,7 @@ public class UnionTest {
     @ParameterizedTest
     @MethodSource("unionTypes")
     void pojoToDocumentRoundTrip(UnionType pojo) {
-        var document = Document.createTyped(pojo);
+        var document = Document.of(pojo);
         var builder = UnionType.builder();
         document.deserializeInto(builder);
         var output = builder.build();
@@ -70,7 +70,7 @@ public class UnionTest {
 
     record UnknownDocument() implements Document {
 
-        private static final Map<String, Document> members = Map.of("UNKNOWN!!!", Document.createDouble(3.2));
+        private static final Map<String, Document> members = Map.of("UNKNOWN!!!", Document.of(3.2));
 
         @Override
         public ShapeType type() {
@@ -112,6 +112,6 @@ public class UnionTest {
     @Test
     void unknownUnionSerFails() {
         var union = UnionType.builder().$unknownMember("foo").build();
-        assertThrows(SerializationException.class, () -> Document.createTyped(union));
+        assertThrows(SerializationException.class, () -> Document.of(union));
     }
 }

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/Utils.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/Utils.java
@@ -15,7 +15,7 @@ final class Utils {
     private Utils() {}
 
     static <T extends SerializableStruct> T pojoToDocumentRoundTrip(T pojo) {
-        var document = Document.createTyped(pojo);
+        var document = Document.of(pojo);
         ShapeBuilder<T> builder = getBuilder(pojo);
         document.deserializeInto(builder);
         return builder.build();

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -1054,13 +1054,13 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
             @Override
             public Void arrayNode(ArrayNode node) {
                 // List defaults must always be empty
-                writer.write("${document:T}.createList($T.emptyList())", Collections.class);
+                writer.write("${document:T}.of($T.emptyList())", Collections.class);
                 return null;
             }
 
             @Override
             public Void booleanNode(BooleanNode node) {
-                writer.write("${document:T}.createBoolean($L)", node.getValue());
+                writer.write("${document:T}.of($L)", node.getValue());
                 return null;
             }
 
@@ -1072,9 +1072,9 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
             @Override
             public Void numberNode(NumberNode node) {
                 if (node.isFloatingPointNumber()) {
-                    writer.write("${document:T}.createDouble($L)", node.getValue().doubleValue());
+                    writer.write("${document:T}.of($L)", node.getValue().doubleValue());
                 } else {
-                    writer.write("${document:T}.createInteger($L)", node.getValue().intValue());
+                    writer.write("${document:T}.of($L)", node.getValue().intValue());
                 }
                 return null;
             }
@@ -1082,13 +1082,13 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
             @Override
             public Void objectNode(ObjectNode node) {
                 // Map defaults must always be empty
-                writer.write("${document:T}.createStringMap($T.emptyMap())", Collections.class);
+                writer.write("${document:T}.of($T.emptyMap())", Collections.class);
                 return null;
             }
 
             @Override
             public Void stringNode(StringNode node) {
-                writer.write("${document:T}.createString($S)", node.getValue());
+                writer.write("${document:T}.of($S)", node.getValue());
                 return null;
             }
         }

--- a/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
+++ b/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
@@ -240,7 +240,7 @@ public final class ClientInterfaceGenerator
             writer.putContext("nodes", consumers);
             writer.putContext("list", List.class);
             writer.write(
-                "${document:T}.createList(${list:T}.of(${#nodes}${value:C}${^key.last}, ${/key.last}${/nodes}))"
+                "${document:T}.of(${list:T}.of(${#nodes}${value:C}${^key.last}, ${/key.last}${/nodes}))"
             );
             writer.popState();
             return null;
@@ -250,7 +250,7 @@ public final class ClientInterfaceGenerator
         public Void objectNode(ObjectNode objectNode) {
             writer.pushState();
             writer.putContext("map", Map.class);
-            writer.openBlock("${document:T}.createStringMap(${map:T}.of(", "))", () -> {
+            writer.openBlock("${document:T}.of(${map:T}.of(", "))", () -> {
                 var iter = objectNode.getMembers().entrySet().iterator();
                 while (iter.hasNext()) {
                     var entry = iter.next();
@@ -271,19 +271,19 @@ public final class ClientInterfaceGenerator
 
         @Override
         public Void booleanNode(BooleanNode booleanNode) {
-            writer.writeInline("${document:T}.createBoolean($L)", booleanNode.getValue());
+            writer.writeInline("${document:T}.of($L)", booleanNode.getValue());
             return null;
         }
 
         @Override
         public Void numberNode(NumberNode numberNode) {
-            writer.writeInline("${document:T}.createNumber($L)", numberNode.getValue());
+            writer.writeInline("${document:T}.ofNumber($L)", numberNode.getValue());
             return null;
         }
 
         @Override
         public Void stringNode(StringNode stringNode) {
-            writer.writeInline("${document:T}.createString($S)", stringNode.getValue());
+            writer.writeInline("${document:T}.of($S)", stringNode.getValue());
             return null;
         }
 

--- a/codegen/plugins/types/src/it/java/software/amazon/smithy/java/codegen/types/GenericSerdeTest.java
+++ b/codegen/plugins/types/src/it/java/software/amazon/smithy/java/codegen/types/GenericSerdeTest.java
@@ -50,7 +50,7 @@ public class GenericSerdeTest {
     @ParameterizedTest
     @MethodSource("types")
     <T extends SerializableShape> void serdeTest(T pojo, ShapeBuilder<T> builder) {
-        var document = Document.createTyped(pojo);
+        var document = Document.of(pojo);
         document.deserializeInto(builder);
         var output = builder.build();
         assertEquals(pojo.hashCode(), output.hashCode());

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/document/Document.java
@@ -58,7 +58,7 @@ import software.amazon.smithy.model.shapes.ShapeType;
  *
  * <h3>Typed documents</h3>
  *
- * <p>Document types can be combined with a typed schema using {@link #createTyped(SerializableShape)}. This kind of
+ * <p>Document types can be combined with a typed schema using {@link #of(SerializableShape)}. This kind of
  * document type allows (but does not require) codecs to serialize or deserialize the document exactly as if the shape
  * itself was serialized or deserialized directly.
  */
@@ -330,7 +330,7 @@ public interface Document extends SerializableShape {
     }
 
     /**
-     * Unwrap the document and convert to a standard library type compatible with {@link #createFromObject(Object)}.
+     * Unwrap the document and convert to a standard library type compatible with {@link #ofObject(Object)}.
      *
      * @return the unwrapped document value.
      */
@@ -424,7 +424,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createNumber(Number value) {
+    static Document ofNumber(Number value) {
         return new Documents.NumberDocument(DocumentUtils.getSchemaForNumber(value), value);
     }
 
@@ -434,7 +434,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createByte(byte value) {
+    static Document of(byte value) {
         return new Documents.NumberDocument(PreludeSchemas.BYTE, value);
     }
 
@@ -444,7 +444,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createShort(short value) {
+    static Document of(short value) {
         return new Documents.NumberDocument(PreludeSchemas.SHORT, value);
     }
 
@@ -454,7 +454,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createInteger(int value) {
+    static Document of(int value) {
         return new Documents.NumberDocument(PreludeSchemas.INTEGER, value);
     }
 
@@ -464,7 +464,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createLong(long value) {
+    static Document of(long value) {
         return new Documents.NumberDocument(PreludeSchemas.LONG, value);
     }
 
@@ -474,7 +474,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createFloat(float value) {
+    static Document of(float value) {
         return new Documents.NumberDocument(PreludeSchemas.FLOAT, value);
     }
 
@@ -484,7 +484,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createDouble(double value) {
+    static Document of(double value) {
         return new Documents.NumberDocument(PreludeSchemas.DOUBLE, value);
     }
 
@@ -494,7 +494,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createBigInteger(BigInteger value) {
+    static Document of(BigInteger value) {
         return new Documents.NumberDocument(PreludeSchemas.BIG_INTEGER, value);
     }
 
@@ -504,7 +504,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createBigDecimal(BigDecimal value) {
+    static Document of(BigDecimal value) {
         return new Documents.NumberDocument(PreludeSchemas.BIG_DECIMAL, value);
     }
 
@@ -514,7 +514,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createBoolean(boolean value) {
+    static Document of(boolean value) {
         return new Documents.BooleanDocument(PreludeSchemas.BOOLEAN, value);
     }
 
@@ -524,7 +524,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createString(String value) {
+    static Document of(String value) {
         return new Documents.StringDocument(PreludeSchemas.STRING, value);
     }
 
@@ -534,12 +534,12 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createBlob(ByteBuffer value) {
+    static Document of(ByteBuffer value) {
         return new Documents.BlobDocument(PreludeSchemas.BLOB, value);
     }
 
-    static Document createBlob(byte[] value) {
-        return createBlob(ByteBuffer.wrap(value));
+    static Document of(byte[] value) {
+        return of(ByteBuffer.wrap(value));
     }
 
     /**
@@ -548,7 +548,7 @@ public interface Document extends SerializableShape {
      * @param value Value to wrap.
      * @return the Document type.
      */
-    static Document createTimestamp(Instant value) {
+    static Document of(Instant value) {
         return new Documents.TimestampDocument(PreludeSchemas.TIMESTAMP, value);
     }
 
@@ -558,7 +558,7 @@ public interface Document extends SerializableShape {
      * @param values Values to wrap.
      * @return the Document type.
      */
-    static Document createList(List<Document> values) {
+    static Document of(List<Document> values) {
         return new Documents.ListDocument(Documents.LIST_SCHEMA, values);
     }
 
@@ -568,7 +568,7 @@ public interface Document extends SerializableShape {
      * @param members Members to wrap.
      * @return the Document type.
      */
-    static Document createStringMap(Map<String, Document> members) {
+    static Document of(Map<String, Document> members) {
         return new Documents.StringMapDocument(Documents.STR_MAP_SCHEMA, members);
     }
 
@@ -600,36 +600,36 @@ public interface Document extends SerializableShape {
      * @return the created document.
      * @throws UnsupportedOperationException if the given object {@code o} cannot be converted to a document.
      */
-    static Document createFromObject(Object o) {
+    static Document ofObject(Object o) {
         if (o instanceof Document d) {
             return d;
         } else if (o instanceof SerializableShape s) {
-            return createTyped(s);
+            return of(s);
         } else if (o instanceof String s) {
-            return createString(s);
+            return of(s);
         } else if (o instanceof Boolean b) {
-            return createBoolean(b);
+            return of(b);
         } else if (o instanceof Number n) {
-            return createNumber(n);
+            return ofNumber(n);
         } else if (o instanceof ByteBuffer b) {
-            return createBlob(b);
+            return of(b);
         } else if (o instanceof byte[] b) {
-            return createBlob(b);
+            return of(b);
         } else if (o instanceof Instant i) {
-            return createTimestamp(i);
+            return of(i);
         } else if (o instanceof List<?> l) {
             List<Document> values = new ArrayList<>(l.size());
             for (var v : l) {
-                values.add(createFromObject(v));
+                values.add(ofObject(v));
             }
-            return createList(values);
+            return of(values);
         } else if (o instanceof Map<?, ?> m) {
             Map<String, Document> values = new LinkedHashMap<>(m.size());
             for (var entry : m.entrySet()) {
-                var key = createFromObject(entry.getKey());
-                values.put(key.asString(), createFromObject(entry.getValue()));
+                var key = ofObject(entry.getKey());
+                values.put(key.asString(), ofObject(entry.getValue()));
             }
-            return createStringMap(values);
+            return of(values);
         } else if (o == null) {
             return null;
         } else {
@@ -647,7 +647,7 @@ public interface Document extends SerializableShape {
      * @param shape Shape to turn into a Document.
      * @return the Document type.
      */
-    static Document createTyped(SerializableShape shape) {
+    static Document of(SerializableShape shape) {
         var parser = new DocumentParser();
         shape.serialize(parser);
         return parser.getResult();

--- a/core/src/test/java/software/amazon/smithy/java/core/schema/ValidatorTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/schema/ValidatorTest.java
@@ -663,7 +663,7 @@ public class ValidatorTest {
                 ShapeType.DOCUMENT,
                 (Consumer<ShapeSerializer>) serializer -> serializer.writeDocument(
                     PreludeSchemas.STRING,
-                    Document.createString("hi")
+                    Document.of("hi")
                 )
             ),
             Arguments.of(

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/TypeRegistryTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/TypeRegistryTest.java
@@ -75,7 +75,7 @@ public class TypeRegistryTest {
             .putType(ShapeId.from("smithy.example#Person"), Person.class, Person::builder)
             .build();
         var person = Person.builder().name("Phreddie").build();
-        var document = Document.createTyped(person);
+        var document = Document.of(person);
         var deserialized = registry.deserialize(document);
 
         assertThat(deserialized, instanceOf(Person.class));

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/BlobDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/BlobDocumentTest.java
@@ -23,16 +23,16 @@ public class BlobDocumentTest {
 
     @Test
     public void createsDocument() {
-        var document = Document.createBlob(wrap("hi".getBytes(StandardCharsets.UTF_8)));
+        var document = Document.of(wrap("hi".getBytes(StandardCharsets.UTF_8)));
 
         assertThat(document.type(), equalTo(ShapeType.BLOB));
         assertThat(document.asBlob(), equalTo(wrap("hi".getBytes(StandardCharsets.UTF_8))));
-        assertThat(document, equalTo(Document.createBlob(wrap("hi".getBytes(StandardCharsets.UTF_8)))));
+        assertThat(document, equalTo(Document.of(wrap("hi".getBytes(StandardCharsets.UTF_8)))));
     }
 
     @Test
     public void serializesShape() {
-        var document = Document.createBlob(wrap("hi".getBytes(StandardCharsets.UTF_8)));
+        var document = Document.of(wrap("hi".getBytes(StandardCharsets.UTF_8)));
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
@@ -44,7 +44,7 @@ public class BlobDocumentTest {
 
     @Test
     public void serializesContents() {
-        var document = Document.createBlob("hi".getBytes(StandardCharsets.UTF_8));
+        var document = Document.of("hi".getBytes(StandardCharsets.UTF_8));
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override
@@ -60,7 +60,7 @@ public class BlobDocumentTest {
     @Test
     public void toObjectReturnsSelf() {
         var bytes = "a".getBytes(StandardCharsets.UTF_8);
-        var doc = Document.createBlob(bytes);
+        var doc = Document.of(bytes);
 
         assertThat(doc.asObject(), is(wrap(bytes)));
     }

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/BooleanDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/BooleanDocumentTest.java
@@ -19,16 +19,16 @@ import software.amazon.smithy.model.shapes.ShapeType;
 public class BooleanDocumentTest {
     @Test
     public void createsDocument() {
-        var document = Document.createBoolean(true);
+        var document = Document.of(true);
 
         assertThat(document.type(), equalTo(ShapeType.BOOLEAN));
         assertThat(document.asBoolean(), equalTo(true));
-        assertThat(document, equalTo(Document.createBoolean(true)));
+        assertThat(document, equalTo(Document.of(true)));
     }
 
     @Test
     public void serializesShape() {
-        var document = Document.createBoolean(true);
+        var document = Document.of(true);
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
@@ -40,7 +40,7 @@ public class BooleanDocumentTest {
 
     @Test
     public void serializesContent() {
-        var document = Document.createBoolean(true);
+        var document = Document.of(true);
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentDeserializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentDeserializerTest.java
@@ -23,16 +23,16 @@ public class DocumentDeserializerTest {
     public void deserializesMapIntoBuilder() {
         Person.Builder builder = Person.builder();
 
-        var document = Document.createStringMap(
+        var document = Document.of(
             Map.of(
                 "name",
-                Document.createString("Savage Bob"),
+                Document.of("Savage Bob"),
                 "age",
-                Document.createInteger(100),
+                Document.of(100),
                 "birthday",
-                Document.createTimestamp(Instant.EPOCH),
+                Document.of(Instant.EPOCH),
                 "binary",
-                Document.createBlob(wrap("hi".getBytes(StandardCharsets.UTF_8)))
+                Document.of(wrap("hi".getBytes(StandardCharsets.UTF_8)))
             )
         );
 
@@ -53,7 +53,7 @@ public class DocumentDeserializerTest {
             .binary(wrap("hi".getBytes(StandardCharsets.UTF_8)))
             .build();
 
-        var bobDocument = Document.createTyped(person);
+        var bobDocument = Document.of(person);
         var personCopy = bobDocument.asShape(Person.builder());
 
         assertThat(personCopy.name(), is("Savage Bob"));

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentTest.java
@@ -43,14 +43,14 @@ import software.amazon.smithy.model.shapes.ShapeType;
 public class DocumentTest {
     @Test
     public void getAsNumber() {
-        assertThat(Document.createByte((byte) 1).asNumber(), equalTo(Byte.valueOf((byte) 1)));
-        assertThat(Document.createShort((short) 1).asNumber(), equalTo(Short.valueOf((short) 1)));
-        assertThat(Document.createInteger(1).asNumber(), equalTo(Integer.valueOf(1)));
-        assertThat(Document.createLong(1L).asNumber(), equalTo(Long.valueOf(1L)));
-        assertThat(Document.createFloat(1f).asNumber(), equalTo(Float.valueOf(1f)));
-        assertThat(Document.createDouble(1.0).asNumber(), equalTo(Double.valueOf(1.0)));
-        assertThat(Document.createBigDecimal(new BigDecimal(1)).asNumber(), equalTo(new BigDecimal(1)));
-        assertThat(Document.createBigInteger(BigInteger.valueOf(1)).asNumber(), equalTo(BigInteger.valueOf(1)));
+        assertThat(Document.of((byte) 1).asNumber(), equalTo(Byte.valueOf((byte) 1)));
+        assertThat(Document.of((short) 1).asNumber(), equalTo(Short.valueOf((short) 1)));
+        assertThat(Document.of(1).asNumber(), equalTo(Integer.valueOf(1)));
+        assertThat(Document.of(1L).asNumber(), equalTo(Long.valueOf(1L)));
+        assertThat(Document.of(1f).asNumber(), equalTo(Float.valueOf(1f)));
+        assertThat(Document.of(1.0).asNumber(), equalTo(Double.valueOf(1.0)));
+        assertThat(Document.of(new BigDecimal(1)).asNumber(), equalTo(new BigDecimal(1)));
+        assertThat(Document.of(BigInteger.valueOf(1)).asNumber(), equalTo(BigInteger.valueOf(1)));
     }
 
     @ParameterizedTest
@@ -65,19 +65,19 @@ public class DocumentTest {
 
     public static List<Arguments> defaultSerializationProvider() {
         return List.of(
-            Arguments.of(Document.createByte((byte) 1)),
-            Arguments.of(Document.createShort((short) 1)),
-            Arguments.of(Document.createInteger(1)),
-            Arguments.of(Document.createLong(1L)),
-            Arguments.of(Document.createFloat(1f)),
-            Arguments.of(Document.createDouble(1.0)),
-            Arguments.of(Document.createBigInteger(BigInteger.valueOf(1))),
-            Arguments.of(Document.createBigDecimal(new BigDecimal(1))),
-            Arguments.of(Document.createString("a")),
-            Arguments.of(Document.createBlob("a".getBytes(StandardCharsets.UTF_8))),
-            Arguments.of(Document.createBoolean(true)),
-            Arguments.of(Document.createTimestamp(Instant.EPOCH)),
-            Arguments.of(Document.createList(List.of(Document.createInteger(1), Document.createString("a"))))
+            Arguments.of(Document.of((byte) 1)),
+            Arguments.of(Document.of((short) 1)),
+            Arguments.of(Document.of(1)),
+            Arguments.of(Document.of(1L)),
+            Arguments.of(Document.of(1f)),
+            Arguments.of(Document.of(1.0)),
+            Arguments.of(Document.of(BigInteger.valueOf(1))),
+            Arguments.of(Document.of(new BigDecimal(1))),
+            Arguments.of(Document.of("a")),
+            Arguments.of(Document.of("a".getBytes(StandardCharsets.UTF_8))),
+            Arguments.of(Document.of(true)),
+            Arguments.of(Document.of(Instant.EPOCH)),
+            Arguments.of(Document.of(List.of(Document.of(1), Document.of("a"))))
         );
     }
 
@@ -96,14 +96,14 @@ public class DocumentTest {
 
     public static List<Arguments> onesProvider() {
         return List.of(
-            Arguments.of(Document.createByte((byte) 1)),
-            Arguments.of(Document.createShort((short) 1)),
-            Arguments.of(Document.createInteger(1)),
-            Arguments.of(Document.createLong(1L)),
-            Arguments.of(Document.createFloat(1f)),
-            Arguments.of(Document.createDouble(1.0)),
-            Arguments.of(Document.createBigInteger(BigInteger.valueOf(1))),
-            Arguments.of(Document.createBigDecimal(new BigDecimal("1.0")))
+            Arguments.of(Document.of((byte) 1)),
+            Arguments.of(Document.of((short) 1)),
+            Arguments.of(Document.of(1)),
+            Arguments.of(Document.of(1L)),
+            Arguments.of(Document.of(1f)),
+            Arguments.of(Document.of(1.0)),
+            Arguments.of(Document.of(BigInteger.valueOf(1))),
+            Arguments.of(Document.of(new BigDecimal("1.0")))
         );
     }
 
@@ -115,71 +115,71 @@ public class DocumentTest {
 
     public static List<Arguments> invalidConversionSupplier() {
         return List.of(
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asNumber),
-            Arguments.of(Document.createInteger(1), (Consumer<Document>) Document::asString),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asBoolean),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asTimestamp),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asByte),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asShort),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asInteger),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asLong),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asFloat),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asDouble),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asBigDecimal),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asBigInteger),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asList),
-            Arguments.of(Document.createString("a"), (Consumer<Document>) Document::asStringMap),
-            Arguments.of(Document.createInteger(1), (Consumer<Document>) Document::asBlob),
-            Arguments.of(Document.createInteger(1), (Consumer<Document>) d -> d.getMember("a"))
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asNumber),
+            Arguments.of(Document.of(1), (Consumer<Document>) Document::asString),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asBoolean),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asTimestamp),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asByte),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asShort),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asInteger),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asLong),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asFloat),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asDouble),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asBigDecimal),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asBigInteger),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asList),
+            Arguments.of(Document.of("a"), (Consumer<Document>) Document::asStringMap),
+            Arguments.of(Document.of(1), (Consumer<Document>) Document::asBlob),
+            Arguments.of(Document.of(1), (Consumer<Document>) d -> d.getMember("a"))
         );
     }
 
     @ParameterizedTest
     @MethodSource("ofValueProvider")
     public void documentFromValue(Document value, Object expected, Function<Document, Object> extractor) {
-        var document = Document.createTyped(value);
+        var document = Document.of(value);
         var extracted = extractor.apply(document);
         assertThat(extracted, equalTo(expected));
     }
 
     public static List<Arguments> ofValueProvider() {
         return List.of(
-            Arguments.of(Document.createString("a"), "a", (Function<Document, Object>) Document::asString),
-            Arguments.of(Document.createByte((byte) 1), (byte) 1, (Function<Document, Object>) Document::asByte),
-            Arguments.of(Document.createShort((short) 1), (short) 1, (Function<Document, Object>) Document::asShort),
-            Arguments.of(Document.createInteger(1), 1, (Function<Document, Object>) Document::asInteger),
-            Arguments.of(Document.createLong(1L), 1L, (Function<Document, Object>) Document::asLong),
-            Arguments.of(Document.createFloat(1f), 1f, (Function<Document, Object>) Document::asFloat),
-            Arguments.of(Document.createDouble(1.0), 1.0, (Function<Document, Object>) Document::asDouble),
+            Arguments.of(Document.of("a"), "a", (Function<Document, Object>) Document::asString),
+            Arguments.of(Document.of((byte) 1), (byte) 1, (Function<Document, Object>) Document::asByte),
+            Arguments.of(Document.of((short) 1), (short) 1, (Function<Document, Object>) Document::asShort),
+            Arguments.of(Document.of(1), 1, (Function<Document, Object>) Document::asInteger),
+            Arguments.of(Document.of(1L), 1L, (Function<Document, Object>) Document::asLong),
+            Arguments.of(Document.of(1f), 1f, (Function<Document, Object>) Document::asFloat),
+            Arguments.of(Document.of(1.0), 1.0, (Function<Document, Object>) Document::asDouble),
             Arguments.of(
-                Document.createBigInteger(BigInteger.valueOf(1)),
+                Document.of(BigInteger.valueOf(1)),
                 BigInteger.valueOf(1),
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.of(
-                Document.createBigDecimal(new BigDecimal(1)),
+                Document.of(new BigDecimal(1)),
                 new BigDecimal(1),
                 (Function<Document, Object>) Document::asBigDecimal
             ),
-            Arguments.of(Document.createBoolean(true), true, (Function<Document, Object>) Document::asBoolean),
+            Arguments.of(Document.of(true), true, (Function<Document, Object>) Document::asBoolean),
             Arguments.of(
-                Document.createBlob("a".getBytes(StandardCharsets.UTF_8)),
+                Document.of("a".getBytes(StandardCharsets.UTF_8)),
                 wrap("a".getBytes(StandardCharsets.UTF_8)),
                 (Function<Document, Object>) Document::asBlob
             ),
             Arguments.of(
-                Document.createTimestamp(Instant.EPOCH),
+                Document.of(Instant.EPOCH),
                 Instant.EPOCH,
                 (Function<Document, Object>) Document::asTimestamp
             ),
             Arguments.of(
-                Document.createList(List.of(Document.createInteger(1), Document.createInteger(2))),
-                List.of(Document.createInteger(1), Document.createInteger(2)),
+                Document.of(List.of(Document.of(1), Document.of(2))),
+                List.of(Document.of(1), Document.of(2)),
                 (Function<Document, Object>) Document::asList
             ),
             Arguments.of(
-                Document.createStringMap(Map.of("A", Document.createInteger(1))),
-                Map.of("A", Document.createInteger(1)),
+                Document.of(Map.of("A", Document.of(1))),
+                Map.of("A", Document.of(1)),
                 (Function<Document, Object>) Document::asStringMap
             )
         );
@@ -193,7 +193,7 @@ public class DocumentTest {
             .binary(wrap("hi".getBytes(StandardCharsets.UTF_8)))
             .birthday(Instant.EPOCH)
             .build();
-        var doc = Document.createTyped(person);
+        var doc = Document.of(person);
 
         assertThat(doc.discriminator(), equalTo(Person.ID));
         assertThat(doc.getMember("name").asString(), equalTo("A"));
@@ -216,67 +216,67 @@ public class DocumentTest {
     public static List<Arguments> deserializesDocumentProvider() {
         return List.of(
             Arguments.of(
-                Document.createString("a"),
+                Document.of("a"),
                 "a",
                 (Function<ShapeDeserializer, Object>) s -> s.readString(PreludeSchemas.STRING)
             ),
             Arguments.of(
-                Document.createBlob("a".getBytes(StandardCharsets.UTF_8)),
+                Document.of("a".getBytes(StandardCharsets.UTF_8)),
                 wrap("a".getBytes(StandardCharsets.UTF_8)),
                 (Function<ShapeDeserializer, Object>) s -> s.readBlob(PreludeSchemas.BLOB)
             ),
             Arguments.of(
-                Document.createBoolean(true),
+                Document.of(true),
                 true,
                 (Function<ShapeDeserializer, Object>) s -> s.readBoolean(PreludeSchemas.BOOLEAN)
             ),
             Arguments.of(
-                Document.createByte((byte) 1),
+                Document.of((byte) 1),
                 (byte) 1,
                 (Function<ShapeDeserializer, Object>) s -> s.readByte(PreludeSchemas.BYTE)
             ),
             Arguments.of(
-                Document.createShort((short) 1),
+                Document.of((short) 1),
                 (short) 1,
                 (Function<ShapeDeserializer, Object>) s -> s.readShort(PreludeSchemas.SHORT)
             ),
             Arguments.of(
-                Document.createInteger(1),
+                Document.of(1),
                 1,
                 (Function<ShapeDeserializer, Object>) s -> s.readInteger(PreludeSchemas.INTEGER)
             ),
             Arguments.of(
-                Document.createLong(1L),
+                Document.of(1L),
                 1L,
                 (Function<ShapeDeserializer, Object>) s -> s.readLong(PreludeSchemas.LONG)
             ),
             Arguments.of(
-                Document.createFloat(1f),
+                Document.of(1f),
                 1f,
                 (Function<ShapeDeserializer, Object>) s -> s.readFloat(PreludeSchemas.FLOAT)
             ),
             Arguments.of(
-                Document.createDouble(1.0),
+                Document.of(1.0),
                 1.0,
                 (Function<ShapeDeserializer, Object>) s -> s.readDouble(PreludeSchemas.DOUBLE)
             ),
             Arguments.of(
-                Document.createBigInteger(BigInteger.ONE),
+                Document.of(BigInteger.ONE),
                 BigInteger.ONE,
                 (Function<ShapeDeserializer, Object>) s -> s.readBigInteger(PreludeSchemas.BIG_INTEGER)
             ),
             Arguments.of(
-                Document.createBigDecimal(BigDecimal.ONE),
+                Document.of(BigDecimal.ONE),
                 BigDecimal.ONE,
                 (Function<ShapeDeserializer, Object>) s -> s.readBigDecimal(PreludeSchemas.BIG_DECIMAL)
             ),
             Arguments.of(
-                Document.createString("a"),
-                Document.createString("a"),
+                Document.of("a"),
+                Document.of("a"),
                 (Function<ShapeDeserializer, Object>) ShapeDeserializer::readDocument
             ),
             Arguments.of(
-                Document.createTimestamp(Instant.EPOCH),
+                Document.of(Instant.EPOCH),
                 Instant.EPOCH,
                 (Function<ShapeDeserializer, Object>) s -> s.readTimestamp(PreludeSchemas.TIMESTAMP)
             )
@@ -285,7 +285,7 @@ public class DocumentTest {
 
     @Test
     public void deserializesListDocuments() {
-        Document value = Document.createList(List.of(Document.createString("a"), Document.createString("b")));
+        Document value = Document.of(List.of(Document.of("a"), Document.of("b")));
         DocumentDeserializer deserializer = new DocumentDeserializer(value);
         List<String> result = new ArrayList<>();
 
@@ -298,7 +298,7 @@ public class DocumentTest {
 
     @Test
     public void deserializesStringMap() {
-        Document value = Document.createStringMap(Map.of("a", Document.createString("v")));
+        Document value = Document.of(Map.of("a", Document.of("v")));
         DocumentDeserializer deserializer = new DocumentDeserializer(value);
         Map<String, String> result = new HashMap<>();
 
@@ -314,7 +314,7 @@ public class DocumentTest {
     @Test
     public void throwsWhenDocumentWritesNothing() {
         var e = Assertions.assertThrows(SerializationException.class, () -> {
-            var document = Document.createTyped(encoder -> {});
+            var document = Document.of(encoder -> {});
             // Trigger the lazy document to create the underlying document.
             document.getMember("hello!");
         });
@@ -336,20 +336,20 @@ public class DocumentTest {
 
     static List<Arguments> normalizedEqualsTestProvider() {
         return List.of(
-            Arguments.of(Document.createString("hi")),
-            Arguments.of(Document.createBlob("hi".getBytes(StandardCharsets.UTF_8))),
-            Arguments.of(Document.createByte((byte) 1)),
-            Arguments.of(Document.createShort((short) 1)),
-            Arguments.of(Document.createInteger(1)),
-            Arguments.of(Document.createLong(1L)),
-            Arguments.of(Document.createFloat(1f)),
-            Arguments.of(Document.createDouble(1.0)),
-            Arguments.of(Document.createBigInteger(BigInteger.ONE)),
-            Arguments.of(Document.createBigDecimal(BigDecimal.ONE)),
-            Arguments.of(Document.createBoolean(true)),
-            Arguments.of(Document.createStringMap(Map.of("hi", Document.createString("there")))),
-            Arguments.of(Document.createList(List.of(Document.createString("hi")))),
-            Arguments.of(Document.createTimestamp(Instant.EPOCH))
+            Arguments.of(Document.of("hi")),
+            Arguments.of(Document.of("hi".getBytes(StandardCharsets.UTF_8))),
+            Arguments.of(Document.of((byte) 1)),
+            Arguments.of(Document.of((short) 1)),
+            Arguments.of(Document.of(1)),
+            Arguments.of(Document.of(1L)),
+            Arguments.of(Document.of(1f)),
+            Arguments.of(Document.of(1.0)),
+            Arguments.of(Document.of(BigInteger.ONE)),
+            Arguments.of(Document.of(BigDecimal.ONE)),
+            Arguments.of(Document.of(true)),
+            Arguments.of(Document.of(Map.of("hi", Document.of("there")))),
+            Arguments.of(Document.of(List.of(Document.of("hi")))),
+            Arguments.of(Document.of(Instant.EPOCH))
         );
     }
 
@@ -361,19 +361,19 @@ public class DocumentTest {
 
     public static List<Arguments> inEqualDocumentsTestProvider() {
         return List.of(
-            Arguments.of(Document.createString("a"), Document.createInteger(1)),
-            Arguments.of(Document.createList(List.of(Document.createInteger(1))), Document.createList(List.of())),
+            Arguments.of(Document.of("a"), Document.of(1)),
+            Arguments.of(Document.of(List.of(Document.of(1))), Document.of(List.of())),
             Arguments.of(
-                Document.createList(List.of(Document.createInteger(1))),
-                Document.createList(List.of(Document.createInteger(2)))
+                Document.of(List.of(Document.of(1))),
+                Document.of(List.of(Document.of(2)))
             ),
             Arguments.of(
-                Document.createStringMap(Map.of("a", Document.createString("a"))),
-                Document.createStringMap(Map.of())
+                Document.of(Map.of("a", Document.of("a"))),
+                Document.of(Map.of())
             ),
             Arguments.of(
-                Document.createStringMap(Map.of("a", Document.createString("a"))),
-                Document.createStringMap(Map.of("a", Document.createString("b")))
+                Document.of(Map.of("a", Document.of("a"))),
+                Document.of(Map.of("a", Document.of("b")))
             )
         );
     }
@@ -505,7 +505,7 @@ public class DocumentTest {
     @ParameterizedTest
     @MethodSource("documentToObjectProvider")
     public void convertsDocumentToObject(Object value, ShapeType type) {
-        var document = Document.createFromObject(value);
+        var document = Document.ofObject(value);
 
         assertThat(document.type(), is(type));
 
@@ -535,35 +535,35 @@ public class DocumentTest {
 
     @Test
     public void returnsDocumentsAsIs() {
-        var document = Document.createString("hi");
-        var created = Document.createFromObject(document);
+        var document = Document.of("hi");
+        var created = Document.of(document);
 
         assertThat(document, is(created));
     }
 
     @Test
     public void convertsNullObjectToNullDocumentValue() {
-        assertThat(Document.createFromObject(null), nullValue());
+        assertThat(Document.ofObject(null), nullValue());
     }
 
     @Test
     public void createsDocumentFromSerializableShape() {
         Bird bird = Bird.builder().name("Iago").build();
-        var document = Document.createFromObject(bird);
+        var document = Document.of(bird);
 
         assertThat(document.type(), is(ShapeType.STRUCTURE));
     }
 
     @Test
     public void returnsNullForNonStructures() {
-        var document = Document.createString("Hi");
+        var document = Document.of("Hi");
 
         Assertions.assertThrows(DiscriminatorException.class, document::discriminator);
     }
 
     @Test
     public void returnsNullForMapsMissingType() {
-        var document = Document.createStringMap(Map.of("hi", Document.createString("bye")));
+        var document = Document.of(Map.of("hi", Document.of("bye")));
 
         Assertions.assertThrows(DiscriminatorException.class, document::discriminator);
     }
@@ -571,15 +571,16 @@ public class DocumentTest {
     @Test
     public void returnsShapeIdForTypedDocuments() {
         var person = Person.builder().build();
-        var document = Document.createTyped(person);
+        var document = Document.of(person);
 
         assertThat(document.discriminator(), equalTo(Person.ID));
     }
 
     @Test
     public void documentsDefaultToSizeNegativeOne() {
-        var document = Document.createInteger(1);
+        var document = Document.of(1);
 
         assertThat(document.size(), is(-1));
     }
 }
+

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/ListDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/ListDocumentTest.java
@@ -25,18 +25,18 @@ public class ListDocumentTest {
 
     @Test
     public void createsDocument() {
-        List<Document> values = List.of(Document.createInteger(1), Document.createInteger(2));
-        var document = Document.createList(values);
+        List<Document> values = List.of(Document.of(1), Document.of(2));
+        var document = Document.of(values);
 
         assertThat(document.type(), equalTo(ShapeType.LIST));
         assertThat(document.size(), is(2));
         assertThat(document.asList(), equalTo(values));
-        assertThat(document, equalTo(Document.createList(values)));
+        assertThat(document, equalTo(Document.of(values)));
     }
 
     @Test
     public void serializesShape() {
-        var document = Document.createList(List.of(Document.createString("a"), Document.createString("b")));
+        var document = Document.of(List.of(Document.of("a"), Document.of("b")));
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
@@ -48,8 +48,8 @@ public class ListDocumentTest {
 
     @Test
     public void serializesContents() {
-        List<Document> values = List.of(Document.createString("a"), Document.createString("b"));
-        var document = Document.createList(values);
+        List<Document> values = List.of(Document.of("a"), Document.of("b"));
+        var document = Document.of(values);
 
         List<String> writtenStrings = new ArrayList<>();
 
@@ -84,8 +84,8 @@ public class ListDocumentTest {
 
     @Test
     public void handlesNullValues() {
-        List<Document> values = Arrays.asList(Document.createString("a"), null);
-        var document = Document.createList(values);
+        List<Document> values = Arrays.asList(Document.of("a"), null);
+        var document = Document.of(values);
 
         List<String> writtenStrings = new ArrayList<>();
 

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/MapDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/MapDocumentTest.java
@@ -27,22 +27,22 @@ public class MapDocumentTest {
     public void createsDocument() {
         Map<String, Document> entries = Map.of(
             "a",
-            Document.createBoolean(true),
+            Document.of(true),
             "b",
-            Document.createBoolean(false)
+            Document.of(false)
         );
-        var map = Document.createStringMap(entries);
+        var map = Document.of(entries);
 
         assertThat(map.type(), is(ShapeType.MAP));
         assertThat(map.size(), is(2));
         assertThat(map.asStringMap(), equalTo(entries));
-        assertThat(Document.createStringMap(map.asStringMap()), equalTo(map));
+        assertThat(Document.of(map.asStringMap()), equalTo(map));
     }
 
     @Test
     public void serializesShape() {
-        Map<String, Document> entries = Map.of("a", Document.createInteger(1), "b", Document.createInteger(2));
-        var map = Document.createStringMap(entries);
+        Map<String, Document> entries = Map.of("a", Document.of(1), "b", Document.of(2));
+        var map = Document.of(entries);
 
         map.serialize(new SpecificShapeSerializer() {
             @Override
@@ -54,8 +54,8 @@ public class MapDocumentTest {
 
     @Test
     public void serializesContent() {
-        Map<String, Document> entries = Map.of("a", Document.createInteger(1), "b", Document.createInteger(2));
-        var map = Document.createStringMap(entries);
+        Map<String, Document> entries = Map.of("a", Document.of(1), "b", Document.of(2));
+        var map = Document.of(entries);
 
         var keys = new ArrayList<>();
         map.serializeContents(new SpecificShapeSerializer() {

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/NumberDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/NumberDocumentTest.java
@@ -24,11 +24,11 @@ public class NumberDocumentTest {
     @ParameterizedTest
     @MethodSource("defaultSerializationProvider")
     public void defaultSerialization(Number value, ShapeType type) {
-        var document = Document.createNumber(value);
+        var document = Document.ofNumber(value);
 
         assertThat(document.type(), equalTo(type));
         assertThat(document.asNumber(), is(value));
-        assertThat(document, equalTo(Document.createNumber(document.asNumber())));
+        assertThat(document, equalTo(Document.ofNumber(document.asNumber())));
 
         ShapeSerializer serializer = new InterceptingSerializer() {
             @Override

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/StringDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/StringDocumentTest.java
@@ -20,16 +20,16 @@ public class StringDocumentTest {
 
     @Test
     public void createsDocument() {
-        var document = Document.createString("hi");
+        var document = Document.of("hi");
 
         assertThat(document.type(), equalTo(ShapeType.STRING));
         assertThat(document.asString(), equalTo("hi"));
-        assertThat(document, equalTo(Document.createString("hi")));
+        assertThat(document, equalTo(Document.of("hi")));
     }
 
     @Test
     public void serializesShape() {
-        var document = Document.createString("hi");
+        var document = Document.of("hi");
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
@@ -41,7 +41,7 @@ public class StringDocumentTest {
 
     @Test
     public void serializesContent() {
-        var document = Document.createString("hi");
+        var document = Document.of("hi");
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/TimestampDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/TimestampDocumentTest.java
@@ -29,16 +29,16 @@ public class TimestampDocumentTest {
     @Test
     public void createsDocument() {
         var time = getTestTime();
-        var document = Document.createTimestamp(time);
+        var document = Document.of(time);
 
         assertThat(document.type(), equalTo(ShapeType.TIMESTAMP));
         assertThat(document.asTimestamp(), equalTo(time));
-        assertThat(document, equalTo(Document.createTimestamp(time)));
+        assertThat(document, equalTo(Document.of(time)));
     }
 
     @Test
     public void serializesShape() {
-        var document = Document.createTimestamp(getTestTime());
+        var document = Document.of(getTestTime());
 
         document.serialize(new SpecificShapeSerializer() {
             @Override
@@ -51,7 +51,7 @@ public class TimestampDocumentTest {
     @Test
     public void serializesContent() {
         var time = getTestTime();
-        var document = Document.createTimestamp(time);
+        var document = Document.of(time);
 
         ShapeSerializer serializer = new SpecificShapeSerializer() {
             @Override

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentMemberTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentMemberTest.java
@@ -60,8 +60,8 @@ public class TypedDocumentMemberTest {
             );
         };
 
-        var document = Document.createTyped(serializableShape);
-        var documentCopy = Document.createTyped(serializableShape);
+        var document = Document.of(serializableShape);
+        var documentCopy = Document.of(serializableShape);
 
         assertThat(document.getMember("foo"), equalTo(document.getMember("foo"))); // map value not cached
         assertThat(document.getMember("foo"), equalTo(document.getMember("foo"))); // cached at this point
@@ -82,7 +82,7 @@ public class TypedDocumentMemberTest {
             .putMember("foo", PreludeSchemas.INTEGER)
             .build();
 
-        var document1 = Document.createTyped(encoder -> {
+        var document1 = Document.of(encoder -> {
             encoder.writeStruct(
                 structSchema1,
                 new SerializableStruct() {
@@ -104,7 +104,7 @@ public class TypedDocumentMemberTest {
             );
         });
 
-        var document2 = Document.createTyped(encoder -> {
+        var document2 = Document.of(encoder -> {
             encoder.writeStruct(
                 structSchema2,
                 new SerializableStruct() {
@@ -154,7 +154,7 @@ public class TypedDocumentMemberTest {
         var structSchema = Schema.structureBuilder(ShapeId.from("smithy.example#Foo"))
             .putMember("a", targetSchema)
             .build();
-        var document = Document.createTyped(encoder -> {
+        var document = Document.of(encoder -> {
             encoder.writeStruct(
                 structSchema,
                 new SerializableStruct() {
@@ -614,20 +614,20 @@ public class TypedDocumentMemberTest {
             // Get the document as a list.
             Arguments.of(
                 ShapeType.DOCUMENT,
-                List.of(Document.createInteger(1)),
+                List.of(Document.of(1)),
                 (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeList(
                     schema,
                     null,
                     1,
                     (v, c) -> c.writeInteger(PreludeSchemas.INTEGER, 1)
                 ),
-                (Function<Document, Object>) d -> Document.createTyped(Document.createList(d.asList())).asList()
+                (Function<Document, Object>) d -> Document.of(Document.of(d.asList())).asList()
             ),
 
             // Get the document as a string map.
             Arguments.of(
                 Documents.STR_MAP_SCHEMA,
-                Map.of("a", Document.createInteger(1)),
+                Map.of("a", Document.of(1)),
                 (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
                     null,
@@ -645,7 +645,7 @@ public class TypedDocumentMemberTest {
             // Get a member from a map by name.
             Arguments.of(
                 Documents.STR_MAP_SCHEMA,
-                Document.createInteger(1),
+                Document.of(1),
                 (BiConsumer<Schema, ShapeSerializer>) (schema, s) -> s.writeMap(
                     schema,
                     null,

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentTest.java
@@ -58,7 +58,7 @@ public class TypedDocumentTest {
     @Test
     public void wrapsStructContentWithTypeAndSchema() {
         var serializableShape = createSerializableShape();
-        var result = Document.createTyped(serializableShape);
+        var result = Document.of(serializableShape);
 
         assertThat(result.type(), equalTo(ShapeType.STRUCTURE));
         assertThat(
@@ -80,8 +80,8 @@ public class TypedDocumentTest {
         assertThat(result, equalTo(result));
         assertThat(result, not(equalTo(null)));
         assertThat(result, not(equalTo("X")));
-        assertThat(result, equalTo(Document.createTyped(serializableShape)));
-        assertThat(result.hashCode(), equalTo(Document.createTyped(serializableShape).hashCode()));
+        assertThat(result, equalTo(Document.of(serializableShape)));
+        assertThat(result.hashCode(), equalTo(Document.of(serializableShape).hashCode()));
 
         // Writes as document unless getting contents.
         result.serialize(new SpecificShapeSerializer() {
@@ -92,11 +92,11 @@ public class TypedDocumentTest {
         });
 
         // This is basically recreating the same document with the same captured schema.
-        assertThat(result, equalTo(Document.createTyped(result)));
+        assertThat(result, equalTo(Document.of(result)));
 
         // Not equal because the left member has a schema with the same value, but the right has no schema.
-        assertThat(result.getMember("a"), not(equalTo(Document.createString("1"))));
-        assertThat(result.getMember("b"), not(equalTo(Document.createString("2"))));
+        assertThat(result.getMember("a"), not(equalTo(Document.of("1"))));
+        assertThat(result.getMember("b"), not(equalTo(Document.of("2"))));
 
         // Converts to a string map.
         var copy1 = result.asStringMap();
@@ -107,7 +107,7 @@ public class TypedDocumentTest {
     @Test
     public void getsSchemaValue() {
         var serializableShape = createSerializableShape();
-        var result = (SerializableStruct) Document.createTyped(serializableShape);
+        var result = (SerializableStruct) Document.of(serializableShape);
         var schema = result.schema();
 
         assertThat(result.getMemberValue(schema.member("a")), instanceOf(Document.class));

--- a/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicClient.java
+++ b/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicClient.java
@@ -110,7 +110,7 @@ public final class DynamicClient extends Client {
      * @return the output of the operation.
      */
     public Document call(String operation) {
-        return call(operation, Document.createStringMap(Map.of()));
+        return call(operation, Document.of(Map.of()));
     }
 
     /**
@@ -151,7 +151,7 @@ public final class DynamicClient extends Client {
      * @return the output of the operation.
      */
     public CompletableFuture<Document> callAsync(String operation) {
-        return callAsync(operation, Document.createStringMap(Map.of()));
+        return callAsync(operation, Document.of(Map.of()));
     }
 
     /**

--- a/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/SchemaGuidedDocumentBuilder.java
+++ b/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/SchemaGuidedDocumentBuilder.java
@@ -43,7 +43,7 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<WrappedDocument>
             if (map.isEmpty() && target.type() == ShapeType.UNION) {
                 throw new IllegalArgumentException("No value set for union document: " + schema().id());
             }
-            return new WrappedDocument(service, target, Document.createStringMap(map));
+            return new WrappedDocument(service, target, Document.of(map));
         } else if (result != null) {
             return new WrappedDocument(service, target, result);
         } else {
@@ -55,7 +55,7 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<WrappedDocument>
     public void setMemberValue(Schema member, Object value) {
         if (map != null) {
             SchemaUtils.validateMemberInSchema(target, member, value);
-            map.put(member.memberName(), Document.createFromObject(value));
+            map.put(member.memberName(), Document.ofObject(value));
         } else {
             ShapeBuilder.super.setMemberValue(member, value);
         }
@@ -83,39 +83,39 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<WrappedDocument>
 
     private Document deserialize(ShapeDeserializer decoder, Schema schema) {
         return switch (schema.type()) {
-            case BLOB -> Document.createBlob(decoder.readBlob(target));
-            case BOOLEAN -> Document.createBoolean(decoder.readBoolean(target));
-            case STRING, ENUM -> Document.createString(decoder.readString(target));
-            case TIMESTAMP -> Document.createTimestamp(decoder.readTimestamp(target));
-            case BYTE -> Document.createByte(decoder.readByte(target));
-            case SHORT -> Document.createShort(decoder.readShort(target));
-            case INTEGER, INT_ENUM -> Document.createInteger(decoder.readInteger(target));
-            case LONG -> Document.createLong(decoder.readLong(target));
-            case FLOAT -> Document.createFloat(decoder.readFloat(target));
+            case BLOB -> Document.of(decoder.readBlob(target));
+            case BOOLEAN -> Document.of(decoder.readBoolean(target));
+            case STRING, ENUM -> Document.of(decoder.readString(target));
+            case TIMESTAMP -> Document.of(decoder.readTimestamp(target));
+            case BYTE -> Document.of(decoder.readByte(target));
+            case SHORT -> Document.of(decoder.readShort(target));
+            case INTEGER, INT_ENUM -> Document.of(decoder.readInteger(target));
+            case LONG -> Document.of(decoder.readLong(target));
+            case FLOAT -> Document.of(decoder.readFloat(target));
             case DOCUMENT -> decoder.readDocument();
-            case DOUBLE -> Document.createDouble(decoder.readDouble(target));
-            case BIG_DECIMAL -> Document.createBigDecimal(decoder.readBigDecimal(target));
-            case BIG_INTEGER -> Document.createBigInteger(decoder.readBigInteger(target));
+            case DOUBLE -> Document.of(decoder.readDouble(target));
+            case BIG_DECIMAL -> Document.of(decoder.readBigDecimal(target));
+            case BIG_INTEGER -> Document.of(decoder.readBigInteger(target));
             case LIST -> {
                 var items = new SchemaList(schema.listMember());
                 decoder.readList(target, items, (it, memberDeserializer) -> {
                     it.add(deserialize(memberDeserializer, it.schema));
                 });
-                yield Document.createList(items);
+                yield Document.of(items);
             }
             case MAP -> {
                 var map = new SchemaMap(schema);
                 decoder.readStringMap(schema, map, (state, mapKey, memberDeserializer) -> {
                     state.put(mapKey, deserialize(memberDeserializer, state.schema.mapValueMember()));
                 });
-                yield Document.createStringMap(map);
+                yield Document.of(map);
             }
             case STRUCTURE, UNION -> {
                 var map = new HashMap<String, Document>();
                 decoder.readStruct(schema, map, (state, memberSchema, memberDeserializer) -> {
                     state.put(memberSchema.memberName(), deserialize(memberDeserializer, memberSchema));
                 });
-                yield Document.createStringMap(map);
+                yield Document.of(map);
             }
             default -> throw new UnsupportedOperationException("Unsupported target type: " + target.type());
         };

--- a/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/SchemaInterceptingSerializer.java
+++ b/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/SchemaInterceptingSerializer.java
@@ -33,7 +33,7 @@ final class SchemaInterceptingSerializer implements ShapeSerializer {
     @Override
     public void writeStruct(Schema schema, SerializableStruct struct) {
         delegateSerializer
-            .writeStruct(delegateSchema, new WrappedDocument(service, schema, Document.createTyped(struct)));
+            .writeStruct(delegateSchema, new WrappedDocument(service, schema, Document.of(struct)));
     }
 
     @Override

--- a/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicClientTest.java
+++ b/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicClientTest.java
@@ -146,7 +146,7 @@ public class DynamicClientTest {
             })
             .build();
 
-        var result = client.callAsync("GetSprocket", Document.createFromObject(Map.of("id", "1"))).get();
+        var result = client.callAsync("GetSprocket", Document.ofObject(Map.of("id", "1"))).get();
         assertThat(result.type(), is(ShapeType.STRUCTURE));
         assertThat(result.getMember("id").asString(), equalTo("1"));
     }
@@ -155,7 +155,7 @@ public class DynamicClientTest {
     public void deserializesDynamicErrorsWithAbsoluteId() {
         var client = createErrorClient("{\"__type\":\"smithy.example#InvalidSprocketId\", \"id\":\"1\"}");
         var e = Assertions.assertThrows(ApiException.class, () -> {
-            client.call("GetSprocket", Document.createFromObject(Map.of("id", "1")));
+            client.call("GetSprocket", Document.ofObject(Map.of("id", "1")));
         });
 
         assertThat(e, instanceOf(ModeledApiException.class));
@@ -172,7 +172,7 @@ public class DynamicClientTest {
     public void deserializesDynamicErrorsWithRelativeId() {
         var client = createErrorClient("{\"__type\":\"InvalidSprocketId\", \"id\":\"1\"}");
         var e = Assertions.assertThrows(ApiException.class, () -> {
-            client.call("GetSprocket", Document.createFromObject(Map.of("id", "1")));
+            client.call("GetSprocket", Document.ofObject(Map.of("id", "1")));
         });
 
         assertThat(e, instanceOf(ModeledApiException.class));
@@ -189,7 +189,7 @@ public class DynamicClientTest {
     public void deserializesDynamicErrorsWithRelativeIdFromService() {
         var client = createErrorClient("{\"__type\":\"ServiceFooError\", \"why\":\"IDK\"}");
         var e = Assertions.assertThrows(ApiException.class, () -> {
-            client.call("GetSprocket", Document.createFromObject(Map.of("id", "1")));
+            client.call("GetSprocket", Document.ofObject(Map.of("id", "1")));
         });
 
         assertThat(e, instanceOf(ModeledApiException.class));

--- a/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/SchemaGuidedDocumentBuilderTest.java
+++ b/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/SchemaGuidedDocumentBuilderTest.java
@@ -109,7 +109,7 @@ public class SchemaGuidedDocumentBuilderTest {
     public void deserializesMember() {
         var converter = new SchemaConverter(model);
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleStruct")));
-        var document = Document.createFromObject(Map.of("foo", "bar"));
+        var document = Document.ofObject(Map.of("foo", "bar"));
 
         var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
         builder.deserializeMember(new DocumentDeserializer(document), schema.member("baz"));
@@ -136,8 +136,8 @@ public class SchemaGuidedDocumentBuilderTest {
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleStruct")));
         var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
 
-        builder.setMemberValue(schema.member("foo"), Document.createString("bar1"));
-        builder.setMemberValue(schema.member("baz"), Document.createFromObject(Map.of("foo", "bar2")));
+        builder.setMemberValue(schema.member("foo"), Document.of("bar1"));
+        builder.setMemberValue(schema.member("baz"), Document.ofObject(Map.of("foo", "bar2")));
 
         var result = builder.build();
 
@@ -200,28 +200,28 @@ public class SchemaGuidedDocumentBuilderTest {
 
     static List<Arguments> deserializesShapesProvider() {
         return List.of(
-            Arguments.of("MyDocument", Document.createFromObject(Map.of("a", "b"))),
-            Arguments.of("MyString", Document.createString("hi")),
-            Arguments.of("MyBoolean", Document.createBoolean(true)),
-            Arguments.of("MyTimestamp", Document.createTimestamp(Instant.EPOCH)),
-            Arguments.of("MyBlob", Document.createBlob("foo".getBytes(StandardCharsets.UTF_8))),
-            Arguments.of("MyByte", Document.createByte((byte) 1)),
-            Arguments.of("MyShort", Document.createShort((short) 1)),
-            Arguments.of("MyInteger", Document.createInteger(1)),
-            Arguments.of("MyLong", Document.createLong(1L)),
-            Arguments.of("MyFloat", Document.createFloat(1f)),
-            Arguments.of("MyDouble", Document.createDouble(1d)),
-            Arguments.of("MyBigInteger", Document.createBigInteger(BigInteger.ONE)),
-            Arguments.of("MyBigDecimal", Document.createBigDecimal(BigDecimal.ONE)),
-            Arguments.of("MyIntEnum", Document.createInteger(1)),
-            Arguments.of("MyEnum", Document.createString("foo")),
-            Arguments.of("SimpleList", Document.createFromObject(List.of("a", "b"))),
-            Arguments.of("SimpleMap", Document.createFromObject(Map.of("foo", "bar"))),
+            Arguments.of("MyDocument", Document.ofObject(Map.of("a", "b"))),
+            Arguments.of("MyString", Document.of("hi")),
+            Arguments.of("MyBoolean", Document.of(true)),
+            Arguments.of("MyTimestamp", Document.of(Instant.EPOCH)),
+            Arguments.of("MyBlob", Document.of("foo".getBytes(StandardCharsets.UTF_8))),
+            Arguments.of("MyByte", Document.of((byte) 1)),
+            Arguments.of("MyShort", Document.of((short) 1)),
+            Arguments.of("MyInteger", Document.of(1)),
+            Arguments.of("MyLong", Document.of(1L)),
+            Arguments.of("MyFloat", Document.of(1f)),
+            Arguments.of("MyDouble", Document.of(1d)),
+            Arguments.of("MyBigInteger", Document.of(BigInteger.ONE)),
+            Arguments.of("MyBigDecimal", Document.of(BigDecimal.ONE)),
+            Arguments.of("MyIntEnum", Document.of(1)),
+            Arguments.of("MyEnum", Document.of("foo")),
+            Arguments.of("SimpleList", Document.ofObject(List.of("a", "b"))),
+            Arguments.of("SimpleMap", Document.ofObject(Map.of("foo", "bar"))),
             Arguments.of(
                 "SimpleStruct",
-                Document.createFromObject(Map.of("foo", "bar", "baz", Document.createFromObject(Map.of("foo", "hi"))))
+                Document.ofObject(Map.of("foo", "bar", "baz", Document.ofObject(Map.of("foo", "hi"))))
             ),
-            Arguments.of("SimpleUnion", Document.createFromObject(Map.of("foo", "bar")))
+            Arguments.of("SimpleUnion", Document.ofObject(Map.of("foo", "bar")))
         );
     }
 }

--- a/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/SchemaInterceptingSerializerTest.java
+++ b/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/SchemaInterceptingSerializerTest.java
@@ -114,19 +114,19 @@ public class SchemaInterceptingSerializerTest {
     static List<Arguments> interceptsWithSchemaProvider() {
         var bytes = ByteBuffer.wrap("hi".getBytes(StandardCharsets.UTF_8));
         return List.of(
-            Arguments.arguments("MyBoolean", Document.createBoolean(true)),
-            Arguments.arguments("MyString", Document.createString("hi")),
-            Arguments.arguments("MyByte", Document.createByte((byte) 1)),
-            Arguments.arguments("MyShort", Document.createShort((short) 1)),
-            Arguments.arguments("MyInteger", Document.createInteger(1)),
-            Arguments.arguments("MyLong", Document.createLong(1L)),
-            Arguments.arguments("MyFloat", Document.createFloat(1f)),
-            Arguments.arguments("MyDouble", Document.createDouble(1d)),
-            Arguments.arguments("MyBigDecimal", Document.createBigDecimal(BigDecimal.ONE)),
-            Arguments.arguments("MyBigInteger", Document.createBigInteger(BigInteger.ONE)),
-            Arguments.arguments("MyTimestamp", Document.createTimestamp(Instant.EPOCH)),
-            Arguments.arguments("MyBlob", Document.createBlob(bytes)),
-            Arguments.arguments("MyDocument", Document.createString("hi"))
+            Arguments.arguments("MyBoolean", Document.of(true)),
+            Arguments.arguments("MyString", Document.of("hi")),
+            Arguments.arguments("MyByte", Document.of((byte) 1)),
+            Arguments.arguments("MyShort", Document.of((short) 1)),
+            Arguments.arguments("MyInteger", Document.of(1)),
+            Arguments.arguments("MyLong", Document.of(1L)),
+            Arguments.arguments("MyFloat", Document.of(1f)),
+            Arguments.arguments("MyDouble", Document.of(1d)),
+            Arguments.arguments("MyBigDecimal", Document.of(BigDecimal.ONE)),
+            Arguments.arguments("MyBigInteger", Document.of(BigInteger.ONE)),
+            Arguments.arguments("MyTimestamp", Document.of(Instant.EPOCH)),
+            Arguments.arguments("MyBlob", Document.of(bytes)),
+            Arguments.arguments("MyDocument", Document.of("hi"))
         );
     }
 
@@ -137,7 +137,7 @@ public class SchemaInterceptingSerializerTest {
         var wrapped = new WrappedDocument(
             ShapeId.from("smithy.example#S"),
             listSchema,
-            Document.createList(Arrays.asList(Document.createString("a"), null))
+            Document.of(Arrays.asList(Document.of("a"), null))
         );
 
         wrapped.serialize(new SpecificShapeSerializer() {
@@ -167,7 +167,7 @@ public class SchemaInterceptingSerializerTest {
         var wrapped = new WrappedDocument(
             ShapeId.from("smithy.example#S"),
             mapSchema,
-            Document.createFromObject(Map.of("foo", "bar"))
+            Document.ofObject(Map.of("foo", "bar"))
         );
 
         wrapped.serialize(new SpecificShapeSerializer() {
@@ -206,7 +206,7 @@ public class SchemaInterceptingSerializerTest {
         var wrapped = new WrappedDocument(
             ShapeId.from("smithy.example#S"),
             mapSchema,
-            Document.createFromObject(Map.of("foo", "bar"))
+            Document.ofObject(Map.of("foo", "bar"))
         );
 
         wrapped.serialize(new SpecificShapeSerializer() {
@@ -245,12 +245,12 @@ public class SchemaInterceptingSerializerTest {
         var wrapped = new WrappedDocument(
             ShapeId.from("smithy.example#S"),
             structSchema,
-            Document.createFromObject(
+            Document.ofObject(
                 Map.of(
                     "foo",
                     "bar",
                     "baz",
-                    Document.createFromObject(Map.of("foo", "hi"))
+                    Document.ofObject(Map.of("foo", "hi"))
                 )
             )
         );

--- a/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/WrappedDocumentTest.java
+++ b/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/WrappedDocumentTest.java
@@ -42,7 +42,7 @@ public class WrappedDocumentTest {
         var schema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
             .putMember("foo", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(Map.of("__type", "foo#Bar", "foo", "bar"));
+        var document = Document.ofObject(Map.of("__type", "foo#Bar", "foo", "bar"));
 
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
 
@@ -56,7 +56,7 @@ public class WrappedDocumentTest {
         var schema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
             .putMember("foo", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(Map.of("__type", "foo#Bar", "foo", "bar"));
+        var document = Document.ofObject(Map.of("__type", "foo#Bar", "foo", "bar"));
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
 
         assertThat(sd.getMemberValue(schema.member("foo")), equalTo("bar"));
@@ -67,7 +67,7 @@ public class WrappedDocumentTest {
         var schema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
             .putMember("foo", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(Map.of());
+        var document = Document.of(Map.of());
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
 
         assertThat(sd.getMemberValue(schema.member("foo")), nullValue());
@@ -79,7 +79,7 @@ public class WrappedDocumentTest {
         var schema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
             .putMember("foo", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(Map.of("foo", "bar"));
+        var document = Document.ofObject(Map.of("foo", "bar"));
 
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
 
@@ -91,7 +91,7 @@ public class WrappedDocumentTest {
         var schema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
             .putMember("foo", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(Map.of("foo", "bar"));
+        var document = Document.ofObject(Map.of("foo", "bar"));
 
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
 
@@ -114,79 +114,79 @@ public class WrappedDocumentTest {
         return List.of(
             Arguments.arguments(
                 PreludeSchemas.BOOLEAN,
-                Document.createBoolean(true),
+                Document.of(true),
                 true,
                 (Function<Document, Object>) Document::asBoolean
             ),
             Arguments.arguments(
                 PreludeSchemas.STRING,
-                Document.createString("hi"),
+                Document.of("hi"),
                 "hi",
                 (Function<Document, Object>) Document::asString
             ),
             Arguments.arguments(
                 PreludeSchemas.BYTE,
-                Document.createByte((byte) 1),
+                Document.of((byte) 1),
                 (byte) 1,
                 (Function<Document, Object>) Document::asByte
             ),
             Arguments.arguments(
                 PreludeSchemas.SHORT,
-                Document.createShort((short) 1),
+                Document.of((short) 1),
                 (short) 1,
                 (Function<Document, Object>) Document::asShort
             ),
             Arguments.arguments(
                 PreludeSchemas.INTEGER,
-                Document.createInteger(1),
+                Document.of(1),
                 1,
                 (Function<Document, Object>) Document::asInteger
             ),
             Arguments.arguments(
                 PreludeSchemas.LONG,
-                Document.createLong(1L),
+                Document.of(1L),
                 1L,
                 (Function<Document, Object>) Document::asLong
             ),
             Arguments.arguments(
                 PreludeSchemas.FLOAT,
-                Document.createFloat(1f),
+                Document.of(1f),
                 1f,
                 (Function<Document, Object>) Document::asFloat
             ),
             Arguments.arguments(
                 PreludeSchemas.DOUBLE,
-                Document.createDouble(1d),
+                Document.of(1d),
                 1d,
                 (Function<Document, Object>) Document::asDouble
             ),
             Arguments.arguments(
                 PreludeSchemas.BIG_DECIMAL,
-                Document.createBigDecimal(BigDecimal.ONE),
+                Document.of(BigDecimal.ONE),
                 BigDecimal.ONE,
                 (Function<Document, Object>) Document::asBigDecimal
             ),
             Arguments.arguments(
                 PreludeSchemas.BIG_INTEGER,
-                Document.createBigInteger(BigInteger.ONE),
+                Document.of(BigInteger.ONE),
                 BigInteger.ONE,
                 (Function<Document, Object>) Document::asBigInteger
             ),
             Arguments.arguments(
                 PreludeSchemas.TIMESTAMP,
-                Document.createTimestamp(Instant.EPOCH),
+                Document.of(Instant.EPOCH),
                 Instant.EPOCH,
                 (Function<Document, Object>) Document::asTimestamp
             ),
             Arguments.arguments(
                 PreludeSchemas.BIG_INTEGER,
-                Document.createBigInteger(BigInteger.ONE),
+                Document.of(BigInteger.ONE),
                 BigInteger.ONE,
                 (Function<Document, Object>) Document::asNumber
             ),
             Arguments.arguments(
                 PreludeSchemas.BLOB,
-                Document.createBlob(bytes),
+                Document.of(bytes),
                 bytes,
                 (Function<Document, Object>) Document::asBlob
             )
@@ -198,7 +198,7 @@ public class WrappedDocumentTest {
         var schema = Schema.listBuilder(ShapeId.from("foo#Bar"))
             .putMember("member", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(List.of("a", "b"));
+        var document = Document.ofObject(List.of("a", "b"));
 
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
 
@@ -217,7 +217,7 @@ public class WrappedDocumentTest {
             .putMember("key", PreludeSchemas.STRING)
             .putMember("value", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(Map.of("a", "b"));
+        var document = Document.ofObject(Map.of("a", "b"));
 
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
 
@@ -235,7 +235,7 @@ public class WrappedDocumentTest {
             .putMember("a", PreludeSchemas.STRING)
             .putMember("b", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(Map.of("a", "a", "b", "b", "c", "c"));
+        var document = Document.ofObject(Map.of("a", "a", "b", "b", "c", "c"));
 
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
 
@@ -259,7 +259,7 @@ public class WrappedDocumentTest {
         var wrapped = new WrappedDocument(
             ShapeId.from("smithy.example#S"),
             PreludeSchemas.STRING,
-            Document.createString("hi")
+            Document.of("hi")
         );
         Schema[] set = new Schema[1];
 
@@ -279,7 +279,7 @@ public class WrappedDocumentTest {
             .putMember("a", PreludeSchemas.STRING)
             .putMember("b", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(Map.of("a", "a", "b", "b", "c", "c"));
+        var document = Document.ofObject(Map.of("a", "a", "b", "b", "c", "c"));
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
         Schema[] set = new Schema[3];
 
@@ -307,7 +307,7 @@ public class WrappedDocumentTest {
             .putMember("a", PreludeSchemas.STRING)
             .putMember("b", PreludeSchemas.STRING)
             .build();
-        var document = Document.createFromObject(Map.of("a", "a"));
+        var document = Document.ofObject(Map.of("a", "a"));
         var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
         Schema[] set = new Schema[2];
 

--- a/examples/restjson-example/src/it/java/software/amazon/smithy/java/example/GenericTest.java
+++ b/examples/restjson-example/src/it/java/software/amazon/smithy/java/example/GenericTest.java
@@ -91,7 +91,7 @@ public class GenericTest {
         System.out.println(codec.serializeToString(input));
 
         // Convert to a Document and then serialize to JSON.
-        Document document = Document.createTyped(input);
+        Document document = Document.of(input);
         System.out.println(codec.serializeToString(document));
 
         // Send the Document to a person builder.

--- a/json-codec/src/main/java/software/amazon/smithy/java/json/JsonDocuments.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/json/JsonDocuments.java
@@ -40,23 +40,23 @@ public final class JsonDocuments {
 
     private JsonDocuments() {}
 
-    public static Document createString(String value, JsonCodec.Settings settings) {
+    public static Document of(String value, JsonCodec.Settings settings) {
         return new StringDocument(value, settings);
     }
 
-    public static Document createBoolean(boolean value, JsonCodec.Settings settings) {
+    public static Document of(boolean value, JsonCodec.Settings settings) {
         return new BooleanDocument(value, settings);
     }
 
-    public static Document createNumber(Number value, JsonCodec.Settings settings) {
+    public static Document of(Number value, JsonCodec.Settings settings) {
         return new NumberDocument(value, settings, DocumentUtils.getSchemaForNumber(value));
     }
 
-    public static Document createList(List<Document> values, JsonCodec.Settings settings) {
+    public static Document of(List<Document> values, JsonCodec.Settings settings) {
         return new ListDocument(values, settings);
     }
 
-    public static Document createMap(Map<String, Document> values, JsonCodec.Settings settings) {
+    public static Document of(Map<String, Document> values, JsonCodec.Settings settings) {
         return new MapDocument(values, settings);
     }
 

--- a/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonDeserializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonDeserializer.java
@@ -196,10 +196,10 @@ final class JacksonJsonDeserializer implements ShapeDeserializer {
             }
             return switch (token) {
                 case VALUE_NULL -> null;
-                case VALUE_STRING -> JsonDocuments.createString(parser.getText(), settings);
-                case VALUE_TRUE -> JsonDocuments.createBoolean(true, settings);
-                case VALUE_FALSE -> JsonDocuments.createBoolean(false, settings);
-                case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> JsonDocuments.createNumber(
+                case VALUE_STRING -> JsonDocuments.of(parser.getText(), settings);
+                case VALUE_TRUE -> JsonDocuments.of(true, settings);
+                case VALUE_FALSE -> JsonDocuments.of(false, settings);
+                case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> JsonDocuments.of(
                     parser.getNumberValue(),
                     settings
                 );
@@ -208,7 +208,7 @@ final class JacksonJsonDeserializer implements ShapeDeserializer {
                     for (token = parser.nextToken(); token != END_ARRAY; token = parser.nextToken()) {
                         values.add(readDocument());
                     }
-                    yield JsonDocuments.createList(values, settings);
+                    yield JsonDocuments.of(values, settings);
                 }
                 case START_OBJECT -> {
                     Map<String, Document> values = new LinkedHashMap<>();
@@ -216,7 +216,7 @@ final class JacksonJsonDeserializer implements ShapeDeserializer {
                         parser.nextToken();
                         values.put(field, readDocument());
                     }
-                    yield JsonDocuments.createMap(values, settings);
+                    yield JsonDocuments.of(values, settings);
                 }
                 default -> throw new SerializationException("Unexpected token: " + describeToken());
             };

--- a/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDocumentTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDocumentTest.java
@@ -437,7 +437,7 @@ public class JsonDocumentTest {
         var de = codec.createDeserializer("true".getBytes(StandardCharsets.UTF_8));
         var json = de.readDocument();
 
-        assertThat(Document.equals(json, Document.createBoolean(true)), is(true));
+        assertThat(Document.equals(json, Document.of(true)), is(true));
     }
 
     @Test

--- a/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
+++ b/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
@@ -43,7 +43,7 @@ public class JsonSerializerTest {
 
     @Test
     public void writesDocumentsInline() throws Exception {
-        var document = Document.createList(List.of(Document.createString("a")));
+        var document = Document.of(List.of(Document.of("a")));
 
         try (JsonCodec codec = JsonCodec.builder().build(); var output = new ByteArrayOutputStream()) {
             try (var serializer = codec.createSerializer(output)) {
@@ -70,49 +70,49 @@ public class JsonSerializerTest {
         var now = Instant.now();
 
         return List.of(
-            Arguments.of(Document.createString("a"), "\"a\""),
-            Arguments.of(Document.createBlob("a".getBytes(StandardCharsets.UTF_8)), "\"YQ==\""),
-            Arguments.of(Document.createByte((byte) 1), "1"),
-            Arguments.of(Document.createShort((short) 1), "1"),
-            Arguments.of(Document.createInteger(1), "1"),
-            Arguments.of(Document.createLong(1L), "1"),
-            Arguments.of(Document.createFloat(1.1f), "1.1"),
-            Arguments.of(Document.createFloat(Float.NaN), "\"NaN\""),
-            Arguments.of(Document.createFloat(Float.POSITIVE_INFINITY), "\"Infinity\""),
-            Arguments.of(Document.createFloat(Float.NEGATIVE_INFINITY), "\"-Infinity\""),
-            Arguments.of(Document.createDouble(1.1), "1.1"),
-            Arguments.of(Document.createDouble(Double.NaN), "\"NaN\""),
-            Arguments.of(Document.createDouble(Double.POSITIVE_INFINITY), "\"Infinity\""),
-            Arguments.of(Document.createDouble(Double.NEGATIVE_INFINITY), "\"-Infinity\""),
-            Arguments.of(Document.createBigInteger(BigInteger.ZERO), "0"),
-            Arguments.of(Document.createBigDecimal(BigDecimal.ONE), "1"),
-            Arguments.of(Document.createBoolean(true), "true"),
-            Arguments.of(Document.createTimestamp(now), Double.toString(((double) now.toEpochMilli()) / 1000)),
-            Arguments.of(Document.createList(List.of(Document.createString("a"))), "[\"a\"]"),
+            Arguments.of(Document.of("a"), "\"a\""),
+            Arguments.of(Document.of("a".getBytes(StandardCharsets.UTF_8)), "\"YQ==\""),
+            Arguments.of(Document.of((byte) 1), "1"),
+            Arguments.of(Document.of((short) 1), "1"),
+            Arguments.of(Document.of(1), "1"),
+            Arguments.of(Document.of(1L), "1"),
+            Arguments.of(Document.of(1.1f), "1.1"),
+            Arguments.of(Document.of(Float.NaN), "\"NaN\""),
+            Arguments.of(Document.of(Float.POSITIVE_INFINITY), "\"Infinity\""),
+            Arguments.of(Document.of(Float.NEGATIVE_INFINITY), "\"-Infinity\""),
+            Arguments.of(Document.of(1.1), "1.1"),
+            Arguments.of(Document.of(Double.NaN), "\"NaN\""),
+            Arguments.of(Document.of(Double.POSITIVE_INFINITY), "\"Infinity\""),
+            Arguments.of(Document.of(Double.NEGATIVE_INFINITY), "\"-Infinity\""),
+            Arguments.of(Document.of(BigInteger.ZERO), "0"),
+            Arguments.of(Document.of(BigDecimal.ONE), "1"),
+            Arguments.of(Document.of(true), "true"),
+            Arguments.of(Document.of(now), Double.toString(((double) now.toEpochMilli()) / 1000)),
+            Arguments.of(Document.of(List.of(Document.of("a"))), "[\"a\"]"),
             Arguments.of(
-                Document.createList(
+                Document.of(
                     List.of(
-                        Document.createList(List.of(Document.createString("a"), Document.createString("b"))),
-                        Document.createString("c")
+                        Document.of(List.of(Document.of("a"), Document.of("b"))),
+                        Document.of("c")
                     )
                 ),
                 "[[\"a\",\"b\"],\"c\"]"
             ),
             Arguments.of(
-                Document.createList(List.of(Document.createString("a"), Document.createString("b"))),
+                Document.of(List.of(Document.of("a"), Document.of("b"))),
                 "[\"a\",\"b\"]"
             ),
-            Arguments.of(Document.createStringMap(Map.of("a", Document.createString("av"))), "{\"a\":\"av\"}"),
-            Arguments.of(Document.createStringMap(new LinkedHashMap<>() {
+            Arguments.of(Document.of(Map.of("a", Document.of("av"))), "{\"a\":\"av\"}"),
+            Arguments.of(Document.of(new LinkedHashMap<>() {
                 {
-                    this.put("a", Document.createString("av"));
-                    this.put("b", Document.createString("bv"));
-                    this.put("c", Document.createInteger(1));
+                    this.put("a", Document.of("av"));
+                    this.put("b", Document.of("bv"));
+                    this.put("c", Document.of(1));
                     this.put(
                         "d",
-                        Document.createList(List.of(Document.createInteger(1), Document.createInteger(2)))
+                        Document.of(List.of(Document.of(1), Document.of(2)))
                     );
-                    this.put("e", Document.createStringMap(Map.of("ek", Document.createString("ek1"))));
+                    this.put("e", Document.of(Map.of("ek", Document.of("ek1"))));
                 }
             }), "{\"a\":\"av\",\"b\":\"bv\",\"c\":1,\"d\":[1,2],\"e\":{\"ek\":\"ek1\"}}")
         );
@@ -231,7 +231,7 @@ public class JsonSerializerTest {
     @Test
     public void writesDunderTypeAndMoreMembers() throws Exception {
         var struct = new NestedStruct();
-        var document = Document.createTyped(struct);
+        var document = Document.of(struct);
         try (var codec = JsonCodec.builder().build(); var output = new ByteArrayOutputStream()) {
             try (var serializer = codec.createSerializer(output)) {
                 document.serialize(serializer);
@@ -244,8 +244,8 @@ public class JsonSerializerTest {
     @Test
     public void writesNestedDunderType() throws Exception {
         var struct = new NestedStruct();
-        var document = Document.createTyped(struct);
-        var map = Document.createStringMap(Map.of("a", document));
+        var document = Document.of(struct);
+        var map = Document.of(Map.of("a", document));
         try (var codec = JsonCodec.builder().build(); var output = new ByteArrayOutputStream()) {
             try (var serializer = codec.createSerializer(output)) {
                 map.serialize(serializer);
@@ -258,7 +258,7 @@ public class JsonSerializerTest {
     @Test
     public void writesDunderTypeForEmptyStruct() throws Exception {
         var struct = new EmptyStruct();
-        var document = Document.createTyped(struct);
+        var document = Document.of(struct);
         try (var codec = JsonCodec.builder().build(); var output = new ByteArrayOutputStream()) {
             try (var serializer = codec.createSerializer(output)) {
                 document.serialize(serializer);

--- a/mock-client-plugin/src/test/java/software/amazon/smithy/java/client/http/mock/MockPluginTest.java
+++ b/mock-client-plugin/src/test/java/software/amazon/smithy/java/client/http/mock/MockPluginTest.java
@@ -87,13 +87,13 @@ public class MockPluginTest {
         mockQueue.enqueue(
             client.createStruct(
                 ShapeId.from("smithy.example#GetSprocketOutput"),
-                Document.createStringMap(Map.of("id", Document.createString("a")))
+                Document.of(Map.of("id", Document.of("a")))
             )
         );
         mockQueue.enqueue(
             client.createStruct(
                 ShapeId.from("smithy.example#GetSprocketOutput"),
-                Document.createStringMap(Map.of("id", Document.createString("b")))
+                Document.of(Map.of("id", Document.of("b")))
             )
         );
 
@@ -216,21 +216,21 @@ public class MockPluginTest {
         aQueue.enqueue(
             client.createStruct(
                 ShapeId.from("smithy.example#GetSprocketOutput"),
-                Document.createStringMap(Map.of("id", Document.createString("a")))
+                Document.of(Map.of("id", Document.of("a")))
             )
         );
 
         bQueue.enqueue(
             client.createStruct(
                 ShapeId.from("smithy.example#GetSprocketOutput"),
-                Document.createStringMap(Map.of("id", Document.createString("b")))
+                Document.of(Map.of("id", Document.of("b")))
             )
         );
 
-        var aresult = client.call("GetSprocket", Document.createStringMap(Map.of("id", Document.createString("a"))));
+        var aresult = client.call("GetSprocket", Document.of(Map.of("id", Document.of("a"))));
         assertThat(aresult.getMember("id").asString(), equalTo("a"));
 
-        var bresult = client.call("GetSprocket", Document.createStringMap(Map.of("id", Document.createString("b"))));
+        var bresult = client.call("GetSprocket", Document.of(Map.of("id", Document.of("b"))));
         assertThat(bresult.getMember("id").asString(), equalTo("b"));
 
         assertThat(mock.getRequests(), hasSize(2));

--- a/protocol-tests/src/test/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestDocumentTest.java
+++ b/protocol-tests/src/test/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestDocumentTest.java
@@ -56,7 +56,7 @@ public class ProtocolTestDocumentTest {
     @Test
     public void wrapsStructContentWithTypeAndSchema() {
         var serializableShape = createSerializableShape();
-        var result = Document.createTyped(serializableShape);
+        var result = Document.of(serializableShape);
 
         assertThat(result.type(), equalTo(ShapeType.STRUCTURE));
         assertThat(
@@ -78,8 +78,8 @@ public class ProtocolTestDocumentTest {
         assertThat(result, equalTo(result));
         assertThat(result, not(equalTo(null)));
         assertThat(result, not(equalTo("X")));
-        assertThat(result, equalTo(Document.createTyped(serializableShape)));
-        assertThat(result.hashCode(), equalTo(Document.createTyped(serializableShape).hashCode()));
+        assertThat(result, equalTo(Document.of(serializableShape)));
+        assertThat(result.hashCode(), equalTo(Document.of(serializableShape).hashCode()));
 
         // Writes as document unless getting contents.
         result.serialize(new SpecificShapeSerializer() {
@@ -90,11 +90,11 @@ public class ProtocolTestDocumentTest {
         });
 
         // This is basically recreating the same document with the same captured schema.
-        assertThat(result, equalTo(Document.createTyped(result)));
+        assertThat(result, equalTo(Document.of(result)));
 
         // Not equal because the left member has a schema with the same value, but the right has no schema.
-        assertThat(result.getMember("a"), not(equalTo(Document.createString("1"))));
-        assertThat(result.getMember("b"), not(equalTo(Document.createString("2"))));
+        assertThat(result.getMember("a"), not(equalTo(Document.of("1"))));
+        assertThat(result.getMember("b"), not(equalTo(Document.of("2"))));
 
         // Converts to a string map.
         var copy1 = result.asStringMap();


### PR DESCRIPTION
Now Documents are all created using Document.of, Document.ofNumber, and Document.ofObject. These methods remove the old methods like createString, createNumber, createStringMap, etc. ofNumber and ofObject are separate to avoid boxed numbers and booleans from going through them rather than of(boolean) for example.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
