### PR TITLE
Make JsonCodec.Settings into JsonSettings

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/core/serde/TimestampFormatter.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/TimestampFormatter.java
@@ -61,7 +61,13 @@ public interface TimestampFormatter {
         return of(trait.getFormat());
     }
 
-    private static TimestampFormatter of(TimestampFormatTrait.Format format) {
+    /**
+     * Create a TimestampFormatter from the given format.
+     *
+     * @param format Format to create.
+     * @return the created formatter.
+     */
+    static TimestampFormatter of(TimestampFormatTrait.Format format) {
         return switch (format) {
             case DATE_TIME -> Prelude.DATE_TIME;
             case EPOCH_SECONDS -> Prelude.EPOCH_SECONDS;

--- a/json-codec/src/main/java/software/amazon/smithy/java/json/JsonDocuments.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/json/JsonDocuments.java
@@ -40,27 +40,27 @@ public final class JsonDocuments {
 
     private JsonDocuments() {}
 
-    public static Document of(String value, JsonCodec.Settings settings) {
+    public static Document of(String value, JsonSettings settings) {
         return new StringDocument(value, settings);
     }
 
-    public static Document of(boolean value, JsonCodec.Settings settings) {
+    public static Document of(boolean value, JsonSettings settings) {
         return new BooleanDocument(value, settings);
     }
 
-    public static Document of(Number value, JsonCodec.Settings settings) {
+    public static Document of(Number value, JsonSettings settings) {
         return new NumberDocument(value, settings, DocumentUtils.getSchemaForNumber(value));
     }
 
-    public static Document of(List<Document> values, JsonCodec.Settings settings) {
+    public static Document of(List<Document> values, JsonSettings settings) {
         return new ListDocument(values, settings);
     }
 
-    public static Document of(Map<String, Document> values, JsonCodec.Settings settings) {
+    public static Document of(Map<String, Document> values, JsonSettings settings) {
         return new MapDocument(values, settings);
     }
 
-    record StringDocument(String value, JsonCodec.Settings settings) implements Document {
+    record StringDocument(String value, JsonSettings settings) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.STRING;
@@ -98,7 +98,7 @@ public final class JsonDocuments {
         }
     }
 
-    record NumberDocument(Number value, JsonCodec.Settings settings, Schema schema) implements Document {
+    record NumberDocument(Number value, JsonSettings settings, Schema schema) implements Document {
         @Override
         public ShapeType type() {
             return schema.type();
@@ -161,7 +161,7 @@ public final class JsonDocuments {
         }
     }
 
-    record BooleanDocument(boolean value, JsonCodec.Settings settings) implements Document {
+    record BooleanDocument(boolean value, JsonSettings settings) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.BOOLEAN;
@@ -178,7 +178,7 @@ public final class JsonDocuments {
         }
     }
 
-    record ListDocument(List<Document> values, JsonCodec.Settings settings) implements Document {
+    record ListDocument(List<Document> values, JsonSettings settings) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.LIST;
@@ -213,7 +213,7 @@ public final class JsonDocuments {
         }
     }
 
-    record MapDocument(Map<String, Document> values, JsonCodec.Settings settings) implements Document {
+    record MapDocument(Map<String, Document> values, JsonSettings settings) implements Document {
         @Override
         public ShapeType type() {
             return ShapeType.MAP;
@@ -269,9 +269,9 @@ public final class JsonDocuments {
      */
     private static final class JsonDocumentDeserializer extends DocumentDeserializer {
 
-        private final JsonCodec.Settings settings;
+        private final JsonSettings settings;
 
-        JsonDocumentDeserializer(JsonCodec.Settings settings, Document value) {
+        JsonDocumentDeserializer(JsonSettings settings, Document value) {
             super(value);
             this.settings = settings;
         }

--- a/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSerdeProvider.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSerdeProvider.java
@@ -16,10 +16,10 @@ public interface JsonSerdeProvider {
 
     String getName();
 
-    ShapeDeserializer newDeserializer(byte[] source, JsonCodec.Settings settings);
+    ShapeDeserializer newDeserializer(byte[] source, JsonSettings settings);
 
-    ShapeDeserializer newDeserializer(ByteBuffer source, JsonCodec.Settings settings);
+    ShapeDeserializer newDeserializer(ByteBuffer source, JsonSettings settings);
 
-    ShapeSerializer newSerializer(OutputStream sink, JsonCodec.Settings settings);
+    ShapeSerializer newSerializer(OutputStream sink, JsonSettings settings);
 
 }

--- a/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSettings.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSettings.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.util.Objects;
+import java.util.ServiceLoader;
+import software.amazon.smithy.java.core.serde.TimestampFormatter;
+
+/**
+ * Settings used by a {@link JsonCodec}.
+ */
+public final class JsonSettings {
+
+    private static final JsonSerdeProvider PROVIDER;
+
+    static {
+        final String preferredName = System.getProperty("smithy-java.json-provider");
+        JsonSerdeProvider selected = null;
+        for (JsonSerdeProvider provider : ServiceLoader.load(JsonSerdeProvider.class)) {
+            if (preferredName != null) {
+                if (provider.getName().equals(preferredName)) {
+                    selected = provider;
+                    break;
+                }
+            }
+            if (selected == null) {
+                selected = provider;
+            } else if (provider.getPriority() > selected.getPriority()) {
+                selected = provider;
+            }
+        }
+        if (selected == null) {
+            throw new IllegalStateException("At least one JSON provider should be registered.");
+        }
+        PROVIDER = selected;
+    }
+
+    private final TimestampResolver timestampResolver;
+    private final JsonFieldMapper fieldMapper;
+    private final boolean forbidUnknownUnionMembers;
+    private final String defaultNamespace;
+    private final JsonSerdeProvider provider;
+
+    private JsonSettings(Builder builder) {
+        this.timestampResolver = builder.useTimestampFormat
+            ? new TimestampResolver.UseTimestampFormatTrait(builder.defaultTimestampFormat)
+            : new TimestampResolver.StaticFormat(builder.defaultTimestampFormat);
+        this.fieldMapper = builder.useJsonName
+            ? new JsonFieldMapper.UseJsonNameTrait()
+            : JsonFieldMapper.UseMemberName.INSTANCE;
+        this.forbidUnknownUnionMembers = builder.forbidUnknownUnionMembers;
+        this.defaultNamespace = builder.defaultNamespace;
+        this.provider = builder.provider;
+    }
+
+    /**
+     * Create a settings builder.
+     *
+     * @return the builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The timestamp resolver used to determine the timestamp format of a timestamp.
+     *
+     * @return the timestamp resolver.
+     */
+    public TimestampResolver timestampResolver() {
+        return timestampResolver;
+    }
+
+    /**
+     * The field mapper used to identify JSON fields (e.g., use member names, use the jsonName trait, etc.).
+     *
+     * @return the field mapper.
+     */
+    public JsonFieldMapper fieldMapper() {
+        return fieldMapper;
+    }
+
+    /**
+     * Whether unknown union members should fail deserialization.
+     *
+     * @return true if unknown union members are forbidden.
+     */
+    public boolean forbidUnknownUnionMembers() {
+        return forbidUnknownUnionMembers;
+    }
+
+    /**
+     * The default namespace to use when attempting to deserialize documents into types and the document discriminator
+     * uses a relative ID.
+     *
+     * @return the default namespace or null.
+     */
+    public String defaultNamespace() {
+        return defaultNamespace;
+    }
+
+    JsonSerdeProvider provider() {
+        return provider;
+    }
+
+    void updateBuilder(Builder builder) {
+        builder.forbidUnknownUnionMembers(forbidUnknownUnionMembers);
+        builder.defaultNamespace(defaultNamespace);
+        builder.overrideSerdeProvider(provider);
+        if (timestampResolver instanceof TimestampResolver.UseTimestampFormatTrait) {
+            builder.useTimestampFormat(true);
+        }
+        if (fieldMapper instanceof JsonFieldMapper.UseJsonNameTrait) {
+            builder.useJsonName(true);
+        }
+    }
+
+    /**
+     * Convert the settings object to a builder.
+     *
+     * @return the builder.
+     */
+    public Builder toBuilder() {
+        var builder = new Builder();
+        updateBuilder(builder);
+        return builder;
+    }
+
+    /**
+     * Creates a JsonSettings object.
+     */
+    public static final class Builder {
+        private boolean useJsonName;
+        private boolean useTimestampFormat = false;
+        private TimestampFormatter defaultTimestampFormat = TimestampFormatter.Prelude.EPOCH_SECONDS;
+        private boolean forbidUnknownUnionMembers;
+        private String defaultNamespace;
+        private JsonSerdeProvider provider = PROVIDER;
+
+        private Builder() {}
+
+        /**
+         * Create the JsonSettings object.
+         *
+         * @return the created JsonSettings.
+         */
+        public JsonSettings build() {
+            return new JsonSettings(this);
+        }
+
+        /**
+         * Whether to use the jsonName trait or just the member name.
+         *
+         * <p>The jsonName trait is ignored by default.
+         *
+         * @param useJsonName True to use the jsonName trait.
+         * @return the builder.
+         */
+        public Builder useJsonName(boolean useJsonName) {
+            this.useJsonName = useJsonName;
+            return this;
+        }
+
+        /**
+         * Whether to use the timestampFormat trait or ignore it.
+         *
+         * <p>The timestampFormat trait is ignored by default.
+         *
+         * @param useTimestampFormat True to honor the timestampFormat trait.
+         * @return the builder.
+         */
+        public Builder useTimestampFormat(boolean useTimestampFormat) {
+            this.useTimestampFormat = useTimestampFormat;
+            return this;
+        }
+
+        /**
+         * The default timestamp format to assume for timestamp values.
+         *
+         * <p>Assumes "epoch-seconds" by default.
+         *
+         * @param defaultTimestampFormat The default timestamp format to assume.
+         * @return the builder.
+         */
+        public Builder defaultTimestampFormat(TimestampFormatter defaultTimestampFormat) {
+            this.defaultTimestampFormat = Objects.requireNonNull(defaultTimestampFormat);
+            return this;
+        }
+
+        /**
+         * Whether to forbid or ignore unknown union members.
+         *
+         * <p>Unknown union members are ignored by default.
+         *
+         * @param forbid True to forbid unknown union members.
+         * @return the builder.
+         */
+        public Builder forbidUnknownUnionMembers(boolean forbid) {
+            this.forbidUnknownUnionMembers = forbid;
+            return this;
+        }
+
+        /**
+         * Sets the default namespace when attempting to deserialize documents that use a relative shape ID.
+         *
+         * <p>No default namespace is used unless one is explicitly provided.
+         *
+         * @param defaultNamespace Default namespace to set.
+         * @return the builder.
+         */
+        public Builder defaultNamespace(String defaultNamespace) {
+            this.defaultNamespace = defaultNamespace;
+            return this;
+        }
+
+        /**
+         * Uses a custom JSON serde provider.
+         *
+         * @param provider the JSON serde provider to use.
+         * @return the builder.
+         */
+        Builder overrideSerdeProvider(JsonSerdeProvider provider) {
+            this.provider = Objects.requireNonNull(provider);
+            return this;
+        }
+    }
+}

--- a/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonDeserializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonDeserializer.java
@@ -24,19 +24,19 @@ import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.document.Document;
-import software.amazon.smithy.java.json.JsonCodec;
 import software.amazon.smithy.java.json.JsonDocuments;
+import software.amazon.smithy.java.json.JsonSettings;
 import software.amazon.smithy.java.json.TimestampResolver;
 import software.amazon.smithy.model.shapes.ShapeType;
 
 final class JacksonJsonDeserializer implements ShapeDeserializer {
 
     private JsonParser parser;
-    private final JsonCodec.Settings settings;
+    private final JsonSettings settings;
 
     JacksonJsonDeserializer(
         JsonParser parser,
-        JsonCodec.Settings settings
+        JsonSettings settings
     ) {
         this.parser = parser;
         this.settings = settings;

--- a/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerdeProvider.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerdeProvider.java
@@ -14,8 +14,8 @@ import java.nio.ByteBuffer;
 import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
-import software.amazon.smithy.java.json.JsonCodec;
 import software.amazon.smithy.java.json.JsonSerdeProvider;
+import software.amazon.smithy.java.json.JsonSettings;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -45,7 +45,7 @@ public class JacksonJsonSerdeProvider implements JsonSerdeProvider {
     @Override
     public ShapeDeserializer newDeserializer(
         byte[] source,
-        JsonCodec.Settings settings
+        JsonSettings settings
     ) {
         try {
             return new JacksonJsonDeserializer(FACTORY.createParser(source), settings);
@@ -55,7 +55,7 @@ public class JacksonJsonSerdeProvider implements JsonSerdeProvider {
     }
 
     @Override
-    public ShapeDeserializer newDeserializer(ByteBuffer source, JsonCodec.Settings settings) {
+    public ShapeDeserializer newDeserializer(ByteBuffer source, JsonSettings settings) {
         try {
             int offset = source.arrayOffset() + source.position();
             int length = source.remaining();
@@ -68,7 +68,7 @@ public class JacksonJsonSerdeProvider implements JsonSerdeProvider {
     @Override
     public ShapeSerializer newSerializer(
         OutputStream sink,
-        JsonCodec.Settings settings
+        JsonSettings settings
     ) {
         try {
             return new JacksonJsonSerializer(FACTORY.createGenerator(sink), settings);

--- a/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerializer.java
+++ b/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerializer.java
@@ -21,19 +21,19 @@ import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.io.ByteBufferUtils;
-import software.amazon.smithy.java.json.JsonCodec;
+import software.amazon.smithy.java.json.JsonSettings;
 import software.amazon.smithy.model.shapes.ShapeType;
 
 final class JacksonJsonSerializer implements ShapeSerializer {
 
     private JsonGenerator generator;
-    private final JsonCodec.Settings settings;
+    private final JsonSettings settings;
     private SerializeDocumentContents serializeDocumentContents;
     private final ShapeSerializer structSerializer = new JsonStructSerializer();
 
     JacksonJsonSerializer(
         JsonGenerator generator,
-        JsonCodec.Settings settings
+        JsonSettings settings
     ) {
         this.generator = generator;
         this.settings = settings;


### PR DESCRIPTION
This allows for using JsonSettings independent of the codec and sharing settings across codes. I'll use it to add the ability to convert untyped JSON data into JsonDocuments soon using a JsonSettings object rather than a codec.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
