### PR TITLE
Add sources and javadoc jars to publication, Fix staging directory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,8 @@ jreleaser {
                     snapshotUrl = "https://aws.oss.sonatype.org/content/repositories/snapshots"
                     closeRepository.set(true)
                     releaseRepository.set(true)
-                    stagingRepositories.add("${rootProject.buildDir}/staging")
+                    verifyPom.set(true)
+                    stagingRepository(rootProject.layout.buildDirectory.dir("staging").get().asFile.path)
                 }
             }
         }

--- a/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
@@ -25,10 +25,9 @@ val licenseSpec = copySpec {
  * Extra Jars
  * ============================
  */
-// Build a javadoc JAR too.
-tasks.register<Jar>("javadocJar") {
-    from(tasks.named("javadoc"))
-    archiveClassifier.set("javadoc")
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 // TODO: Remove this once package is ready for docs

--- a/buildSrc/src/main/kotlin/smithy-java.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.publishing-conventions.gradle.kts
@@ -17,7 +17,7 @@ publishing {
     repositories {
         maven {
             name = "stagingRepository"
-            url = uri("${rootProject.layout.buildDirectory}/staging")
+            url = rootProject.layout.buildDirectory.dir("staging").get().asFile.toURI()
         }
     }
     // Add license spec to all maven publications

--- a/framework-errors/build.gradle.kts
+++ b/framework-errors/build.gradle.kts
@@ -32,8 +32,19 @@ afterEvaluate {
     }
 }
 
+// TODO: This is needed because the type-mapping file is mapped (twice) in the source-set above and source-set below,
+//  but really we shouldn't be doing that
+tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
 tasks.named("compileJava") {
     dependsOn("smithyBuild")
+}
+
+// Needed because sources-jar needs to run after smithy-build is done
+tasks.named("sourcesJar") {
+    mustRunAfter("compileJava")
 }
 
 // Helps Intellij plugin identify models


### PR DESCRIPTION
*Description of changes:*
- Staging directory was incorrectly set 
  - ex: the directories getting created were named `/property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /` under each module's build dir
    -  specifically, `DirectoryProperty` being interpolated, which doesn't have a toString method
  - This may have still worked because the dirs still get created and populated, but it's still wrong
  - The correct path is `build/staging`, and all publications should be put there
- Javadoc and Sources jars were not being created in the publications
- `framework-errors` package had some ordering and duplication issues, workarounds added

*Testing:*
- `gradle clean build publish`
- set up dummy signing secrets with JReleaser, run `gradle jreleaserRelease`
- inspect trace log, should fail (no nexus credentials)
  - verify POM checker passes
  - verify artifacts are signed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
