### PR TITLE
Make operation implementations singletons

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/EffectiveAuthSchemeTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/EffectiveAuthSchemeTest.java
@@ -19,10 +19,10 @@ import software.amazon.smithy.model.traits.synthetic.NoAuthTrait;
 public class EffectiveAuthSchemeTest {
     @Test
     void generatedOperationHaveExpectedSchemes() {
-        assertEquals(new NoAuth().effectiveAuthSchemes(), List.of(NoAuthTrait.ID));
+        assertEquals(NoAuth.instance().effectiveAuthSchemes(), List.of(NoAuthTrait.ID));
         assertEquals(
-                new AllAuth().effectiveAuthSchemes(),
+                AllAuth.instance().effectiveAuthSchemes(),
                 List.of(HttpApiKeyAuthTrait.ID, HttpBasicAuthTrait.ID));
-        assertEquals(new ScopedAuth().effectiveAuthSchemes(), List.of(HttpBasicAuthTrait.ID));
+        assertEquals(ScopedAuth.instance().effectiveAuthSchemes(), List.of(HttpBasicAuthTrait.ID));
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
@@ -56,6 +56,8 @@ public final class OperationGenerator
                                     public final class ${shape:T} implements ${operationType:C} {
                                         ${id:C|}
 
+                                        private static final ${shape:T} $$INSTANCE = new ${shape:T}();
+
                                         private ${schema:C|}
 
                                         ${typeRegistrySection:C|}
@@ -65,6 +67,12 @@ public final class OperationGenerator
                                         ${?idempotencyTokenMember}private static final ${sdkSchema:T} IDEMPOTENCY_TOKEN_MEMBER = ${inputType:T}.$$SCHEMA.member(${idempotencyTokenMember:S});${/idempotencyTokenMember}
                                         ${?inputStreamMember}private static final ${sdkSchema:T} INPUT_STREAM_MEMBER = ${inputType:T}.$$SCHEMA.member(${inputStreamMember:S});${/inputStreamMember}
                                         ${?outputStreamMember}private static final ${sdkSchema:T} OUTPUT_STREAM_MEMBER = ${outputType:T}.$$SCHEMA.member(${outputStreamMember:S});${/outputStreamMember}
+
+                                        public static ${shape:T} instance() {
+                                            return $$INSTANCE;
+                                        }
+
+                                        private ${shape:T}() {}
 
                                         @Override
                                         public ${sdkShapeBuilder:N}<${inputType:T}> inputBuilder() {

--- a/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
+++ b/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
@@ -109,7 +109,7 @@ public final class ClientImplementationGenerator
                             @Override
                             public ${?async}${future:T}<${/async}${output:T}${?async}>${/async} ${name:L}(${input:T} input, ${overrideConfig:T} overrideConfig) {${^async}
                                 try {
-                                    ${/async}return call(input, new ${operation:T}(), overrideConfig)${^async}.join()${/async};${^async}
+                                    ${/async}return call(input, ${operation:T}.instance(), overrideConfig)${^async}.join()${/async};${^async}
                                 } catch (${completionException:T} e) {
                                     throw unwrapAndThrow(e);
                                 }${/async}

--- a/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
+++ b/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
@@ -321,7 +321,7 @@ public final class ClientInterfaceGenerator
                      * @return Paginator that can be used to retrieval paginated results.
                      */
                     default ${paginator:T}<${output:T}> ${name:L}Paginator(${input:T} input) {
-                        return ${paginator:T}.paginate(input, new ${operation:T}(), this::${name:L});
+                        return ${paginator:T}.paginate(input, ${operation:T}.instance(), this::${name:L});
                     }
                     """;
             writer.pushState();

--- a/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/generators/ServiceGenerator.java
+++ b/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/generators/ServiceGenerator.java
@@ -276,13 +276,13 @@ public final class ServiceGenerator implements
                         """
                                 @Override
                                 public ${nextStage:L} add${operation:T}Operation(${asyncOperationType:T} operation) {
-                                    this.${operationFieldName:L} = s -> ${operationClass:T}.ofAsync("${operation:T}", operation::${operationFieldName:L}, new ${apiOperationClass:T}(), s);
+                                    this.${operationFieldName:L} = s -> ${operationClass:T}.ofAsync("${operation:T}", operation::${operationFieldName:L}, ${apiOperationClass:T}.instance(), s);
                                     return this;
                                 }
 
                                 @Override
                                 public ${nextStage:L} add${operation:T}Operation(${syncOperationType:T} operation) {
-                                    this.${operationFieldName:L} = s -> ${operationClass:T}.of("${operation:T}", operation::${operationFieldName:L}, new ${apiOperationClass:T}(), s);
+                                    this.${operationFieldName:L} = s -> ${operationClass:T}.of("${operation:T}", operation::${operationFieldName:L}, ${apiOperationClass:T}.instance(), s);
                                     return this;
                                 }
                                 """;

--- a/examples/dynamodb/src/jmh/java/software/amazon/smithy/java/examples/dynamodb/DynamoDBSerde.java
+++ b/examples/dynamodb/src/jmh/java/software/amazon/smithy/java/examples/dynamodb/DynamoDBSerde.java
@@ -75,7 +75,7 @@ public class DynamoDBSerde {
         @Setup
         public void setup() throws URISyntaxException {
             endpoint = new URI("https://dynamodb.us-east-1.amazonaws.com");
-            operation = new PutItem();
+            operation = PutItem.instance();
             protocol = new AwsJson1Protocol(ShapeId.from("com.amazonaws.dynamodb#DynamoDB_20120810"));
             req = PutItemInput.builder().tableName("a").item(testItem.getValue()).build();
         }
@@ -97,7 +97,7 @@ public class DynamoDBSerde {
             // This isn't actually used, but needed for the protocol implementation.
             endpoint = new URI("https://dynamodb.us-east-1.amazonaws.com");
             req = HttpRequest.builder().method("POST").uri(endpoint).build();
-            operation = new GetItem();
+            operation = GetItem.instance();
             protocol = new AwsJson1Protocol(ShapeId.from("com.amazonaws.dynamodb#DynamoDB_20120810"));
         }
     }

--- a/examples/restjson-example/src/it/java/software/amazon/smithy/java/example/ClientConfigTest.java
+++ b/examples/restjson-example/src/it/java/software/amazon/smithy/java/example/ClientConfigTest.java
@@ -132,17 +132,17 @@ public class ClientConfigTest {
 
         @Override
         public GetPersonImageOutput getPersonImage(GetPersonImageInput input, RequestOverrideConfig overrideConfig) {
-            return call(input, new GetPersonImage(), overrideConfig).join();
+            return call(input, GetPersonImage.instance(), overrideConfig).join();
         }
 
         @Override
         public PutPersonOutput putPerson(PutPersonInput input, RequestOverrideConfig overrideConfig) {
-            return call(input, new PutPerson(), overrideConfig).join();
+            return call(input, PutPerson.instance(), overrideConfig).join();
         }
 
         @Override
         public PutPersonImageOutput putPersonImage(PutPersonImageInput input, RequestOverrideConfig overrideConfig) {
-            return call(input, new PutPersonImage(), overrideConfig).join();
+            return call(input, PutPersonImage.instance(), overrideConfig).join();
         }
 
         static PersonDirectoryClientWithDefaults.Builder builder() {

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
@@ -352,14 +352,12 @@ public final class ProtocolTestExtension implements BeforeAllCallback, AfterAllC
     }
 
     private static ApiOperation<?, ?> getApiOperation(SymbolProvider provider, Shape shape) {
+        var fqn = provider.toSymbol(shape).getFullName();
         try {
-            var fqn = provider.toSymbol(shape).getFullName();
-            return CodegenUtils.getImplementationByName(ApiOperation.class, fqn).getDeclaredConstructor().newInstance();
-        } catch (InvocationTargetException
-                | InstantiationException
-                | IllegalAccessException
-                | NoSuchMethodException e) {
-            throw new RuntimeException(e);
+            var method = CodegenUtils.getClassForName(fqn).getMethod("instance");
+            return (ApiOperation<?, ?>) method.invoke(null);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new IllegalStateException("Could not instantiate ApiOperation: " + fqn, e);
         }
     }
 


### PR DESCRIPTION
### Description of changes
Makes all generated ApiOperation implementation singletons so we do not need to re-instantiate for each client `call`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
