### PR TITLE
Remove windows from the CI for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         java: [17]
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Windows builds are terribly slow and slow development. Removing it for now. Created a backlog task #640 to re-nable it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
