### PR TITLE
Add integration tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
+      - name: Integration tests
+        run: ./gradlew integ -Plog-tests --stacktrace
+
       - name: Allow long file names in git for windows
         if: matrix.os == 'windows-latest'
         run: git config --system core.longpaths true


### PR DESCRIPTION
*Description of changes:*
- At some point, integ tests were removed from CI (or they were never added in the first place)
- [One test](https://github.com/smithy-lang/smithy-java/blob/main/examples/event-streaming-client/src/it/java/software/amazon/smithy/java/example/eventstreaming/EventStreamTest.java#L29) is disabled currently, it should be fixed whenever possible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
