### PR TITLE
Add service schema to clients

### DIFF
--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
@@ -47,14 +47,9 @@ public abstract class Client {
         }
 
         this.config = configBuilder.build();
-
         this.pipeline = ClientPipeline.of(config.protocol(), config.transport());
-
-        // TODO: Add an interceptor to throw service-specific exceptions (e.g., PersonDirectoryClientException).
         this.interceptor = ClientInterceptor.chain(config.interceptors());
-
         this.identityResolvers = IdentityResolvers.of(config.identityResolvers());
-
         this.typeRegistry = typeRegistry();
 
         if (config.retryStrategy() != null) {
@@ -184,7 +179,9 @@ public abstract class Client {
          */
         @SuppressWarnings("unchecked")
         public B withConfiguration(ClientConfig config) {
-            configBuilder.transport(config.transport())
+            configBuilder
+                    .service(config.service())
+                    .transport(config.transport())
                     .protocol(config.protocol())
                     .endpointResolver(config.endpointResolver())
                     .authSchemeResolver(config.authSchemeResolver())

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientConfig.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientConfig.java
@@ -19,6 +19,7 @@ import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
 import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.retries.api.RetryStrategy;
 
@@ -48,6 +49,7 @@ public final class ClientConfig {
     private final List<IdentityResolver<?>> identityResolvers;
     private final Context context;
     private final Set<Class<? extends ClientPlugin>> appliedPlugins;
+    private final ApiService service;
 
     private final RetryStrategy retryStrategy;
     private final String retryScope;
@@ -86,6 +88,7 @@ public final class ClientConfig {
 
         this.context = Context.unmodifiableCopy(builder.context);
         this.appliedPlugins = Collections.unmodifiableSet(new LinkedHashSet<>(builder.appliedPlugins));
+        this.service = Objects.requireNonNull(builder.service, "Missing required service schema");
     }
 
     /**
@@ -111,6 +114,15 @@ public final class ClientConfig {
      */
     public Set<Class<? extends ClientPlugin>> appliedPlugins() {
         return appliedPlugins;
+    }
+
+    /**
+     * Get the configured service schema.
+     *
+     * @return the service schema.
+     */
+    public ApiService service() {
+        return service;
     }
 
     /**
@@ -244,6 +256,7 @@ public final class ClientConfig {
      * Static builder for ClientConfiguration.
      */
     public static final class Builder {
+        private ApiService service;
         private ClientTransport<?, ?> transport;
         private ClientProtocol<?, ?> protocol;
         private EndpointResolver endpointResolver;
@@ -258,6 +271,7 @@ public final class ClientConfig {
 
         private Builder copyBuilder() {
             Builder builder = new Builder();
+            builder.service = service;
             builder.transport = transport;
             builder.protocol = protocol;
             builder.endpointResolver = endpointResolver;
@@ -270,6 +284,13 @@ public final class ClientConfig {
             builder.retryScope = retryScope;
             builder.appliedPlugins.addAll(appliedPlugins);
             return builder;
+        }
+
+        /**
+         * @return Get the service schema.
+         */
+        public ApiService service() {
+            return service;
         }
 
         /**
@@ -340,6 +361,17 @@ public final class ClientConfig {
          */
         public String retryScope() {
             return retryScope;
+        }
+
+        /**
+         * Set the service schema.
+         *
+         * @param service The service schema.
+         * @return Returns the builder.
+         */
+        public Builder service(ApiService service) {
+            this.service = service;
+            return this;
         }
 
         /**

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/endpoint/EndpointResolverTest.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/endpoint/EndpointResolverTest.java
@@ -11,6 +11,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
@@ -155,6 +156,11 @@ public class EndpointResolverTest {
         public List<ShapeId> effectiveAuthSchemes() {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public ApiService service() {
+            return null;
+        }
     }
 
     private static final class TestOperationStaticPrefix implements
@@ -189,6 +195,11 @@ public class EndpointResolverTest {
         @Override
         public Schema outputSchema() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ApiService service() {
+            return null;
         }
 
         @Override

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/interceptors/TestStructs.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/interceptors/TestStructs.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.client.core.interceptors;
 
 import java.util.List;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
@@ -53,6 +54,11 @@ public final class TestStructs {
         @Override
         public List<ShapeId> effectiveAuthSchemes() {
             return List.of();
+        }
+
+        @Override
+        public ApiService service() {
+            return null;
         }
     };
 

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/pagination/models/PaginationService.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/pagination/models/PaginationService.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.pagination.models;
+
+import software.amazon.smithy.java.core.schema.ApiService;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class PaginationService implements ApiService {
+    @Override
+    public Schema schema() {
+        return Schema.createService(ShapeId.from("smithy.example#Pagination"));
+    }
+}

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/pagination/models/TestOperationPaginated.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/pagination/models/TestOperationPaginated.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.client.core.pagination.models;
 
 import java.util.List;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
@@ -56,5 +57,10 @@ public final class TestOperationPaginated implements ApiOperation<GetFoosInput, 
     @Override
     public List<ShapeId> effectiveAuthSchemes() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ApiService service() {
+        return new PaginationService();
     }
 }

--- a/client/client-http/src/test/java/software/amazon/smithy/java/client/http/JavaHttpClientTest.java
+++ b/client/client-http/src/test/java/software/amazon/smithy/java/client/http/JavaHttpClientTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.aws.client.awsjson.AwsJson1Protocol;
 import software.amazon.smithy.java.client.core.ClientConfig;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
+import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class JavaHttpClientTest {
@@ -82,6 +83,8 @@ public class JavaHttpClientTest {
         builder.protocol(new AwsJson1Protocol(ShapeId.from("foo#Bar")));
         builder.transport(new JavaHttpClientTransport());
         builder.endpointResolver(EndpointResolver.staticEndpoint(new URI("localhost:8080")));
+        var serviceSchema = Schema.createService(ShapeId.from("foo#Bar"));
+        builder.service(() -> serviceSchema);
         var config = builder.build();
 
         assertThat(config.interceptors(), not(empty()));

--- a/client/client-http/src/test/java/software/amazon/smithy/java/client/http/plugins/UserAgentPluginTest.java
+++ b/client/client-http/src/test/java/software/amazon/smithy/java/client/http/plugins/UserAgentPluginTest.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.java.client.core.FeatureId;
 import software.amazon.smithy.java.client.core.interceptors.RequestHook;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
@@ -132,6 +133,11 @@ public class UserAgentPluginTest {
 
             @Override
             public Schema outputSchema() {
+                return null;
+            }
+
+            @Override
+            public ApiService service() {
                 return null;
             }
 

--- a/client/client-waiters/src/test/java/software/amazon/smithy/java/client/waiters/models/TestOperationWaitable.java
+++ b/client/client-waiters/src/test/java/software/amazon/smithy/java/client/waiters/models/TestOperationWaitable.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.client.waiters.models;
 
 import java.util.List;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
@@ -48,5 +49,10 @@ public final class TestOperationWaitable implements ApiOperation<GetFoosInput, G
     @Override
     public List<ShapeId> effectiveAuthSchemes() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ApiService service() {
+        return new WaiterApiService();
     }
 }

--- a/client/client-waiters/src/test/java/software/amazon/smithy/java/client/waiters/models/WaiterApiService.java
+++ b/client/client-waiters/src/test/java/software/amazon/smithy/java/client/waiters/models/WaiterApiService.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.waiters.models;
+
+import software.amazon.smithy.java.core.schema.ApiService;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class WaiterApiService implements ApiService {
+    @Override
+    public Schema schema() {
+        return Schema.createService(ShapeId.from("smithy.example#Waiter"));
+    }
+}

--- a/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicOperation.java
+++ b/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicOperation.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.dynamicclient;
 import java.util.List;
 import java.util.Set;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.schema.TraitKey;
@@ -18,7 +19,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 
 final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDocument> {
 
-    private final ShapeId service;
+    private final ApiService service;
     private final Schema operationSchema;
     private final Schema inputSchema;
     private final Schema outputSchema;
@@ -27,7 +28,7 @@ final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDoc
     private final List<ShapeId> effectiveAuthSchemes;
 
     public DynamicOperation(
-            ShapeId service,
+            ApiService service,
             Schema operationSchema,
             Schema inputSchema,
             Schema outputSchema,
@@ -60,6 +61,11 @@ final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDoc
     }
 
     @Override
+    public ApiService service() {
+        return service;
+    }
+
+    @Override
     public Schema inputSchema() {
         return inputSchema;
     }
@@ -71,12 +77,12 @@ final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDoc
 
     @Override
     public ShapeBuilder<WrappedDocument> inputBuilder() {
-        return SchemaConverter.createDocumentBuilder(inputSchema(), service);
+        return SchemaConverter.createDocumentBuilder(inputSchema(), service.schema().id());
     }
 
     @Override
     public ShapeBuilder<WrappedDocument> outputBuilder() {
-        return SchemaConverter.createDocumentBuilder(outputSchema(), service);
+        return SchemaConverter.createDocumentBuilder(outputSchema(), service.schema().id());
     }
 
     @Override

--- a/client/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicClientTest.java
+++ b/client/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicClientTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait;
 import software.amazon.smithy.java.aws.client.awsjson.AwsJson1Protocol;
 import software.amazon.smithy.java.client.core.ClientTransport;
 import software.amazon.smithy.java.client.core.MessageExchange;
@@ -26,6 +27,7 @@ import software.amazon.smithy.java.client.http.HttpMessageExchange;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.error.CallException;
 import software.amazon.smithy.java.core.error.ModeledException;
+import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.http.api.HttpRequest;
 import software.amazon.smithy.java.http.api.HttpResponse;
@@ -89,6 +91,21 @@ public class DynamicClientTest {
     @Test
     public void requiresServiceAndModel() {
         Assertions.assertThrows(NullPointerException.class, () -> DynamicClient.builder().build());
+    }
+
+    @Test
+    public void createsServiceSchema() throws Exception {
+        var client = DynamicClient.builder()
+                .service(service)
+                .model(model)
+                .protocol(new AwsJson1Protocol(service))
+                .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+                .transport(mockTransport())
+                .endpointResolver(EndpointResolver.staticEndpoint("https://foo.com"))
+                .build();
+
+        assertThat(client.config().service().schema().id(), equalTo(service));
+        assertThat(client.config().service().schema().hasTrait(TraitKey.get(AwsJson1_0Trait.class)), is(true));
     }
 
     @Test

--- a/client/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicOperationTest.java
+++ b/client/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicOperationTest.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.core.schema.ApiService;
+import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.java.dynamicschemas.SchemaConverter;
@@ -50,9 +52,12 @@ public class DynamicOperationTest {
         var input = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#PutFooInput")));
         var output = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#PutFooOutput")));
 
+        var serviceSchema = Schema.createService(ShapeId.from("smithy.example#S"));
+        ApiService apiService = () -> serviceSchema;
+
         var e = Assertions.assertThrows(UnsupportedOperationException.class, () -> {
             DynamicOperation o = new DynamicOperation(
-                    ShapeId.from("smithy.example#S"),
+                    apiService,
                     operationSchema,
                     input,
                     output,
@@ -86,8 +91,11 @@ public class DynamicOperationTest {
         var input = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#PutFooInput")));
         var output = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#PutFooOutput")));
 
+        var serviceSchema = Schema.createService(ShapeId.from("smithy.example#S"));
+        ApiService apiService = () -> serviceSchema;
+
         var o = new DynamicOperation(
-                ShapeId.from("smithy.example#S"),
+                apiService,
                 operationSchema,
                 input,
                 output,

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/SymbolProperties.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/SymbolProperties.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.codegen;
 
 import software.amazon.smithy.codegen.core.Property;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.java.core.schema.ApiService;
 
 /**
  * Contains properties that may be added to symbols by smithy-java.
@@ -72,6 +73,13 @@ public final class SymbolProperties {
      * <p>This property is expected on all {@code Service} shape symbols.
      */
     public static final Property<Symbol> SERVICE_EXCEPTION = Property.named("service-exception");
+
+    /**
+     * Symbol representing the {@link ApiService} of a service.
+     *
+     * <p>This property is expected on all {@code Service} shape symbols.
+     */
+    public static final Property<Symbol> SERVICE_API_SERVICE = Property.named("service-api-service");
 
     private SymbolProperties() {}
 }

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ApiServiceGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ApiServiceGenerator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.generators;
+
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
+import software.amazon.smithy.java.codegen.CodeGenerationContext;
+import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.SymbolProperties;
+import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.core.schema.ApiService;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class ApiServiceGenerator
+        implements Consumer<GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings>> {
+
+    @Override
+    public void accept(GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
+        var shape = directive.shape();
+        var delegator = directive.context().writerDelegator();
+        var serviceSymbol = directive.symbolProvider().toSymbol(shape);
+        var apiSymbol = serviceSymbol.expectProperty(SymbolProperties.SERVICE_API_SERVICE);
+        var syntheticShape = StructureShape.builder()
+                .id(apiSymbol.getNamespace() + "#" + apiSymbol.getName())
+                .addTrait(new DocumentationTrait("Service API schema"))
+                .build();
+
+        delegator.useFileWriter(apiSymbol.getDeclarationFile(), apiSymbol.getNamespace(), writer -> {
+            writer.pushState(new ClassSection(syntheticShape));
+            var template = """
+                    public final class ${serviceApiName:L} implements ${apiServiceType:T} {
+                        private static final ${serviceApiName:L} $$INSTANCE = new ${serviceApiName:L}();
+                        private ${schema:C}
+
+                        /**
+                         * Get an instance of this {@code ApiService}.
+                         *
+                         * @return An instance of this class.
+                         */
+                        public static ${serviceApiName:L} instance() {
+                            return $$INSTANCE;
+                        }
+
+                        private ${serviceApiName:L}() {}
+
+                        @Override
+                        public ${sdkSchema:N} schema() {
+                            return $$SCHEMA;
+                        }
+                    }""";
+            writer.putContext("apiServiceType", ApiService.class);
+            writer.putContext("serviceApiName", apiSymbol.getName());
+            writer.putContext("sdkSchema", Schema.class);
+            writer.putContext("schema", new SchemaFieldGenerator(directive, writer, shape));
+            writer.write(template);
+            writer.popState();
+        });
+    }
+}

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ResourceGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ResourceGenerator.java
@@ -5,25 +5,24 @@
 
 package software.amazon.smithy.java.codegen.generators;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.directed.ContextualDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateResourceDirective;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
+import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.core.schema.ApiResource;
+import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.BottomUpIndex;
-import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -73,19 +72,17 @@ public final class ResourceGenerator
                                     return $$PROPERTIES;
                                 }
 
-                                ${lifecycleOperations:C|}
-                                ${?hasCollectionOperations}
+                                ${?specificApiServiceType}
                                 @Override
-                                public ${list:T}<${sdkSchema:T}> collectionOperations() {
-                                    return $$COLLECTION_OPERATIONS;
+                                public ${apiServiceType:T} service() {
+                                    return ${specificApiServiceType:T}.instance();
                                 }
-                                ${/hasCollectionOperations}
-                                ${?hasOperations}
+                                ${/specificApiServiceType}${^specificApiServiceType}
                                 @Override
-                                public ${list:T}<${sdkSchema:T}> operations() {
-                                    return $$OPERATIONS;
+                                public ${apiServiceType:T} service() {
+                                    return null;
                                 }
-                                ${/hasOperations}
+                                ${/specificApiServiceType}
                                 ${?hasResource}
                                 @Override
                                 public ${resourceType:T} boundResource() {
@@ -114,21 +111,21 @@ public final class ResourceGenerator
                                     directive,
                                     writer,
                                     shape));
-                    writer.putContext(
-                            "lifecycleOperations",
-                            new LifecycleOperationGenerator(
-                                    writer,
-                                    directive.symbolProvider(),
-                                    directive.model(),
-                                    shape));
-                    writer.putContext("hasCollectionOperations", !shape.getCollectionOperations().isEmpty());
-                    writer.putContext("hasOperations", !shape.getOperations().isEmpty());
+
                     var bottomUpIndex = BottomUpIndex.of(directive.model());
                     var resourceOptional = bottomUpIndex.getResourceBinding(directive.service(), shape);
                     writer.putContext("hasResource", resourceOptional.isPresent());
                     resourceOptional.ifPresent(
                             resourceShape -> writer.putContext("resource",
                                     directive.symbolProvider().toSymbol(resourceShape)));
+
+                    writer.putContext("apiServiceType", ApiService.class);
+                    var apiService = CodegenUtils.tryGetServiceProperty(
+                            directive,
+                            SymbolProperties.SERVICE_API_SERVICE);
+                    if (apiService != null) {
+                        writer.putContext("specificApiServiceType", apiService);
+                    }
 
                     writer.write(template);
                     writer.popState();
@@ -161,70 +158,12 @@ public final class ResourceGenerator
                             private static final ${map:T}<${string:T}, ${sdkSchema:T}> $$PROPERTIES = ${map:T}.of(${#props}${key:S}, ${value:L}${^key.last},
                                 ${/key.last}${/props});
                             """);
-            if (!resourceShape.getCollectionOperations().isEmpty()) {
-                writer.putContext("colOperations", getOperationSymbols(resourceShape.getCollectionOperations()));
-                writer.write(
-                        """
-                                private static final ${list:T}<${sdkSchema:T}>$$COLLECTION_OPERATIONS = ${list:T}.of(${#colOperations}${value:T}.$$SCHEMA${^key.last},
-                                    ${/key.last}${/colOperations});""");
-            }
-            if (!resourceShape.getOperations().isEmpty()) {
-                writer.putContext("operations", getOperationSymbols(resourceShape.getOperations()));
-                writer.write(
-                        """
-                                private static final ${list:T}<${sdkSchema:T}> $$OPERATIONS = ${list:T}.of(${#operations}${value:T}.$$SCHEMA${^key.last},
-                                    ${/key.last}${/operations});""");
-            }
             writer.popState();
         }
 
         private String getSchema(ShapeId value) {
             var target = model.expectShape(value);
             return directive.context().schemaFieldOrder().getSchemaFieldName(target, writer);
-        }
-
-        private List<Symbol> getOperationSymbols(Set<ShapeId> shapeIds) {
-            List<Symbol> operations = new ArrayList<>();
-            for (var operation : resourceShape.getOperations()) {
-                var op = symbolProvider.toSymbol(model.expectShape(operation));
-                operations.add(op);
-            }
-            return operations;
-        }
-    }
-
-    private record LifecycleOperationGenerator(
-            JavaWriter writer,
-            SymbolProvider symbolProvider,
-            Model model,
-            ResourceShape resourceShape) implements Runnable {
-
-        @Override
-        public void run() {
-            writer.pushState();
-            writer.putContext("shapeId", ShapeId.class);
-            resourceShape.getCreate().ifPresent(id -> writeLifecycleOp(id, "create"));
-            resourceShape.getPut().ifPresent(id -> writeLifecycleOp(id, "put"));
-            resourceShape.getRead().ifPresent(id -> writeLifecycleOp(id, "read"));
-            resourceShape.getUpdate().ifPresent(id -> writeLifecycleOp(id, "update"));
-            resourceShape.getDelete().ifPresent(id -> writeLifecycleOp(id, "delete"));
-            resourceShape.getList().ifPresent(id -> writeLifecycleOp(id, "list"));
-            writer.popState();
-        }
-
-        private void writeLifecycleOp(ShapeId operationShapeId, String lifecycleOperation) {
-            var operationShape = model.expectShape(operationShapeId, OperationShape.class);
-            writer.pushState();
-            writer.putContext("lifecycleOperation", lifecycleOperation);
-            writer.putContext("operation", symbolProvider.toSymbol(operationShape));
-            writer.write("""
-                    @Override
-                    public ${sdkSchema:T} ${lifecycleOperation:L}() {
-                        return ${operation:T}.$$SCHEMA;
-                    }
-                    """);
-            writer.newLine();
-            writer.popState();
         }
     }
 }

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -123,13 +123,8 @@ public final class StructureGenerator<
             writer.putContext("shape", directive.symbol());
             writer.putContext("serializableStruct", SerializableStruct.class);
 
-            var service = directive.service();
-            var serviceSymbol = service != null ? directive.symbolProvider().toSymbol(service) : null;
-            if (serviceSymbol == null) {
-                writer.putContext("sdkException", ModeledException.class);
-            } else {
-                writer.putContext("sdkException", serviceSymbol.expectProperty(SymbolProperties.SERVICE_EXCEPTION));
-            }
+            var sdkError = CodegenUtils.tryGetServiceProperty(directive, SymbolProperties.SERVICE_EXCEPTION);
+            writer.putContext("sdkException", sdkError == null ? ModeledException.class : sdkError);
 
             writer.putContext("id", new IdStringGenerator(writer, shape));
             writer.putContext(

--- a/codegen/plugins/client-codegen/src/it/java/software/amazon/smithy/java/codegen/client/GenericClientTest.java
+++ b/codegen/plugins/client-codegen/src/it/java/software/amazon/smithy/java/codegen/client/GenericClientTest.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.java.codegen.client.util.EchoServer;
 import software.amazon.smithy.java.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.http.api.HttpRequest;
 import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 public class GenericClientTest {
     private static final EchoServer server = new EchoServer();
@@ -157,5 +158,16 @@ public class GenericClientTest {
         var input = EchoInput.builder().string(value).build();
         var output = client.echo(input);
         assertEquals(value, output.string());
+    }
+
+    @Test
+    public void generatedApiService() {
+        var client = TestServiceClient.builder()
+                .protocol(new RestJsonClientProtocol(PreludeSchemas.DOCUMENT.id()))
+                .endpointResolver(ENDPOINT_RESOLVER)
+                .build();
+
+        assertEquals(client.config().service().schema().id(),
+                ShapeId.from("smithy.java.codegen.server.test#TestService"));
     }
 }

--- a/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/ClientJavaSymbolProvider.java
+++ b/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/ClientJavaSymbolProvider.java
@@ -31,6 +31,8 @@ final class ClientJavaSymbolProvider extends JavaSymbolProvider {
                 .putProperty(ClientSymbolProperties.ASYNC_SYMBOL, getSymbolFromName(true))
                 .putProperty(SymbolProperties.SERVICE_EXCEPTION,
                         CodegenUtils.getServiceExceptionSymbol(packageNamespace(), serviceName))
+                .putProperty(SymbolProperties.SERVICE_API_SERVICE,
+                        CodegenUtils.getServiceApiSymbol(packageNamespace(), serviceName))
                 .build();
     }
 

--- a/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/DirectedJavaClientCodegen.java
+++ b/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/DirectedJavaClientCodegen.java
@@ -12,6 +12,7 @@ import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.client.generators.ClientImplementationGenerator;
 import software.amazon.smithy.java.codegen.client.generators.ClientInterfaceGenerator;
+import software.amazon.smithy.java.codegen.generators.ApiServiceGenerator;
 import software.amazon.smithy.java.codegen.generators.EnumGenerator;
 import software.amazon.smithy.java.codegen.generators.ListGenerator;
 import software.amazon.smithy.java.codegen.generators.MapGenerator;
@@ -109,8 +110,8 @@ final class DirectedJavaClientCodegen
         new ClientInterfaceGenerator().accept(directive);
         new ClientImplementationGenerator().accept(directive);
 
-        // Don't generate the root-level service exception when using external types.
         if (!directive.context().settings().useExternalTypes()) {
+            new ApiServiceGenerator().accept(directive);
             new ServiceExceptionGenerator<>().accept(directive);
         }
     }

--- a/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
+++ b/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
@@ -32,6 +32,7 @@ import software.amazon.smithy.java.client.core.pagination.Paginator;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.java.codegen.client.ClientSymbolProperties;
 import software.amazon.smithy.java.codegen.client.sections.ClientInterfaceAdditionalMethodsSection;
 import software.amazon.smithy.java.codegen.integrations.core.GenericTraitInitializer;
@@ -132,7 +133,9 @@ public final class ClientInterfaceGenerator
                                             ${defaultAuth:C|}${/defaultSchemes}
 
                                             private Builder() {${?defaultSchemes}
-                                                configBuilder().putSupportedAuthSchemes(${#defaultSchemes}${value:L}.createAuthScheme(${key:L})${^key.last}, ${/key.last}${/defaultSchemes});
+                                                configBuilder()
+                                                    .putSupportedAuthSchemes(${#defaultSchemes}${value:L}.createAuthScheme(${key:L})${^key.last}, ${/key.last}${/defaultSchemes})
+                                                    .service(${serviceApi:T}.instance());
                                             ${/defaultSchemes}}
 
                                             @Override
@@ -203,6 +206,9 @@ public final class ClientInterfaceGenerator
                     writer.putContext("hasDefaults", !defaultPlugins.isEmpty());
                     writer.putContext("defaultPlugins", new PluginPropertyWriter(writer, defaultPlugins));
                     writer.putContext("settings", getBuilderSettings(directive.settings()));
+
+                    var serviceSymbol = directive.symbolProvider().toSymbol(directive.service());
+                    writer.putContext("serviceApi", serviceSymbol.expectProperty(SymbolProperties.SERVICE_API_SERVICE));
                     writer.write(template);
                     writer.popState();
                 });

--- a/codegen/plugins/server-codegen/src/main/java/software/amazon/smithy/java/codegen/server/DirectedJavaServerCodegen.java
+++ b/codegen/plugins/server-codegen/src/main/java/software/amazon/smithy/java/codegen/server/DirectedJavaServerCodegen.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.codegen.core.directed.GenerateUnionDirective;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.codegen.generators.ApiServiceGenerator;
 import software.amazon.smithy.java.codegen.generators.EnumGenerator;
 import software.amazon.smithy.java.codegen.generators.ListGenerator;
 import software.amazon.smithy.java.codegen.generators.MapGenerator;
@@ -112,8 +113,8 @@ final class DirectedJavaServerCodegen
     public void generateService(GenerateServiceDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
         new ServiceGenerator().accept(directive);
 
-        // Don't generate the root-level service exception when using external types.
         if (!directive.context().settings().useExternalTypes()) {
+            new ApiServiceGenerator().accept(directive);
             new ServiceExceptionGenerator<>().accept(directive);
         }
     }

--- a/codegen/plugins/server-codegen/src/main/java/software/amazon/smithy/java/codegen/server/ServiceJavaSymbolProvider.java
+++ b/codegen/plugins/server-codegen/src/main/java/software/amazon/smithy/java/codegen/server/ServiceJavaSymbolProvider.java
@@ -68,6 +68,8 @@ public final class ServiceJavaSymbolProvider extends JavaSymbolProvider {
                 .putProperty(SymbolProperties.IS_PRIMITIVE, false)
                 .putProperty(SymbolProperties.SERVICE_EXCEPTION,
                         CodegenUtils.getServiceExceptionSymbol(packageNamespace(), serviceName))
+                .putProperty(SymbolProperties.SERVICE_API_SERVICE,
+                        CodegenUtils.getServiceApiSymbol(packageNamespace(), serviceName))
                 .namespace(format("%s.service", packageNamespace()), ".")
                 .declarationFile(format("./%s/service/%s.java", packageNamespace().replace(".", "/"), serviceName))
                 .build();

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ApiOperation.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ApiOperation.java
@@ -108,9 +108,17 @@ public interface ApiOperation<I extends SerializableStruct, O extends Serializab
     }
 
     /**
+     * Get the service shape that the operation is contained within.
+     *
+     * @return the service shape of the operation.
+     */
+    ApiService service();
+
+    /**
      * Api Resource that this operation is bound to, if any.
      *
-     * <p>Note: Operations can be bound to only a single resource within a service, and may be bound to the service directly.
+     * <p>Note: Operations can be bound to only a single resource within a service, and may be bound to the service
+     * directly.
      *
      * @return Resource the operation is bound to or null if the operation has no parent resource.
      */

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ApiResource.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ApiResource.java
@@ -6,7 +6,6 @@
 package software.amazon.smithy.java.core.schema;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -39,75 +38,12 @@ public interface ApiResource {
     }
 
     /**
-     * Lifecycle operation used to create the resource.
+     * Get the service shape that the resource is contained within.
      *
-     * @return Schema of the create lifecycle operation, or null
+     * @return the service shape at the root of the resource tree.
      */
-    default Schema create() {
+    default ApiService service() {
         return null;
-    }
-
-    /**
-     * Idempotent lifecycle operation used to create the resource.
-     *
-     * @return Schema of the put lifecycle operation, or null.
-     */
-    default Schema put() {
-        return null;
-    }
-
-    /**
-     * Lifecycle operation used to read the resource.
-     *
-     * @return Schema of the read lifecycle operation, or null
-     */
-    default Schema read() {
-        return null;
-    }
-
-    /**
-     * Lifecycle operation used to create the resource.
-     *
-     * @return Schema of the update lifecycle operation, or null
-     */
-    default Schema update() {
-        return null;
-    }
-
-    /**
-     * Lifecycle operation used to delete the resource.
-     *
-     * @return Schema of the delete lifecycle operation, or null
-     */
-    default Schema delete() {
-        return null;
-    }
-
-    /**
-     * Lifecycle operation used to list resources of this type.
-     *
-     * @return Schema of the list lifecycle operation, or null
-     */
-    default Schema list() {
-        return null;
-    }
-
-    /**
-     * Non-lifecycle collection operations bound to the resource, if any.
-     *
-     * @return list of bound non-lifecycle collection operation schemas.
-     */
-    default List<Schema> collectionOperations() {
-        return Collections.emptyList();
-    }
-
-    /**
-     * Non-lifecycle instance operations bound to the resource, if any.
-     *
-     * @return list of bound non-lifecycle operation schemas.
-     */
-    default List<Schema> operations() {
-        return Collections.emptyList();
     }
 
     /**

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ApiService.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ApiService.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.core.schema;
+
+/**
+ * Represents a modeled Smithy service.
+ */
+public interface ApiService {
+    /**
+     * Get the schema of the service.
+     *
+     * @return Returns the service schema, including the shape ID and relevant traits.
+     */
+    Schema schema();
+}

--- a/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
+++ b/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.java.core.error.CallException;
 import software.amazon.smithy.java.core.error.ErrorFault;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.java.logging.InternalLogger;
@@ -78,6 +79,8 @@ final class MockClient extends Client {
             configBuilder().transport(new PlaceHolderTransport<>(HttpMessageExchange.INSTANCE));
             configBuilder().authSchemeResolver(AuthSchemeResolver.NO_AUTH);
             configBuilder().endpointResolver(EndpointResolver.staticEndpoint("http://example.com"));
+            var serviceSchema = Schema.createService(ShapeId.from("smithy.test#Service"));
+            configBuilder().service(() -> serviceSchema);
             return new MockClient(this);
         }
     }


### PR DESCRIPTION
Clients now get access to the schema of the service, providing the shape ID and traits of the service allowed for code generation. This can be used to know what service is being called for telemetry, or implement things like endpoint resolvers or custom auth handling based on traits applied to a service.

Each generated ApiOperation now provides a getter called `service()` to get the generated ApiService for the client. Resources get this method too. The generated ApiService only provides the schema of the service. It doesn't provide a full accounting of every operation or resource within the service as there isn't a clear use for that, it adds complexity due to bidirectional references, and we want to avoid eagerly loading every shape in a service when the ApiService is loaded. This commit also simplifies the generated ApiResource for this same reason, removing the operation and sub-resource schemas.

DynamicClient will now automatically generate an ApiService based on the Smithy model.

----

You can get the service schema in an interceptor using:

```java
var client = ExampleClient.builder()
    .addInterceptor(new ClientInterceptor() {
        @Override
        public void readBeforeAttempt(RequestHook<?, ?, ?> hook) {
            var service = hook.operation().service();
        }
    })
    // ...
    .build();
```

Here is an example generated ApiService schema class.

```java
package software.amazon.smithy.java.examples.dynamodb.model;

import software.amazon.smithy.java.core.schema.ApiService;
import software.amazon.smithy.java.core.schema.Schema;
import software.amazon.smithy.model.shapes.ShapeId;
import software.amazon.smithy.model.traits.XmlNamespaceTrait;
import software.amazon.smithy.utils.SmithyGenerated;

/**
 * Service API schema.
 */
@SmithyGenerated
public final class DynamoDBApiService implements ApiService {
    private static final DynamoDBApiService $INSTANCE = new DynamoDBApiService();
    private static final Schema $SCHEMA = Schema.createService(ShapeId.from("com.amazonaws.dynamodb#DynamoDB_20120810"),
        XmlNamespaceTrait.builder().uri("http://dynamodb.amazonaws.com/doc/2012-08-10/").build());

    /**
     * Get an instance of this {@code ApiService}.
     *
     * @return An instance of this class.
     */
    public static DynamoDBApiService instance() {
        return $INSTANCE;
    }

    private DynamoDBApiService() {}

    @Override
    public Schema schema() {
        return $SCHEMA;
    }
}
```

Here is an example of an ApiOperation that references it:

```java
@SmithyGenerated
public final class DescribeTable implements ApiOperation<DescribeTableInput, DescribeTableOutput> {
    // ...

    @Override
    public DynamoDBApiService service() {
        return DynamoDBApiService.instance();
    }
}
```

Here's an example of an operation that is bound to a resource but still provides direct access to the service:

```java
@SmithyGenerated
public final class GetOrder implements ApiOperation<GetOrderInput, GetOrderOutput> {

    // ...

    @Override
    public CoffeeShopApiService service() {
        return CoffeeShopApiService.instance();
    }

    @Override
    public ApiResource boundResource() {
        return Order.instance();
    }
}
```

Here is an example of a generated resource that provides access to the service:

```java
/**
 * An Order resource, which has an id and describes an order by the type of coffee
 * and the order's status
 */
@SmithyGenerated
public final class Order implements ApiResource {
    private static final Order $INSTANCE = new Order();
    private static final Map<String, Schema> $IDENTIFIERS = Map.of("id", Schemas.UUID);
    private static final Map<String, Schema> $PROPERTIES = Map.of("coffeeType", CoffeeType.$SCHEMA,
        "status", OrderStatus.$SCHEMA);

    private static final Schema $SCHEMA = Schema.createResource(ShapeId.from("com.example#Order"));

    public static final ShapeId $ID = $SCHEMA.id();

    /**
     * Get an instance of this {@code ApiResource}.
     *
     * @return An instance of this class.
     */
    public static Order instance() {
        return $INSTANCE;
    }

    private Order() {}

    @Override
    public Schema schema() {
        return $SCHEMA;
    }

    @Override
    public Map<String, Schema> identifiers() {
        return $IDENTIFIERS;
    }

    @Override
    public Map<String, Schema> properties() {
        return $PROPERTIES;
    }

    @Override
    public CoffeeShopApiService service() {
        return CoffeeShopApiService.instance();
    }
}
```

A builder for a generated client hooks up the service schema in the config:

```java
final class Builder extends Client.Builder<TestServiceClient, Builder> implements TestSettings<Builder> {
        // ...

        private Builder() {
            configBuilder()
                .putSupportedAuthSchemes(testAuthSchemeSchemeFactory.createAuthScheme(testAuthSchemeScheme))
                .service(TestServiceApiService.instance());
        }

        // ...
```