### PR TITLE
Add Document support to RPCv2 CBOR

### DIFF
--- a/codecs/cbor-codec/build.gradle.kts
+++ b/codecs/cbor-codec/build.gradle.kts
@@ -11,4 +11,5 @@ extra["moduleName"] = "software.amazon.smithy.java.cbor"
 dependencies {
     api(project(":core"))
     testFixturesImplementation(libs.assertj.core)
+    testImplementation(project(":codecs:json-codec"))
 }

--- a/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborDocuments.java
+++ b/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborDocuments.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.cbor;
+
+import java.util.Map;
+import java.util.Set;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.core.serde.document.DocumentDeserializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class CborDocuments {
+
+    private static final Schema STRING_MAP_KEY;
+
+    static {
+        var tempSchema = Schema.structureBuilder(PreludeSchemas.DOCUMENT.id())
+                .putMember("key", PreludeSchemas.STRING)
+                .build();
+        STRING_MAP_KEY = tempSchema.mapKeyMember();
+    }
+
+    private CborDocuments() {}
+
+    public static Document of(Map<String, Document> values, CborSettings settings) {
+        return new MapDocument(values, settings);
+    }
+
+    private static final class MapDocument implements Document {
+        private final Map<String, Document> values;
+        private final CborSettings settings;
+
+        private MapDocument(Map<String, Document> values, CborSettings settings) {
+            this.values = values;
+            this.settings = settings;
+        }
+
+        @Override
+        public ShapeType type() {
+            return ShapeType.MAP;
+        }
+
+        @Override
+        public ShapeId discriminator() {
+            String discriminator = null;
+            var member = values.get("__type");
+            if (member != null && member.type() == ShapeType.STRING) {
+                discriminator = member.asString();
+            }
+            return DocumentDeserializer.parseDiscriminator(discriminator, settings.defaultNamespace());
+        }
+
+        @Override
+        public Map<String, Document> asStringMap() {
+            return values;
+        }
+
+        @Override
+        public Document getMember(String memberName) {
+            return values.get(memberName);
+        }
+
+        @Override
+        public Set<String> getMemberNames() {
+            return values.keySet();
+        }
+
+        @Override
+        public int size() {
+            return values.size();
+        }
+
+        @Override
+        public ShapeDeserializer createDeserializer() {
+            return new CborDocumentSerializer(settings, this);
+        }
+
+        @Override
+        public void serializeContents(ShapeSerializer serializer) {
+            serializer.writeMap(PreludeSchemas.DOCUMENT, values, values.size(), (stringMap, mapSerializer) -> {
+                for (var e : stringMap.entrySet()) {
+                    mapSerializer.writeEntry(STRING_MAP_KEY, e.getKey(), e.getValue(), Document::serializeContents);
+                }
+            });
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return Document.equals(this, obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return values.hashCode();
+        }
+    }
+
+    /**
+     * Customized version of DocumentDeserializer to account for the settings of the CBOR codec.
+     */
+    private static final class CborDocumentSerializer extends DocumentDeserializer {
+
+        private final CborSettings settings;
+
+        CborDocumentSerializer(CborSettings settings, Document value) {
+            super(value);
+            this.settings = settings;
+        }
+
+        @Override
+        protected DocumentDeserializer deserializer(Document nextValue) {
+            return new CborDocumentSerializer(settings, nextValue);
+        }
+    }
+}

--- a/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborSerdeProvider.java
+++ b/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborSerdeProvider.java
@@ -16,11 +16,11 @@ public interface CborSerdeProvider {
 
     String getName();
 
-    ShapeDeserializer newDeserializer(byte[] source, Rpcv2CborCodec.Settings settings);
+    ShapeDeserializer newDeserializer(byte[] source, CborSettings settings);
 
-    ShapeDeserializer newDeserializer(ByteBuffer source, Rpcv2CborCodec.Settings settings);
+    ShapeDeserializer newDeserializer(ByteBuffer source, CborSettings settings);
 
-    ShapeSerializer newSerializer(OutputStream sink, Rpcv2CborCodec.Settings settings);
+    ShapeSerializer newSerializer(OutputStream sink, CborSettings settings);
 
-    ByteBuffer serialize(SerializableStruct struct, Rpcv2CborCodec.Settings settings);
+    ByteBuffer serialize(SerializableStruct struct, CborSettings settings);
 }

--- a/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborSettings.java
+++ b/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborSettings.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.cbor;
+
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+public final class CborSettings {
+    private static final CborSerdeProvider PROVIDER;
+
+    static {
+        final String preferredName = System.getProperty("smithy-java.cbor-provider");
+        CborSerdeProvider selected = null;
+        for (var provider : ServiceLoader.load(CborSerdeProvider.class)) {
+            if (preferredName != null) {
+                if (provider.getName().equals(preferredName)) {
+                    selected = provider;
+                    break;
+                }
+            }
+            if (selected == null) {
+                selected = provider;
+            } else if (provider.getPriority() > selected.getPriority()) {
+                selected = provider;
+            }
+        }
+        if (selected == null) {
+            selected = new DefaultCborSerdeProvider();
+        }
+        PROVIDER = selected;
+    }
+
+    private static final CborSettings DEFAULT = builder().build();
+
+    public static CborSettings defaultSettings() {
+        return DEFAULT;
+    }
+
+    private final String defaultNamespace;
+    private final CborSerdeProvider provider;
+
+    private CborSettings(Builder builder) {
+        this.defaultNamespace = builder.defaultNamespace;
+        this.provider = builder.provider;
+    }
+
+    public CborSerdeProvider provider() {
+        return provider;
+    }
+
+    public String defaultNamespace() {
+        return defaultNamespace;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String defaultNamespace;
+        private CborSerdeProvider provider = PROVIDER;
+
+        /**
+         * Sets the default namespace when attempting to deserialize documents that use a relative shape ID.
+         *
+         * <p>No default namespace is used unless one is explicitly provided.
+         *
+         * @param defaultNamespace Default namespace to set.
+         * @return the builder.
+         */
+        public Builder defaultNamespace(String defaultNamespace) {
+            this.defaultNamespace = defaultNamespace;
+            return this;
+        }
+
+        /**
+         * Uses a custom CBOR serde provider.
+         *
+         * @param provider the CBOR serde provider to use.
+         * @return the builder.
+         */
+        Builder overrideSerdeProvider(CborSerdeProvider provider) {
+            this.provider = Objects.requireNonNull(provider, "provider");
+            return this;
+        }
+
+        public Builder updateBuilder(CborSettings settings) {
+            overrideSerdeProvider(settings.provider());
+            defaultNamespace(settings.defaultNamespace());
+            return this;
+        }
+
+        public CborSettings build() {
+            return new CborSettings(this);
+        }
+    }
+}

--- a/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/DefaultCborSerdeProvider.java
+++ b/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/DefaultCborSerdeProvider.java
@@ -23,22 +23,22 @@ final class DefaultCborSerdeProvider implements CborSerdeProvider {
     }
 
     @Override
-    public ShapeDeserializer newDeserializer(byte[] source, Rpcv2CborCodec.Settings settings) {
-        return new CborDeserializer(source);
+    public ShapeDeserializer newDeserializer(byte[] source, CborSettings settings) {
+        return new CborDeserializer(source, settings);
     }
 
     @Override
-    public ShapeDeserializer newDeserializer(ByteBuffer source, Rpcv2CborCodec.Settings settings) {
-        return new CborDeserializer(source);
+    public ShapeDeserializer newDeserializer(ByteBuffer source, CborSettings settings) {
+        return new CborDeserializer(source, settings);
     }
 
     @Override
-    public ShapeSerializer newSerializer(OutputStream sink, Rpcv2CborCodec.Settings settings) {
+    public ShapeSerializer newSerializer(OutputStream sink, CborSettings settings) {
         return new CborSerializer(new Sink.OutputStreamSink(sink));
     }
 
     @Override
-    public ByteBuffer serialize(SerializableStruct struct, Rpcv2CborCodec.Settings settings) {
+    public ByteBuffer serialize(SerializableStruct struct, CborSettings settings) {
         var sink = new Sink.ResizingSink();
         var serializer = new CborSerializer(sink);
         struct.serialize(serializer);

--- a/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/Rpcv2CborCodec.java
+++ b/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/Rpcv2CborCodec.java
@@ -7,38 +7,15 @@ package software.amazon.smithy.java.cbor;
 
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.ServiceLoader;
 import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 
 public final class Rpcv2CborCodec implements Codec {
-    private static final CborSerdeProvider PROVIDER;
+    private final CborSettings settings;
 
-    static {
-        final String preferredName = System.getProperty("smithy-java.cbor-provider");
-        CborSerdeProvider selected = null;
-        for (var provider : ServiceLoader.load(CborSerdeProvider.class)) {
-            if (preferredName != null) {
-                if (provider.getName().equals(preferredName)) {
-                    selected = provider;
-                    break;
-                }
-            }
-            if (selected == null) {
-                selected = provider;
-            } else if (provider.getPriority() > selected.getPriority()) {
-                selected = provider;
-            }
-        }
-        if (selected == null) {
-            selected = new DefaultCborSerdeProvider();
-        }
-        PROVIDER = selected;
-    }
-
-    private Rpcv2CborCodec() {
-
+    private Rpcv2CborCodec(Builder builder) {
+        this.settings = builder.settings == null ? CborSettings.defaultSettings() : builder.settings.build();
     }
 
     public static Builder builder() {
@@ -47,24 +24,70 @@ public final class Rpcv2CborCodec implements Codec {
 
     @Override
     public ShapeSerializer createSerializer(OutputStream sink) {
-        return PROVIDER.newSerializer(sink, new Rpcv2CborCodec.Settings());
+        return settings.provider().newSerializer(sink, settings);
     }
 
     @Override
     public ShapeDeserializer createDeserializer(byte[] source) {
-        return PROVIDER.newDeserializer(source, new Rpcv2CborCodec.Settings());
+        return settings.provider().newDeserializer(source, settings);
     }
 
     @Override
     public ShapeDeserializer createDeserializer(ByteBuffer source) {
-        return PROVIDER.newDeserializer(source, new Rpcv2CborCodec.Settings());
+        return settings.provider().newDeserializer(source, settings);
     }
 
-    public record Settings() {}
-
     public static final class Builder {
+        private CborSettings.Builder settings;
+
+        private Builder() {
+
+        }
+
+        private CborSettings.Builder settings() {
+            if (settings == null) {
+                settings = CborSettings.builder();
+            }
+            return settings;
+        }
+
+        /**
+         * Sets the default namespace when attempting to deserialize documents that use a relative shape ID.
+         *
+         * <p>No default namespace is used unless one is explicitly provided.
+         *
+         * @param defaultNamespace Default namespace to set.
+         * @return the builder.
+         */
+        public Builder defaultNamespace(String defaultNamespace) {
+            settings().defaultNamespace(defaultNamespace);
+            return this;
+        }
+
+        /**
+         * Uses a custom CBOR serde provider.
+         *
+         * @param provider the CBOR serde provider to use.
+         * @return the builder.
+         */
+        public Builder overrideSerdeProvider(CborSerdeProvider provider) {
+            settings().overrideSerdeProvider(provider);
+            return this;
+        }
+
+        /**
+         * Use the given settings object with this codec.
+         *
+         * @param settings Settings to use.
+         * @return the builder.
+         */
+        public Builder settings(CborSettings settings) {
+            settings().updateBuilder(settings);
+            return this;
+        }
+
         public Rpcv2CborCodec build() {
-            return new Rpcv2CborCodec();
+            return new Rpcv2CborCodec(this);
         }
     }
 }

--- a/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborDocumentTest.java
+++ b/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborDocumentTest.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.cbor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.comparesEqualTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.SerializationException;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.document.DiscriminatorException;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.json.JsonCodec;
+import software.amazon.smithy.java.json.JsonSettings;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+
+public class CborDocumentTest {
+    private static ShapeDeserializer toCbor(String json) {
+        return toCbor(json, JsonSettings.builder().build(), CborSettings.defaultSettings());
+    }
+
+    private static ShapeDeserializer toCbor(String json, JsonSettings jsonSettings, CborSettings settings) {
+        try (var jsonCodec = JsonCodec.builder().settings(jsonSettings).build()) {
+            var de = jsonCodec.createDeserializer(json.getBytes(StandardCharsets.UTF_8));
+            return toCbor(de.readDocument(), settings);
+        }
+    }
+
+    private static ShapeDeserializer toCbor(Document d) {
+        return toCbor(d, CborSettings.defaultSettings());
+    }
+
+    private static ShapeDeserializer toCbor(Document d, CborSettings settings) {
+        try (var cborCodec = Rpcv2CborCodec.builder().settings(settings).build()) {
+            var doc = cborCodec.serialize(d);
+            return Rpcv2CborCodec.builder().settings(settings).build().createDeserializer(doc);
+        }
+    }
+
+    @Test
+    public void convertsNumberToNumber() {
+        var de = toCbor("120");
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.LONG));
+        assertThat(document.asByte(), is((byte) 120));
+        assertThat(document.asShort(), is((short) 120));
+        assertThat(document.asInteger(), is(120));
+        assertThat(document.asLong(), is(120L));
+        assertThat(document.asFloat(), is(120f));
+        assertThat(document.asDouble(), is(120.0));
+        assertThat(document.asBigInteger(), equalTo(BigInteger.valueOf(120)));
+        assertThat(document.asBigDecimal(), comparesEqualTo(BigDecimal.valueOf(120.0)));
+    }
+
+    @Test
+    public void convertsDoubleToNumber() {
+        var de = toCbor("1.1");
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.DOUBLE));
+        assertThat(document.asFloat(), is(1.1f));
+        assertThat(document.asDouble(), is(1.1));
+    }
+
+    @Test
+    public void convertsTrueToBoolean() {
+        var de = toCbor("true");
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.BOOLEAN));
+        assertThat(document.asBoolean(), is(true));
+    }
+
+    @Test
+    public void convertsFalseToBoolean() {
+        var de = toCbor("false");
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.BOOLEAN));
+        assertThat(document.asBoolean(), is(false));
+    }
+
+    @Test
+    public void convertsToTimestampWithEpochSeconds() {
+        var de = toCbor(Document.of(Instant.EPOCH));
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.TIMESTAMP));
+        assertThat(document.asTimestamp(), equalTo(Instant.EPOCH));
+    }
+
+    @Test
+    public void convertsToTimestampFailsOnUnknownType() {
+        var de = toCbor("true");
+        var document = de.readDocument();
+
+        var e = Assertions.assertThrows(SerializationException.class, document::asTimestamp);
+        e.printStackTrace();
+        assertThat(e.getMessage(), containsString("Expected a timestamp document, but found boolean"));
+    }
+
+    @Test
+    public void convertsToList() {
+        var de = toCbor("[1, 2, 3]");
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.LIST));
+        assertThat(document.size(), is(3));
+
+        var list = document.asList();
+        assertThat(list, hasSize(3));
+        assertThat(list.get(0).type(), is(ShapeType.LONG));
+        assertThat(list.get(0).asInteger(), is(1));
+        assertThat(list.get(1).asInteger(), is(2));
+        assertThat(list.get(2).asInteger(), is(3));
+    }
+
+    @Test
+    public void convertsToMap() {
+        var de = toCbor("{\"a\":1,\"b\":true}");
+
+        var document = de.readDocument();
+        assertThat(document.type(), is(ShapeType.MAP));
+        assertThat(document.size(), is(2));
+
+        var map = document.asStringMap();
+        assertThat(map.keySet(), hasSize(2));
+        assertThat(map.get("a").type(), is(ShapeType.LONG));
+        assertThat(map.get("a").asInteger(), is(1));
+        assertThat(document.getMember("a").type(), is(ShapeType.LONG));
+
+        assertThat(map.get("b").type(), is(ShapeType.BOOLEAN));
+        assertThat(map.get("b").asBoolean(), is(true));
+        assertThat(document.getMember("b").type(), is(ShapeType.BOOLEAN));
+    }
+
+    @Test
+    public void otherDocumentsReturnSizeOfNegativeOne() {
+        var de = toCbor("1");
+        var document = de.readDocument();
+
+        assertThat(document.size(), is(-1));
+    }
+
+    @Test
+    public void nullAndMissingMapMembersReturnsNull() {
+        var de = toCbor("{\"a\":null}");
+
+        var document = de.readDocument();
+        assertThat(document.getMember("a"), nullValue());
+        assertThat(document.getMember("d"), nullValue());
+    }
+
+    @ParameterizedTest
+    @MethodSource("failToConvertSource")
+    public void failToConvert(String json, Consumer<Document> consumer) {
+        var de = toCbor(json);
+        var document = de.readDocument();
+
+        Assertions.assertThrows(SerializationException.class, () -> consumer.accept(document));
+    }
+
+    public static List<Arguments> failToConvertSource() {
+        return List.of(
+                Arguments.of("1", (Consumer<Document>) Document::asBoolean),
+                Arguments.of("1", (Consumer<Document>) Document::asBlob),
+                Arguments.of("1", (Consumer<Document>) Document::asString),
+                Arguments.of("1", (Consumer<Document>) Document::asList),
+                Arguments.of("1", (Consumer<Document>) Document::asStringMap),
+                Arguments.of("1", (Consumer<Document>) Document::asBlob),
+
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asBoolean),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asList),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asStringMap),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asBlob),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asBoolean),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asByte),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asShort),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asInteger),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asLong),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asFloat),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asDouble),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asBigInteger),
+                Arguments.of("\"1\"", (Consumer<Document>) Document::asBigDecimal));
+    }
+
+    @ParameterizedTest
+    @MethodSource("serializeContentSource")
+    public void serializeContent(String json) {
+        var de = toCbor(json);
+        var document = de.readDocument();
+        var codec = Rpcv2CborCodec.builder().build();
+        var ser = codec.serialize(document);
+        var roundtrip = codec.createDeserializer(ser).readDocument();
+        assertEquals(roundtrip, document);
+    }
+
+    public static List<Arguments> serializeContentSource() {
+        return List.of(
+                Arguments.of("true"),
+                Arguments.of("false"),
+                Arguments.of("1"),
+                Arguments.of("1.1"),
+                Arguments.of("[1,2,3]"),
+                Arguments.of("{\"a\":1,\"b\":[1,true,-20,\"hello\"]}"));
+    }
+
+    @Test
+    public void deserializesIntoBuilder() {
+        var base = new TestPojo.Builder();
+        base.name = "Hank";
+        base.binary = ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8));
+        base.date = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        base.numbers.addAll(List.of(1, 2, 3));
+        var codec = Rpcv2CborCodec.builder().build();
+        var ser = codec.serialize(base.build());
+        var de = codec.createDeserializer(ser);
+        var document = de.readDocument();
+
+        var builder = new TestPojo.Builder();
+        document.deserializeInto(builder);
+        var pojo = builder.build();
+
+        assertThat(pojo.name, equalTo(base.name));
+        assertThat(pojo.binary, equalTo(base.binary));
+        assertThat(pojo.date, equalTo(base.date));
+        assertThat(pojo.numbers, equalTo(base.numbers));
+    }
+
+    private static final class TestPojo implements SerializableStruct {
+
+        private static final ShapeId ID = ShapeId.from("smithy.example#Foo");
+
+        private static final Schema NUMBERS_LIST = Schema.listBuilder(ShapeId.from("smithy.example#Numbers"))
+                .putMember("member", PreludeSchemas.INTEGER)
+                .build();
+
+        private static final Schema SCHEMA = Schema.structureBuilder(ID)
+                .putMember("name", PreludeSchemas.STRING)
+                .putMember("binary", PreludeSchemas.BLOB, new JsonNameTrait("BINARY"))
+                .putMember("date", PreludeSchemas.TIMESTAMP, new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME))
+                .putMember("numbers", NUMBERS_LIST)
+                .build();
+
+        private static final Schema NAME = SCHEMA.member("name");
+        private static final Schema BINARY = SCHEMA.member("binary");
+        private static final Schema DATE = SCHEMA.member("date");
+        private static final Schema NUMBERS = SCHEMA.member("numbers");
+
+        private final String name;
+        private final ByteBuffer binary;
+        private final Instant date;
+        private final List<Integer> numbers;
+
+        TestPojo(Builder builder) {
+            this.name = builder.name;
+            this.binary = builder.binary;
+            this.date = builder.date;
+            this.numbers = builder.numbers;
+        }
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (name != null) {
+                serializer.writeString(NAME, name);
+            }
+
+            if (binary != null) {
+                serializer.writeBlob(BINARY, binary);
+            }
+
+            if (date != null) {
+                serializer.writeTimestamp(DATE, date);
+            }
+
+            serializer.writeList(NUMBERS, numbers, numbers.size(), (elements, ser) -> {
+                for (var e : elements) {
+                    ser.writeInteger(PreludeSchemas.INTEGER, e);
+                }
+            });
+        }
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return switch (member.memberIndex()) {
+                case 0 -> (T) name;
+                case 1 -> (T) binary;
+                case 2 -> (T) date;
+                case 3 -> (T) numbers;
+                default -> throw new UnsupportedOperationException(member.toString());
+            };
+        }
+
+        private static final class Builder implements ShapeBuilder<TestPojo> {
+
+            private String name;
+            private ByteBuffer binary;
+            private Instant date;
+            private final List<Integer> numbers = new ArrayList<>();
+
+            @Override
+            public Schema schema() {
+                return SCHEMA;
+            }
+
+            @Override
+            public Builder deserialize(ShapeDeserializer decoder) {
+                decoder.readStruct(SCHEMA, this, (pojo, member, deser) -> {
+                    switch (member.memberName()) {
+                        case "name" -> pojo.name = deser.readString(NAME);
+                        case "binary" -> pojo.binary = deser.readBlob(BINARY);
+                        case "date" -> pojo.date = deser.readTimestamp(DATE);
+                        case "numbers" -> {
+                            deser.readList(NUMBERS, pojo.numbers, (values, de) -> {
+                                values.add(de.readInteger(NUMBERS_LIST.member("member")));
+                            });
+                        }
+                        default -> throw new UnsupportedOperationException(member.toString());
+                    }
+                });
+                return this;
+            }
+
+            @Override
+            public TestPojo build() {
+                return new TestPojo(this);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("checkEqualitySource")
+    public void checkEquality(String left, String right, boolean equal) {
+        var de1 = toCbor(left);
+        var leftValue = de1.readDocument();
+
+        var de2 = toCbor(right);
+        var rightValue = de2.readDocument();
+
+        System.out.println(leftValue);
+        System.out.println(rightValue);
+        assertThat(leftValue.equals(rightValue), is(equal));
+    }
+
+    public static List<Arguments> checkEqualitySource() {
+        return List.of(
+                Arguments.of("1", "1", true),
+                Arguments.of("1", "1.1", false),
+                Arguments.of("true", "true", true),
+                Arguments.of("true", "false", false),
+                Arguments.of("1", "false", false),
+                Arguments.of("1", "\"1\"", false),
+                Arguments.of("\"foo\"", "\"foo\"", true),
+                Arguments.of("[\"foo\"]", "[\"foo\"]", true),
+                Arguments.of("{\"foo\":\"foo\"}", "{\"foo\":\"foo\"}", true),
+                Arguments.of("{\"foo\":\"foo\"}", "{\"foo\":\"bar\"}", false));
+    }
+
+    @Test
+    public void canNormalizeCborDocuments() {
+        var de = toCbor("true");
+        var json = de.readDocument();
+
+        assertThat(Document.equals(json, Document.of(true)), is(true));
+    }
+
+    @Test
+    public void throwsWhenGettingDisciminatorOfWrongType() {
+        var de = toCbor("\"hi\"");
+        var json = de.readDocument();
+
+        Assertions.assertThrows(DiscriminatorException.class, json::discriminator);
+    }
+
+    @Test
+    public void findsDiscriminatorForAbsoluteShapeId() {
+        var de = toCbor("{\"__type\":\"com.example#Foo\"}");
+        var json = de.readDocument();
+
+        assertThat(json.discriminator(), equalTo(ShapeId.from("com.example#Foo")));
+    }
+
+    @Test
+    public void findsDiscriminatorForRelativeShapeId() {
+        var ns = "com.foo";
+        var de = toCbor("{\"__type\":\"Foo\"}",
+                JsonSettings.builder().defaultNamespace(ns).build(),
+                CborSettings.builder().defaultNamespace(ns).build());
+        var doc = de.readDocument();
+
+        assertThat(doc.discriminator(), equalTo(ShapeId.from("com.foo#Foo")));
+    }
+
+    @Test
+    public void failsToParseRelativeDiscriminatorWithNoDefaultNamespace() {
+        toCbor("{\"__type\":\"Foo\"}").readDocument();
+    }
+}

--- a/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborSerializerTest.java
+++ b/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborSerializerTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.io.ByteBufferUtils;
 
 public class CborSerializerTest {
-    private static final Rpcv2CborCodec.Settings SETTINGS = new Rpcv2CborCodec.Settings();
+    private static final CborSettings SETTINGS = CborSettings.defaultSettings();
     private static final DefaultCborSerdeProvider CODEC = new DefaultCborSerdeProvider();
 
     @Test


### PR DESCRIPTION
Adds Document support to CBOR and the RPCv2 CBOR protocol. Does not add BigNum support.

#603 