### PR TITLE
Eagerly resolve deferred schemas

### DIFF
--- a/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/RecursionTests.java
+++ b/codegen/core/src/it/java/software/amazon/smithy/java/codegen/test/RecursionTests.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.codegen.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -106,5 +107,10 @@ public class RecursionTests {
         assertEquals(recursive.hashCode(), output.hashCode());
         assertEquals(recursive, output);
         assertNotEquals(AttributeValue.Type.$UNKNOWN, output.type());
+    }
+
+    @Test
+    void verifyRecursiveSchemaResolved() {
+        assertThat(AttributeValue.$SCHEMA.resolve()).isSameAs(AttributeValue.$SCHEMA);
     }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemasGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemasGenerator.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.codegen.generators;
 
+import java.util.List;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.directed.ContextualDirective;
 import software.amazon.smithy.codegen.core.directed.CustomizeDirective;
@@ -60,30 +61,31 @@ public final class SchemasGenerator
                                          */
                                         final class ${className:L} {
                                             ${#builders}${value:C|}
-                                            ${/builders}${#schemas}
+                                            ${/builders}${schemas:C|}
+                                            ${#resolvers}
                                             ${value:C|}
-                                            ${/schemas}
+                                            ${/resolvers}
 
                                             private ${className:L}() {}
                                         }
                                         """;
-                        var builders = shapeOrder.stream()
-                                .filter(SchemaFieldOrder.SchemaField::isRecursive)
+                        var recursiveShapes =
+                                shapeOrder.stream().filter(SchemaFieldOrder.SchemaField::isRecursive).toList();
+                        var builders = recursiveShapes.stream()
                                 .map(s -> new SchemaBuilderGenerator(writer,
                                         s,
                                         directive.model(),
                                         directive.context()))
                                 .toList();
-                        var schemas = shapeOrder.stream()
-                                .map(
-                                        s -> new StaticSchemaFieldsGenerator(
-                                                directive,
-                                                writer,
-                                                s))
+                        var resolvers = recursiveShapes.stream()
+                                .map(s -> new ResolverGenerator(writer, s))
                                 .toList();
+                        var schemas = new StaticSchemaFieldsGenerator(directive, shapeOrder, writer);
+                        writer.pushState();
                         writer.putContext("className", className);
                         writer.putContext("schemas", schemas);
                         writer.putContext("builders", builders);
+                        writer.putContext("resolvers", resolvers);
                         writer.write(template);
                         writer.popState();
                     });
@@ -91,204 +93,268 @@ public final class SchemasGenerator
 
     }
 
-    private static final class StaticSchemaFieldsGenerator extends ShapeVisitor.Default<Void> implements Runnable {
+    private static final class StaticSchemaFieldsGenerator implements Runnable {
         private final JavaWriter writer;
-        private final SchemaFieldOrder.SchemaField schemaField;
-        private final Shape shape;
-        private final Model model;
+        private final List<SchemaFieldOrder.SchemaField> schemaFields;
         private final CodeGenerationContext context;
         private final ContextualDirective<CodeGenerationContext, ?> directive;
+        private boolean insideStaticBlock;
 
         private StaticSchemaFieldsGenerator(
                 ContextualDirective<CodeGenerationContext, ?> directive,
-                JavaWriter writer,
-                SchemaFieldOrder.SchemaField schemaField
+                List<SchemaFieldOrder.SchemaField> schemaFields,
+                JavaWriter writer
         ) {
             this.directive = directive;
             this.writer = writer;
-            this.schemaField = schemaField;
-            this.shape = schemaField.shape();
-            this.model = directive.model();
+            this.schemaFields = schemaFields;
             this.context = directive.context();
+            this.insideStaticBlock = false;
         }
 
         @Override
         public void run() {
             writer.pushState();
-            writer.pushState();
-            writer.putContext("schemaClass", Schema.class);
-            writer.putContext("id", CodegenUtils.getOriginalId(shape));
-            writer.putContext("shapeId", ShapeId.class);
-            writer.putContext("schemaBuilder", SchemaBuilder.class);
-            writer.putContext("name", schemaField.fieldName());
-            writer.putContext("traits", new TraitInitializerGenerator(writer, shape, context));
-            writer.putContext("recursive", schemaField.isRecursive());
-            shape.accept(this);
-            writer.popState();
-
-        }
-
-        @Override
-        protected Void getDefault(Shape shape) {
-            throw new IllegalStateException("Tried to create schema field for invalid shape: " + shape);
-        }
-
-        @Override
-        public Void blobShape(BlobShape blobShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createBlob(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void booleanShape(BooleanShape booleanShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createBoolean(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void listShape(ListShape shape) {
-            writer.write(
-                    """
-                            static final ${schemaClass:T} ${name:L} = ${?recursive}${name:L}_BUILDER${/recursive}${^recursive}${schemaClass:T}.listBuilder(${shapeId:T}.from(${id:S})${traits:C})${/recursive}
-                                ${C|}
-                                .build();
-                            """,
-                    (Runnable) () -> shape.getMember().accept(this));
-            return null;
-        }
-
-        @Override
-        public Void mapShape(MapShape shape) {
-            writer.write(
-                    """
-                            static final ${schemaClass:T} ${name:L} = ${?recursive}${name:L}_BUILDER${/recursive}${^recursive}${schemaClass:T}.mapBuilder(${shapeId:T}.from(${id:S})${traits:C})${/recursive}
-                                ${C|}
-                                ${C|}
-                                .build();
-                            """,
-                    (Runnable) () -> shape.getKey().accept(this),
-                    (Runnable) () -> shape.getValue().accept(this));
-            return null;
-        }
-
-        @Override
-        public Void byteShape(ByteShape byteShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createByte(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void shortShape(ShortShape shortShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createShort(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void integerShape(IntegerShape integerShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createInteger(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void longShape(LongShape longShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createLong(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void floatShape(FloatShape floatShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createFloat(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void documentShape(DocumentShape documentShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createDocument(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void doubleShape(DoubleShape doubleShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createDouble(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void bigIntegerShape(BigIntegerShape bigIntegerShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createBigInteger(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void bigDecimalShape(BigDecimalShape bigDecimalShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createBigDecimal(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void structureShape(StructureShape shape) {
-            generateStructMemberSchemas(shape, "structureBuilder");
-            return null;
-        }
-
-        @Override
-        public Void unionShape(UnionShape shape) {
-            generateStructMemberSchemas(shape, "unionBuilder");
-            return null;
-        }
-
-        private void generateStructMemberSchemas(Shape shape, String builderMethod) {
-            writer.pushState();
-            writer.putContext("hasMembers", !shape.members().isEmpty());
-            writer.putContext("builderMethod", builderMethod);
-            writer.write(
-                    """
-                            static final ${schemaClass:T} ${name:L} = ${?recursive}${name:L}_BUILDER${/recursive}${^recursive}${schemaClass:T}.${builderMethod:L}(${shapeId:T}.from(${id:S})${traits:C})${/recursive}${?hasMembers}
-                                ${C|}
-                                ${/hasMembers}.build();
-                            """,
-                    (Runnable) () -> shape.members().forEach(m -> m.accept(this)));
-
+            for (SchemaFieldOrder.SchemaField schemaField : schemaFields) {
+                if (schemaField.isRecursive() && !insideStaticBlock) {
+                    insideStaticBlock = true;
+                    writer.openBlock("\nstatic {");
+                } else if (!schemaField.isRecursive() && insideStaticBlock) {
+                    insideStaticBlock = false;
+                    writer.closeBlock("}\n");
+                }
+                writer.pushState();
+                writer.putContext("schemaClass", Schema.class);
+                writer.putContext("id", CodegenUtils.getOriginalId(schemaField.shape()));
+                writer.putContext("shapeId", ShapeId.class);
+                writer.putContext("schemaBuilder", SchemaBuilder.class);
+                writer.putContext("name", schemaField.fieldName());
+                writer.putContext("traits", new TraitInitializerGenerator(writer, schemaField.shape(), context));
+                schemaField.shape().accept(new StaticSchemaFieldGenerator(writer, schemaField, directive));
+                writer.popState();
+            }
+            if (insideStaticBlock) {
+                writer.closeBlock("}\n");
+            }
             writer.popState();
         }
 
-        @Override
-        public Void memberShape(MemberShape shape) {
-            var target = model.expectShape(shape.getTarget());
-            writer.pushState();
-            writer.putContext("memberName", shape.getMemberName());
-            writer.putContext("schema", directive.context().schemaFieldOrder().getSchemaFieldName(target, writer));
-            writer.putContext("traits", new TraitInitializerGenerator(writer, shape, context));
-            writer.putContext("recursive", CodegenUtils.recursiveShape(model, target));
-            writer.write(".putMember(${memberName:S}, ${schema:L}${?recursive}_BUILDER${/recursive}${traits:C})");
-            writer.popState();
-            return null;
+        private static final class StaticSchemaFieldGenerator extends ShapeVisitor.Default<Void> {
+
+            private final JavaWriter writer;
+            private final SchemaFieldOrder.SchemaField schemaField;
+            private final ContextualDirective<CodeGenerationContext, ?> directive;
+            private final Model model;
+            private final CodeGenerationContext context;
+
+            private StaticSchemaFieldGenerator(
+                    JavaWriter writer,
+                    SchemaFieldOrder.SchemaField schemaField,
+                    ContextualDirective<CodeGenerationContext, ?> directive
+            ) {
+                this.writer = writer;
+                this.schemaField = schemaField;
+                this.directive = directive;
+                this.model = directive.model();
+                this.context = directive.context();
+            }
+
+            @Override
+            protected Void getDefault(Shape shape) {
+                throw new IllegalStateException("Tried to create schema field for invalid shape: " + shape);
+            }
+
+            @Override
+            public Void blobShape(BlobShape blobShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createBlob(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void booleanShape(BooleanShape booleanShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createBoolean(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void listShape(ListShape shape) {
+                String template;
+                if (schemaField.isRecursive()) {
+                    template = """
+                                ${name:L}_BUILDER
+                                    ${C|}
+                                    .build();
+                            """;
+                } else {
+                    template =
+                            """
+                                    static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.listBuilder(${shapeId:T}.from(${id:S})${traits:C})
+                                        ${C|}
+                                        .build();
+                                    """;
+                }
+                writer.write(template, (Runnable) () -> shape.getMember().accept(this));
+
+                return null;
+            }
+
+            @Override
+            public Void mapShape(MapShape shape) {
+                String template;
+                if (schemaField.isRecursive()) {
+                    template = """
+                                ${name:L}_BUILDER
+                                    ${C|}
+                                    ${C|}
+                                    .build();
+                            """;
+                } else {
+                    template =
+                            """
+                                    static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.mapBuilder(${shapeId:T}.from(${id:S})${traits:C})
+                                        ${C|}
+                                        ${C|}
+                                        .build();
+                                    """;
+                }
+                writer.write(template,
+                        (Runnable) () -> shape.getKey().accept(this),
+                        (Runnable) () -> shape.getValue().accept(this));
+                return null;
+            }
+
+            @Override
+            public Void byteShape(ByteShape byteShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createByte(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void shortShape(ShortShape shortShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createShort(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void integerShape(IntegerShape integerShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createInteger(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void longShape(LongShape longShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createLong(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void floatShape(FloatShape floatShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createFloat(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void documentShape(DocumentShape documentShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createDocument(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void doubleShape(DoubleShape doubleShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createDouble(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void bigIntegerShape(BigIntegerShape bigIntegerShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createBigInteger(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void bigDecimalShape(BigDecimalShape bigDecimalShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createBigDecimal(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void structureShape(StructureShape shape) {
+                generateStructMemberSchemas(shape, "structureBuilder");
+                return null;
+            }
+
+            @Override
+            public Void unionShape(UnionShape shape) {
+                generateStructMemberSchemas(shape, "unionBuilder");
+                return null;
+            }
+
+            private void generateStructMemberSchemas(Shape shape, String builderMethod) {
+                String template;
+                if (schemaField.isRecursive()) {
+                    template = """
+                                ${name:L}_BUILDER${?hasMembers}
+                                    ${C|}
+                                    ${/hasMembers}.build();
+                            """;
+                } else {
+                    template =
+                            """
+                                    static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.${builderMethod:L}(${shapeId:T}.from(${id:S})${traits:C})${?hasMembers}
+                                             ${C|}
+                                             ${/hasMembers}.build();
+                                    """;
+                }
+                writer.pushState();
+                writer.putContext("hasMembers", !shape.members().isEmpty());
+                writer.putContext("builderMethod", builderMethod);
+
+                writer.write(
+                        template,
+                        (Runnable) () -> shape.members().forEach(m -> m.accept(this)));
+
+                writer.popState();
+            }
+
+            @Override
+            public Void memberShape(MemberShape shape) {
+                var target = model.expectShape(shape.getTarget());
+                writer.pushState();
+                writer.putContext("memberName", shape.getMemberName());
+                writer.putContext("schema", directive.context().schemaFieldOrder().getSchemaFieldName(target, writer));
+                writer.putContext("traits", new TraitInitializerGenerator(writer, shape, context));
+                writer.putContext("recursive", CodegenUtils.recursiveShape(model, target));
+                writer.write(".putMember(${memberName:S}, ${schema:L}${?recursive}_BUILDER${/recursive}${traits:C})");
+                writer.popState();
+                return null;
+            }
+
+            @Override
+            public Void timestampShape(TimestampShape timestampShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createTimestamp(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
+
+            @Override
+            public Void stringShape(StringShape stringShape) {
+                writer.write(
+                        "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createString(${shapeId:T}.from(${id:S})${traits:C});");
+                return null;
+            }
         }
 
-        @Override
-        public Void timestampShape(TimestampShape timestampShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createTimestamp(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
-
-        @Override
-        public Void stringShape(StringShape stringShape) {
-            writer.write(
-                    "static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.createString(${shapeId:T}.from(${id:S})${traits:C});");
-            return null;
-        }
     }
 
     private static final class SchemaBuilderGenerator extends ShapeVisitor.Default<Void> implements Runnable {
@@ -358,4 +424,16 @@ public final class SchemasGenerator
         }
     }
 
+    private record ResolverGenerator(JavaWriter writer, SchemaFieldOrder.SchemaField schemaField) implements Runnable {
+
+        @Override
+        public void run() {
+            writer.pushState();
+            writer.putContext("schemaClass", Schema.class);
+            writer.putContext("name", schemaField.fieldName());
+            writer.putContext("builderName", schemaField.fieldName() + "_BUILDER");
+            writer.write("static final ${schemaClass:T} ${name:L} = ${builderName:L}.build().resolve();");
+            writer.popState();
+        }
+    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ResolvedRootSchema.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ResolvedRootSchema.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.core.schema;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A Resolved Schema which was initially deferred.
+ */
+final class ResolvedRootSchema extends Schema {
+
+    private final Map<String, Schema> members;
+    private final List<Schema> memberList;
+    private final int requiredMemberCount;
+    private final long requiredStructureMemberBitfield;
+    private final Set<Integer> intEnumValues;
+
+    ResolvedRootSchema(DeferredRootSchema deferredRootSchema) {
+        super(deferredRootSchema.type(),
+                deferredRootSchema.id(),
+                deferredRootSchema.traits,
+                deferredRootSchema.memberBuilders,
+                deferredRootSchema.stringEnumValues);
+        var resolvedMembers = deferredRootSchema.resolvedMembers();
+        this.memberList = resolvedMembers.memberList();
+        this.requiredMemberCount = resolvedMembers.requiredMemberCount();
+        this.requiredStructureMemberBitfield = resolvedMembers.requiredStructureMemberBitfield();
+        this.members = resolvedMembers.members();
+        this.intEnumValues = deferredRootSchema.intEnumValues;
+
+    }
+
+    @Override
+    public List<Schema> members() {
+        return memberList;
+    }
+
+    @Override
+    public Schema member(String memberName) {
+        return members.get(memberName);
+    }
+
+    @Override
+    public Set<Integer> intEnumValues() {
+        return intEnumValues;
+    }
+
+    @Override
+    int requiredMemberCount() {
+        return requiredMemberCount;
+    }
+
+    @Override
+    long requiredByValidationBitmask() {
+        return 0;
+    }
+
+    @Override
+    long requiredStructureMemberBitfield() {
+        return requiredStructureMemberBitfield;
+    }
+
+}

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/Schema.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/Schema.java
@@ -23,7 +23,7 @@ import software.amazon.smithy.model.traits.Trait;
  * <p>Note: when creating a structure schema, all required members must come before optional members.
  */
 public abstract sealed class Schema implements MemberLookup
-        permits RootSchema, MemberSchema, DeferredRootSchema, DeferredMemberSchema {
+        permits RootSchema, MemberSchema, DeferredRootSchema, DeferredMemberSchema, ResolvedRootSchema {
 
     private final ShapeType type;
     private final ShapeId id;
@@ -498,4 +498,15 @@ public abstract sealed class Schema implements MemberLookup
      * This allows for an inexpensive comparison for required structure member validation.
      */
     abstract long requiredStructureMemberBitfield();
+
+    /**
+     * Resolve this Schema and return a resolved instance. The resolved instance can be the same Schema
+     * if the Schema doesn't need any resolution.
+     * This is primarily useful for Schemas of recursive structures which need to be resolved after construction.
+     *
+     * @return A resolved Schema.
+     */
+    public Schema resolve() {
+        return this;
+    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/SchemaBuilder.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/SchemaBuilder.java
@@ -141,7 +141,8 @@ public final class SchemaBuilder {
                     traits,
                     new ArrayList<>(members),
                     Collections.emptySet(),
-                    Collections.emptySet());
+                    Collections.emptySet(),
+                    this);
         } else {
             builtShape = new RootSchema(
                     type,
@@ -153,6 +154,13 @@ public final class SchemaBuilder {
         }
 
         return builtShape;
+    }
+
+    void resolve(Schema schema) {
+        if (!(builtShape instanceof DeferredRootSchema)) {
+            throw new IllegalStateException("Cannot resolve built shape " + id);
+        }
+        this.builtShape = schema;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Now that we have centralized the Schemas in a single class, this gives us a hook to also resolve them eagerly. Doing this avoids having to do volatile reads at runtime.
DynamicSchemas however still need a volatile read, since we don't have a similar hook for them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
