### PR TITLE
Move uniqueItems validation to Validator

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ListsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ListsTest.java
@@ -11,14 +11,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.*;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,7 +35,6 @@ import software.amazon.smithy.java.codegen.test.model.SetsAllTypesInput;
 import software.amazon.smithy.java.codegen.test.model.SparseListsInput;
 import software.amazon.smithy.java.core.schema.SerializableShape;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
-import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.json.JsonCodec;
 import software.amazon.smithy.utils.ListUtils;
@@ -280,21 +281,19 @@ public class ListsTest {
             "{\"setOfUnion\":[{\"a\": \"str\"}, {\"b\": 1}, {\"a\": \"str\"}]}",
             "{\"setOfEnum\":[\"A\", \"B\", \"A\"]}",
             "{\"setOfIntEnum\":[1,1,2]}",
-            "{\"setOfStruct\":[{\"fieldA\": \"a\"}, {\"fieldA\": \"a\"}, {\"fieldA\": \"z\"}]",
+            "{\"setOfStruct\":[{\"fieldA\": \"a\"}, {\"fieldA\": \"a\"}, {\"fieldA\": \"z\"}]}",
             "{\"setOfStringList\":[[\"a\", \"b\"],[\"c\", \"d\"],[\"a\", \"b\"]]}",
-            "{\"setOfStringMap\": [{\"a\": \"b\", \"c\": \"d\"}, {\"c\": \"d\", \"a\": \"b\"}]"
+            "{\"setOfStringMap\": [{\"a\": \"b\", \"c\": \"d\"}, {\"c\": \"d\", \"a\": \"b\"}]}"
         );
     }
 
+    // Uniqueness is enforced in validation only.
     @ParameterizedTest
     @MethodSource("nonUniqueSources")
