### PR TITLE
Rename ApiException and ModeledApiException and add error

### DIFF
--- a/aws/event-streams/src/main/java/software/amazon/smithy/java/events/aws/AwsEventShapeEncoder.java
+++ b/aws/event-streams/src/main/java/software/amazon/smithy/java/events/aws/AwsEventShapeEncoder.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import software.amazon.eventstream.HeaderValue;
 import software.amazon.eventstream.Message;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.TraitKey;
@@ -79,7 +79,7 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
     public AwsEventFrame encodeFailure(Throwable exception) {
         AwsEventFrame frame;
         Schema exceptionSchema;
-        if (exception instanceof ModeledApiException me && (exceptionSchema = possibleExceptions.get(
+        if (exception instanceof ModeledException me && (exceptionSchema = possibleExceptions.get(
                 me.schema().id())) != null) {
             var headers = new HashMap<String, HeaderValue>();
             headers.put(":message-type", HeaderValue.fromString("exception"));

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientPipeline.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientPipeline.java
@@ -33,7 +33,7 @@ import software.amazon.smithy.java.client.core.interceptors.OutputHook;
 import software.amazon.smithy.java.client.core.interceptors.RequestHook;
 import software.amazon.smithy.java.client.core.interceptors.ResponseHook;
 import software.amazon.smithy.java.context.Context;
-import software.amazon.smithy.java.core.schema.ApiException;
+import software.amazon.smithy.java.core.error.CallException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.logging.InternalLogger;
@@ -260,7 +260,7 @@ final class ClientPipeline<RequestT, ResponseT> {
         for (var authSchemeOption : authSchemeOptions) {
             options.add(authSchemeOption.schemeId().toString());
         }
-        throw new ApiException(
+        throw new CallException(
                 "No auth scheme could be resolved for operation " + call.operation.schema().id()
                         + "; protocol=" + protocol.id()
                         + "; requestClass=" + request.getClass()

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientProtocol.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientProtocol.java
@@ -9,7 +9,7 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.client.core.endpoint.Endpoint;
 import software.amazon.smithy.java.context.Context;
-import software.amazon.smithy.java.core.schema.ApiException;
+import software.amazon.smithy.java.core.error.CallException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
@@ -79,7 +79,7 @@ public interface ClientProtocol<RequestT, ResponseT> {
      * @param request      Request that was sent for this response.
      * @param response     Response to deserialize.
      * @return the deserialized output shape.
-     * @throws ApiException if an error occurs, including deserialized modeled errors and protocol errors.
+     * @throws CallException if an error occurs, including deserialized modeled errors and protocol errors.
      */
     <I extends SerializableStruct, O extends SerializableStruct> CompletableFuture<O> deserializeResponse(
             ApiOperation<I, O> operation,

--- a/client-core/src/main/java/software/amazon/smithy/java/client/core/plugins/ExceptionMapper.java
+++ b/client-core/src/main/java/software/amazon/smithy/java/client/core/plugins/ExceptionMapper.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.plugins;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.ClientPlugin;
+import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
+import software.amazon.smithy.java.client.core.interceptors.OutputHook;
+import software.amazon.smithy.java.core.error.CallException;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+
+/**
+ * Converts exceptions so that they adhere to client-specific requirements.
+ *
+ * <p>This plugin allows for:
+ * <ul>
+ *     <li>Converting specific exceptions by class equality to another exception using
+ *     {@link Builder#convert(Class, Function)}.</li>
+ *     <li>Throwing exceptions as-is if they extend from a specific exception using
+ *     {@link Builder#baseApiExceptionMapper(Class, Function)}.</li>
+ *     <li>Changing {@link CallException}s that don't extend from a specific ApiException into the desired
+ *     ApiException subtype using {@link Builder#baseApiExceptionMapper(Class, Function)}.</li>
+ *     <li>Converting all other totally unknown exceptions into another kind of exception type using
+ *     {@link Builder#rootExceptionMapper}</li>
+ * </ul>
+ *
+ * <pre>{@code
+ * ExceptionMapper mapper = ExceptionMapper.builder()
+ *     .convert(SomeSpecificError.class, e -> new OtherError(e.getMessage(), e))
+ *     .baseApiExceptionMapper(MyError.class, e -> {
+ *         return switch(e.getFault()) {
+ *             case CLIENT -> new MyClientError(e);
+ *             case SERVER -> new MyServerError(e);
+ *             default -> new MyError(e);
+ *         }
+ *     })
+ *     .rootExceptionMapper(e -> new MyClientError(e))
+ *     .build();
+ * }</pre>
+ */
+public final class ExceptionMapper implements ClientPlugin {
+
+    private final Map<Class<? extends RuntimeException>,
+            Function<RuntimeException, RuntimeException>> mappers = new HashMap<>();
+    private final Class<? extends CallException> baseApiExceptionType;
+    private final Function<CallException, ? extends CallException> baseApiExceptionMapper;
+    private final Function<RuntimeException, ? extends RuntimeException> rootExceptionMapper;
+
+    private ExceptionMapper(Builder builder) {
+        this.mappers.putAll(builder.mappers);
+        this.baseApiExceptionType = builder.baseApiExceptionType;
+        this.baseApiExceptionMapper = builder.baseApiExceptionMapper;
+        this.rootExceptionMapper = builder.rootExceptionMapper;
+    }
+
+    @Override
+    public void configureClient(ClientConfig.Builder config) {
+        config.addInterceptor(new ExceptionInterceptor());
+    }
+
+    private final class ExceptionInterceptor implements ClientInterceptor {
+        @Override
+        public <O extends SerializableStruct> O modifyBeforeCompletion(
+                OutputHook<?, O, ?, ?> hook,
+                RuntimeException error
+        ) {
+            if (error == null) {
+                return hook.output();
+            }
+
+            // Perform specific error conversions.
+            var mapper = mappers.get(error.getClass());
+            if (mapper != null) {
+                throw mapper.apply(error);
+            }
+
+            // Perform base API error conversions for unknown ApiExceptions.
+            if (baseApiExceptionType != null && error instanceof CallException a) {
+                throw baseApiExceptionType.isInstance(error) ? error : baseApiExceptionMapper.apply(a);
+            }
+
+            throw rootExceptionMapper.apply(error);
+        }
+    }
+
+    /**
+     * Builds up an exception mapper.
+     */
+    public static final class Builder {
+        private final Map<Class<? extends RuntimeException>,
+                Function<RuntimeException, RuntimeException>> mappers = new HashMap<>();
+        private Class<? extends CallException> baseApiExceptionType;
+        private Function<CallException, ? extends CallException> baseApiExceptionMapper;
+        private Function<RuntimeException, ? extends RuntimeException> rootExceptionMapper = Function.identity();
+
+        public ExceptionMapper build() {
+            return new ExceptionMapper(this);
+        }
+
+        /**
+         * Converts a specific error to another kind of error.
+         *
+         * <p>These explicit conversions are check first before applying {@link #baseApiExceptionMapper} or
+         * {@link #rootExceptionMapper}.
+         *
+         * @param exception Exception to convert.
+         * @param mapper The mapper used to create the converted exception.
+         * @return the builder.
+         * @param <C> The exception to convert.
+         */
+        @SuppressWarnings("unchecked")
+        public <C extends RuntimeException> Builder convert(Class<C> exception, Function<C, RuntimeException> mapper) {
+            mappers.put(exception, (Function<RuntimeException, RuntimeException>) mapper);
+            return this;
+        }
+
+        /**
+         * Converts instances of {@link CallException} that don't implement the given {@code baseType} into an exception
+         * that does extend from it using the given {@code mapper} function.
+         *
+         * <p>Setting a baseApiExceptionMapper is optional. This allows clients to create a base exception type for
+         * all API-level exceptions.
+         *
+         * @param baseType The base type ApiExceptions should extend from.
+         * @param mapper A mapper used to convert the found exception into a subtype of {@code baseType}.
+         * @return the builder.
+         * @param <C> the base type.
+         */
+        public <C extends CallException> Builder baseApiExceptionMapper(
+                Class<C> baseType,
+                Function<CallException, ? extends C> mapper
+        ) {
+            this.baseApiExceptionType = baseType;
+            this.baseApiExceptionMapper = mapper;
+            return this;
+        }
+
+        /**
+         * Overrides the root exception mapper, used to convert completely unknown errors that don't extend from
+         * {@link CallException}.
+         *
+         * <p>By default, the root exception mapper simply throws the given exception as-is.
+         *
+         * @param mapper The root-level exception mapper used to convert the given error or return it as-is.
+         * @return the builder.
+         */
+        public Builder rootExceptionMapper(Function<RuntimeException, ? extends RuntimeException> mapper) {
+            this.rootExceptionMapper = Objects.requireNonNull(mapper, "rootExceptionMapper cannot be null");
+            return this;
+        }
+    }
+}

--- a/client-core/src/test/java/software/amazon/smithy/java/client/core/plugins/ApplyModelRetryInfoPluginTest.java
+++ b/client-core/src/test/java/software/amazon/smithy/java/client/core/plugins/ApplyModelRetryInfoPluginTest.java
@@ -9,8 +9,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.java.core.schema.ApiException;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.CallException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.retries.api.RetrySafety;
@@ -23,7 +23,7 @@ public class ApplyModelRetryInfoPluginTest {
     @Test
     public void marksSafeWhenOperationIsReadOnly() {
         var schema = Schema.createOperation(ShapeId.from("com#Foo"), new ReadonlyTrait());
-        var e = new ApiException("err");
+        var e = new CallException("err");
 
         ApplyModelRetryInfoPlugin.applyRetryInfoFromModel(schema, e);
 
@@ -33,7 +33,7 @@ public class ApplyModelRetryInfoPluginTest {
     @Test
     public void marksSafeWhenOperationIsIdempotent() {
         var schema = Schema.createOperation(ShapeId.from("com#Foo"), new IdempotentTrait());
-        var e = new ApiException("err");
+        var e = new CallException("err");
 
         ApplyModelRetryInfoPlugin.applyRetryInfoFromModel(schema, e);
 
@@ -50,7 +50,7 @@ public class ApplyModelRetryInfoPluginTest {
                 .structureBuilder(ShapeId.from("com#Err"), RetryableTrait.builder().throttling(true).build())
                 .build();
 
-        var e = new ModeledApiException(errorSchema, "err") {
+        var e = new ModeledException(errorSchema, "err") {
             @Override
             public void serializeMembers(ShapeSerializer serializer) {
                 throw new UnsupportedOperationException();

--- a/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
+++ b/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.client.http.HttpClientProtocol;
 import software.amazon.smithy.java.client.http.HttpErrorDeserializer;
 import software.amazon.smithy.java.context.Context;
-import software.amazon.smithy.java.core.schema.ApiException;
+import software.amazon.smithy.java.core.error.CallException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.InputEventStreamingApiOperation;
 import software.amazon.smithy.java.core.schema.OutputEventStreamingApiOperation;
@@ -145,7 +145,7 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
      * @return Returns the deserialized error.
      */
     protected <I extends SerializableStruct,
-            O extends SerializableStruct> CompletableFuture<? extends ApiException> createError(
+            O extends SerializableStruct> CompletableFuture<? extends CallException> createError(
                     ApiOperation<I, O> operation,
                     Context context,
                     TypeRegistry typeRegistry,

--- a/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingErrorFactory.java
+++ b/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingErrorFactory.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.java.client.http.binding;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.client.http.HttpErrorDeserializer;
 import software.amazon.smithy.java.context.Context;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.http.api.HttpResponse;
@@ -33,11 +33,11 @@ public final class HttpBindingErrorFactory implements HttpErrorDeserializer.Know
     }
 
     @Override
-    public CompletableFuture<ModeledApiException> createError(
+    public CompletableFuture<ModeledException> createError(
             Context context,
             Codec codec,
             HttpResponse response,
-            ShapeBuilder<ModeledApiException> builder
+            ShapeBuilder<ModeledException> builder
     ) {
         return httpBinding.responseDeserializer()
                 .payloadCodec(codec)

--- a/client-http/src/test/java/software/amazon/smithy/java/client/http/AmznErrorHeaderExtractorTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/client/http/AmznErrorHeaderExtractorTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.nullValue;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
@@ -53,7 +53,7 @@ public class AmznErrorHeaderExtractorTest {
                 .headers(HttpHeaders.of(Map.of("x-amzn-errortype", List.of("baz#Bam"))))
                 .build();
         var registry = TypeRegistry.builder()
-                .putType(ShapeId.from("baz#Bam"), ModeledApiException.class, ApiExceptionBuilder::new)
+                .putType(ShapeId.from("baz#Bam"), ModeledException.class, ApiExceptionBuilder::new)
                 .build();
 
         assertThat(extractor.resolveId(response, "com.foo", registry), equalTo(ShapeId.from("baz#Bam")));
@@ -71,7 +71,7 @@ public class AmznErrorHeaderExtractorTest {
                                         List.of("baz#Bam:http://internal.amazon.com/coral/com.amazon.coral.validate/"))))
                 .build();
         var registry = TypeRegistry.builder()
-                .putType(ShapeId.from("baz#Bam"), ModeledApiException.class, ApiExceptionBuilder::new)
+                .putType(ShapeId.from("baz#Bam"), ModeledException.class, ApiExceptionBuilder::new)
                 .build();
 
         assertThat(extractor.resolveId(response, "com.foo", registry), equalTo(ShapeId.from("baz#Bam")));
@@ -89,7 +89,7 @@ public class AmznErrorHeaderExtractorTest {
                                         List.of("Bam:http://internal.amazon.com/coral/com.amazon.coral.validate/"))))
                 .build();
         var registry = TypeRegistry.builder()
-                .putType(ShapeId.from("com.foo#Bam"), ModeledApiException.class, ApiExceptionBuilder::new)
+                .putType(ShapeId.from("com.foo#Bam"), ModeledException.class, ApiExceptionBuilder::new)
                 .build();
 
         assertThat(extractor.resolveId(response, "com.foo", registry), equalTo(ShapeId.from("com.foo#Bam")));
@@ -107,7 +107,7 @@ public class AmznErrorHeaderExtractorTest {
                                         List.of("baz#Bam:http://internal.amazon.com/coral/com.amazon.coral.validate/"))))
                 .build();
         var registry = TypeRegistry.builder()
-                .putType(ShapeId.from("baz#Bam"), ModeledApiException.class, ApiExceptionBuilder::new)
+                .putType(ShapeId.from("baz#Bam"), ModeledException.class, ApiExceptionBuilder::new)
                 .build();
 
         assertThat(extractor.resolveId(response, "com.foo", registry), equalTo(ShapeId.from("baz#Bam")));
@@ -125,7 +125,7 @@ public class AmznErrorHeaderExtractorTest {
                                         List.of("other#Bam:http://internal.amazon.com/coral/com.amazon.coral.validate/"))))
                 .build();
         var registry = TypeRegistry.builder()
-                .putType(ShapeId.from("com.foo#Bam"), ModeledApiException.class, ApiExceptionBuilder::new)
+                .putType(ShapeId.from("com.foo#Bam"), ModeledException.class, ApiExceptionBuilder::new)
                 .build();
 
         assertThat(extractor.resolveId(response, "com.foo", registry), equalTo(ShapeId.from("com.foo#Bam")));
@@ -147,7 +147,7 @@ public class AmznErrorHeaderExtractorTest {
         assertThat(extractor.resolveId(response, "com.foo", registry), nullValue());
     }
 
-    private static final class ApiExceptionBuilder implements ShapeBuilder<ModeledApiException> {
+    private static final class ApiExceptionBuilder implements ShapeBuilder<ModeledException> {
 
         @Override
         public Schema schema() {
@@ -155,17 +155,17 @@ public class AmznErrorHeaderExtractorTest {
         }
 
         @Override
-        public ModeledApiException build() {
+        public ModeledException build() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public ShapeBuilder<ModeledApiException> deserialize(ShapeDeserializer decoder) {
+        public ShapeBuilder<ModeledException> deserialize(ShapeDeserializer decoder) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public ShapeBuilder<ModeledApiException> errorCorrection() {
+        public ShapeBuilder<ModeledException> errorCorrection() {
             throw new UnsupportedOperationException();
         }
     }

--- a/client-http/src/test/java/software/amazon/smithy/java/client/http/plugins/ApplyHttpRetryInfoPluginTest.java
+++ b/client-http/src/test/java/software/amazon/smithy/java/client/http/plugins/ApplyHttpRetryInfoPluginTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.client.core.CallContext;
 import software.amazon.smithy.java.client.core.settings.ClockSetting;
 import software.amazon.smithy.java.context.Context;
-import software.amazon.smithy.java.core.schema.ApiException;
+import software.amazon.smithy.java.core.error.CallException;
 import software.amazon.smithy.java.http.api.HttpHeaders;
 import software.amazon.smithy.java.http.api.HttpResponse;
 import software.amazon.smithy.java.retries.api.RetrySafety;
@@ -32,7 +32,7 @@ public class ApplyHttpRetryInfoPluginTest {
                 .statusCode(500)
                 .headers(HttpHeaders.of(Map.of("retry-after", List.of("10"))))
                 .build();
-        var e = new ApiException("err");
+        var e = new CallException("err");
         var context = Context.create();
 
         ApplyHttpRetryInfoPlugin.applyRetryInfo(response, e, context);
@@ -48,7 +48,7 @@ public class ApplyHttpRetryInfoPluginTest {
                 .statusCode(500)
                 .headers(HttpHeaders.of(Map.of("retry-after", List.of("Wed, 21 Oct 2015 07:28:00 GMT"))))
                 .build();
-        var e = new ApiException("err");
+        var e = new CallException("err");
         var context = Context.create();
         context.put(ClockSetting.CLOCK, Clock.fixed(Instant.parse("2015-10-21T05:28:00Z"), ZoneId.of("UTC")));
 
@@ -62,7 +62,7 @@ public class ApplyHttpRetryInfoPluginTest {
     @Test
     public void appliesThrottlingStatusCode503() {
         var response = HttpResponse.builder().statusCode(503).build();
-        var e = new ApiException("err");
+        var e = new CallException("err");
         var context = Context.create();
 
         ApplyHttpRetryInfoPlugin.applyRetryInfo(response, e, context);
@@ -75,7 +75,7 @@ public class ApplyHttpRetryInfoPluginTest {
     @Test
     public void appliesThrottlingStatusCode429() {
         var response = HttpResponse.builder().statusCode(429).build();
-        var e = new ApiException("err");
+        var e = new CallException("err");
         var context = Context.create();
 
         ApplyHttpRetryInfoPlugin.applyRetryInfo(response, e, context);
@@ -88,7 +88,7 @@ public class ApplyHttpRetryInfoPluginTest {
     @Test
     public void retriesSafe5xx() {
         var response = HttpResponse.builder().statusCode(500).build();
-        var e = new ApiException("err");
+        var e = new CallException("err");
         var context = Context.create();
         context.put(CallContext.IDEMPOTENCY_TOKEN, "foo");
 
@@ -102,7 +102,7 @@ public class ApplyHttpRetryInfoPluginTest {
     @Test
     public void doesNotRetryUnsafe5xx() {
         var response = HttpResponse.builder().statusCode(500).build();
-        var e = new ApiException("err");
+        var e = new CallException("err");
         var context = Context.create();
 
         ApplyHttpRetryInfoPlugin.applyRetryInfo(response, e, context);
@@ -115,7 +115,7 @@ public class ApplyHttpRetryInfoPluginTest {
     @Test
     public void doesNotRetryNormal4xx() {
         var response = HttpResponse.builder().statusCode(400).build();
-        var e = new ApiException("err");
+        var e = new CallException("err");
         var context = Context.create();
 
         ApplyHttpRetryInfoPlugin.applyRetryInfo(response, e, context);

--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ExceptionsTest.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/ExceptionsTest.java
@@ -21,7 +21,7 @@ import software.amazon.smithy.java.codegen.test.model.EmptyException;
 import software.amazon.smithy.java.codegen.test.model.ExceptionWithExtraStringException;
 import software.amazon.smithy.java.codegen.test.model.OptionalMessageException;
 import software.amazon.smithy.java.codegen.test.model.SimpleException;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.SerializableShape;
 
 @ExtendWith(ReloadClassesExtension.class)
@@ -39,7 +39,7 @@ public class ExceptionsTest {
     @ParameterizedTest
     @MethodSource("exceptions")
     @Order(1)
-    void simpleExceptionToDocumentRoundTrip(ModeledApiException exception) {
+    void simpleExceptionToDocumentRoundTrip(ModeledException exception) {
         var output = Utils.pojoToDocumentRoundTrip(exception);
         assertEquals(exception.getMessage(), output.getMessage());
         assertEquals(exception.getCause(), output.getCause());

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/OperationGenerator.java
@@ -17,10 +17,10 @@ import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.ApiResource;
 import software.amazon.smithy.java.core.schema.InputEventStreamingApiOperation;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
 import software.amazon.smithy.java.core.schema.OutputEventStreamingApiOperation;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
@@ -161,7 +161,7 @@ public final class OperationGenerator
                     writer.putContext("list", List.class);
                     writer.putContext("string", String.class);
                     writer.putContext("set", Set.class);
-                    writer.putContext("modeledApiException", ModeledApiException.class);
+                    writer.putContext("modeledApiException", ModeledException.class);
 
                     writer.putContext(
                             "operationType",

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.java.codegen.sections.BuilderSetterSection;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.sections.GetterSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.PresenceTracker;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.document.Document;
@@ -120,7 +120,7 @@ public final class StructureGenerator<
             writer.putContext("isError", shape.hasTrait(ErrorTrait.class));
             writer.putContext("shape", directive.symbol());
             writer.putContext("serializableStruct", SerializableStruct.class);
-            writer.putContext("sdkException", ModeledApiException.class);
+            writer.putContext("sdkException", ModeledException.class);
             writer.putContext("id", new IdStringGenerator(writer, shape));
             writer.putContext(
                     "schemas",

--- a/codegen/plugins/server/src/it/java/software/amazon/smithy/java/codegen/server/ServiceBuilderTest.java
+++ b/codegen/plugins/server/src/it/java/software/amazon/smithy/java/codegen/server/ServiceBuilderTest.java
@@ -25,7 +25,7 @@ import smithy.java.codegen.server.test.service.EchoOperation;
 import smithy.java.codegen.server.test.service.GetBeerOperationAsync;
 import smithy.java.codegen.server.test.service.GetErrorOperationAsync;
 import smithy.java.codegen.server.test.service.TestService;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.framework.model.InternalFailureException;
 import software.amazon.smithy.java.framework.model.UnknownOperationException;
 import software.amazon.smithy.java.server.Operation;
@@ -57,7 +57,7 @@ public class ServiceBuilderTest {
             Throwable exception;
             try {
                 Class<?> clazz = Class.forName(input.exceptionClass());
-                if (ModeledApiException.class.isAssignableFrom(clazz)) {
+                if (ModeledException.class.isAssignableFrom(clazz)) {
                     Object builderInstance = clazz.getDeclaredMethod("builder").invoke(null);
                     builderInstance = builderInstance.getClass()
                             .getMethod("message")

--- a/core/src/main/java/software/amazon/smithy/java/core/error/CallException.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/error/CallException.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package software.amazon.smithy.java.core.schema;
+package software.amazon.smithy.java.core.error;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -17,99 +17,59 @@ import software.amazon.smithy.java.retries.api.RetrySafety;
  * errors, and shape validation errors. It should not be used for illegal arguments, null argument validation,
  * or other kinds of logic errors sufficiently covered by the Java standard library.
  */
-public class ApiException extends RuntimeException implements RetryInfo {
+public class CallException extends RuntimeException implements RetryInfo {
 
     private static final boolean GLOBAL_CAPTURE_STACK_TRACE_ENABLED = Boolean.getBoolean(
             "smithy.java.captureExceptionStackTraces");
 
-    /**
-     * The party that is at fault for the error, if any.
-     *
-     * <p>This kind of enum is used rather than top-level client/server errors that services extend from because
-     * services generate their own dedicated error hierarchies that all extend from a common base-class for the
-     * service.
-     */
-    public enum Fault {
-        /**
-         * The client is at fault for this error (e.g., it omitted a required parameter or sent an invalid request).
-         */
-        CLIENT,
-
-        /**
-         * The server is at fault (e.g., it was unable to connect to a database, or other unexpected errors occurred).
-         */
-        SERVER,
-
-        /**
-         * The fault isn't necessarily client or server.
-         */
-        OTHER;
-
-        /**
-         * Create a Fault based on an HTTP status code.
-         *
-         * @param statusCode HTTP status code to check.
-         * @return the created fault.
-         */
-        public static Fault ofHttpStatusCode(int statusCode) {
-            if (statusCode >= 400 && statusCode <= 499) {
-                return ApiException.Fault.CLIENT;
-            } else if (statusCode >= 500 && statusCode <= 599) {
-                return ApiException.Fault.SERVER;
-            } else {
-                return ApiException.Fault.OTHER;
-            }
-        }
-    }
-
-    private final Fault errorType;
+    private final ErrorFault errorType;
 
     // Mutable retryInfo
     private RetrySafety isRetrySafe = RetrySafety.MAYBE;
     private boolean isThrottle = false;
     private Duration retryAfter = null;
 
-    public ApiException(String message) {
-        this(message, Fault.OTHER, null);
+    public CallException(String message) {
+        this(message, ErrorFault.OTHER, null);
     }
 
-    public ApiException(String message, boolean captureStackTrace) {
-        this(message, Fault.OTHER, captureStackTrace);
+    public CallException(String message, boolean captureStackTrace) {
+        this(message, ErrorFault.OTHER, captureStackTrace);
     }
 
-    public ApiException(String message, Fault errorType) {
+    public CallException(String message, ErrorFault errorType) {
         this(message, errorType, null);
     }
 
-    public ApiException(String message, Fault errorType, boolean captureStackTrace) {
+    public CallException(String message, ErrorFault errorType, boolean captureStackTrace) {
         this(message, null, errorType, captureStackTrace);
     }
 
-    protected ApiException(String message, Fault errorType, Boolean captureStackTrace) {
+    protected CallException(String message, ErrorFault errorType, Boolean captureStackTrace) {
         this(message, null, errorType, captureStackTrace);
     }
 
-    public ApiException(String message, Throwable cause) {
+    public CallException(String message, Throwable cause) {
         this(message, cause, (Boolean) null);
     }
 
-    public ApiException(String message, Throwable cause, boolean captureStackTrace) {
-        this(message, cause, Fault.OTHER, captureStackTrace);
+    public CallException(String message, Throwable cause, boolean captureStackTrace) {
+        this(message, cause, ErrorFault.OTHER, captureStackTrace);
     }
 
-    protected ApiException(String message, Throwable cause, Boolean captureStackTrace) {
-        this(message, cause, Fault.OTHER, captureStackTrace);
+    protected CallException(String message, Throwable cause, Boolean captureStackTrace) {
+        this(message, cause, ErrorFault.OTHER, captureStackTrace);
     }
 
-    public ApiException(String message, Throwable cause, Fault errorType) {
+    public CallException(String message, Throwable cause, ErrorFault errorType) {
         this(message, cause, errorType, false);
     }
 
-    public ApiException(String message, Throwable cause, Fault errorType, boolean captureStackTrace) {
+    public CallException(String message, Throwable cause, ErrorFault errorType, boolean captureStackTrace) {
         this(message, cause, errorType, (Boolean) captureStackTrace);
     }
 
-    protected ApiException(String message, Throwable cause, Fault errorType, Boolean captureStackTrace) {
+    protected CallException(String message, Throwable cause, ErrorFault errorType, Boolean captureStackTrace) {
         super(
                 message,
                 cause,
@@ -123,7 +83,7 @@ public class ApiException extends RuntimeException implements RetryInfo {
      *
      * @return Returns the error type (e.g., client, server, etc).
      */
-    public Fault getFault() {
+    public ErrorFault getFault() {
         return errorType;
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/core/error/ErrorFault.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/error/ErrorFault.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.core.error;
+
+/**
+ * The party that is at fault for the error, if any.
+ *
+ * <p>This kind of enum is used rather than top-level client/server errors that services extend from because
+ * services generate their own dedicated error hierarchies that all extend from a common base-class for the
+ * service.
+ */
+public enum ErrorFault {
+    /**
+     * The client is at fault for this error (e.g., it omitted a required parameter or sent an invalid request).
+     */
+    CLIENT,
+
+    /**
+     * The server is at fault (e.g., it was unable to connect to a database, or other unexpected errors occurred).
+     */
+    SERVER,
+
+    /**
+     * The fault isn't necessarily client or server.
+     */
+    OTHER;
+
+    /**
+     * Create a Fault based on an HTTP status code.
+     *
+     * @param statusCode HTTP status code to check.
+     * @return the created fault.
+     */
+    public static ErrorFault ofHttpStatusCode(int statusCode) {
+        if (statusCode >= 400 && statusCode <= 499) {
+            return ErrorFault.CLIENT;
+        } else if (statusCode >= 500 && statusCode <= 599) {
+            return ErrorFault.SERVER;
+        } else {
+            return ErrorFault.OTHER;
+        }
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/core/error/ModeledException.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/error/ModeledException.java
@@ -3,35 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package software.amazon.smithy.java.core.schema;
+package software.amazon.smithy.java.core.error;
+
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.TraitKey;
 
 /**
  * The top-level exception that should be used to throw modeled errors from clients and servers.
  */
-public abstract class ModeledApiException extends ApiException implements SerializableStruct {
+public abstract class ModeledException extends CallException implements SerializableStruct {
 
     private final Schema schema;
     private boolean deserialized = false;
 
-    protected ModeledApiException(Schema schema, String message) {
+    protected ModeledException(Schema schema, String message) {
         super(message);
         this.schema = schema;
     }
 
-    protected ModeledApiException(Schema schema, String message, Fault errorType) {
+    protected ModeledException(Schema schema, String message, ErrorFault errorType) {
         super(message, null, errorType, null);
         this.schema = schema;
     }
 
-    protected ModeledApiException(Schema schema, String message, Fault errorType, Throwable cause) {
+    protected ModeledException(Schema schema, String message, ErrorFault errorType, Throwable cause) {
         super(message, cause, errorType, null);
         this.schema = schema;
     }
 
-    protected ModeledApiException(
+    protected ModeledException(
             Schema schema,
             String message,
-            Fault errorType,
+            ErrorFault errorType,
             Throwable cause,
             Boolean captureStackTrace,
             boolean deserialized
@@ -41,7 +45,7 @@ public abstract class ModeledApiException extends ApiException implements Serial
         this.deserialized = deserialized;
     }
 
-    protected ModeledApiException(
+    protected ModeledException(
             Schema schema,
             String message,
             Throwable cause,
@@ -53,16 +57,16 @@ public abstract class ModeledApiException extends ApiException implements Serial
         this.deserialized = deserialized;
     }
 
-    protected ModeledApiException(Schema schema, String message, Throwable cause) {
+    protected ModeledException(Schema schema, String message, Throwable cause) {
         super(message, cause, (Boolean) null);
         this.schema = schema;
     }
 
-    protected ModeledApiException(
+    protected ModeledException(
             Schema schema,
             String message,
             Throwable cause,
-            Fault errorType,
+            ErrorFault errorType,
             Boolean captureStackTrace,
             boolean deserialized
     ) {

--- a/core/src/test/java/software/amazon/smithy/java/core/schema/ApiExceptionTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/schema/ApiExceptionTest.java
@@ -12,12 +12,13 @@ import static org.hamcrest.Matchers.nullValue;
 
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.core.error.CallException;
 import software.amazon.smithy.java.retries.api.RetrySafety;
 
 public class ApiExceptionTest {
     @Test
     public void resetsRetryStateWhenSetToNotRetry() {
-        var e = new ApiException("foo");
+        var e = new CallException("foo");
         var after = Duration.ofDays(2);
 
         e.isRetrySafe(RetrySafety.YES);

--- a/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DocumentException.java
+++ b/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DocumentException.java
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.java.dynamicclient;
 
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
@@ -14,9 +14,9 @@ import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
- * A {@link ModeledApiException} that provides access to the contents of the exception as a document.
+ * A {@link ModeledException} that provides access to the contents of the exception as a document.
  */
-public final class DocumentException extends ModeledApiException {
+public final class DocumentException extends ModeledException {
 
     private final WrappedDocument document;
 
@@ -49,7 +49,7 @@ public final class DocumentException extends ModeledApiException {
         return document;
     }
 
-    static final class SchemaGuidedExceptionBuilder implements ShapeBuilder<ModeledApiException> {
+    static final class SchemaGuidedExceptionBuilder implements ShapeBuilder<ModeledException> {
 
         private final Schema target;
         private final SchemaGuidedDocumentBuilder delegateBuilder;

--- a/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicClient.java
+++ b/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicClient.java
@@ -22,9 +22,9 @@ import software.amazon.smithy.java.client.core.Client;
 import software.amazon.smithy.java.client.core.ClientProtocolFactory;
 import software.amazon.smithy.java.client.core.ProtocolSettings;
 import software.amazon.smithy.java.client.core.RequestOverrideConfig;
-import software.amazon.smithy.java.core.schema.ApiException;
+import software.amazon.smithy.java.core.error.CallException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
@@ -55,7 +55,7 @@ import software.amazon.smithy.model.shapes.ToShapeId;
  *     <li>No code generated types. You have to construct input and use output manually using document APIs.</li>
  *     <li>No support for streaming inputs or outputs.</li>
  *     <li>All errors are created as an {@link DocumentException} if the error is modeled, allowing document access
- *     to the modeled error contents. Other errors are deserialized as {@link ApiException}.
+ *     to the modeled error contents. Other errors are deserialized as {@link CallException}.
  * </ul>
  */
 public final class DynamicClient extends Client {
@@ -90,7 +90,7 @@ public final class DynamicClient extends Client {
     private void registerError(ShapeId e, TypeRegistry.Builder registryBuilder) {
         var error = model.expectShape(e);
         var errorSchema = schemaConverter.getSchema(error);
-        registryBuilder.putType(e, ModeledApiException.class, () -> {
+        registryBuilder.putType(e, ModeledException.class, () -> {
             return new DocumentException.SchemaGuidedExceptionBuilder(service.getId(), errorSchema);
         });
     }

--- a/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicClientTest.java
+++ b/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicClientTest.java
@@ -24,8 +24,8 @@ import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
 import software.amazon.smithy.java.client.core.interceptors.RequestHook;
 import software.amazon.smithy.java.client.http.HttpMessageExchange;
 import software.amazon.smithy.java.context.Context;
-import software.amazon.smithy.java.core.schema.ApiException;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.CallException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.http.api.HttpRequest;
 import software.amazon.smithy.java.http.api.HttpResponse;
@@ -153,11 +153,11 @@ public class DynamicClientTest {
     @Test
     public void deserializesDynamicErrorsWithAbsoluteId() {
         var client = createErrorClient("{\"__type\":\"smithy.example#InvalidSprocketId\", \"id\":\"1\"}");
-        var e = Assertions.assertThrows(ApiException.class, () -> {
+        var e = Assertions.assertThrows(CallException.class, () -> {
             client.call("GetSprocket", Document.ofObject(Map.of("id", "1")));
         });
 
-        assertThat(e, instanceOf(ModeledApiException.class));
+        assertThat(e, instanceOf(ModeledException.class));
         assertThat(e, instanceOf(DocumentException.class));
 
         var de = (DocumentException) e;
@@ -170,11 +170,11 @@ public class DynamicClientTest {
     @Test
     public void deserializesDynamicErrorsWithRelativeId() {
         var client = createErrorClient("{\"__type\":\"InvalidSprocketId\", \"id\":\"1\"}");
-        var e = Assertions.assertThrows(ApiException.class, () -> {
+        var e = Assertions.assertThrows(CallException.class, () -> {
             client.call("GetSprocket", Document.ofObject(Map.of("id", "1")));
         });
 
-        assertThat(e, instanceOf(ModeledApiException.class));
+        assertThat(e, instanceOf(ModeledException.class));
         assertThat(e, instanceOf(DocumentException.class));
 
         var de = (DocumentException) e;
@@ -187,11 +187,11 @@ public class DynamicClientTest {
     @Test
     public void deserializesDynamicErrorsWithRelativeIdFromService() {
         var client = createErrorClient("{\"__type\":\"ServiceFooError\", \"why\":\"IDK\"}");
-        var e = Assertions.assertThrows(ApiException.class, () -> {
+        var e = Assertions.assertThrows(CallException.class, () -> {
             client.call("GetSprocket", Document.ofObject(Map.of("id", "1")));
         });
 
-        assertThat(e, instanceOf(ModeledApiException.class));
+        assertThat(e, instanceOf(ModeledException.class));
         assertThat(e, instanceOf(DocumentException.class));
 
         var de = (DocumentException) e;

--- a/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSerializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSerializer.java
@@ -14,7 +14,7 @@ import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.concurrent.Flow;
 import java.util.function.BiConsumer;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
@@ -105,7 +105,7 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
         }
 
         if (isFailure) {
-            responseStatus = ModeledApiException.getHttpStatusCode(schema);
+            responseStatus = ModeledException.getHttpStatusCode(schema);
             // TODO: Update this to only use the full ID if the schema namespace is outside the
             //       service namespace
             headers.put("X-Amzn-Errortype", List.of(schema.id().toString()));

--- a/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseDeserializer.java
+++ b/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseDeserializer.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.java.http.binding;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.Codec;
@@ -23,7 +23,7 @@ public final class ResponseDeserializer {
 
     private final HttpBindingDeserializer.Builder deserBuilder = HttpBindingDeserializer.builder();
     private ShapeBuilder<?> outputShapeBuilder;
-    private ShapeBuilder<? extends ModeledApiException> errorShapeBuilder;
+    private ShapeBuilder<? extends ModeledException> errorShapeBuilder;
     private final ConcurrentMap<Schema, BindingMatcher> bindingCache;
 
     ResponseDeserializer(ConcurrentMap<Schema, BindingMatcher> bindingCache) {
@@ -105,7 +105,7 @@ public final class ResponseDeserializer {
      * @param errorShapeBuilder Error shape builder.
      * @return Returns the deserializer.
      */
-    public ResponseDeserializer errorShapeBuilder(ShapeBuilder<? extends ModeledApiException> errorShapeBuilder) {
+    public ResponseDeserializer errorShapeBuilder(ShapeBuilder<? extends ModeledException> errorShapeBuilder) {
         this.errorShapeBuilder = errorShapeBuilder;
         outputShapeBuilder = null;
         return this;

--- a/mock-client-plugin/src/test/java/software/amazon/smithy/java/client/http/mock/MockPluginTest.java
+++ b/mock-client-plugin/src/test/java/software/amazon/smithy/java/client/http/mock/MockPluginTest.java
@@ -23,7 +23,8 @@ import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
 import software.amazon.smithy.java.client.core.interceptors.OutputHook;
-import software.amazon.smithy.java.core.schema.ApiException;
+import software.amazon.smithy.java.core.error.CallException;
+import software.amazon.smithy.java.core.error.ErrorFault;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.dynamicclient.DynamicClient;
 import software.amazon.smithy.java.framework.model.InternalFailureException;
@@ -115,8 +116,8 @@ public class MockPluginTest {
                 .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
                 .build();
 
-        var e = Assertions.assertThrows(ApiException.class, () -> client.call("GetSprocket"));
-        assertThat(e.getFault(), equalTo(ApiException.Fault.SERVER));
+        var e = Assertions.assertThrows(CallException.class, () -> client.call("GetSprocket"));
+        assertThat(e.getFault(), equalTo(ErrorFault.SERVER));
         assertThat(e.isRetrySafe(), equalTo(RetrySafety.MAYBE));
 
         assertThat(mock.getRequests(), hasSize(1));
@@ -166,8 +167,8 @@ public class MockPluginTest {
                 })
                 .build();
 
-        var e = Assertions.assertThrows(ApiException.class, () -> client.call("GetSprocket"));
-        assertThat(e.getFault(), is(ApiException.Fault.CLIENT));
+        var e = Assertions.assertThrows(CallException.class, () -> client.call("GetSprocket"));
+        assertThat(e.getFault(), is(ErrorFault.CLIENT));
 
         assertThat(mock.getRequests(), hasSize(1));
 

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/HttpClientResponseProtocolTestProvider.java
@@ -23,8 +23,8 @@ import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeOption;
 import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
 import software.amazon.smithy.java.client.http.HttpMessageExchange;
 import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.http.api.HttpHeaders;
 import software.amazon.smithy.java.http.api.HttpRequest;
@@ -126,7 +126,7 @@ final class HttpClientResponseProtocolTestProvider extends
                         fail("Expected an exception but got a successful response %s", actualOutput);
                     }
                 } catch (Exception e) {
-                    if (isErrorTestCase && e instanceof ModeledApiException mae) {
+                    if (isErrorTestCase && e instanceof ModeledException mae) {
                         actualOutput = mae;
                     } else {
                         throw e;

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
@@ -19,7 +19,8 @@ import software.amazon.smithy.java.client.core.endpoint.Endpoint;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import software.amazon.smithy.java.client.http.HttpMessageExchange;
 import software.amazon.smithy.java.context.Context;
-import software.amazon.smithy.java.core.schema.ApiException;
+import software.amazon.smithy.java.core.error.CallException;
+import software.amazon.smithy.java.core.error.ErrorFault;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
@@ -48,8 +49,8 @@ final class MockClient extends Client {
         try {
             return call(input, operation, overrideConfig).exceptionallyCompose(exc -> {
                 if (exc instanceof CompletionException ce
-                        && ce.getCause() instanceof ApiException apiException
-                        && apiException.getFault().equals(ApiException.Fault.SERVER)) {
+                        && ce.getCause() instanceof CallException apiException
+                        && apiException.getFault().equals(ErrorFault.SERVER)) {
                     LOGGER.debug("Ignoring expected exception", apiException);
                     return CompletableFuture.completedFuture(null);
                 } else {

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
@@ -25,8 +25,8 @@ import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaSymbolProvider;
 import software.amazon.smithy.java.codegen.server.ServerSymbolProperties;
 import software.amazon.smithy.java.codegen.server.ServiceJavaSymbolProvider;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.logging.InternalLogger;
@@ -368,9 +368,9 @@ public final class ProtocolTestExtension implements BeforeAllCallback, AfterAllC
         try {
             var fqn = provider.toSymbol(shape).getFullName();
             var exceptionClazz = CodegenUtils.getClassForName(fqn);
-            if (ModeledApiException.class.isAssignableFrom(exceptionClazz)) {
+            if (ModeledException.class.isAssignableFrom(exceptionClazz)) {
                 var builder = exceptionClazz.getDeclaredMethod("builder").invoke(null);
-                return () -> (ShapeBuilder<? extends ModeledApiException>) builder;
+                return () -> (ShapeBuilder<? extends ModeledException>) builder;
             } else {
                 throw new IllegalArgumentException(exceptionClazz + "is not a ModeledApiException");
             }

--- a/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestProtocolProvider.java
+++ b/protocol-tests/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestProtocolProvider.java
@@ -11,7 +11,7 @@ import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import software.amazon.smithy.java.context.Context;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.server.Service;
 import software.amazon.smithy.java.server.core.Job;
@@ -105,7 +105,7 @@ public class ProtocolTestProtocolProvider implements ServerProtocolProvider {
             var protocol = job.request().context().get(PROTOCOL_TO_TEST);
             if (protocol != null) {
                 if (isError) {
-                    return protocol.serializeError(job, (ModeledApiException) output);
+                    return protocol.serializeError(job, (ModeledException) output);
                 } else {
                     return protocol.serializeOutput(job, output);
                 }

--- a/server-core/src/main/java/software/amazon/smithy/java/server/core/OperationHandler.java
+++ b/server-core/src/main/java/software/amazon/smithy/java/server/core/OperationHandler.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.server.core;
 
 import java.util.concurrent.CompletableFuture;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.framework.model.InternalFailureException;
 import software.amazon.smithy.java.server.Operation;
@@ -26,8 +26,8 @@ public class OperationHandler implements Handler {
             response.whenComplete((result, error) -> {
                 SerializableStruct output = result;
                 if (error != null) {
-                    ModeledApiException modeledError;
-                    if (error instanceof ModeledApiException e) {
+                    ModeledException modeledError;
+                    if (error instanceof ModeledException e) {
                         modeledError = e;
                     } else {
                         modeledError = InternalFailureException.builder().withCause(error).build();
@@ -43,7 +43,7 @@ public class OperationHandler implements Handler {
             SerializableStruct response;
             try {
                 response = (SerializableStruct) operation.function().apply(inputShape, null);
-            } catch (ModeledApiException e) {
+            } catch (ModeledException e) {
                 job.setFailure(e);
                 response = e;
             } catch (Exception e) {

--- a/server-core/src/main/java/software/amazon/smithy/java/server/core/ServerProtocol.java
+++ b/server-core/src/main/java/software/amazon/smithy/java/server/core/ServerProtocol.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.java.server.core;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.framework.model.InternalFailureException;
@@ -39,11 +39,11 @@ public abstract class ServerProtocol {
     public final CompletableFuture<Void> serializeError(Job job, Throwable error) {
         return serializeError(
                 job,
-                error instanceof ModeledApiException me ? me
+                error instanceof ModeledException me ? me
                         : translate(error));
     }
 
-    private static ModeledApiException translate(Throwable error) {
+    private static ModeledException translate(Throwable error) {
         if (error instanceof SerializationException se) {
             return MalformedRequestException.builder()
                     .withoutStackTrace()
@@ -56,7 +56,7 @@ public abstract class ServerProtocol {
 
     protected abstract CompletableFuture<Void> serializeOutput(Job job, SerializableStruct output, boolean isError);
 
-    public final CompletableFuture<Void> serializeError(Job job, ModeledApiException error) {
+    public final CompletableFuture<Void> serializeError(Job job, ModeledException error) {
         // Check both implicit errors and operation errors to see if modeled API exception is
         // defined as part of service interface. Otherwise, throw generic exception.
         if (!job.operation().getOwningService().typeRegistry().contains(error.schema().id())

--- a/server-rpcv2-cbor/src/main/java/software/amazon/smithy/java/server/protocols/rpcv2/RpcV2CborProtocol.java
+++ b/server-rpcv2-cbor/src/main/java/software/amazon/smithy/java/server/protocols/rpcv2/RpcV2CborProtocol.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.java.server.protocols.rpcv2;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.smithy.java.cbor.Rpcv2CborCodec;
-import software.amazon.smithy.java.core.schema.ModeledApiException;
+import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.framework.model.MalformedRequestException;
 import software.amazon.smithy.java.framework.model.UnknownOperationException;
@@ -95,7 +95,7 @@ final class RpcV2CborProtocol extends ServerProtocol {
         var httpJob = job.asHttpJob();
         final int statusCode;
         if (isError) {
-            statusCode = ModeledApiException.getHttpStatusCode(output.schema());
+            statusCode = ModeledException.getHttpStatusCode(output.schema());
         } else {
             statusCode = 200;
         }


### PR DESCRIPTION
Rename ApiException and ModeledApiException and move

ApiException is renamed to CallException to better indicate that the error may not have actually hit a service or be related to the API (e.g., it could be a timeout, networking error, protocol error, etc.)

ModeledApiException is renamed to ModeledException since it no longer extends from ApiException and Api isn't helping make the name more clear.

Exceptions have been moved to a top-level error package, since not all errors are modeled or have a schema, and to better group them.