### PR TITLE
Add flag to indicate that a modeled exception was deserialized

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -209,10 +209,12 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
                     if (shape.hasTrait(ErrorTrait.class)) {
                         if (shape.getMember("message").isPresent()) {
                             writer.write(
-                                "super($$SCHEMA, builder.message, builder.$$cause, builder.$$captureStackTrace);"
+                                "super($$SCHEMA, builder.message, builder.$$cause, builder.$$captureStackTrace, builder.$$deserialized);"
                             );
                         } else {
-                            writer.write("super($$SCHEMA, null, builder.$$cause, builder.$$captureStackTrace);");
+                            writer.write(
+                                "super($$SCHEMA, null, builder.$$cause, builder.$$captureStackTrace, builder.$$deserialized);"
+                            );
                         }
                     }
 
@@ -743,6 +745,7 @@ public final class StructureGenerator<T extends ShapeDirective<StructureShape, C
             if (shape.hasTrait(ErrorTrait.class)) {
                 writer.write("private $T $$cause;", Throwable.class);
                 writer.write("private $T $$captureStackTrace;", Boolean.class);
+                writer.write("private boolean $$deserialized;");
             }
             writer.popState();
         }

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ModeledApiException.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ModeledApiException.java
@@ -11,6 +11,7 @@ package software.amazon.smithy.java.core.schema;
 public abstract class ModeledApiException extends ApiException implements SerializableStruct {
 
     private final Schema schema;
+    private boolean deserialized = false;
 
     protected ModeledApiException(Schema schema, String message) {
         super(message);
@@ -32,15 +33,24 @@ public abstract class ModeledApiException extends ApiException implements Serial
         String message,
         Fault errorType,
         Throwable cause,
-        Boolean captureStackTrace
+        Boolean captureStackTrace,
+        boolean deserialized
     ) {
         super(message, cause, errorType, captureStackTrace);
         this.schema = schema;
+        this.deserialized = deserialized;
     }
 
-    protected ModeledApiException(Schema schema, String message, Throwable cause, Boolean captureStackTrace) {
+    protected ModeledApiException(
+        Schema schema,
+        String message,
+        Throwable cause,
+        Boolean captureStackTrace,
+        boolean deserialized
+    ) {
         super(message, cause, captureStackTrace);
         this.schema = schema;
+        this.deserialized = deserialized;
     }
 
     protected ModeledApiException(Schema schema, String message, Throwable cause) {
@@ -53,10 +63,12 @@ public abstract class ModeledApiException extends ApiException implements Serial
         String message,
         Throwable cause,
         Fault errorType,
-        Boolean captureStackTrace
+        Boolean captureStackTrace,
+        boolean deserialized
     ) {
         super(message, cause, errorType, captureStackTrace);
         this.schema = schema;
+        this.deserialized = deserialized;
     }
 
     @Override
@@ -80,5 +92,17 @@ public abstract class ModeledApiException extends ApiException implements Serial
             return errorTrait.getDefaultHttpStatusCode();
         }
         return 500;
+    }
+
+    /**
+     * Check if the error was deserialized from a response.
+     *
+     * <p>Errors deserialized from a response should not be re-serialized by servers.
+     * Instead, these errors should be treated as an internal failures.
+     *
+     * @return true if the error was created by deserializing a response.
+     */
+    public boolean deserialized() {
+        return deserialized;
     }
 }


### PR DESCRIPTION
### Description of changes
Adds a flag to Modeled Exceptions to indicate that they were deserialized from a response. Servers will then treat these exceptions as unmodeled an un-serializable.

This prevents servers from re-serializing a modeled exception from a smithy-java client used inside the server's business logic to a client of the server. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
