### PR TITLE
Use interceptors and identity resolvers from request overrides when present

### DIFF
--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
@@ -95,8 +95,8 @@ public abstract class Client {
         } else {
             callConfig = config.withRequestOverride(overrideConfig);
             callPipeline = ClientPipeline.of(callConfig.protocol(), callConfig.transport());
-            callInterceptor = ClientInterceptor.chain(config.interceptors());
-            callIdentityResolvers = IdentityResolvers.of(config.identityResolvers());
+            callInterceptor = ClientInterceptor.chain(callConfig.interceptors());
+            callIdentityResolvers = IdentityResolvers.of(callConfig.identityResolvers());
         }
 
         var callBuilder = ClientCall.<I, O>builder();


### PR DESCRIPTION
The accidental use of `config` instead of `callConfig` previously made it impossible to specify overrides for either of these options through the RequestOverrideConfig API.