### PR TITLE
Add a way to register classes without eager load

### DIFF
--- a/core/src/test/java/software/amazon/smithy/java/core/serde/TypeRegistryTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/TypeRegistryTest.java
@@ -80,4 +80,17 @@ public class TypeRegistryTest {
         assertThat(deserialized, instanceOf(Person.class));
         assertThat(((Person) deserialized).name(), equalTo("Phreddie"));
     }
+
+    @Test
+    public void registersLazyTypes() {
+        TypeRegistry registry = TypeRegistry.builder()
+                .putType(ShapeId.from("smithy.example#Person"), () -> Person.class, () -> Person::builder)
+                .build();
+        var person = Person.builder().name("Pharkus").build();
+        var document = Document.of(person);
+        var deserialized = registry.deserialize(document);
+
+        assertThat(deserialized, instanceOf(Person.class));
+        assertThat(((Person) deserialized).name(), equalTo("Pharkus"));
+    }
 }


### PR DESCRIPTION
When registering a lot of classes in a type registry, you don't want to eagerly load all the classes up front. This would pull in virtually the entire graph of the model at startup.

This adds an alternative, albeit more cumbersome, API to register classes and builders with a type registry that only eagerly loads classes on first use by putting them into Suppliers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
