### PR TITLE
Unwrap document value for getMemberValue

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -65,9 +65,8 @@ public final class UnionGenerator
                     }
 
                     @Override
-                    @SuppressWarnings("unchecked")
                     public <T> T getMemberValue(${sdkSchema:N} member) {
-                        return (T) ${schemaUtils:N}.validateMemberInSchema($$SCHEMA, member, getValue());
+                        return ${schemaUtils:N}.validateMemberInSchema($$SCHEMA, member, getValue());
                     }
 
                     public abstract <T> T getValue();

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/SchemaUtils.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/SchemaUtils.java
@@ -58,7 +58,7 @@ public final class SchemaUtils {
      * @throws IllegalArgumentException if the member is not part of parent.
      * @return the given {@code value}.
      */
-    public static Object validateMemberInSchema(Schema parent, Schema member, Object value) {
+    public static <T> T validateMemberInSchema(Schema parent, Schema member, T value) {
         try {
             if (member == parent.members().get(member.memberIndex())) {
                 return value;

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/Unit.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/Unit.java
@@ -42,9 +42,8 @@ public final class Unit implements SerializableStruct {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T> T getMemberValue(Schema member) {
-        return (T) SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
+        return SchemaUtils.validateMemberInSchema(SCHEMA, member, null);
     }
 
     public static Builder builder() {

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/document/Documents.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/document/Documents.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.java.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.core.schema.Schema;
-import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -279,9 +278,8 @@ final class Documents {
         }
 
         @Override
-        @SuppressWarnings("unchecked")
         public <T> T getMemberValue(Schema member) {
-            return (T) SchemaUtils.validateMemberInSchema(schema, member, members.get(member.memberName()));
+            return DocumentUtils.getMemberValue(this, schema, member);
         }
     }
 

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentTest.java
@@ -583,4 +583,3 @@ public class DocumentTest {
         assertThat(document.size(), is(-1));
     }
 }
-

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/TypedDocumentTest.java
@@ -7,7 +7,6 @@ package software.amazon.smithy.java.core.serde.document;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -110,10 +109,8 @@ public class TypedDocumentTest {
         var result = (SerializableStruct) Document.of(serializableShape);
         var schema = result.schema();
 
-        assertThat(result.getMemberValue(schema.member("a")), instanceOf(Document.class));
-        assertThat(((Document) result.getMemberValue(schema.member("a"))).asString(), equalTo("1"));
-        assertThat(result.getMemberValue(schema.member("b")), instanceOf(Document.class));
-        assertThat(((Document) result.getMemberValue(schema.member("b"))).asString(), equalTo("2"));
+        assertThat(result.getMemberValue(schema.member("a")), equalTo("1"));
+        assertThat(result.getMemberValue(schema.member("b")), equalTo("2"));
 
         var bogus = Schema.createString(ShapeId.from("foo#Bar"));
         Assertions.assertThrows(IllegalArgumentException.class, () -> result.getMemberValue(bogus));

--- a/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/WrappedDocument.java
+++ b/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/WrappedDocument.java
@@ -15,10 +15,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.java.core.schema.Schema;
-import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.core.serde.document.DocumentUtils;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 
@@ -67,17 +67,8 @@ record WrappedDocument(ShapeId service, Schema schema, Document delegate) implem
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T> T getMemberValue(Schema member) {
-        // Make sure it's part of the schema.
-        var value = SchemaUtils.validateMemberInSchema(schema, member, getMember(member.memberName()));
-        // If it's a document, unwrap it.
-        // This should work for most use cases of DynamicClient, but this won't perfectly interoperate with all
-        // use-cases or be a stand-in when an actual type is expected.
-        if (value instanceof Document d) {
-            value = d.asObject();
-        }
-        return (T) value;
+        return DocumentUtils.getMemberValue(this, schema, member);
     }
 
     @Override


### PR DESCRIPTION
getMemberValue should unwrap the document and convert it to an object. This matches the behavior of DynamicClient, and mimics how normal structures return values.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
