### PR TITLE
Exclude smithy-cli from being included by validation model

### DIFF
--- a/framework-errors/build.gradle.kts
+++ b/framework-errors/build.gradle.kts
@@ -14,7 +14,9 @@ dependencies {
 
     // Validation error is imported separately, b/c it is used a bit uniquely in protocol tests.
     // TODO: Can this be collapsed into the framework errors when they are upstreamed?
-    api(libs.smithy.validation.model)
+    api(libs.smithy.validation.model) {
+        exclude(group = "software.amazon.smithy", module = "smithy-cli")
+    }
 }
 
 // Add generated Java sources to the main sourceSet


### PR DESCRIPTION
*Description of changes:*
- the validation model package [explicitly declares a runtime dependency on the smithy-cli](https://github.com/smithy-lang/smithy/blob/main/smithy-validation-model/build.gradle.kts#L16)
  - it does this because it is required to by the gradle plugin [here](https://github.com/smithy-lang/smithy-gradle-plugin/blame/0ca9089034ce99f4d859f2679ce6b1532c02057e/smithy-base/src/main/java/software/amazon/smithy/gradle/internal/CliDependencyResolver.java#L127-L141)
- the cli will then transitively be included at runtime in projects that use validation model (or *its* consumers) 
- this change is a temporary workaround that directly removes the cli from being included
- long term, we should update the gradle plugin such that the cli is not required to be as runtime dependency for projects in the smithy repo

Example: Lambda Endpoint
- before validation-model was added in #516, the runtime size was approximately 1.7MB
- after:
```
📦 Dependency Size Analysis: 'runtimeClasspath'
═════════════════════════════════════════════════════════════════
  *  smithy-cli-1.54.0.jar                            │ 4.37 MB
  *  smithy-model-1.54.0.jar                          │ 1.29 MB
  *  core-0.0.1.jar                                   │ 176.97 KB
  ...
🏷️ Total size: 6.59 MB

```
- with this change:
```
📦 Dependency Size Analysis: 'runtimeClasspath'
═════════════════════════════════════════════════════════════════
  *  smithy-model-1.54.0.jar                          │ 1.29 MB
  *  core-0.0.1.jar                                   │ 176.97 KB
  *  smithy-utils-1.54.0.jar                          │ 92.71 KB
  ...
🏷️ Total size: 1.79 MB
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