-    void nonUniqueThrows(String source) {
+    void nonUniqueIsAllowed(String source) {
         try (var codec = JsonCodec.builder().useJsonName(true).build()) {
-            var exc = assertThrows(
-                SerializationException.class,
-                () -> codec.deserializeShape(source, SetsAllTypesInput.builder())
-            );
-            assertTrue(exc.getMessage().contains("Member must have unique values"));
+            // This not throwing is the test.
+            codec.deserializeShape(source, SetsAllTypesInput.builder());
         }
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/JavaSymbolProvider.java
@@ -13,11 +13,9 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Flow;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -53,7 +51,6 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.StreamingTrait;
-import software.amazon.smithy.model.traits.UniqueItemsTrait;
 import software.amazon.smithy.model.traits.UnitTypeTrait;
 import software.amazon.smithy.utils.CaseUtils;
 
@@ -132,17 +129,6 @@ public class JavaSymbolProvider implements ShapeVisitor<Symbol>, SymbolProvider 
 
     @Override
     public Symbol listShape(ListShape listShape) {
-        // Lists with unique Items are treated as Sequenced Sets
-        if (listShape.hasTrait(UniqueItemsTrait.class)) {
-            return CodegenUtils.fromClass(Set.class)
-                .toBuilder()
-                .putProperty(SymbolProperties.COLLECTION_IMMUTABLE_WRAPPER, "unmodifiableSet")
-                .putProperty(SymbolProperties.COLLECTION_IMPLEMENTATION_CLASS, LinkedHashSet.class)
-                .putProperty(SymbolProperties.COLLECTION_EMPTY_METHOD, "emptySet()")
-                .putProperty(SymbolProperties.REQUIRES_STATIC_DEFAULT, false)
-                .addReference(listShape.getMember().accept(this))
-                .build();
-        }
         return CodegenUtils.fromClass(List.class)
             .toBuilder()
             .putProperty(SymbolProperties.COLLECTION_IMMUTABLE_WRAPPER, "unmodifiableList")

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -17,7 +17,6 @@ import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.model.traits.SparseTrait;
-import software.amazon.smithy.model.traits.UniqueItemsTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -71,14 +70,10 @@ public final class ListGenerator
                             @Override
                             public void accept(${shape:B} state, ${shapeDeserializer:T} deserializer) {
                                 if (deserializer.isNull()) {
-                                    ${?sparse}${?unique}if (!${/unique}state.add(${/sparse}deserializer.readNull()${^sparse};${/sparse}${?sparse})${^unique};${/unique}${?unique}) {
-                                        throw new ${serdeException:T}("Member must have unique values");
-                                    }${/unique}${/sparse}
+                                    ${?sparse}state.add(deserializer.readNull());${/sparse}
                                     return;
                                 }
-                                ${?unique}if (!${/unique}state.add($memberDeserializer:C)${^unique};${/unique}${?unique}) {
-                                    throw new ${serdeException:T}("Member must have unique values");
-                                }${/unique}
+                                state.add($memberDeserializer:C);
                             }
                         }
                         """;
@@ -92,7 +87,6 @@ public final class ListGenerator
                     writer.putContext("biConsumer", BiConsumer.class);
                     writer.putContext("shapeSerializer", ShapeSerializer.class);
                     writer.putContext("shapeDeserializer", ShapeDeserializer.class);
-                    writer.putContext("unique", directive.shape().hasTrait(UniqueItemsTrait.class));
                     writer.putContext("serdeException", SerializationException.class);
                     writer.putContext("sparse", directive.shape().hasTrait(SparseTrait.class));
                     writer.putContext("valueSchema", valueSchema);

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/Schema.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/Schema.java
@@ -72,6 +72,7 @@ public abstract sealed class Schema implements MemberLookup
     final double minDoubleConstraint;
     final double maxDoubleConstraint;
     final ValidatorOfString stringValidation;
+    final boolean uniqueItemsConstraint;
 
     private Schema listMember;
     private Schema mapKeyMember;
@@ -115,6 +116,7 @@ public abstract sealed class Schema implements MemberLookup
         this.minRangeConstraint = validationState.minRangeConstraint();
         this.maxRangeConstraint = validationState.maxRangeConstraint();
         this.stringValidation = validationState.stringValidation();
+        this.uniqueItemsConstraint = type == ShapeType.LIST && hasTrait(TraitKey.UNIQUE_ITEMS_TRAIT);
 
         // Only use the slow version of required member validation if there are > 64 required members.
         this.requiredMemberCount = SchemaBuilder.computeRequiredMemberCount(type, members);
@@ -147,6 +149,7 @@ public abstract sealed class Schema implements MemberLookup
         this.maxLongConstraint = builder.validationState.maxLongConstraint();
         this.minDoubleConstraint = builder.validationState.minDoubleConstraint();
         this.maxDoubleConstraint = builder.validationState.maxDoubleConstraint();
+        this.uniqueItemsConstraint = type == ShapeType.LIST && hasTrait(TraitKey.UNIQUE_ITEMS_TRAIT);
 
         // Compute the expected bitfield, and adjust how it's computed based on if the target is a builder or not.
         if (builder.target != null) {

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/TraitKey.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/TraitKey.java
@@ -36,6 +36,7 @@ import software.amazon.smithy.model.traits.SparseTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.traits.UniqueItemsTrait;
 import software.amazon.smithy.model.traits.XmlAttributeTrait;
 import software.amazon.smithy.model.traits.XmlFlattenedTrait;
 import software.amazon.smithy.model.traits.XmlNameTrait;
@@ -62,6 +63,7 @@ public final class TraitKey<T extends Trait> {
 
     public static final TraitKey<RequiredTrait> REQUIRED_TRAIT = TraitKey.get(RequiredTrait.class);
     public static final TraitKey<DefaultTrait> DEFAULT_TRAIT = TraitKey.get(DefaultTrait.class);
+    public static final TraitKey<UniqueItemsTrait> UNIQUE_ITEMS_TRAIT = TraitKey.get(UniqueItemsTrait.class);
     public static final TraitKey<TimestampFormatTrait> TIMESTAMP_FORMAT_TRAIT = TraitKey.get(
         TimestampFormatTrait.class
     );

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ValidationError.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ValidationError.java
@@ -128,4 +128,14 @@ public interface ValidationError {
             }
         }
     }
+
+    record UniqueItemConflict(String path, int position, Schema schema, String message) implements ValidationError {
+        public UniqueItemConflict(String path, int position, Schema schema) {
+            this(path, position, schema, createMessage(position));
+        }
+
+        private static String createMessage(int position) {
+            return "Conflicting list item found at position " + position;
+        }
+    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/Validator.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/Validator.java
@@ -243,7 +243,14 @@ public final class Validator {
 
                 // Push a preliminary value of null. Each list element will swap this path position with its index.
                 pushPath(null);
+
+                // When necessary, validate unique items using an intermediate document representation of each value.
+                if (size != 1 && schema.uniqueItemsConstraint) {
+                    ValidatorOfUniqueItems.validate(schema, state, consumer, this);
+                }
+
                 consumer.accept(state, listValidator);
+
                 popPath();
 
                 // Grab the count and reset the schema and count.

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ValidatorOfUniqueItems.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ValidatorOfUniqueItems.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.core.schema;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import software.amazon.smithy.java.core.serde.InterceptingSerializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.core.serde.document.DocumentParser;
+
+/**
+ * Receives list values, turns them into documents, and makes sure they are all unique.
+ */
+final class ValidatorOfUniqueItems extends InterceptingSerializer {
+    private final Schema container;
+    private final DocumentParser parser = new DocumentParser();
+    private final Set<Document> values = new HashSet<>();
+    private final Validator.ShapeValidator validator;
+    private int position = 0;
+
+    static <T> void validate(
+        Schema container,
+        T state,
+        BiConsumer<T, ShapeSerializer> consumer,
+        Validator.ShapeValidator validator
+    ) {
+        consumer.accept(state, new ValidatorOfUniqueItems(container, validator));
+    }
+
+    private ValidatorOfUniqueItems(Schema container, Validator.ShapeValidator validator) {
+        this.container = container;
+        this.validator = validator;
+    }
+
+    @Override
+    protected ShapeSerializer before(Schema schema) {
+        return parser;
+    }
+
+    @Override
+    protected void after(Schema schema) {
+        if (!values.add(parser.getResult())) {
+            validator.swapPath(position);
+            validator.addError(new ValidationError.UniqueItemConflict(validator.createPath(), position, container));
+        }
+        position++;
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/document/DocumentParser.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/document/DocumentParser.java
@@ -26,22 +26,20 @@ import software.amazon.smithy.model.shapes.ShapeType;
 /**
  * Converts the Smithy data model into Documents.
  */
-final class DocumentParser implements ShapeSerializer {
+public final class DocumentParser implements ShapeSerializer {
 
     private Document result;
-    private boolean wroteSomething = false;
 
-    Document getResult() {
-        if (!wroteSomething) {
-            throw new SerializationException(
-                "Unable to create a document from ShapeSerializer that serialized nothing"
-            );
-        }
+    /**
+     * Get the currently stored result, or null if nothing was serialized.
+     *
+     * @return the result.
+     */
+    public Document getResult() {
         return result;
     }
 
     private void setResult(Document result) {
-        wroteSomething = true;
         this.result = result;
     }
 
@@ -98,11 +96,7 @@ final class DocumentParser implements ShapeSerializer {
     @Override
     public <T> void writeMap(Schema schema, T state, int size, BiConsumer<T, MapSerializer> consumer) {
         var keyMember = schema.mapKeyMember();
-        if (keyMember == null) {
-            throw new SerializationException(
-                "Cannot create a map from a schema that does not define a map key: " + schema
-            );
-        } else if (keyMember.type() == ShapeType.STRING || keyMember.type() == ShapeType.ENUM) {
+        if (keyMember.type() == ShapeType.STRING || keyMember.type() == ShapeType.ENUM) {
             var serializer = new DocumentMapSerializer(size);
             consumer.accept(state, serializer);
             setResult(new Documents.StringMapDocument(schema, serializer.entries));

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentTest.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.core.serde.document;
 import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -311,20 +310,6 @@ public class DocumentTest {
         assertThat(result, equalTo(Map.of("a", "v")));
     }
 
-    @Test
-    public void throwsWhenDocumentWritesNothing() {
-        var e = Assertions.assertThrows(SerializationException.class, () -> {
-            var document = Document.of(encoder -> {});
-            // Trigger the lazy document to create the underlying document.
-            document.getMember("hello!");
-        });
-
-        assertThat(
-            e.getMessage(),
-            containsString("Unable to create a document from ShapeSerializer that serialized nothing")
-        );
-    }
-
     @ParameterizedTest
     @MethodSource("normalizedEqualsTestProvider")
     public void normalizedEqualsTest(Document value) {
@@ -583,4 +568,3 @@ public class DocumentTest {
         assertThat(document.size(), is(-1));
     }
 }
-


### PR DESCRIPTION
Rather than validate unique items in list shape creation, we now validate it only during validation. This allows clients and servers to losslessly deserialize even lists with unique items and doesn't require any kind of potential modality in deserialization between client and server. It also means that POJOs don't throw framework errors, which we're trying to decouple from the core libraries. Finally, this now allows things like DynamicCLient and documents to validate uniqueItems.

To implement uniqueItems, we create a set of documents and emit an error on each list index that is a duplicate of a previous index.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
