### PR TITLE
Really enable exception response tests

### DIFF
--- a/aws/client/aws-client-awsjson/src/it/java/software/amazon/smithy/java/client/aws/jsonprotocols/AwsJson1ProtocolTests.java
+++ b/aws/client/aws-client-awsjson/src/it/java/software/amazon/smithy/java/client/aws/jsonprotocols/AwsJson1ProtocolTests.java
@@ -50,7 +50,13 @@ public class AwsJson1ProtocolTests {
     @ProtocolTestFilter(
             skipTests = {
                     "AwsJson10ClientPopulatesDefaultsValuesWhenMissingInResponse",
-                    "AwsJson10ClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse"
+                    "AwsJson10ClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse",
+                    //The below fail because we haven't implemented code based exception handling
+                    "AwsJson10FooErrorUsingCode",
+                    "AwsJson10FooErrorUsingCodeAndNamespace",
+                    "AwsJson10FooErrorUsingCodeUriAndNamespace",
+                    "AwsJson10FooErrorWithDunderTypeUriAndNamespace"
+
             },
             skipOperations = "aws.protocoltests.json10#OperationWithRequiredMembersWithDefaults")
     public void responseTest(Runnable test) {

--- a/aws/client/aws-client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
+++ b/aws/client/aws-client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
@@ -66,7 +66,11 @@ public class RestJson1ProtocolTests {
     @HttpClientResponseTests
     @ProtocolTestFilter(
             skipTests = {
-                    "RestJsonInputAndOutputWithQuotedStringHeaders"
+                    "RestJsonInputAndOutputWithQuotedStringHeaders",
+                    "RestJsonFooErrorUsingCode",
+                    "RestJsonFooErrorUsingCodeAndNamespace",
+                    "RestJsonFooErrorUsingCodeUriAndNamespace",
+                    "RestJsonFooErrorWithDunderTypeUriAndNamespace"
             })
     public void responseTest(Runnable test) {
         test.run();

--- a/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
+++ b/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
@@ -57,6 +57,10 @@ public class RestXmlProtocolTests {
     }
 
     @HttpClientResponseTests
+    @ProtocolTestFilter(skipTests = {
+            "InvalidGreetingError",
+            "ComplexError"
+    })
     public void responseTest(Runnable test) {
         test.run();
     }

--- a/aws/server/aws-server-restjson/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
+++ b/aws/server/aws-server-restjson/src/it/java/software/amazon/smithy/java/server/protocols/restjson/AwsRestJson1ProtocolTests.java
@@ -73,7 +73,10 @@ public class AwsRestJson1ProtocolTests {
                     "RestJsonStreamingTraitsWithMediaTypeWithBlob",
                     "RestJsonDeserializesDenseSetMapAndSkipsNull",
                     "RestJsonServerPopulatesDefaultsInResponseWhenMissingInParams",
+                    // These can be fixed after https://github.com/smithy-lang/smithy-java/blob/main/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSerializer.java#L109
                     "RestJsonInvalidGreetingError",
+                    "RestJsonComplexErrorWithNoMessage",
+                    "RestJsonEmptyComplexErrorWithNoMessage",
                     //TODO this breaks because of Validation and errorCorrection doesn't handle that.
                     "RestJsonServerPopulatesNestedDefaultValuesWhenMissingInInResponseParams"
 

--- a/client/client-rpcv2-cbor/src/it/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocolTests.java
+++ b/client/client-rpcv2-cbor/src/it/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocolTests.java
@@ -35,7 +35,10 @@ public class RpcV2CborProtocolTests {
     @HttpClientResponseTests
     @ProtocolTestFilter(
             skipTests = {
-                    "RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse"
+                    "RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse",
+                    "RpcV2CborInvalidGreetingError",
+                    "RpcV2CborEmptyComplexError",
+                    "RpcV2CborComplexError"
             })
     public void responseTest(Runnable test) {
         test.run();

--- a/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
+++ b/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
@@ -314,21 +314,20 @@ public final class ProtocolTestExtension implements BeforeAllCallback, AfterAllC
                 });
                 for (var errorId : operation.getErrors()) {
                     var error = serviceModel.getShape(errorId);
-                    if (error.map(Shape::isStructureShape).orElse(false)) {
-                        continue;
-                    }
-                    var errorShape = error.get().asStructureShape().get();
-                    errorShape.getTrait(HttpResponseTestsTrait.class).ifPresent(httpResponseTestsTrait -> {
-                        for (var testCase : httpResponseTestsTrait.getTestCases()) {
-                            if (testTypeFiler.test(testCase)) {
-                                responseTestsCases.add(
-                                        new HttpResponseProtocolTestCase(
-                                                testCase,
-                                                true,
-                                                getApiExceptionBuilder(symbolProvider, errorShape)));
+                    if (error.isPresent() && error.get().isStructureShape()) {
+                        var errorShape = error.get().asStructureShape().get();
+                        errorShape.getTrait(HttpResponseTestsTrait.class).ifPresent(httpResponseTestsTrait -> {
+                            for (var testCase : httpResponseTestsTrait.getTestCases()) {
+                                if (testTypeFiler.test(testCase)) {
+                                    responseTestsCases.add(
+                                            new HttpResponseProtocolTestCase(
+                                                    testCase,
+                                                    true,
+                                                    getApiExceptionBuilder(symbolProvider, errorShape)));
+                                }
                             }
-                        }
-                    });
+                        });
+                    }
                 }
                 operation.getTrait(HttpMalformedRequestTestsTrait.class)
                         .map(HttpMalformedRequestTestsTrait::getTestCases)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There was a minor bug in https://github.com/smithy-lang/smithy-java/pull/474 which causes the tests to not run. This is why https://github.com/smithy-lang/smithy-java/pull/548/ and https://github.com/smithy-lang/smithy-java/pull/549/ was able to remove these tests. 

Fixed the issue and added these back.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
