### PR TITLE
Make more XML codec and protocol fixes

### DIFF
--- a/aws/client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
+++ b/aws/client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
@@ -67,12 +67,6 @@ public class RestXmlProtocolTests {
     @ProtocolTestFilter(
         skipTests = {
             "RestXmlDateTimeWithFractionalSeconds",
-            "HttpPayloadTraitsWithBlob",
-            "HttpPayloadTraitsWithMediaTypeWithBlob",
-            "RestXmlEnumPayloadResponse",
-            "RestXmlStringPayloadResponse",
-            "RestXmlHttpPayloadWithUnion",
-            "BodyWithXmlName",
         }
     )
     public void responseTest(Runnable test) {

--- a/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseDeserializer.java
@@ -73,7 +73,7 @@ public final class ResponseDeserializer {
     private DataStream bodyDataStream(HttpResponse response) {
         var contentType = response.headers().contentType();
         var contentLength = response.headers().contentLength();
-        return DataStream.ofPublisher(response.body(), contentType, contentLength == null ? -1 : contentLength);
+        return DataStream.withMetadata(response.body(), contentType, contentLength, null);
     }
 
     /**

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/WrappedDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/WrappedDataStream.java
@@ -15,7 +15,7 @@ final class WrappedDataStream implements DataStream {
     private final DataStream delegate;
     private final String contentType;
     private final long contentLength;
-    private boolean isReplayable;
+    private final boolean isReplayable;
 
     WrappedDataStream(DataStream delegate, long contentLength, String contentType, boolean isReplayable) {
         this.delegate = delegate;

--- a/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlInfo.java
+++ b/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlInfo.java
@@ -44,7 +44,7 @@ final class XmlInfo {
     }
 
     private static String getName(Schema schema) {
-        var xmlName = schema.getTrait(TraitKey.XML_NAME_TRAIT);
+        var xmlName = schema.getDirectTrait(TraitKey.XML_NAME_TRAIT);
         if (xmlName != null) {
             return xmlName.getValue();
         } else if (schema.isMember()) {


### PR DESCRIPTION
* Handles unions used as httpPayload.
* Handles things bound to httpPayload that aren't present.
* Better wrapping of DataStreams and only when necessary based on metadata like content-length and content-type.
* Only use traits directly applied to shapes when deserializing based on xmlName traits.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
