### PR TITLE
Make dynamic schema conversion public

### DIFF
--- a/client/dynamic-client/build.gradle.kts
+++ b/client/dynamic-client/build.gradle.kts
@@ -8,6 +8,7 @@ extra["displayName"] = "Smithy :: Java :: Dynamic client"
 extra["moduleName"] = "software.amazon.smithy.java.dynamicclient"
 
 dependencies {
+    api(project(":dynamic-schemas"))
     api(project(":client:client-core"))
 
     testImplementation(project(":aws:client:aws-client-restjson"))

--- a/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DocumentException.java
+++ b/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DocumentException.java
@@ -11,6 +11,8 @@ import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.dynamicschemas.SchemaConverter;
+import software.amazon.smithy.java.dynamicschemas.WrappedDocument;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -52,11 +54,11 @@ public final class DocumentException extends ModeledException {
     static final class SchemaGuidedExceptionBuilder implements ShapeBuilder<ModeledException> {
 
         private final Schema target;
-        private final SchemaGuidedDocumentBuilder delegateBuilder;
+        private final ShapeBuilder<WrappedDocument> delegateBuilder;
 
         SchemaGuidedExceptionBuilder(ShapeId service, Schema target) {
             this.target = target;
-            this.delegateBuilder = new SchemaGuidedDocumentBuilder(service, target);
+            this.delegateBuilder = SchemaConverter.createDocumentBuilder(target, service);
         }
 
         @Override

--- a/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicClient.java
+++ b/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicClient.java
@@ -29,6 +29,8 @@ import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.dynamicschemas.SchemaConverter;
+import software.amazon.smithy.java.dynamicschemas.WrappedDocument;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
@@ -176,7 +178,7 @@ public final class DynamicClient extends Client {
             RequestOverrideConfig overrideConfig
     ) {
         var apiOperation = getApiOperation(operation);
-        var inputStruct = new WrappedDocument(service.getId(), apiOperation.inputSchema(), input);
+        var inputStruct = new WrappedDocument(apiOperation.inputSchema(), input, service.getId());
         return call(inputStruct, apiOperation, overrideConfig).thenApply(Function.identity());
     }
 
@@ -192,7 +194,7 @@ public final class DynamicClient extends Client {
         if (value.type() != ShapeType.MAP && value.type() != ShapeType.STRUCTURE) {
             throw new IllegalArgumentException("Document value must be a map or structure, found " + value.type());
         }
-        return new WrappedDocument(service.getId(), schema, value);
+        return new WrappedDocument(schema, value, service.getId());
     }
 
     private ApiOperation<WrappedDocument, WrappedDocument> getApiOperation(String name) {

--- a/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicOperation.java
+++ b/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicOperation.java
@@ -12,6 +12,8 @@ import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.java.dynamicschemas.SchemaConverter;
+import software.amazon.smithy.java.dynamicschemas.WrappedDocument;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDocument> {
@@ -69,12 +71,12 @@ final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDoc
 
     @Override
     public ShapeBuilder<WrappedDocument> inputBuilder() {
-        return new SchemaGuidedDocumentBuilder(service, inputSchema());
+        return SchemaConverter.createDocumentBuilder(inputSchema(), service);
     }
 
     @Override
     public ShapeBuilder<WrappedDocument> outputBuilder() {
-        return new SchemaGuidedDocumentBuilder(service, outputSchema());
+        return SchemaConverter.createDocumentBuilder(outputSchema(), service);
     }
 
     @Override

--- a/client/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicOperationTest.java
+++ b/client/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicOperationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.java.dynamicschemas.SchemaConverter;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.DeprecatedTrait;

--- a/config/spotbugs/filter.xml
+++ b/config/spotbugs/filter.xml
@@ -52,12 +52,12 @@
 
     <Match>
         <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS"/>
-        <Class name="software.amazon.smithy.java.dynamicclient.SchemaGuidedDocumentBuilder$SchemaList"/>
+        <Class name="software.amazon.smithy.java.dynamicschemas.SchemaGuidedDocumentBuilder$SchemaList"/>
     </Match>
 
     <Match>
         <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS"/>
-        <Class name="software.amazon.smithy.java.dynamicclient.SchemaGuidedDocumentBuilder$SchemaMap"/>
+        <Class name="software.amazon.smithy.java.dynamicschemas.SchemaGuidedDocumentBuilder$SchemaMap"/>
     </Match>
 
     <Match>

--- a/dynamic-schemas/README.md
+++ b/dynamic-schemas/README.md
@@ -1,0 +1,21 @@
+# dynamic-schemas
+
+Can dynamically create a Smithy-Java `Schema` from a Smithy model `Shape` and
+can wrap a document to have it appear to be a typed value using a schema.
+
+## Example usage
+
+```java 
+// (1) Load up a model
+var model = Model.assembler()
+    .addImport("/path/to/model.json")
+    .assemble()
+    .unwrap();
+
+// (2) Create a SchemaConverter
+var schemaConverter = new SchemaConverter(model);
+
+// (3) Convert a Shape to a Schema
+var shape = model.expectShape(ShapeId.from("com.example#Foo"));
+var schema = schemaConverter.getSchema(shape);
+```

--- a/dynamic-schemas/build.gradle.kts
+++ b/dynamic-schemas/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("smithy-java.module-conventions")
+}
+
+description = "This module provides a way to dynamically create Smithy Java schemas from a model"
+
+extra["displayName"] = "Smithy :: Java :: Dynamic Schemas"
+extra["moduleName"] = "software.amazon.smithy.java.dynamicschemas"
+
+dependencies {
+    api(project(":core"))
+}

--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilder.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package software.amazon.smithy.java.dynamicclient;
+package software.amazon.smithy.java.dynamicschemas;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,9 +23,9 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<WrappedDocument>
     private Document result;
     private final Map<String, Document> map;
 
-    SchemaGuidedDocumentBuilder(ShapeId service, Schema target) {
-        this.service = service;
+    SchemaGuidedDocumentBuilder(Schema target, ShapeId service) {
         this.target = target;
+        this.service = service;
         this.map = switch (target.type()) {
             case STRUCTURE, UNION, MAP -> new HashMap<>();
             default -> null;
@@ -43,9 +43,9 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<WrappedDocument>
             if (map.isEmpty() && target.type() == ShapeType.UNION) {
                 throw new IllegalArgumentException("No value set for union document: " + schema().id());
             }
-            return new WrappedDocument(service, target, Document.of(map));
+            return new WrappedDocument(target, Document.of(map), service);
         } else if (result != null) {
-            return new WrappedDocument(service, target, result);
+            return new WrappedDocument(target, result, service);
         } else {
             throw new IllegalArgumentException("No value was set on document builder for " + schema().id());
         }

--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaInterceptingSerializer.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaInterceptingSerializer.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package software.amazon.smithy.java.dynamicclient;
+package software.amazon.smithy.java.dynamicschemas;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -33,7 +33,7 @@ final class SchemaInterceptingSerializer implements ShapeSerializer {
     @Override
     public void writeStruct(Schema schema, SerializableStruct struct) {
         delegateSerializer
-                .writeStruct(delegateSchema, new WrappedDocument(service, schema, Document.of(struct)));
+                .writeStruct(delegateSchema, new WrappedDocument(schema, Document.of(struct), service));
     }
 
     @Override

--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/package-info.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/package-info.java
@@ -1,0 +1,4 @@
+@SmithyUnstableApi
+package software.amazon.smithy.java.dynamicschemas;
+
+import software.amazon.smithy.utils.SmithyUnstableApi;

--- a/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/SchemaConverterTest.java
+++ b/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/SchemaConverterTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package software.amazon.smithy.java.dynamicclient;
+package software.amazon.smithy.java.dynamicschemas;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;

--- a/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilderTest.java
+++ b/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilderTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package software.amazon.smithy.java.dynamicclient;
+package software.amazon.smithy.java.dynamicschemas;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -96,7 +96,7 @@ public class SchemaGuidedDocumentBuilderTest {
         var converter = new SchemaConverter(model);
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#" + name)));
 
-        var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
+        var builder = SchemaConverter.createDocumentBuilder(schema, ShapeId.from("smithy.example#Foo"));
         source.deserializeInto(builder);
 
         var result = builder.build();
@@ -111,7 +111,7 @@ public class SchemaGuidedDocumentBuilderTest {
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleStruct")));
         var document = Document.ofObject(Map.of("foo", "bar"));
 
-        var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
+        var builder = SchemaConverter.createDocumentBuilder(schema, ShapeId.from("smithy.example#Foo"));
         builder.deserializeMember(new DocumentDeserializer(document), schema.member("baz"));
 
         var result = builder.build();
@@ -125,7 +125,7 @@ public class SchemaGuidedDocumentBuilderTest {
         var converter = new SchemaConverter(model);
         var member = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleStruct"))).member("foo");
         var schema = PreludeSchemas.STRING;
-        var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
+        var builder = SchemaConverter.createDocumentBuilder(schema, ShapeId.from("smithy.example#Foo"));
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> builder.setMemberValue(member, "x"));
     }
@@ -134,7 +134,7 @@ public class SchemaGuidedDocumentBuilderTest {
     public void deserializesMultipleMembersUsingDocuments() {
         var converter = new SchemaConverter(model);
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleStruct")));
-        var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
+        var builder = SchemaConverter.createDocumentBuilder(schema, ShapeId.from("smithy.example#Foo"));
 
         builder.setMemberValue(schema.member("foo"), Document.of("bar1"));
         builder.setMemberValue(schema.member("baz"), Document.ofObject(Map.of("foo", "bar2")));
@@ -149,7 +149,7 @@ public class SchemaGuidedDocumentBuilderTest {
     public void deserializesMultipleMembersUsingObjects() {
         var converter = new SchemaConverter(model);
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleStruct")));
-        var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
+        var builder = SchemaConverter.createDocumentBuilder(schema, ShapeId.from("smithy.example#Foo"));
 
         builder.setMemberValue(schema.member("foo"), "bar1");
         builder.setMemberValue(schema.member("baz"), Map.of("foo", "bar2"));
@@ -165,7 +165,7 @@ public class SchemaGuidedDocumentBuilderTest {
         var converter = new SchemaConverter(model);
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleStruct")));
         var member = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleMap"))).member("key");
-        var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
+        var builder = SchemaConverter.createDocumentBuilder(schema, ShapeId.from("smithy.example#Foo"));
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> builder.setMemberValue(member, "bar1"));
     }
@@ -175,7 +175,7 @@ public class SchemaGuidedDocumentBuilderTest {
         var converter = new SchemaConverter(model);
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleList")));
         var member = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleList"))).member("member");
-        var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
+        var builder = SchemaConverter.createDocumentBuilder(schema, ShapeId.from("smithy.example#Foo"));
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> builder.setMemberValue(member, "bar1"));
     }
@@ -184,7 +184,7 @@ public class SchemaGuidedDocumentBuilderTest {
     public void throwsWhenNoValueSetForScalar() {
         var converter = new SchemaConverter(model);
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleList")));
-        var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
+        var builder = SchemaConverter.createDocumentBuilder(schema, ShapeId.from("smithy.example#Foo"));
 
         Assertions.assertThrows(IllegalArgumentException.class, builder::build);
     }
@@ -193,7 +193,7 @@ public class SchemaGuidedDocumentBuilderTest {
     public void throwsWhenNoValueSetForUnion() {
         var converter = new SchemaConverter(model);
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleUnion")));
-        var builder = new SchemaGuidedDocumentBuilder(ShapeId.from("smithy.example#Foo"), schema);
+        var builder = SchemaConverter.createDocumentBuilder(schema, ShapeId.from("smithy.example#Foo"));
 
         Assertions.assertThrows(IllegalArgumentException.class, builder::build);
     }

--- a/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/SchemaInterceptingSerializerTest.java
+++ b/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/SchemaInterceptingSerializerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package software.amazon.smithy.java.dynamicclient;
+package software.amazon.smithy.java.dynamicschemas;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -96,7 +96,7 @@ public class SchemaInterceptingSerializerTest {
     public void interceptsWithSchema(String name, Document value) {
         var converter = new SchemaConverter(model);
         var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#" + name)));
-        var wrapped = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, value);
+        var wrapped = new WrappedDocument(schema, value, ShapeId.from("smithy.example#S"));
 
         Schema[] written = new Schema[1];
 
@@ -134,9 +134,9 @@ public class SchemaInterceptingSerializerTest {
         var converter = new SchemaConverter(model);
         var listSchema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleList")));
         var wrapped = new WrappedDocument(
-                ShapeId.from("smithy.example#S"),
                 listSchema,
-                Document.of(Arrays.asList(Document.of("a"), null)));
+                Document.of(Arrays.asList(Document.of("a"), null)),
+                ShapeId.from("smithy.example#S"));
 
         wrapped.serialize(new SpecificShapeSerializer() {
             @Override
@@ -163,9 +163,9 @@ public class SchemaInterceptingSerializerTest {
         var converter = new SchemaConverter(model);
         var mapSchema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleMap")));
         var wrapped = new WrappedDocument(
-                ShapeId.from("smithy.example#S"),
                 mapSchema,
-                Document.ofObject(Map.of("foo", "bar")));
+                Document.ofObject(Map.of("foo", "bar")),
+                ShapeId.from("smithy.example#S"));
 
         wrapped.serialize(new SpecificShapeSerializer() {
             @Override
@@ -201,9 +201,9 @@ public class SchemaInterceptingSerializerTest {
         var converter = new SchemaConverter(model);
         var mapSchema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#DocumentMap")));
         var wrapped = new WrappedDocument(
-                ShapeId.from("smithy.example#S"),
                 mapSchema,
-                Document.ofObject(Map.of("foo", "bar")));
+                Document.ofObject(Map.of("foo", "bar")),
+                ShapeId.from("smithy.example#S"));
 
         wrapped.serialize(new SpecificShapeSerializer() {
             @Override
@@ -239,14 +239,14 @@ public class SchemaInterceptingSerializerTest {
         var converter = new SchemaConverter(model);
         var structSchema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#SimpleStruct")));
         var wrapped = new WrappedDocument(
-                ShapeId.from("smithy.example#S"),
                 structSchema,
                 Document.ofObject(
                         Map.of(
                                 "foo",
                                 "bar",
                                 "baz",
-                                Document.ofObject(Map.of("foo", "hi")))));
+                                Document.ofObject(Map.of("foo", "hi")))),
+                ShapeId.from("smithy.example#S"));
 
         wrapped.serialize(new SpecificShapeSerializer() {
             @Override

--- a/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/WrappedDocumentTest.java
+++ b/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/WrappedDocumentTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package software.amazon.smithy.java.dynamicclient;
+package software.amazon.smithy.java.dynamicschemas;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -44,7 +44,7 @@ public class WrappedDocumentTest {
                 .build();
         var document = Document.ofObject(Map.of("__type", "foo#Bar", "foo", "bar"));
 
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
 
         assertThat(sd.type(), is(ShapeType.STRUCTURE));
         assertThat(sd.discriminator().toString(), equalTo("foo#Bar"));
@@ -57,7 +57,7 @@ public class WrappedDocumentTest {
                 .putMember("foo", PreludeSchemas.STRING)
                 .build();
         var document = Document.ofObject(Map.of("__type", "foo#Bar", "foo", "bar"));
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
 
         assertThat(sd.getMemberValue(schema.member("foo")), equalTo("bar"));
     }
@@ -68,7 +68,7 @@ public class WrappedDocumentTest {
                 .putMember("foo", PreludeSchemas.STRING)
                 .build();
         var document = Document.of(Map.of());
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
 
         assertThat(sd.getMemberValue(schema.member("foo")), nullValue());
         assertThat(sd.getMember("foo"), nullValue());
@@ -81,7 +81,7 @@ public class WrappedDocumentTest {
                 .build();
         var document = Document.ofObject(Map.of("foo", "bar"));
 
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
 
         Assertions.assertThrows(DiscriminatorException.class, sd::discriminator);
     }
@@ -93,7 +93,7 @@ public class WrappedDocumentTest {
                 .build();
         var document = Document.ofObject(Map.of("foo", "bar"));
 
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
 
         assertThat(sd.getMemberNames(), contains("foo"));
         var member = sd.getMember("foo");
@@ -103,7 +103,7 @@ public class WrappedDocumentTest {
     @ParameterizedTest
     @MethodSource("convertsToTypeProvider")
     public void convertsToType(Schema schema, Document value, Object expected, Function<Document, Object> mapper) {
-        var wrapped = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, value);
+        var wrapped = new WrappedDocument(schema, value, ShapeId.from("smithy.example#S"));
 
         assertThat(wrapped.type(), equalTo(schema.type()));
         assertThat(mapper.apply(wrapped), equalTo(expected));
@@ -186,7 +186,7 @@ public class WrappedDocumentTest {
                 .build();
         var document = Document.ofObject(List.of("a", "b"));
 
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
 
         assertThat(sd.type(), is(ShapeType.LIST));
         assertThat(sd.size(), equalTo(2));
@@ -205,7 +205,7 @@ public class WrappedDocumentTest {
                 .build();
         var document = Document.ofObject(Map.of("a", "b"));
 
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
 
         assertThat(sd.type(), is(ShapeType.MAP));
         assertThat(sd.size(), equalTo(1));
@@ -223,7 +223,7 @@ public class WrappedDocumentTest {
                 .build();
         var document = Document.ofObject(Map.of("a", "a", "b", "b", "c", "c"));
 
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
 
         assertThat(sd.type(), is(ShapeType.STRUCTURE));
         assertThat(sd.getMember("a"), instanceOf(WrappedDocument.class));
@@ -243,9 +243,9 @@ public class WrappedDocumentTest {
     @Test
     public void serializesDocumentLikeShape() {
         var wrapped = new WrappedDocument(
-                ShapeId.from("smithy.example#S"),
                 PreludeSchemas.STRING,
-                Document.of("hi"));
+                Document.of("hi"),
+                ShapeId.from("smithy.example#S"));
         Schema[] set = new Schema[1];
 
         wrapped.serialize(new SpecificShapeSerializer() {
@@ -265,7 +265,7 @@ public class WrappedDocumentTest {
                 .putMember("b", PreludeSchemas.STRING)
                 .build();
         var document = Document.ofObject(Map.of("a", "a", "b", "b", "c", "c"));
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
         Schema[] set = new Schema[3];
 
         sd.serialize(new SpecificShapeSerializer() {
@@ -293,7 +293,7 @@ public class WrappedDocumentTest {
                 .putMember("b", PreludeSchemas.STRING)
                 .build();
         var document = Document.ofObject(Map.of("a", "a"));
-        var sd = new WrappedDocument(ShapeId.from("smithy.example#S"), schema, document);
+        var sd = new WrappedDocument(schema, document, ShapeId.from("smithy.example#S"));
         Schema[] set = new Schema[2];
 
         sd.serialize(new SpecificShapeSerializer() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,7 @@ include(":logging")
 include(":context")
 include(":io")
 include(":core")
+include(":dynamic-schemas")
 
 // Common components
 include(":auth-api")


### PR DESCRIPTION
Various teams need to be able to access the underlying Shape->Schema conversion and WrappedDocuments.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
