### PR TITLE
Improve unique items validation

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ValidatorOfUniqueItems.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ValidatorOfUniqueItems.java
@@ -5,21 +5,37 @@
 
 package software.amazon.smithy.java.core.schema;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Flow;
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.core.serde.InterceptingSerializer;
+import software.amazon.smithy.java.core.serde.MapSerializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.core.serde.document.DocumentParser;
+import software.amazon.smithy.java.io.datastream.DataStream;
 
 /**
- * Receives list values, turns them into documents, and makes sure they are all unique.
+ * Receives list values and makes sure they are all unique.
  */
-final class ValidatorOfUniqueItems extends InterceptingSerializer {
+final class ValidatorOfUniqueItems implements ShapeSerializer {
+    // Implementation notes:
+    // Scalar list values are all added to a set directly to check for uniqueness.
+    // List and map values that are empty are added to a set as empty collections.
+    // Non-empty list and map values are converted to a document to capture the value in-memory to check for uniqueness.
+    // Null values are not supported in lists with unique items, so it causes a validation error.
+    // Structure/unions are converted into a Map<String, Object> using SerializableStruct#getMemberValue on each member.
+
     private final Schema container;
     private final DocumentParser parser = new DocumentParser();
-    private final Set<Document> values = new HashSet<>();
+    private final Set<Object> values = new HashSet<>();
     private final Validator.ShapeValidator validator;
     private int position = 0;
 
@@ -38,16 +54,137 @@ final class ValidatorOfUniqueItems extends InterceptingSerializer {
     }
 
     @Override
-    protected ShapeSerializer before(Schema schema) {
-        return parser;
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
+        addValue(value);
     }
 
     @Override
-    protected void after(Schema schema) {
-        if (!values.add(parser.getResult())) {
-            validator.swapPath(position);
-            validator.addError(new ValidationError.UniqueItemConflict(validator.createPath(), position, container));
+    public void writeBigInteger(Schema schema, BigInteger value) {
+        addValue(value);
+    }
+
+    @Override
+    public void writeBlob(Schema schema, byte[] value) {
+        writeBlob(schema, ByteBuffer.wrap(value));
+    }
+
+    @Override
+    public void writeBlob(Schema schema, ByteBuffer value) {
+        addValue(value);
+    }
+
+    @Override
+    public void writeBoolean(Schema schema, boolean value) {
+        addValue(value);
+    }
+
+    @Override
+    public void writeByte(Schema schema, byte value) {
+        addValue(value);
+    }
+
+    @Override
+    public void writeInteger(Schema schema, int value) {
+        addValue(value);
+    }
+
+    @Override
+    public void writeLong(Schema schema, long value) {
+        addValue(value);
+    }
+
+    @Override
+    public void writeShort(Schema schema, short value) {
+        addValue(value);
+    }
+
+    @Override
+    public void writeString(Schema schema, String value) {
+        addValue(value);
+    }
+
+    @Override
+    public void writeTimestamp(Schema schema, Instant value) {
+        addValue(value);
+    }
+
+    @Override
+    public void writeNull(Schema schema) {
+        // Note that the uniqueItems trait and sparse trait conflict, so this isn't supported.
+        addError("null found in unique items");
+    }
+
+    @Override
+    public void writeDouble(Schema schema, double value) {
+        addError("Double found in unique items");
+    }
+
+    @Override
+    public void writeFloat(Schema schema, float value) {
+        addError("Float found in unique items");
+    }
+
+    @Override
+    public void writeDocument(Schema schema, Document value) {
+        addError("Document found in unique items");
+    }
+
+    @Override
+    public void writeDataStream(Schema schema, DataStream value) {
+        addError("Data stream found in unique items");
+    }
+
+    @Override
+    public void writeEventStream(Schema schema, Flow.Publisher<? extends SerializableStruct> value) {
+        addError("Event stream found in unique items");
+    }
+
+    @Override
+    public <T> void writeList(Schema schema, T listState, int size, BiConsumer<T, ShapeSerializer> consumer) {
+        if (size == 0) {
+            addValue(Collections.emptyList());
+        } else {
+            parser.writeList(schema, listState, size, consumer);
+            addValue(parser.clearResult());
         }
+    }
+
+    @Override
+    public <T> void writeMap(Schema schema, T mapState, int size, BiConsumer<T, MapSerializer> consumer) {
+        if (size == 0) {
+            addValue(Collections.emptyMap());
+        } else {
+            parser.writeMap(schema, mapState, size, consumer);
+            addValue(parser.clearResult());
+        }
+    }
+
+    @Override
+    public void writeStruct(Schema schema, SerializableStruct struct) {
+        Map<String, Object> map = new HashMap<>();
+        for (var member : schema.members()) {
+            var value = struct.getMemberValue(member);
+            if (value != null) {
+                map.put(member.memberName(), value);
+            }
+        }
+        addValue(map);
+    }
+
+    private void addValue(Object value) {
+        if (!values.add(value)) {
+            addError(null);
+        } else {
+            position++;
+        }
+    }
+
+    private void addError(String message) {
+        validator.swapPath(position);
+        var error = message == null
+            ? new ValidationError.UniqueItemConflict(validator.createPath(), position, container)
+            : new ValidationError.UniqueItemConflict(validator.createPath(), position, container, message);
+        validator.addError(error);
         position++;
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/document/DocumentParser.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/document/DocumentParser.java
@@ -39,6 +39,17 @@ public final class DocumentParser implements ShapeSerializer {
         return result;
     }
 
+    /**
+     * Clears the value stored in the parser, and returns the value.
+     *
+     * @return the result being cleared, or null if no result is stored.
+     */
+    public Document clearResult() {
+        var value = this.result;
+        this.result = null;
+        return value;
+    }
+
     private void setResult(Document result) {
         this.result = result;
     }

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentParserTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentParserTest.java
@@ -19,8 +19,8 @@ public class DocumentParserTest {
     @Test
     public void doesNotDropNullListValues() {
         Schema list = Schema.listBuilder(ShapeId.from("foo#Bar"))
-                .putMember("member", PreludeSchemas.STRING)
-                .build();
+            .putMember("member", PreludeSchemas.STRING)
+            .build();
 
         DocumentParser parser = new DocumentParser();
         parser.writeList(list, null, 4, (_ignore, ser) -> {

--- a/core/src/test/java/software/amazon/smithy/java/core/testmodels/PojoWithValidatedCollection.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/testmodels/PojoWithValidatedCollection.java
@@ -79,8 +79,13 @@ public final class PojoWithValidatedCollection implements SerializableStruct {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T getMemberValue(Schema member) {
-        throw new UnsupportedOperationException("Member value not supported: " + member);
+        return switch (member.memberName()) {
+            case "map" -> (T) map;
+            case "list" -> (T) list;
+            default -> null;
+        };
     }
 
     private static final class InnerListSerializer implements BiConsumer<List<ValidatedPojo>, ShapeSerializer> {


### PR DESCRIPTION
Remove the need to turn every unique items list value into a document. Scalar values are added to a Set and compared directly. Structures/unions are compared by creating a Map<String, Object>, iterating over members in the schema, and using getMemberValue to get the value as a single value rather than needing to construct a document piece by piece. List and maps values still always require a document to compare an in-memory value, unless the collection is empty.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
