### PR TITLE
Add our own exceptions for ClientTransport

### DIFF
--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/ConnectTimeoutException.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/ConnectTimeoutException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.error;
+
+import java.net.ConnectException;
+import java.time.Duration;
+import software.amazon.smithy.java.retries.api.RetryInfo;
+import software.amazon.smithy.java.retries.api.RetrySafety;
+
+/**
+ * A connection could not be established within the configured amount of time.
+ *
+ * <p>This error is always retryable regardless of the type of call.
+ *
+ * <p>This exception is similar to the built-in {@link ConnectException}.
+ */
+public class ConnectTimeoutException extends TransportException implements RetryInfo {
+    public ConnectTimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    public ConnectTimeoutException(String message) {
+        super(message);
+    }
+
+    public ConnectTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public RetrySafety isRetrySafe() {
+        return RetrySafety.NO;
+    }
+
+    @Override
+    public boolean isThrottle() {
+        return false;
+    }
+
+    @Override
+    public Duration retryAfter() {
+        return null;
+    }
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/ConnectionAcquireTimeoutException.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/ConnectionAcquireTimeoutException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.error;
+
+import java.time.Duration;
+import software.amazon.smithy.java.retries.api.RetryInfo;
+import software.amazon.smithy.java.retries.api.RetrySafety;
+
+/**
+ * A connection could not be leased from a connection pool after the configured amount of time.
+ *
+ * <p>This is a best-effort exception. Transports should throw this exception when possible if their connection pooling
+ * allows for it.
+ */
+public class ConnectionAcquireTimeoutException extends TransportException implements RetryInfo {
+    public ConnectionAcquireTimeoutException(String message) {
+        super(message);
+    }
+
+    public ConnectionAcquireTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public RetrySafety isRetrySafe() {
+        return RetrySafety.YES;
+    }
+
+    @Override
+    public boolean isThrottle() {
+        return false;
+    }
+
+    @Override
+    public Duration retryAfter() {
+        return null;
+    }
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/ConnectionClosedException.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/ConnectionClosedException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.error;
+
+/**
+ * Indicates that the connection was unexpectedly closed.
+ *
+ * <p>This is a best-effort exception that may not always be possible to throw based on the underlying transport.
+ */
+public class ConnectionClosedException extends TransportException {
+    public ConnectionClosedException(String message) {
+        super(message);
+    }
+
+    public ConnectionClosedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TlsException.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TlsException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.error;
+
+import javax.net.ssl.SSLException;
+
+/**
+ * Exception thrown when TLS negotiation fails.
+ *
+ * <p>This exception is similar to {@link SSLException}.
+ */
+public class TlsException extends TransportProtocolException {
+    public TlsException(Throwable cause) {
+        super(cause);
+    }
+
+    public TlsException(String message) {
+        super(message);
+    }
+
+    public TlsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TransportException.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TransportException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.error;
+
+import java.time.Duration;
+import software.amazon.smithy.java.client.core.ClientTransport;
+import software.amazon.smithy.java.core.error.CallException;
+import software.amazon.smithy.java.retries.api.RetryInfo;
+import software.amazon.smithy.java.retries.api.RetrySafety;
+
+/**
+ * An exception thrown by a {@link ClientTransport}.
+ *
+ * <p>The base assumption of a transport exception is that it is not retryable. However, subclasses may override the
+ * {@link RetryInfo} implementation.
+ */
+public class TransportException extends CallException {
+    public TransportException(String message) {
+        super(message);
+    }
+
+    public TransportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TransportException(Throwable cause) {
+        this(cause.getMessage(), cause);
+    }
+
+    @Override
+    public RetrySafety isRetrySafe() {
+        return RetrySafety.NO;
+    }
+
+    @Override
+    public boolean isThrottle() {
+        return false;
+    }
+
+    @Override
+    public Duration retryAfter() {
+        return null;
+    }
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TransportProtocolException.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TransportProtocolException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.error;
+
+import java.net.ProtocolException;
+
+/**
+ * The client encountered an underlying protocol error (e.g., TCP, HTTP, MQTT, etc).
+ *
+ * <p>This error is not retryable as the client does not explicitly know if the error occurred after state was changed
+ * on the server.
+ *
+ * <p>This exception is similar to {@link ProtocolException}.
+ */
+public class TransportProtocolException extends TransportException {
+    public TransportProtocolException(Throwable cause) {
+        super(cause);
+    }
+
+    public TransportProtocolException(String message) {
+        super(message);
+    }
+
+    public TransportProtocolException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TransportSocketException.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TransportSocketException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.error;
+
+import java.net.SocketException;
+
+/**
+ * Thrown to indicate that there is an error creating or accessing a Socket.
+ *
+ * <p>This exception is similar to {@link SocketException}.
+ */
+public class TransportSocketException extends TransportException {
+    public TransportSocketException(Throwable cause) {
+        super(cause);
+    }
+
+    public TransportSocketException(String message) {
+        super(message);
+    }
+
+    public TransportSocketException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TransportSocketTimeout.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/error/TransportSocketTimeout.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.error;
+
+import java.net.SocketTimeoutException;
+
+/**
+ * Exception thrown when a socket used by the transport times out.
+ *
+ * <p>This exception is similar to {@link SocketTimeoutException}.
+ */
+public class TransportSocketTimeout extends TransportSocketException {
+    public TransportSocketTimeout(Throwable cause) {
+        super(cause);
+    }
+
+    public TransportSocketTimeout(String message) {
+        super(message);
+    }
+
+    public TransportSocketTimeout(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.aws.client.restjson.RestJsonClientProtocol;
 import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
+import software.amazon.smithy.java.client.core.error.TransportException;
 import software.amazon.smithy.java.client.core.plugins.ApplyModelRetryInfoPlugin;
 import software.amazon.smithy.java.client.core.plugins.DefaultPlugin;
 import software.amazon.smithy.java.client.core.plugins.InjectIdempotencyTokenPlugin;
@@ -97,7 +98,7 @@ public class ClientTest {
     }
 
     @Test
-    public void correctlyUnwraps() throws URISyntaxException {
+    public void correctlyWrapsTransportExceptions() throws URISyntaxException {
         var expectedException = new IOException("A");
         var queue = new MockQueue();
         queue.enqueueError(expectedException);
@@ -111,7 +112,7 @@ public class ClientTest {
                 .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
                 .build();
 
-        var exception = Assertions.assertThrows(IOException.class, () -> c.call("GetSprocket"));
-        assertSame(expectedException, exception);
+        var exception = Assertions.assertThrows(TransportException.class, () -> c.call("GetSprocket"));
+        assertSame(exception.getCause(), expectedException);
     }
 }


### PR DESCRIPTION
To avoid directly exposing the exceptions of the underlying transport of a ClientTransport, which inadvertently allows for coupling of caller logic to a specific transport, we now provide a set of transport exceptions that extend from CallException.

ClienTransports are expected to only throw a subtype of CallException or ClienTransportException, and to wrap other exceptions. ClientPipeline has been updated to also perform this remapping in case a transport either is implemented incorrectly or tries to work around this mapping (which again allows for coupling to a specific transport).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
