### PR TITLE
Fix issues with FractionalSeconds tests

### DIFF
--- a/aws/client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
+++ b/aws/client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
@@ -66,14 +66,8 @@ public class RestJson1ProtocolTests {
     @HttpClientResponseTests
     @ProtocolTestFilter(
             skipTests = {
-                    "RestJsonDateTimeWithFractionalSeconds",
                     "RestJsonInputAndOutputWithQuotedStringHeaders",
                     "HttpPrefixHeadersResponse",
-                    "RestJsonHttpPayloadTraitsWithBlob",
-                    "RestJsonHttpPayloadTraitsWithMediaTypeWithBlob",
-                    "RestJsonEnumPayloadResponse",
-                    "RestJsonStringPayloadResponse",
-                    "RestJsonHttpPayloadWithUnion",
                     "RestJsonInputAndOutputWithQuotedStringHeaders",
                     "DocumentTypeAsPayloadOutput",
                     "DocumentTypeAsPayloadOutputString",

--- a/aws/client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
+++ b/aws/client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
@@ -61,10 +61,6 @@ public class RestXmlProtocolTests {
     }
 
     @HttpClientResponseTests
-    @ProtocolTestFilter(
-            skipTests = {
-                    "RestXmlDateTimeWithFractionalSeconds",
-            })
     public void responseTest(Runnable test) {
         test.run();
     }

--- a/aws/client-rpcv2-cbor-protocol/src/it/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocolTests.java
+++ b/aws/client-rpcv2-cbor-protocol/src/it/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocolTests.java
@@ -36,7 +36,6 @@ public class RpcV2CborProtocolTests {
     @HttpClientResponseTests
     @ProtocolTestFilter(
             skipTests = {
-                    "RpcV2CborDateTimeWithFractionalSeconds",
                     "RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse",
                     //Errors are not yet implemented properly
                     "RpcV2CborInvalidGreetingError",

--- a/protocol-tests/build.gradle.kts
+++ b/protocol-tests/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(project(":server-api"))
     implementation(project(":server-core"))
     implementation(project(":client-http"))
+    implementation(project(":json-codec"))
     implementation(libs.assertj.core)
 
     api(libs.junit.jupiter.api)

--- a/server-aws-rest-json1/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
+++ b/server-aws-rest-json1/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
@@ -64,7 +64,6 @@ public class AwsRestJson1ProtocolTests {
                     "RestJsonDeserializeIgnoreType",
                     "RestJsonDateTimeWithNegativeOffset",
                     "RestJsonDateTimeWithPositiveOffset",
-                    "RestJsonDateTimeWithFractionalSeconds",
                     "RestJsonClientPopulatesDefaultsValuesWhenMissingInResponse",
                     "RestJsonClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse",
                     "RestJsonClientPopulatesNestedDefaultsWhenMissingInResponseBody",


### PR DESCRIPTION
This commit fixes a bug in ProtocolTestDocument that would truncate param values for timestamps given as decimal values. The serde behavior of the codecs was always correct, but the parsed value to compare to would not preserve the fractional seconds and comparisons would fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
