### PR TITLE
Use correct publisher for http body

### DIFF
--- a/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientTransport.java
+++ b/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientTransport.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.java.http.api.HttpHeaders;
 import software.amazon.smithy.java.http.api.HttpRequest;
 import software.amazon.smithy.java.http.api.HttpResponse;
 import software.amazon.smithy.java.http.api.HttpVersion;
+import software.amazon.smithy.java.io.ByteBufferUtils;
 import software.amazon.smithy.java.logging.InternalLogger;
 
 /**
@@ -89,7 +90,7 @@ public class JavaHttpClientTransport implements ClientTransport<HttpRequest, Htt
                 bodyPublisher = java.net.http.HttpRequest.BodyPublishers.noBody();
             } else {
                 bodyPublisher = java.net.http.HttpRequest.BodyPublishers.ofByteArray(
-                    request.body().waitForByteBuffer().array()
+                    ByteBufferUtils.getBytes(request.body().waitForByteBuffer())
                 );
             }
         } else {


### PR DESCRIPTION
### Description of changes
Using the `java.net.http.HttpRequest.BodyPublishers.fromPublisher(` causes the java http request to set the content length as `-1` (i.e. indeterminant). This causes all requests to have a `Transfer-encoding` header set with no `content-length`. For example:
```
GET /order/8dc79aa5-817e-4821-a809-abd0d21356f8 HTTP/1.1
Host: localhost:8888
Transfer-encoding: chunked
User-Agent: Java-http-client/21.0.5
Connection: keep-alive

0
```
 This is incorrect for non-streaming requests which should instead have a `content length` header set. 
 
 This PR updates the java transport to use the correct BodyPublisher method.
 
 Wireshark was used to confirm this change causes the correct HTTP headers to be set on the final request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
