### PR TITLE
Add option to capture Class<T> type of Context.Key

### DIFF
--- a/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/settings/RegionSetting.java
+++ b/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/settings/RegionSetting.java
@@ -27,7 +27,7 @@ public interface RegionSetting<B extends ClientSetting<B>> extends ClientSetting
      *
      * @see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html">AWS service endpoints</a>
      */
-    Context.Key<String> REGION = Context.key("Region name. For example `us-east-2`");
+    Context.Key<String> REGION = Context.key(String.class, "Region name. For example `us-east-2`");
 
     /**
      * Set the AWS region for a client to use.

--- a/aws/sigv4/src/main/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4Settings.java
+++ b/aws/sigv4/src/main/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4Settings.java
@@ -45,7 +45,7 @@ public interface SigV4Settings<B extends ClientSetting<B>> extends ClockSetting<
     /**
      * Service name to use for signing. For example {@code lambda}.
      */
-    Context.Key<String> SIGNING_NAME = Context.key("Signing name to use for computing SigV4 signatures.");
+    Context.Key<String> SIGNING_NAME = Context.key(String.class, "Signing name to use for computing SigV4 signatures.");
 
     /**
      * Signing name to use for the SigV4 signing process.

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/CallContext.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/CallContext.java
@@ -20,48 +20,52 @@ public final class CallContext {
     /**
      * The total amount of time to wait for an API call to complete, including retries, and serialization.
      */
-    public static final Context.Key<Duration> API_CALL_TIMEOUT = Context.key("API call timeout");
+    public static final Context.Key<Duration> API_CALL_TIMEOUT = Context.key(Duration.class, "API call timeout");
 
     /**
      * The amount of time to wait for a single, underlying network request to complete before giving up and timing out.
      */
-    public static final Context.Key<Duration> API_CALL_ATTEMPT_TIMEOUT = Context.key("API call attempt timeout");
+    public static final Context.Key<Duration> API_CALL_ATTEMPT_TIMEOUT = Context.key(
+            Duration.class,
+            "API call attempt timeout");
 
     /**
      * The endpoint resolver used to resolve the destination endpoint for a request.
      */
-    public static final Context.Key<EndpointResolver> ENDPOINT_RESOLVER = Context.key("EndpointResolver");
+    public static final Context.Key<EndpointResolver> ENDPOINT_RESOLVER = Context.key(
+            EndpointResolver.class,
+            "EndpointResolver");
 
     /**
      * The read-only resolved endpoint for the request.
      */
-    public static final Context.Key<Endpoint> ENDPOINT = Context.key("Endpoint of the request");
+    public static final Context.Key<Endpoint> ENDPOINT = Context.key(Endpoint.class, "Endpoint of the request");
 
     /**
      * The identity resolved for the request.
      */
-    public static final Context.Key<Identity> IDENTITY = Context.key("Identity of the caller");
+    public static final Context.Key<Identity> IDENTITY = Context.key(Identity.class, "Identity of the caller");
 
     /**
      * The current number of retry attempts the client has made for the current call, starting at 1.
      *
      * <p>This is a read-only value; modifying this value has no effect on a request.
      */
-    public static final Context.Key<Integer> RETRY_ATTEMPT = Context.key("Retry attempt");
+    public static final Context.Key<Integer> RETRY_ATTEMPT = Context.key(Integer.class, "Retry attempt");
 
     /**
      * The maximum number of retries the client will issue before giving up.
      *
      * <p>This is a read-only value; modifying this value has no effect on a request.
      */
-    public static final Context.Key<Integer> RETRY_MAX = Context.key("Max retries");
+    public static final Context.Key<Integer> RETRY_MAX = Context.key(Integer.class, "Max retries");
 
     /**
      * The idempotency token used with the call, if any.
      *
      * <p>This is a read-only value; modifying this value has no effect on a request.
      */
-    public static final Context.Key<String> IDEMPOTENCY_TOKEN = Context.key("Idempotency token");
+    public static final Context.Key<String> IDEMPOTENCY_TOKEN = Context.key(String.class, "Idempotency token");
 
     /**
      * The set of user-defined feature IDs used with a request.
@@ -70,9 +74,13 @@ public final class CallContext {
      * only ASCII letters, numbers, and hyphens. For example, "P" might be used to indicate that pagination was used
      * with a request.
      */
-    public static final Context.Key<Set<FeatureId>> FEATURE_IDS = Context.key(
-            "Feature IDs used with a request",
-            HashSet::new);
+    @SuppressWarnings("unchecked")
+    public static final Context.Key<Set<FeatureId>> FEATURE_IDS = (Context.Key<Set<FeatureId>>) createFeatureIdKey();
+
+    @SuppressWarnings("rawtypes")
+    private static Context.Key createFeatureIdKey() {
+        return Context.key(Set.class, "Feature IDs used with a request", HashSet::new);
+    }
 
     /**
      * The name of the application, used in things like user-agent headers.
@@ -83,7 +91,7 @@ public final class CallContext {
      *
      * <p>This value should be less than 50 characters.
      */
