### PR TITLE
Support recommended trait

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/BuilderSetterDocumentationInterceptor.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/integrations/javadoc/BuilderSetterDocumentationInterceptor.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.codegen.integrations.javadoc;
 import software.amazon.smithy.java.codegen.sections.BuilderSetterSection;
 import software.amazon.smithy.java.codegen.sections.JavadocSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.model.traits.RecommendedTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 
@@ -20,6 +21,9 @@ final class BuilderSetterDocumentationInterceptor implements CodeInterceptor.App
     public void append(JavaWriter writer, JavadocSection section) {
         if (section.shape().hasTrait(RequiredTrait.class)) {
             writer.writeWithNoFormatting("<p><strong>Required</strong>");
+        }
+        if (section.shape().hasTrait(RecommendedTrait.class)) {
+            writer.writeWithNoFormatting("<p><strong>Recommended</strong>");
         }
         writer.writeWithNoFormatting("@return this builder.");
     }

--- a/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -254,4 +254,45 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                 """)
         );
     }
+
+    @Test
+    void addsBuilderSettersWithRequiredTraitDocs() {
+        var fileContents = getFileStringForClass("BuilderSettersInput");
+        assertThat(
+            fileContents,
+            containsString("""
+                        /**
+                         * Required Field
+                         *
+                         * <p><strong>Required</strong>
+                         * @return this builder.
+                         */
+                        public Builder required(String required) {
+                            this.required = Objects.requireNonNull(required, "required cannot be null");
+                            tracker.setMember($SCHEMA_REQUIRED);
+                            return this;
+                        }
+                """)
+        );
+    }
+
+    @Test
+    void addsBuilderSettersWithRecommendedTraitDocs() {
+        var fileContents = getFileStringForClass("BuilderSettersInput");
+        assertThat(
+            fileContents,
+            containsString("""
+                        /**
+                         * Recommended Field
+                         *
+                         * <p><strong>Recommended</strong>
+                         * @return this builder.
+                         */
+                        public Builder recommended(String recommended) {
+                            this.recommended = recommended;
+                            return this;
+                        }
+                """)
+        );
+    }
 }

--- a/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
+++ b/codegen/core/src/test/resources/software/amazon/smithy/java/codegen/integrations/javadoc/javadoc-test.smithy
@@ -146,5 +146,13 @@ operation BuilderSetters {
     input := {
         /// Member with docs
         foo: String
+
+        /// Required Field
+        @required
+        required: String
+
+        /// Recommended Field
+        @recommended
+        recommended: String
     }
 }


### PR DESCRIPTION
### Description of changes
Adds support for the [@recommended](https://smithy.io/2.0/spec/documentation-traits.html#recommended-trait) trait. Documentation for this trait is generated only on builder setters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
