### PR TITLE
Add MCP Support

### DIFF
--- a/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DocumentException.java
+++ b/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DocumentException.java
@@ -51,12 +51,12 @@ public final class DocumentException extends ModeledException {
         return document;
     }
 
-    static final class SchemaGuidedExceptionBuilder implements ShapeBuilder<ModeledException> {
+    public static final class SchemaGuidedExceptionBuilder implements ShapeBuilder<ModeledException> {
 
         private final Schema target;
         private final ShapeBuilder<WrappedDocument> delegateBuilder;
 
-        SchemaGuidedExceptionBuilder(ShapeId service, Schema target) {
+        public SchemaGuidedExceptionBuilder(ShapeId service, Schema target) {
             this.target = target;
             this.delegateBuilder = SchemaConverter.createDocumentBuilder(target, service);
         }

--- a/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicOperation.java
+++ b/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicOperation.java
@@ -5,8 +5,12 @@
 
 package software.amazon.smithy.java.dynamicclient;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.core.schema.Schema;
@@ -15,9 +19,13 @@ import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.java.dynamicschemas.SchemaConverter;
 import software.amazon.smithy.java.dynamicschemas.WrappedDocument;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 
-final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDocument> {
+public final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDocument> {
 
     private final ApiService service;
     private final Schema operationSchema;
@@ -27,7 +35,7 @@ final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDoc
     private final TypeRegistry typeRegistry;
     private final List<ShapeId> effectiveAuthSchemes;
 
-    public DynamicOperation(
+    DynamicOperation(
             ApiService service,
             Schema operationSchema,
             Schema inputSchema,
@@ -93,5 +101,55 @@ final class DynamicOperation implements ApiOperation<WrappedDocument, WrappedDoc
     @Override
     public List<ShapeId> effectiveAuthSchemes() {
         return effectiveAuthSchemes;
+    }
+
+    public static DynamicOperation create(
+            OperationShape shape,
+            SchemaConverter schemaConverter,
+            Model model,
+            ServiceShape service,
+            TypeRegistry serviceErrorRegistry,
+            BiConsumer<ShapeId, TypeRegistry.Builder> registerErrorCallback
+    ) {
+        var operationSchema = schemaConverter.getSchema(shape);
+
+        List<ShapeId> authSchemes = new ArrayList<>();
+        for (var trait : ServiceIndex.of(model).getEffectiveAuthSchemes(service).values()) {
+            authSchemes.add(trait.toShapeId());
+        }
+
+        var inputSchema = schemaConverter.getSchema(model.expectShape(shape.getInputShape()));
+        var outputSchema = schemaConverter.getSchema(model.expectShape(shape.getOutputShape()));
+
+        // Default to using the service registry.
+        var registry = serviceErrorRegistry;
+
+        var errorSchemas = new HashSet<Schema>();
+        // Create a type registry that is able to deserialize errors using schemas.
+        if (!shape.getErrors().isEmpty()) {
+            var registryBuilder = TypeRegistry.builder();
+            for (var e : shape.getErrors()) {
+                registerErrorCallback.accept(e, registryBuilder);
+                errorSchemas.add(schemaConverter.getSchema(model.expectShape(e)));
+            }
+            // Compose the operation errors with the service errors.
+            registry = TypeRegistry.compose(registryBuilder.build(), serviceErrorRegistry);
+        }
+
+        var serviceSchema = schemaConverter.getSchema(service);
+        var apiService = new ApiService() {
+            @Override
+            public Schema schema() {
+                return serviceSchema;
+            }
+        };
+        return new DynamicOperation(
+                apiService,
+                operationSchema,
+                inputSchema,
+                outputSchema,
+                Collections.unmodifiableSet(errorSchemas),
+                registry,
+                authSchemes);
     }
 }

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSettings.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSettings.java
@@ -43,6 +43,7 @@ public final class JsonSettings {
     private final boolean forbidUnknownUnionMembers;
     private final String defaultNamespace;
     private final JsonSerdeProvider provider;
+    private final boolean serializeTypeInDocuments;
 
     private JsonSettings(Builder builder) {
         this.timestampResolver = builder.useTimestampFormat
@@ -54,6 +55,7 @@ public final class JsonSettings {
         this.forbidUnknownUnionMembers = builder.forbidUnknownUnionMembers;
         this.defaultNamespace = builder.defaultNamespace;
         this.provider = builder.provider;
+        this.serializeTypeInDocuments = builder.serializeTypeInDocuments;
     }
 
     /**
@@ -139,6 +141,7 @@ public final class JsonSettings {
         private boolean forbidUnknownUnionMembers;
         private String defaultNamespace;
         private JsonSerdeProvider provider = PROVIDER;
+        private boolean serializeTypeInDocuments = true;
 
         private Builder() {}
 
@@ -213,6 +216,16 @@ public final class JsonSettings {
          */
         public Builder defaultNamespace(String defaultNamespace) {
             this.defaultNamespace = defaultNamespace;
+            return this;
+        }
+
+        /**
+         *
+         * @param serializeTypeInDocuments
+         * @return
+         */
+        public Builder serializeTypeInDocuments(boolean serializeTypeInDocuments) {
+            this.serializeTypeInDocuments = serializeTypeInDocuments;
             return this;
         }
 

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/TraitKey.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/TraitKey.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.core.schema;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import software.amazon.smithy.model.traits.DefaultTrait;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.EndpointTrait;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
@@ -62,6 +63,7 @@ public final class TraitKey<T extends Trait> {
     // Note that TraitKeys can be accessed at any time through TraitKey#get; these are just pre-defined.
 
     public static final TraitKey<RequiredTrait> REQUIRED_TRAIT = TraitKey.get(RequiredTrait.class);
+    public static final TraitKey<DocumentationTrait> DOCUMENTATION_TRAIT = TraitKey.get(DocumentationTrait.class);
     public static final TraitKey<DefaultTrait> DEFAULT_TRAIT = TraitKey.get(DefaultTrait.class);
     public static final TraitKey<UniqueItemsTrait> UNIQUE_ITEMS_TRAIT = TraitKey.get(UniqueItemsTrait.class);
     public static final TraitKey<TimestampFormatTrait> TIMESTAMP_FORMAT_TRAIT = TraitKey.get(

--- a/examples/mcp-server/README.md
+++ b/examples/mcp-server/README.md
@@ -1,0 +1,64 @@
+## Example: MCP Server
+
+### Usage
+
+To use this example as a template, run the following command with
+the [Smithy CLI](https://smithy.io/2.0/guides/smithy-cli/index.html):
+
+```console
+smithy init -t mcp-server --url https://github.com/smithy-lang/smithy-java
+```
+
+Or
+
+```console
+smithy init -t mcp-server --url git@github.com:smithy-lang/smithy-java.git
+```
+
+To generate a fat jar which contains all the dependencies required to run
+a [Model Context Protocol](https://modelcontextprotocol.io/) (
+MCP) [StdIO](https://modelcontextprotocol.io/docs/concepts/transports#standard-input%2Foutput-stdio) server,
+run the following from the root of the project:
+
+```console
+gradle build
+```
+
+This will generate a fat JAR file at `build/libs/mcp-server-0.0.1-all.jar`. This artifact includes all the necessary
+code to create an MCP server that uses the StdIO transport.
+
+There are two example implementations included:
+
+* `MCPServerExample` : Demonstrates how to build an MCP server by modeling tools as Smithy APIs.
+
+* `ProxyMCPExample` : Shows how to create a Proxy MCP Server for any Smithy service. In this example, a Smithy Java
+  server is started on port 8080, and the MCP server proxies requests to it.
+
+You can run the Proxy MCP Server using the following command:
+
+```
+java -cp mcp-server-0.0.1-all.jar software.amazon.smithy.java.example.server.mcp.ProxyMCPExample
+```
+
+To run the direct MCP server example instead, simply replace `ProxyMCPExample` with `MCPServerExample`.
+
+Here's how you might configure the MCP client to invoke the proxy server:
+
+```json
+{
+  "mcpServers": {
+    "smithy-mcp-server": {
+      "command": "java",
+      "args": [
+        "-cp",
+        "/path/to/build/libs/mcp-server-0.0.1-all.jar",
+        "software.amazon.smithy.java.example.server.mcp.ProxyMCPExample"
+      ]
+    }
+  }
+}
+```
+
+
+
+

--- a/examples/mcp-server/build.gradle.kts
+++ b/examples/mcp-server/build.gradle.kts
@@ -1,0 +1,59 @@
+import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer
+
+plugins {
+    `java-library`
+    id("software.amazon.smithy.gradle.smithy-base")
+    id("com.gradleup.shadow").version("8.3.5")
+}
+
+dependencies {
+    val smithyJavaVersion: String by project
+
+    smithyBuild("software.amazon.smithy.java:plugins:$smithyJavaVersion")
+    implementation("software.amazon.smithy.java:server-proxy:$smithyJavaVersion")
+    implementation("software.amazon.smithy.java:server-mcp:$smithyJavaVersion")
+    implementation("software.amazon.smithy.java:server-netty:$smithyJavaVersion")
+    implementation("software.amazon.smithy.java:aws-server-restjson:$smithyJavaVersion")
+    implementation("software.amazon.smithy.java:aws-client-restjson:$smithyJavaVersion")
+}
+
+// Add generated Java files to the main sourceSet
+afterEvaluate {
+    val serverPath = smithy.getPluginProjectionPath(smithy.sourceProjection.get(), "java-server-codegen")
+    sourceSets {
+        main {
+            java {
+                srcDir(serverPath)
+            }
+        }
+    }
+}
+
+tasks {
+    compileJava {
+        dependsOn(smithyBuild)
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+tasks.shadowJar {
+    val shadePrefix = "software.amazon.smithy.java.internal"
+    relocate("com.jsoniter", "$shadePrefix.jsoniter")
+    relocate("com.fasterxml.jackson", "$shadePrefix.com.fasterxml.jackson")
+    relocate("META-INF/native/libnetty", "META-INF/native/lib${shadePrefix.replace('.', '_')}_netty")
+    relocate("META-INF/native/netty", "META-INF/native/${shadePrefix.replace('.', '_')}_netty")
+    exclude("META-INF/maven/**")
+    mergeServiceFiles()
+    transform(AppendingTransformer::class.java) {
+        resource = "META-INF/smithy/manifest"
+    }
+}
+
+tasks.assemble {
+    dependsOn(tasks.shadowJar)
+}
+

--- a/examples/mcp-server/license.txt
+++ b/examples/mcp-server/license.txt
@@ -1,0 +1,4 @@
+/*
+ * Example file license header.
+ * File header line two
+ */

--- a/examples/mcp-server/settings.gradle.kts
+++ b/examples/mcp-server/settings.gradle.kts
@@ -1,0 +1,20 @@
+/**
+ * Basic usage of generated server stubs.
+ */
+
+pluginManagement {
+    val smithyGradleVersion: String by settings
+
+    plugins {
+        id("software.amazon.smithy.gradle.smithy-base").version(smithyGradleVersion)
+        id("com.gradleup.shadow").version("8.3.5")
+    }
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "SmithyJavaMCPServer"

--- a/examples/mcp-server/smithy-build.json
+++ b/examples/mcp-server/smithy-build.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "sources" : ["src/main/resources/software/amazon/smithy/java/example/server/mcp"],
+  "plugins": {
+    "java-server-codegen": {
+      "service": "smithy.example.mcp#EmployeeService",
+      "namespace": "software.amazon.smithy.java.example.server.mcp",
+      "headerFile": "license.txt",
+      "runtimeTraits": ["smithy.api#documentation", "smithy.api#examples" ]
+    }
+  }
+}

--- a/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/MCPServerExample.java
+++ b/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/MCPServerExample.java
@@ -1,0 +1,30 @@
+package software.amazon.smithy.java.example.server.mcp;
+
+import software.amazon.smithy.java.example.server.mcp.operations.GetCodingStatistics;
+import software.amazon.smithy.java.example.server.mcp.operations.GetEmployeeDetails;
+import software.amazon.smithy.java.example.server.mcp.service.EmployeeService;
+import software.amazon.smithy.java.server.mcp.MCPServer;
+
+public class MCPServerExample {
+
+    public static void main(String[] args) {
+        var service = EmployeeService.builder()
+                .addGetCodingStatisticsOperation(new GetCodingStatistics())
+                .addGetEmployeeDetailsOperation(new GetEmployeeDetails())
+                .build();
+
+        var mcpServer = MCPServer.builder()
+                .stdio()
+                .name("smithy-mcp-server")
+                .addService(service)
+                .build();
+
+        mcpServer.start();
+
+        try {
+            Thread.currentThread().join();
+        } catch (InterruptedException e) {
+            mcpServer.shutdown();
+        }
+    }
+}

--- a/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/ProxyMCPExample.java
+++ b/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/ProxyMCPExample.java
@@ -1,0 +1,56 @@
+package software.amazon.smithy.java.example.server.mcp;
+
+import software.amazon.smithy.java.client.core.auth.scheme.AuthScheme;
+import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
+import software.amazon.smithy.java.example.server.mcp.operations.GetCodingStatistics;
+import software.amazon.smithy.java.example.server.mcp.operations.GetEmployeeDetails;
+import software.amazon.smithy.java.example.server.mcp.service.EmployeeService;
+import software.amazon.smithy.java.server.ProxyService;
+import software.amazon.smithy.java.server.Server;
+import software.amazon.smithy.java.server.mcp.MCPServer;
+import software.amazon.smithy.model.Model;
+
+public class ProxyMCPExample {
+
+    public static void main(String[] args) {
+
+        var service = EmployeeService.builder()
+                .addGetCodingStatisticsOperation(new GetCodingStatistics())
+                .addGetEmployeeDetailsOperation(new GetEmployeeDetails())
+                .build();
+        Server server = Server.builder()
+                .numberOfWorkers(10)
+                .endpoints(8080)
+                .addService(service)
+                .build();
+
+        server.start();
+
+        var model = Model.assembler()
+                .addImport(ProxyMCPExample.class.getResource("main.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        var mcpService = ProxyService.builder()
+                .service(EmployeeService.$ID)
+                .model(model)
+                .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+                .proxyEndpoint("http://localhost:8080")
+                .build();
+
+        var mcpServer = MCPServer.builder()
+                .stdio()
+                .name("smithy-mcp-server")
+                .addService(mcpService)
+                .build();
+        mcpServer.start();
+
+        try {
+            Thread.currentThread().join();
+        } catch (InterruptedException e) {
+            mcpServer.shutdown();
+            server.shutdown();
+        }
+    }
+}

--- a/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/operations/GetCodingStatistics.java
+++ b/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/operations/GetCodingStatistics.java
@@ -1,0 +1,21 @@
+package software.amazon.smithy.java.example.server.mcp.operations;
+
+import software.amazon.smithy.java.example.server.mcp.model.GetCodingStatisticsInput;
+import software.amazon.smithy.java.example.server.mcp.model.GetCodingStatisticsOutput;
+import software.amazon.smithy.java.example.server.mcp.model.NoSuchUserException;
+import software.amazon.smithy.java.example.server.mcp.service.GetCodingStatisticsOperation;
+import software.amazon.smithy.java.server.RequestContext;
+
+import java.util.Map;
+
+public class GetCodingStatistics implements GetCodingStatisticsOperation {
+
+    @Override
+    public GetCodingStatisticsOutput getCodingStatistics(GetCodingStatisticsInput input, RequestContext context) {
+        return switch (input.login()) {
+            case "janedoe" -> GetCodingStatisticsOutput.builder().commits(Map.of()).build();
+            case "johndoe" -> GetCodingStatisticsOutput.builder().commits(Map.of("Java", 100)).build();
+            default -> throw NoSuchUserException.builder().message("User doesn't exist in the system").build();
+        };
+    }
+}

--- a/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/operations/GetEmployeeDetails.java
+++ b/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/operations/GetEmployeeDetails.java
@@ -1,0 +1,20 @@
+package software.amazon.smithy.java.example.server.mcp.operations;
+
+import software.amazon.smithy.java.example.server.mcp.model.GetEmployeeDetailsInput;
+import software.amazon.smithy.java.example.server.mcp.model.GetEmployeeDetailsOutput;
+import software.amazon.smithy.java.example.server.mcp.model.NoSuchUserException;
+import software.amazon.smithy.java.example.server.mcp.service.GetEmployeeDetailsOperation;
+import software.amazon.smithy.java.server.RequestContext;
+
+public class GetEmployeeDetails implements GetEmployeeDetailsOperation {
+
+
+    @Override
+    public GetEmployeeDetailsOutput getEmployeeDetails(GetEmployeeDetailsInput input, RequestContext context) {
+        return switch (input.loginId()) {
+            case "janedoe" -> GetEmployeeDetailsOutput.builder().name("Jane Doe").build();
+            case "johndoe" -> GetEmployeeDetailsOutput.builder().name("John Doe").managerAlias("janedoe").build();
+            default -> throw NoSuchUserException.builder().message("User doesn't exist in the system").build();
+        };
+    }
+}

--- a/examples/mcp-server/src/main/resources/software/amazon/smithy/java/example/server/mcp/main.smithy
+++ b/examples/mcp-server/src/main/resources/software/amazon/smithy/java/example/server/mcp/main.smithy
@@ -1,0 +1,69 @@
+$version: "2"
+
+namespace smithy.example.mcp
+
+use aws.protocols#restJson1
+
+@restJson1
+service EmployeeService {
+    operations: [
+        GetEmployeeDetails
+        GetCodingStatistics
+    ]
+}
+
+@documentation("Get employee information by login id")
+@http(method: "POST", uri: "/get-employee-details")
+operation GetEmployeeDetails {
+    input := {
+        @required
+        loginId: LoginId
+    }
+
+    output: Employee
+
+    errors: [
+        NoSuchUserException
+    ]
+}
+
+structure Employee {
+    @documentation("Name of the employee.")
+    name: String
+
+    @documentation("Login id of the employee's manager. A null/missing value indicates that the employee has no manager.")
+    managerAlias: String
+}
+
+@documentation("Get coding statistics of an employee.")
+@http(method: "POST", uri: "/get-coding-statistics")
+operation GetCodingStatistics {
+    input := {
+        @required
+        login: LoginId
+    }
+
+    output: CodingStatistics
+}
+
+@documentation("Coding statistics of a user.")
+structure CodingStatistics {
+    @documentation("Map of number of commits made per language. This can be empty or null.")
+    commits: CommitMap
+}
+
+@error("client")
+structure NoSuchUserException {
+    message: String
+}
+
+@documentation("Login id of the employee. This is always composed of lower case letters.")
+string LoginId
+
+map CommitMap {
+    @documentation("Language")
+    key: String
+
+    @documentation("Number of commits")
+    value: Integer
+}

--- a/mcp/mcp-schemas/build.gradle.kts
+++ b/mcp/mcp-schemas/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    id("smithy-java.module-conventions")
+    id("software.amazon.smithy.gradle.smithy-base")
+}
+
+description = "This module provides a schemas for MCP integration"
+
+extra["displayName"] = "Smithy :: Java :: MCP Schemas"
+extra["moduleName"] = "software.amazon.smithy.mcp.schemas"
+
+dependencies {
+    smithyBuild(project(":codegen:plugins:types-codegen"))
+    api(project(":core"))
+    api(libs.smithy.model)
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir("model")
+        }
+    }
+}
+
+afterEvaluate {
+    val typePath = smithy.getPluginProjectionPath(smithy.sourceProjection.get(), "java-type-codegen")
+    sourceSets {
+        main {
+            java {
+                srcDir(typePath)
+                include("software/**")
+            }
+            resources {
+                srcDir(typePath)
+                include("META-INF/**")
+            }
+        }
+    }
+}
+
+tasks.named("compileJava") {
+    dependsOn("smithyBuild")
+}
+
+// Needed because sources-jar needs to run after smithy-build is done
+tasks.sourcesJar {
+    mustRunAfter("compileJava")
+}
+
+tasks.processResources {
+    dependsOn("compileJava")
+}

--- a/mcp/mcp-schemas/license.txt
+++ b/mcp/mcp-schemas/license.txt
@@ -1,0 +1,4 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */

--- a/mcp/mcp-schemas/model/main.smithy
+++ b/mcp/mcp-schemas/model/main.smithy
@@ -1,0 +1,157 @@
+$version: "2"
+
+namespace smithy.mcp
+
+structure JsonRpcRequest {
+    @required
+    jsonrpc: String
+
+    @required
+    method: String
+
+    @required
+    id: Integer
+
+    params: Document
+}
+
+structure JsonRpcResponse {
+    @required
+    jsonrpc: String
+
+    result: Document
+
+    error: JsonRpcErrorResponse
+
+    @required
+    id: Integer
+}
+
+structure JsonRpcErrorResponse {
+    @required
+    code: Integer = 0
+
+    message: String
+
+    data: Document
+}
+
+@trait(selector: "service")
+structure jsonRpc2 {}
+
+@trait(selector: "operation")
+structure jsonRpc2Method {
+    @required
+    method: NonEmptyString
+}
+
+@private
+@length(min: 1)
+string NonEmptyString
+
+@mixin
+structure BaseResult {
+    @default("2024-11-05")
+    protocolVersion: String
+}
+
+structure InitializeResult with [BaseResult] {
+    @required
+    capabilities: Capabilities
+
+    @required
+    serverInfo: ServerInfo
+}
+
+structure Capabilities {
+    logging: Document
+    prompts: Prompts
+    tools: Tools
+}
+
+structure Prompts {
+    @default(false)
+    listChanged: Boolean
+}
+
+structure Resources {
+    @default(false)
+    subscribe: Boolean
+}
+
+structure Tools {
+    @default(false)
+    listChanged: Boolean
+}
+
+structure ServerInfo {
+    @required
+    name: String
+
+    @required
+    version: String
+}
+
+structure ListToolsResult {
+    tools: ToolInfoList
+}
+
+structure ToolInfo {
+    @required
+    name: String
+
+    description: String
+
+    inputSchema: ToolInputSchema
+}
+
+list ToolInfoList {
+    member: ToolInfo
+}
+
+structure ToolInputSchema {
+    @default("object")
+    @required
+    type: String
+
+    properties: PropertiesMap
+
+    required: StringList
+}
+
+map PropertiesMap {
+    key: String
+    value: PropertyDetails
+}
+
+structure PropertyDetails {
+    @required
+    type: String
+
+    @required
+    description: String
+}
+
+list StringList {
+    member: String
+}
+
+structure CallToolResult {
+    // TODO add others
+    content: TextContentList
+
+    @default(false)
+    isError: Boolean
+}
+
+list TextContentList {
+    member: TextContent
+}
+
+structure TextContent {
+    @required
+    @default("text")
+    type: String
+
+    text: String
+}

--- a/mcp/mcp-schemas/smithy-build.json
+++ b/mcp/mcp-schemas/smithy-build.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "plugins": {
+    "java-type-codegen": {
+      "namespace": "software.amazon.smithy.java.mcp",
+      "headerFile": "license.txt"
+    }
+  }
+}

--- a/server/server-mcp/build.gradle.kts
+++ b/server/server-mcp/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("smithy-java.module-conventions")
+}
+
+description =
+    "MCP Server support"
+
+extra["displayName"] = "Smithy :: Java :: MCP Server"
+extra["moduleName"] = "software.amazon.smithy.java.server.mcp"
+
+dependencies {
+    api(project(":server:server-api"))
+    implementation(project(":server:server-core"))
+    implementation(project(":logging"))
+    implementation(project(":context"))
+    implementation(project(":codecs:json-codec"))
+    implementation(project(":mcp:mcp-schemas"))
+}
+
+spotbugs {
+    ignoreFailures = true
+}

--- a/server/server-mcp/src/main/java/software/amazon/smithy/java/server/mcp/MCPServer.java
+++ b/server/server-mcp/src/main/java/software/amazon/smithy/java/server/mcp/MCPServer.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.server.mcp;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.TraitKey;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.json.JsonCodec;
+import software.amazon.smithy.java.json.JsonSettings;
+import software.amazon.smithy.java.logging.InternalLogger;
+import software.amazon.smithy.java.mcp.model.CallToolResult;
+import software.amazon.smithy.java.mcp.model.Capabilities;
+import software.amazon.smithy.java.mcp.model.InitializeResult;
+import software.amazon.smithy.java.mcp.model.JsonRpcErrorResponse;
+import software.amazon.smithy.java.mcp.model.JsonRpcRequest;
+import software.amazon.smithy.java.mcp.model.JsonRpcResponse;
+import software.amazon.smithy.java.mcp.model.ListToolsResult;
+import software.amazon.smithy.java.mcp.model.PropertyDetails;
+import software.amazon.smithy.java.mcp.model.ServerInfo;
+import software.amazon.smithy.java.mcp.model.TextContent;
+import software.amazon.smithy.java.mcp.model.ToolInfo;
+import software.amazon.smithy.java.mcp.model.ToolInputSchema;
+import software.amazon.smithy.java.mcp.model.Tools;
+import software.amazon.smithy.java.server.Operation;
+import software.amazon.smithy.java.server.Server;
+import software.amazon.smithy.java.server.Service;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+@SmithyUnstableApi
+public final class MCPServer implements Server {
+
+    private static final InternalLogger LOG = InternalLogger.getLogger(MCPServer.class);
+
+    private static final JsonCodec CODEC = JsonCodec.builder()
+            .settings(JsonSettings.builder()
+                    .serializeTypeInDocuments(false)
+                    .build())
+            .build();
+
+    private final Map<String, Tool> tools;
+    private final Thread listener;
+    private final InputStream is;
+    private final OutputStream os;
+    private final String name;
+
+    MCPServer(MCPServerBuilder builder) {
+        this.tools = createTools(builder.serviceList);
+        this.is = builder.is;
+        this.os = builder.os;
+        this.name = builder.name;
+        this.listener = new Thread(() -> {
+            try {
+                this.listen();
+            } catch (Exception e) {
+                LOG.error("Error handling request", e);
+            }
+        });
+        listener.setName("stdio-dispatcher");
+        listener.setDaemon(true);
+    }
+
+    private void listen() {
+        var scan = new Scanner(is, StandardCharsets.UTF_8);
+        while (scan.hasNextLine()) {
+            var line = scan.nextLine();
+            try {
+                var jsonRequest = CODEC.deserializeShape(line, JsonRpcRequest.builder());
+                handleRequest(jsonRequest);
+            } catch (Exception e) {
+                LOG.error("Error decoding request", e);
+            }
+        }
+    }
+
+    private void handleRequest(JsonRpcRequest req) {
+        try {
+            switch (req.method()) {
+                case "initialize" -> writeResponse(req.id(),
+                        InitializeResult.builder()
+                                .capabilities(Capabilities.builder()
+                                        .tools(Tools.builder().listChanged(false).build())
+                                        .build())
+                                .serverInfo(ServerInfo.builder()
+                                        .name(name)
+                                        .version("1.0.0")
+                                        .build())
+                                .build());
+                case "tools/list" -> writeResponse(req.id(),
+                        ListToolsResult.builder().tools(tools.values().stream().map(Tool::toolInfo).toList()).build());
+                case "tools/call" -> {
+                    var operationName = req.params().getMember("name").asString();
+                    var tool = tools.get(operationName);
+                    var operation = tool.operation();
+                    var input = req.params()
+                            .getMember("arguments")
+                            .asShape(operation.getApiOperation().inputBuilder());
+                    var output = operation.function().apply(input, null);
+                    var result = CallToolResult.builder()
+                            .content(List.of(TextContent.builder()
+                                    .text(CODEC.serializeToString((SerializableShape) output))
+                                    .build()))
+                            .build();
+                    writeResponse(req.id(), result);
+                }
+                default -> {
+                    //For now don't do anything
+                }
+            }
+        } catch (Exception e) {
+            internalError(req, e);
+        }
+    }
+
+    private void writeResponse(int id, SerializableStruct value) {
+        var response = JsonRpcResponse.builder()
+                .id(id)
+                .result(Document.of(value))
+                .jsonrpc("2.0")
+                .build();
+        synchronized (this) {
+            try {
+                os.write(CODEC.serializeToString(response).getBytes(StandardCharsets.UTF_8));
+                os.write('\n');
+                os.flush();
+            } catch (Exception e) {
+                LOG.error("Error encoding response", e);
+            }
+        }
+    }
+
+    private void internalError(JsonRpcRequest req, Exception exception) {
+        String s;
+        try (var sw = new StringWriter();
+                var pw = new PrintWriter(sw)) {
+            exception.printStackTrace(pw);
+            s = sw.toString().replace("\n", "| ");
+        } catch (Exception e) {
+            LOG.error("Error encoding response", e);
+            throw new RuntimeException(e);
+        }
+
+        var error = JsonRpcErrorResponse.builder()
+                .code(500)
+                .message(s)
+                .build();
+        var response = JsonRpcResponse.builder()
+                .id(req.id())
+                .error(error)
+                .jsonrpc("2.0")
+                .build();
+        synchronized (this) {
+            try {
+                os.write(CODEC.serializeToString(response).getBytes(StandardCharsets.UTF_8));
+                os.write('\n');
+            } catch (Exception e) {
+                LOG.error("Error encoding response", e);
+            }
+        }
+    }
+
+    private static Map<String, Tool> createTools(List<Service> serviceList) {
+        var tools = new HashMap<String, Tool>();
+        for (Service service : serviceList) {
+            var serviceName = service.schema().id().getName();
+            for (var operation : service.getAllOperations()) {
+                var operationName = operation.name();
+                Schema schema = operation.getApiOperation().schema();
+                var toolInfo = ToolInfo.builder()
+                        .name(operationName)
+                        .description(createDescription(serviceName,
+                                operationName,
+                                schema
+                                        .expectTrait(TraitKey.DOCUMENTATION_TRAIT)))
+                        .inputSchema(createInputSchema(operation.getApiOperation().inputSchema()))
+                        .build();
+                tools.put(operation.name(), new Tool(toolInfo, operation));
+            }
+        }
+        return tools;
+    }
+
+    private static ToolInputSchema createInputSchema(Schema schema) {
+        var properties = new HashMap<String, PropertyDetails>();
+        var requiredProperties = new ArrayList<String>();
+        for (var member : schema.members()) {
+            var name = member.memberName();
+            if (member.hasTrait(TraitKey.REQUIRED_TRAIT)) {
+                requiredProperties.add(name);
+            }
+            var details = PropertyDetails.builder()
+                    .typeMember(member.type().toString())
+                    .description(member.expectTrait(TraitKey.DOCUMENTATION_TRAIT).getValue())
+                    .build();
+            properties.put(name, details);
+        }
+        return ToolInputSchema.builder().properties(properties).required(requiredProperties).build();
+    }
+
+    private static String createDescription(
+            String serviceName,
+            String operationName,
+            DocumentationTrait documentationTrait
+    ) {
+        return "This tool invokes %s API of %s .".formatted(operationName, serviceName) +
+                documentationTrait.getValue();
+    }
+
+    @Override
+    public void start() {
+        listener.start();
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdown() {
+        //TODO Do we need to better handle this?
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private record Tool(ToolInfo toolInfo, Operation operation) {
+
+    }
+
+    public static MCPServerBuilder builder() {
+        return new MCPServerBuilder();
+    }
+}

--- a/server/server-mcp/src/main/java/software/amazon/smithy/java/server/mcp/MCPServerBuilder.java
+++ b/server/server-mcp/src/main/java/software/amazon/smithy/java/server/mcp/MCPServerBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.server.mcp;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import software.amazon.smithy.java.server.Server;
+import software.amazon.smithy.java.server.Service;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+@SmithyUnstableApi
+public final class MCPServerBuilder {
+
+    InputStream is;
+    OutputStream os;
+    List<Service> serviceList = new ArrayList<>();
+    String name;
+
+    MCPServerBuilder() {}
+
+    public MCPServerBuilder stdio() {
+        this.is = System.in;
+        this.os = System.out;
+        return this;
+    }
+
+    public MCPServerBuilder input(InputStream is) {
+        this.is = is;
+        return this;
+    }
+
+    public MCPServerBuilder output(OutputStream os) {
+        this.os = os;
+        return this;
+    }
+
+    public MCPServerBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public Server build() {
+        validate();
+        return new MCPServer(this);
+    }
+
+    public MCPServerBuilder addService(Service... service) {
+        serviceList.addAll(Arrays.asList(service));
+        return this;
+    }
+
+    private void validate() {
+        Objects.requireNonNull(is, "MCP server input stream is required");
+        Objects.requireNonNull(is, "MCP server output stream is required");
+        if (serviceList.isEmpty()) {
+            throw new IllegalArgumentException("MCP server requires at least one service");
+        }
+    }
+}

--- a/server/server-proxy/build.gradle.kts
+++ b/server/server-proxy/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("smithy-java.module-conventions")
+}
+
+description = "This module provides the proxy server functionality"
+
+extra["displayName"] = "Smithy :: Java :: Proxy server"
+extra["moduleName"] = "software.amazon.smithy.java.server.proxy"
+
+dependencies {
+    api(project(":server:server-api"))
+    api(project(":http:http-api"))
+    api(project(":core"))
+    api(project(":context"))
+    api(project(":framework-errors"))
+    implementation(libs.smithy.model)
+    implementation(project(":io"))
+    implementation(project(":logging"))
+    implementation(project(":dynamic-schemas"))
+    implementation(project(":client:dynamic-client"))
+    implementation(project(":client:client-core"))
+    implementation(project(":aws:client:aws-client-http"))
+}

--- a/server/server-proxy/src/main/java/software/amazon/smithy/java/server/ProxyService.java
+++ b/server/server-proxy/src/main/java/software/amazon/smithy/java/server/ProxyService.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.server;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import software.amazon.smithy.java.auth.api.identity.Identity;
+import software.amazon.smithy.java.aws.client.core.settings.RegionSetting;
+import software.amazon.smithy.java.client.core.auth.identity.IdentityResolver;
+import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
+import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
+import software.amazon.smithy.java.core.error.ModeledException;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.dynamicclient.DocumentException;
+import software.amazon.smithy.java.dynamicclient.DynamicClient;
+import software.amazon.smithy.java.dynamicclient.DynamicOperation;
+import software.amazon.smithy.java.dynamicschemas.SchemaConverter;
+import software.amazon.smithy.java.dynamicschemas.WrappedDocument;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+@SmithyUnstableApi
+public final class ProxyService implements Service {
+
+    private final DynamicClient dynamicClient;
+    private final SchemaConverter schemaConverter;
+    private final Map<String, Operation<WrappedDocument, WrappedDocument>> operations;
+    private final TypeRegistry serviceErrorRegistry;
+    private final Model model;
+    private final ServiceShape service;
+    private final List<Operation<? extends SerializableStruct, ? extends SerializableStruct>> allOperations;
+    private final Schema schema;
+
+    private ProxyService(Builder builder, ServiceShape service, Model model) {
+        this.model = model;
+        this.service = service;
+        DynamicClient.Builder clientBuilder = DynamicClient.builder()
+                .service(service.getId())
+                .model(model)
+                .endpointResolver(EndpointResolver.staticEndpoint(builder.proxyEndpoint));
+        if (builder.identityResolver != null) {
+            clientBuilder.addIdentityResolver(builder.identityResolver);
+        }
+        if (builder.authScheme != null) {
+            clientBuilder.authSchemeResolver(builder.authScheme);
+        }
+        if (builder.region != null) {
+            clientBuilder.putConfig(RegionSetting.REGION, builder.region);
+        }
+        this.dynamicClient = clientBuilder.build();
+        this.schemaConverter = new SchemaConverter(model);
+        this.operations = new HashMap<>();
+        var registryBuilder = TypeRegistry.builder();
+        for (var e : service.getErrors()) {
+            registerError(e, registryBuilder);
+        }
+        this.serviceErrorRegistry = registryBuilder.build();
+        this.allOperations = new ArrayList<>();
+        for (var operation : TopDownIndex.of(model).getContainedOperations(service.getId())) {
+            String operationName = operation.getId().getName();
+            var function =
+                    new DynamicFunction(dynamicClient, operationName, schemaConverter, model, operation, service);
+            Operation<WrappedDocument,
+                    WrappedDocument> serverOperation = Operation.of(operationName,
+                            function,
+                            DynamicOperation.create(operation,
+                                    schemaConverter,
+                                    model,
+                                    service,
+                                    serviceErrorRegistry,
+                                    this::registerError),
+                            this);
+            allOperations.add(serverOperation);
+            operations.put(operationName, serverOperation);
+        }
+        this.schema = schemaConverter.getSchema(service);
+    }
+
+    private void registerError(ShapeId e, TypeRegistry.Builder registryBuilder) {
+        var error = model.expectShape(e);
+        var errorSchema = schemaConverter.getSchema(error);
+        registryBuilder.putType(e,
+                ModeledException.class,
+                () -> new DocumentException.SchemaGuidedExceptionBuilder(service.getId(), errorSchema));
+    }
+
+    @Override
+    public <I extends SerializableStruct,
+            O extends SerializableStruct> Operation<I, O> getOperation(String operationName) {
+        return (Operation<I, O>) operations.get(operationName);
+    }
+
+    @Override
+    public List<Operation<? extends SerializableStruct, ? extends SerializableStruct>> getAllOperations() {
+        return allOperations;
+    }
+
+    @Override
+    public Schema schema() {
+        return schema;
+    }
+
+    @Override
+    public TypeRegistry typeRegistry() {
+        return serviceErrorRegistry;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private String region;
+        private Model model;
+        private ShapeId service;
+        private IdentityResolver<? extends Identity> identityResolver;
+        private String proxyEndpoint;
+        private AuthSchemeResolver authScheme;
+
+        private Builder() {}
+
+        public ProxyService build() {
+            Objects.requireNonNull(model, "model is not set");
+            Objects.requireNonNull(service, "service is not set");
+            ServiceShape shape = model.expectShape(service, ServiceShape.class);
+
+            return new ProxyService(this, shape, model);
+        }
+
+        /**
+         * <strong>Required</strong>: Set the Smithy model to use with the client.
+         *
+         * <p>This model <em>MUST</em> contain the service shape referenced in {@link #service(ShapeId)}.
+         *
+         * <pre>{@code
+         * var model = Model.assembler().discoverModels().assemble().unwrap();
+         * builder.model(model);
+         * }</pre>
+         *
+         * @param model Model to use when calling the service.
+         * @return the builder.
+         */
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+
+        /**
+         * <stong>Required</stong>: Set the service shape ID to call.
+         *
+         * <p>The given shape ID <em>MUST</em> be present in the model given in {@link #model(Model)}.
+         *
+         * @param service Service shape in the model to call with the dynamic client.
+         * @return the builder.
+         */
+        public Builder service(ShapeId service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder identityResolver(IdentityResolver<? extends Identity> identityResolver) {
+            this.identityResolver = Objects.requireNonNull(identityResolver, "credentialsProvider is not set");
+            return this;
+        }
+
+        public Builder proxyEndpoint(String proxyEndpoint) {
+            this.proxyEndpoint = proxyEndpoint;
+            return this;
+        }
+
+        public Builder authSchemeResolver(AuthSchemeResolver authSchemeResolver) {
+            this.authScheme = authSchemeResolver;
+            return this;
+        }
+
+        public Builder region(String region) {
+            this.region = region;
+            return this;
+        }
+    }
+
+    private record DynamicFunction(DynamicClient dynamicClient,
+                                   String operation, 
+                                   SchemaConverter schemaConverter,
+                                   Model model,
+                                   OperationShape operationShape,
+                                   ServiceShape serviceShape) implements BiFunction<WrappedDocument, RequestContext, WrappedDocument> {
+
+        @Override
+            public WrappedDocument apply(WrappedDocument input, RequestContext requestContext) {
+                return createWrappedDocument(operationShape.getOutput().get(), dynamicClient.call(operation, input));
+            }
+
+            private WrappedDocument createWrappedDocument(ToShapeId shape, Document value) {
+                var schema = schemaConverter.getSchema(model.expectShape(shape.toShapeId()));
+                if (value.type() != ShapeType.MAP && value.type() != ShapeType.STRUCTURE) {
+                    throw new IllegalArgumentException("Document value must be a map or structure, found " + value.type());
+                }
+                return new WrappedDocument(schema, value, serviceShape.getId());
+            }
+        }
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ include(":server:server-api")
 include(":server:server-core")
 include(":server:server-netty")
 include(":server:server-rpcv2-cbor")
+include(":server:server-proxy")
 
 // Codegen
 include(":codegen:codegen-core")
@@ -70,3 +71,10 @@ include(":examples:event-streaming-client")
 include(":examples:lambda")
 include(":examples:restjson-client")
 include(":examples:standalone-types")
+include(":examples:mcp-server")
+
+//MCP
+include(":mcp")
+include(":mcp:mcp-schemas")
+include(":server:server-mcp")
+

--- a/smithy-templates.json
+++ b/smithy-templates.json
@@ -56,6 +56,14 @@
         "examples/gradle.properties",
         ".gitignore"
       ]
+    },
+    "mcp-server" : {
+      "documentation" : "Generate or create an MCP server.",
+      "path": "examples/mcp-server",
+      "include": [
+        "examples/gradle.properties",
+        ".gitignore"
+      ]
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds MCP support to smithy-java. Users can now do 2 things,

1. Generate an MCP server for their existing service implementation.
2. Generate a MCP Proxy server for any service with just the smithy model.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