-    public static final Context.Key<String> APPLICATION_ID = Context.key("Application ID");
+    public static final Context.Key<String> APPLICATION_ID = Context.key(String.class, "Application ID");
 
     private CallContext() {}
 }

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/settings/ClockSetting.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/settings/ClockSetting.java
@@ -27,7 +27,7 @@ public interface ClockSetting<B extends ClientSetting<B>> extends ClientSetting<
     /**
      * Override the {@code Clock} implementation to used in clients.
      */
-    Context.Key<Clock> CLOCK = Context.key("Clock override.");
+    Context.Key<Clock> CLOCK = Context.key(Clock.class, "Clock override.");
 
     /**
      * Override the default client clock.

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/HttpContext.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/HttpContext.java
@@ -19,12 +19,13 @@ public final class HttpContext {
      * received in time, then the request is considered timed out. This setting does not apply to streaming
      * operations.
      */
-    public static final Context.Key<Duration> HTTP_REQUEST_TIMEOUT = Context.key("HTTP.RequestTimeout");
+    public static final Context.Key<Duration> HTTP_REQUEST_TIMEOUT = Context.key(Duration.class, "HTTP.RequestTimeout");
 
     /**
      * Custom HTTP headers returned from an {@link EndpointResolver} to use with a request.
      */
     public static final Context.Key<HttpHeaders> ENDPOINT_RESOLVER_HTTP_HEADERS = Context.key(
+            HttpHeaders.class,
             "HTTP headers to use with the request returned from an endpoint resolver");
 
     private HttpContext() {}

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/auth/HttpApiKeyAuthScheme.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/auth/HttpApiKeyAuthScheme.java
@@ -21,10 +21,13 @@ import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
  */
 public final class HttpApiKeyAuthScheme implements AuthScheme<HttpRequest, ApiKeyIdentity> {
     static final Context.Key<String> NAME = Context.key(
+            String.class,
             "Name of the header or query parameter that contains the API key");
     static final Context.Key<HttpApiKeyAuthTrait.Location> IN = Context.key(
+            HttpApiKeyAuthTrait.Location.class,
             "Defines the location of where the key is serialized.");
     static final Context.Key<String> SCHEME = Context.key(
+            String.class,
             "Defines the IANA scheme to use on the Authorization header value.");
 
     private final String scheme;

--- a/client/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockPlugin.java
+++ b/client/mock-client-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockPlugin.java
@@ -53,7 +53,9 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class MockPlugin implements ClientPlugin {
 
     // Used to pass the required context from the wrapped protocol to the wrapped transport.
-    private static final Context.Key<CurrentRequest> CURRENT_REQUEST = Context.key("CURRENT_REQUEST");
+    private static final Context.Key<CurrentRequest> CURRENT_REQUEST = Context.key(
+            CurrentRequest.class,
+            "CURRENT_REQUEST");
 
     private static final Map<ShapeId, ServerProtocolProvider> SERVER_PROTOCOL_HANDLERS = ServiceLoader.load(
             ServerProtocolProvider.class,

--- a/examples/restjson-client/src/it/java/software/amazon/smithy/java/examples/ClientConfigTest.java
+++ b/examples/restjson-client/src/it/java/software/amazon/smithy/java/examples/ClientConfigTest.java
@@ -176,7 +176,7 @@ public class ClientConfigTest {
 
     static final class RegionAwareServicePlugin implements ClientPlugin {
 
-        public static final Context.Key<String> REGION = Context.key("Region for the service");
+        public static final Context.Key<String> REGION = Context.key(String.class, "Region for the service");
 
         @Override
         public void configureClient(ClientConfig.Builder config) {

--- a/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestProtocolProvider.java
+++ b/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestProtocolProvider.java
@@ -41,7 +41,9 @@ public class ProtocolTestProtocolProvider implements ServerProtocolProvider {
 
     private static class DelegatingServerProtocol extends ServerProtocol {
 
-        private static final Context.Key<ServerProtocol> PROTOCOL_TO_TEST = Context.key("protocol-to-test");
+        private static final Context.Key<ServerProtocol> PROTOCOL_TO_TEST = Context.key(
+                ServerProtocol.class,
+                "protocol-to-test");
 
         private final Map<ShapeId, ServerProtocol> delegateProtocols;
 


### PR DESCRIPTION
Context.Key now allows you to optionally provide the Class<T> that's contained in the Key. This makes it possible for Context.Key to be adapted to libraries that provide similar typed attributes but require the Class<T> to be available via a getter of the attribute. However, some libraries don't expose Class<T>. To allow smithy-java compatibility with both kinds of libraries, providing a Class<T> when creating a Context.Key is optional.

This allows smithy-java to interop with both kinds of libraries, though it would not be possible to adapt a context key from a library that doesn't expose Class<T> for use with a library that requires Class<T>.

All publicly exposed Context.Keys in smithy-java have been updated to define the Class<T> of the key.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
