### PR TITLE
Revert "Add integration tests to CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
-      - name: Integration tests
-        run: ./gradlew integ -Plog-tests --stacktrace
-
       - name: Allow long file names in git for windows
         if: matrix.os == 'windows-latest'
         run: git config --system core.longpaths true


### PR DESCRIPTION
This reverts commit a80e657460b492a7fe6ad154109244609e54eb11.
Temporarily revert running integ tests while they're failing on CI