### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
+      - name: Integration tests
+        run: ./gradlew integ -Plog-tests --stacktrace
+
       - name: Allow long file names in git for windows
         if: matrix.os == 'windows-latest'
         run: git config --system core.longpaths true

--- a/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
+++ b/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
@@ -132,11 +132,11 @@ public final class ClientInterfaceGenerator
                                             ${/hasTransportSettings}${?defaultSchemes}
                                             ${defaultAuth:C|}${/defaultSchemes}
 
-                                            private Builder() {${?defaultSchemes}
-                                                configBuilder()
-                                                    .putSupportedAuthSchemes(${#defaultSchemes}${value:L}.createAuthScheme(${key:L})${^key.last}, ${/key.last}${/defaultSchemes})
+                                            private Builder() {
+                                                configBuilder()${?defaultSchemes}
+                                                    .putSupportedAuthSchemes(${#defaultSchemes}${value:L}.createAuthScheme(${key:L})${^key.last}, ${/key.last}${/defaultSchemes})${/defaultSchemes}
                                                     .service(${serviceApi:T}.instance());
-                                            ${/defaultSchemes}}
+                                            }
 
                                             @Override
                                             public ${interface:T} build() {

--- a/examples/restjson-client/src/it/java/software/amazon/smithy/java/example/ClientConfigTest.java
+++ b/examples/restjson-client/src/it/java/software/amazon/smithy/java/example/ClientConfigTest.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.java.example.restjson.client.PersonDirectoryClient
 import software.amazon.smithy.java.example.restjson.model.GetPersonImage;
 import software.amazon.smithy.java.example.restjson.model.GetPersonImageInput;
 import software.amazon.smithy.java.example.restjson.model.GetPersonImageOutput;
+import software.amazon.smithy.java.example.restjson.model.PersonDirectoryApiService;
 import software.amazon.smithy.java.example.restjson.model.PutPerson;
 import software.amazon.smithy.java.example.restjson.model.PutPersonImage;
 import software.amazon.smithy.java.example.restjson.model.PutPersonImageInput;
@@ -154,6 +155,7 @@ public class ClientConfigTest {
 
             private Builder() {
                 ClientConfig.Builder configBuilder = configBuilder();
+                configBuilder.service(PersonDirectoryApiService.instance());
                 configBuilder.protocol(new RestJsonClientProtocol(PreludeSchemas.DOCUMENT.id()));
                 configBuilder.transport(new JavaHttpClientTransport(HttpClient.newHttpClient()));
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The integration tests are failing because the service schemas wasn't set in the client config. We were incorrectly setting this only when auth schemes exist.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
