### PR TITLE
Fix Document serialization of maps with null values

### DIFF
--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonDocuments.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonDocuments.java
@@ -262,7 +262,13 @@ public final class JsonDocuments {
         public void serializeContents(ShapeSerializer serializer) {
             serializer.writeMap(PreludeSchemas.DOCUMENT, values, values.size(), (stringMap, mapSerializer) -> {
                 for (var e : stringMap.entrySet()) {
-                    mapSerializer.writeEntry(STRING_MAP_KEY, e.getKey(), e.getValue(), Document::serializeContents);
+                    mapSerializer.writeEntry(STRING_MAP_KEY, e.getKey(), e.getValue(), (document, ser) -> {
+                        if (document == null) {
+                            ser.writeNull(PreludeSchemas.DOCUMENT);
+                        } else {
+                            document.serializeContents(ser);
+                        }
+                    });
                 }
             });
         }

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDocumentTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDocumentTest.java
@@ -14,6 +14,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
@@ -183,6 +185,33 @@ public class JsonDocumentTest {
         var document = de.readDocument();
         assertThat(document.getMember("c"), nullValue());
         assertThat(document.getMember("d"), nullValue());
+    }
+
+    @Test
+    public void nullMapMemberRoundtrip() {
+        var codec = JsonCodec.builder().build();
+        var doc = codec.createDeserializer("{\"a\":null}".getBytes(StandardCharsets.UTF_8)).readDocument();
+        var roundtrip = codec.createDeserializer(codec.serialize(doc)).readDocument();
+
+        assertEquals(doc, roundtrip);
+    }
+
+    @Test
+    public void nullListMemberRoundtrip() {
+        var codec = JsonCodec.builder().build();
+        var doc = codec.createDeserializer("[null]".getBytes(StandardCharsets.UTF_8)).readDocument();
+        var roundtrip = codec.createDeserializer(codec.serialize(doc)).readDocument();
+
+        assertEquals(doc, roundtrip);
+    }
+
+    @Test
+    public void nullDocument() {
+        var codec = JsonCodec.builder().build();
+        var de = codec.createDeserializer("null".getBytes(StandardCharsets.UTF_8));
+
+        var document = de.readDocument();
+        assertNull(document);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
I discovered that we can't serialize Document maps with null values while implementing CBOR documents. This uses the same approach that we're using in JsonDocuments$ListSerializer.

Fun fact: the JVM generates terrible stack traces when the receiver for an instance method reference is null. The reference `Document::serializeContents` throws a NPE from a synthetic method when the `Document` having its `serializeContents` method invoked is null. You can see that the param in the first argument slot is null in the debugger and infer what's going on, but debugging runtime-generated code is always a nightmare.