### PR TITLE
Fix sourceSets configuration for packages using type-codegen

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.module-conventions.gradle.kts
@@ -49,6 +49,7 @@ afterEvaluate {
         manifest {
             attributes(mapOf("Automatic-Module-Name" to moduleName))
         }
+        duplicatesStrategy = DuplicatesStrategy.FAIL
     }
 }
 

--- a/examples/lambda/build.gradle.kts
+++ b/examples/lambda/build.gradle.kts
@@ -37,7 +37,6 @@ tasks {
 // Add generated Java files to the main sourceSet
 afterEvaluate {
     val serverPath = smithy.getPluginProjectionPath(smithy.sourceProjection.get(), "java-server-codegen")
-    println(serverPath.get())
     sourceSets {
         main {
             java {

--- a/examples/standalone-types/build.gradle.kts
+++ b/examples/standalone-types/build.gradle.kts
@@ -22,9 +22,11 @@ afterEvaluate {
         main {
             java {
                 srcDir(typePath)
+                include("software/**")
             }
             resources {
                 srcDir(typePath)
+                include("META-INF/**")
             }
         }
     }

--- a/framework-errors/build.gradle.kts
+++ b/framework-errors/build.gradle.kts
@@ -36,12 +36,6 @@ afterEvaluate {
     }
 }
 
-// TODO: This is needed because the type-mapping file is mapped (twice) in the source-set above and source-set below,
-//  but really we shouldn't be doing that
-tasks.withType<Jar> {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-}
-
 tasks.named("compileJava") {
     dependsOn("smithyBuild")
 }

--- a/framework-errors/build.gradle.kts
+++ b/framework-errors/build.gradle.kts
@@ -26,9 +26,11 @@ afterEvaluate {
         main {
             java {
                 srcDir(typesPath)
+                include("software/**")
             }
             resources {
                 srcDir(typesPath)
+                include("META-INF/**")
             }
         }
     }


### PR DESCRIPTION
*Description of changes:*
- Because the generated code is flat (no `src/main/java` and `src/main/resources`), the same source directory was being set
  - This was also explicitly called out in the TODO removed in this PR
  - Some zip implementations will fail to unzip when there are duplicate entries
- Adds a fail duplicate strategy to our `module-conventions` plugin so this doesn't happen in the future

*Before*
```
META-INF/
META-INF/LICENSE
META-INF/MANIFEST.MF
META-INF/NOTICE
META-INF/services/
META-INF/services/software.amazon.smithy.model.traits.TraitService
META-INF/smithy-java/
META-INF/smithy-java/type-mappings.properties
META-INF/smithy-java/type-mappings.properties
META-INF/smithy/
META-INF/smithy/errors.smithy
META-INF/smithy/manifest
META-INF/smithy/trait.smithy
errors.smithy
software/
software/amazon/
software/amazon/smithy/
software/amazon/smithy/framework/
software/amazon/smithy/framework/knowledge/
software/amazon/smithy/framework/knowledge/ImplicitErrorIndex.java
software/amazon/smithy/framework/traits/
software/amazon/smithy/framework/traits/ImplicitErrorsTrait.java
software/amazon/smithy/framework/transform/
software/amazon/smithy/framework/transform/AddFrameworkErrorsTransform.java
software/amazon/smithy/java/
software/amazon/smithy/java/framework/
software/amazon/smithy/java/framework/model/
software/amazon/smithy/java/framework/model/AccessDeniedException.java
software/amazon/smithy/java/framework/model/AccessDeniedException.java
software/amazon/smithy/java/framework/model/InternalFailureException.java
software/amazon/smithy/java/framework/model/InternalFailureException.java
software/amazon/smithy/java/framework/model/MalformedRequestException.java
software/amazon/smithy/java/framework/model/MalformedRequestException.java
software/amazon/smithy/java/framework/model/NotAuthorizedException.java
software/amazon/smithy/java/framework/model/NotAuthorizedException.java
software/amazon/smithy/java/framework/model/Schemas.java
software/amazon/smithy/java/framework/model/Schemas.java
software/amazon/smithy/java/framework/model/SharedSerde.java
software/amazon/smithy/java/framework/model/SharedSerde.java
software/amazon/smithy/java/framework/model/ThrottlingException.java
software/amazon/smithy/java/framework/model/ThrottlingException.java
software/amazon/smithy/java/framework/model/UnknownOperationException.java
software/amazon/smithy/java/framework/model/UnknownOperationException.java
software/amazon/smithy/java/framework/model/ValidationException.java
software/amazon/smithy/java/framework/model/ValidationException.java
software/amazon/smithy/java/framework/model/ValidationExceptionField.java
software/amazon/smithy/java/framework/model/ValidationExceptionField.java
trait.smithy

```
*After*
```
META-INF/
META-INF/LICENSE
META-INF/MANIFEST.MF
META-INF/NOTICE
META-INF/services/
META-INF/services/software.amazon.smithy.model.traits.TraitService
META-INF/smithy-java/
META-INF/smithy-java/type-mappings.properties
META-INF/smithy/
META-INF/smithy/errors.smithy
META-INF/smithy/manifest
META-INF/smithy/trait.smithy
software/
software/amazon/
software/amazon/smithy/
software/amazon/smithy/framework/
software/amazon/smithy/framework/knowledge/
software/amazon/smithy/framework/knowledge/ImplicitErrorIndex.java
software/amazon/smithy/framework/traits/
software/amazon/smithy/framework/traits/ImplicitErrorsTrait.java
software/amazon/smithy/framework/transform/
software/amazon/smithy/framework/transform/AddFrameworkErrorsTransform.java
software/amazon/smithy/java/
software/amazon/smithy/java/framework/
software/amazon/smithy/java/framework/model/
software/amazon/smithy/java/framework/model/AccessDeniedException.java
software/amazon/smithy/java/framework/model/InternalFailureException.java
software/amazon/smithy/java/framework/model/MalformedRequestException.java
software/amazon/smithy/java/framework/model/NotAuthorizedException.java
software/amazon/smithy/java/framework/model/Schemas.java
software/amazon/smithy/java/framework/model/SharedSerde.java
software/amazon/smithy/java/framework/model/ThrottlingException.java
software/amazon/smithy/java/framework/model/UnknownOperationException.java
software/amazon/smithy/java/framework/model/ValidationException.java
software/amazon/smithy/java/framework/model/ValidationExceptionField.java

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
