### PR TITLE
Add root-level service exception

### DIFF
--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -387,4 +387,25 @@ public final class CodegenUtils {
     public static boolean isISO8601Date(String string) {
         return ISO_8601_DATE_REGEX.matcher(string).matches();
     }
+
+    /**
+     * Returns the exception class used as the base-level exception for service shapes.
+     *
+     * <p>Exceptions bound to a service that are not an implicit error, framework errors, or an external shape are
+     * code generated to extend from this exception.
+     *
+     * @param packageNamespace The package namespace to use for the service exception.
+     * @param serviceName The name of the service to use for the service exception.
+     * @return the service exception symbol.
+     */
+    public static Symbol getServiceExceptionSymbol(String packageNamespace, String serviceName) {
+        var name = serviceName + "Exception";
+        var filename = String.format("./%s/model/%s.java", packageNamespace.replace(".", "/"), name);
+        return Symbol.builder()
+                .name(name)
+                .namespace(packageNamespace + ".model", ".")
+                .putProperty(SymbolProperties.IS_PRIMITIVE, false)
+                .declarationFile(filename)
+                .build();
+    }
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/SymbolProperties.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/SymbolProperties.java
@@ -66,5 +66,12 @@ public final class SymbolProperties {
      */
     public static final Property<Boolean> EXTERNAL_TYPE = Property.named("external-type");
 
+    /**
+     * Symbol representing the root-level service exception class for a client.
+     *
+     * <p>This property is expected on all {@code Service} shape symbols.
+     */
+    public static final Property<Symbol> SERVICE_EXCEPTION = Property.named("service-exception");
+
     private SymbolProperties() {}
 }

--- a/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ServiceExceptionGenerator.java
+++ b/codegen/core/src/main/java/software/amazon/smithy/java/codegen/generators/ServiceExceptionGenerator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.generators;
+
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.directed.ShapeDirective;
+import software.amazon.smithy.java.codegen.CodeGenerationContext;
+import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.SymbolProperties;
+import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.core.error.ErrorFault;
+import software.amazon.smithy.java.core.error.ModeledException;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class ServiceExceptionGenerator<
+        T extends ShapeDirective<ServiceShape, CodeGenerationContext, JavaCodegenSettings>>
+        implements Consumer<T> {
+
+    @Override
+    public void accept(T directive) {
+        var shape = directive.shape();
+        var delegator = directive.context().writerDelegator();
+        var serviceSymbol = directive.symbolProvider().toSymbol(shape);
+        var errorSymbol = serviceSymbol.expectProperty(SymbolProperties.SERVICE_EXCEPTION);
+
+        var syntheticErrorShape = StructureShape.builder()
+                .id(errorSymbol.getNamespace() + "#" + errorSymbol.getName())
+                .addTrait(new DocumentationTrait(
+                        """
+                                Base-level exception for the service.
+
+                                <p>Some exceptions do not extend from this class, including synthetic, implicit, and shared exception types."""))
+                .addTrait(new ErrorTrait("server"))
+                .build();
+
+        delegator.useFileWriter(errorSymbol.getDeclarationFile(), errorSymbol.getNamespace(), writer -> {
+            writer.pushState(new ClassSection(syntheticErrorShape));
+            var template =
+                    """
+                            public abstract class ${serviceException:L} extends ${modeledException:T} {
+                                protected ${serviceException:L}(
+                                        ${schema:T} schema,
+                                        String message,
+                                        Throwable cause,
+                                        ${errorFault:T} errorType,
+                                        Boolean captureStackTrace,
+                                        boolean deserialized
+                                ) {
+                                    super(schema, message, cause, errorType, captureStackTrace, deserialized);
+                                }
+                            }""";
+            writer.putContext("serviceException", errorSymbol.getName());
+            writer.putContext("modeledException", ModeledException.class);
+            writer.putContext("schema", Schema.class);
+            writer.putContext("errorFault", ErrorFault.class);
+            writer.write(template);
+            writer.popState();
+        });
+    }
+}

--- a/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/ClientJavaSymbolProvider.java
+++ b/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/ClientJavaSymbolProvider.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.codegen.client;
 import static java.lang.String.format;
 
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaSymbolProvider;
 import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.model.Model;
@@ -28,6 +29,8 @@ final class ClientJavaSymbolProvider extends JavaSymbolProvider {
     public Symbol serviceShape(ServiceShape serviceShape) {
         return getSymbolFromName(false).toBuilder()
                 .putProperty(ClientSymbolProperties.ASYNC_SYMBOL, getSymbolFromName(true))
+                .putProperty(SymbolProperties.SERVICE_EXCEPTION,
+                        CodegenUtils.getServiceExceptionSymbol(packageNamespace(), serviceName))
                 .build();
     }
 

--- a/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/DirectedJavaClientCodegen.java
+++ b/codegen/plugins/client/src/main/java/software/amazon/smithy/java/codegen/client/DirectedJavaClientCodegen.java
@@ -18,6 +18,7 @@ import software.amazon.smithy.java.codegen.generators.MapGenerator;
 import software.amazon.smithy.java.codegen.generators.OperationGenerator;
 import software.amazon.smithy.java.codegen.generators.ResourceGenerator;
 import software.amazon.smithy.java.codegen.generators.SchemasGenerator;
+import software.amazon.smithy.java.codegen.generators.ServiceExceptionGenerator;
 import software.amazon.smithy.java.codegen.generators.SharedSerdeGenerator;
 import software.amazon.smithy.java.codegen.generators.StructureGenerator;
 import software.amazon.smithy.java.codegen.generators.UnionGenerator;
@@ -107,6 +108,11 @@ final class DirectedJavaClientCodegen
     public void generateService(GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
         new ClientInterfaceGenerator().accept(directive);
         new ClientImplementationGenerator().accept(directive);
+
+        // Don't generate the root-level service exception when using external types.
+        if (!directive.context().settings().useExternalTypes()) {
+            new ServiceExceptionGenerator<>().accept(directive);
+        }
     }
 
     @Override

--- a/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/DirectedJavaServerCodegen.java
+++ b/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/DirectedJavaServerCodegen.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.java.codegen.generators.MapGenerator;
 import software.amazon.smithy.java.codegen.generators.OperationGenerator;
 import software.amazon.smithy.java.codegen.generators.ResourceGenerator;
 import software.amazon.smithy.java.codegen.generators.SchemasGenerator;
+import software.amazon.smithy.java.codegen.generators.ServiceExceptionGenerator;
 import software.amazon.smithy.java.codegen.generators.SharedSerdeGenerator;
 import software.amazon.smithy.java.codegen.generators.StructureGenerator;
 import software.amazon.smithy.java.codegen.generators.UnionGenerator;
@@ -110,6 +111,11 @@ final class DirectedJavaServerCodegen
     @Override
     public void generateService(GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
         new ServiceGenerator().accept(directive);
+
+        // Don't generate the root-level service exception when using external types.
+        if (!directive.context().settings().useExternalTypes()) {
+            new ServiceExceptionGenerator<>().accept(directive);
+        }
     }
 
     @Override

--- a/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/ServiceJavaSymbolProvider.java
+++ b/codegen/plugins/server/src/main/java/software/amazon/smithy/java/codegen/server/ServiceJavaSymbolProvider.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.codegen.server;
 import static java.lang.String.format;
 
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaSymbolProvider;
 import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.model.Model;
@@ -65,6 +66,8 @@ public final class ServiceJavaSymbolProvider extends JavaSymbolProvider {
         return Symbol.builder()
                 .name(serviceName)
                 .putProperty(SymbolProperties.IS_PRIMITIVE, false)
+                .putProperty(SymbolProperties.SERVICE_EXCEPTION,
+                        CodegenUtils.getServiceExceptionSymbol(packageNamespace(), serviceName))
                 .namespace(format("%s.service", packageNamespace()), ".")
                 .declarationFile(format("./%s/service/%s.java", packageNamespace().replace(".", "/"), serviceName))
                 .build();

--- a/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
+++ b/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
@@ -34,6 +34,9 @@ import software.amazon.smithy.model.shapes.ShapeId;
 final class MockClient extends Client {
     private static final InternalLogger LOGGER = InternalLogger.getLogger(MockClient.class);
 
+    // We inject a synthetic error in the TestTransport that we need to ignore in some tests.
+    private static final String SYNTHETIC_ERROR_SEARCH = "555";
+
     private MockClient(Builder builder) {
         super(builder);
     }
@@ -50,7 +53,8 @@ final class MockClient extends Client {
             return call(input, operation, overrideConfig).exceptionallyCompose(exc -> {
                 if (exc instanceof CompletionException ce
                         && ce.getCause() instanceof CallException apiException
-                        && apiException.getFault().equals(ErrorFault.SERVER)) {
+                        && apiException.getFault().equals(ErrorFault.SERVER)
+                        && exc.getMessage().contains(SYNTHETIC_ERROR_SEARCH)) {
                     LOGGER.debug("Ignoring expected exception", apiException);
                     return CompletableFuture.completedFuture(null);
                 } else {


### PR DESCRIPTION
Generating types for a client or server now will also generate a root-level exception for the service extending from ModeledException. This is not generated when using external types. This allows for catching exceptions of a specific service. However, framework and implicit exceptions are not part of this hierarchy.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
