### PR TITLE
Add accountId to AwsCredentialsIdentity

### DIFF
--- a/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/identity/AwsCredentialsIdentity.java
+++ b/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/identity/AwsCredentialsIdentity.java
@@ -10,8 +10,8 @@ import java.util.Objects;
 import software.amazon.smithy.java.auth.api.identity.Identity;
 
 /**
- * AWS credentials used for accessing services: AWS access key ID, secret access key, and session tokens. These
- * credentials are used to securely sign requests to services (e.g., AWS services) that use them for authentication.
+ * AWS credentials used for accessing services: AWS access key ID, secret access key, optional session tokens, and
+ * optional AWS account ID.
  *
  * <p>For more details on AWS access keys, see:
  * <a href="https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys">
@@ -38,10 +38,21 @@ public interface AwsCredentialsIdentity extends Identity {
      *
      * @return the session token, or null if there is no session token.
      */
-    String sessionToken();
+    default String sessionToken() {
+        return null;
+    }
 
     /**
-     * Constructs a new credentials object, with the specified AWS access key and secret key.
+     * Retrieve the AWS account ID associated with this identity, if found.
+     *
+     * @return the AWS account ID, or null if there is no known associated account ID.
+     */
+    default String accountId() {
+        return null;
+    }
+
+    /**
+     * Constructs a new credentials object with the specified AWS access key and secret key.
      *
      * @param accessKeyId The AWS access key, used to identify the user interacting with services.
      * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with services.
@@ -52,7 +63,7 @@ public interface AwsCredentialsIdentity extends Identity {
     }
 
     /**
-     * Constructs a new credentials object, with the specified AWS access key, secret key, and session token.
+     * Constructs a new credentials object with the specified AWS access key, secret key, and session token.
      *
      * @param accessKeyId The AWS access key, used to identify the user interacting with services.
      * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with services.
@@ -64,7 +75,7 @@ public interface AwsCredentialsIdentity extends Identity {
     }
 
     /**
-     * Constructs a new credentials object, with the specified AWS access key, secret key, and session token.
+     * Constructs a new credentials object with the specified AWS access key, secret key, and session token.
      *
      * @param accessKeyId The AWS access key, used to identify the user interacting with services.
      * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with services.
@@ -78,10 +89,36 @@ public interface AwsCredentialsIdentity extends Identity {
             String sessionToken,
             Instant expirationTime
     ) {
+        return create(
+                Objects.requireNonNull(accessKeyId, "accessKeyId is null"),
+                Objects.requireNonNull(secretAccessKey, "secretAccessKey is null"),
+                sessionToken,
+                expirationTime,
+                null);
+    }
+
+    /**
+     * Constructs a new credentials object with the specified AWS access key, secret key, session token, and account ID.
+     *
+     * @param accessKeyId The AWS access key, used to identify the user interacting with services.
+     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with services.
+     * @param sessionToken The AWS session token, used for authenticating temporary access some resource.
+     * @param expirationTime When the credentials expire, or null if no expiration or unknown.
+     * @param accountId The AWS account ID associated with the credentials, or null if no account ID or unknown.
+     * @return the created identity.
+     */
+    static AwsCredentialsIdentity create(
+            String accessKeyId,
+            String secretAccessKey,
+            String sessionToken,
+            Instant expirationTime,
+            String accountId
+    ) {
         return new AwsCredentialsIdentityRecord(
                 Objects.requireNonNull(accessKeyId, "accessKeyId is null"),
                 Objects.requireNonNull(secretAccessKey, "secretAccessKey is null"),
                 sessionToken,
-                expirationTime);
+                expirationTime,
+                accountId);
     }
 }

--- a/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/identity/AwsCredentialsIdentityRecord.java
+++ b/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/identity/AwsCredentialsIdentityRecord.java
@@ -11,4 +11,5 @@ record AwsCredentialsIdentityRecord(
         String accessKeyId,
         String secretAccessKey,
         String sessionToken,
-        Instant expirationTime) implements AwsCredentialsIdentity {}
+        Instant expirationTime,
+        String accountId) implements AwsCredentialsIdentity {}


### PR DESCRIPTION
Some identity resolvers may be able to provide the AWS account ID when resolving credentials. This change also matches the Java SDK.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
