### PR TITLE
Add Operation filtering

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ApiOperation.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ApiOperation.java
@@ -125,4 +125,13 @@ public interface ApiOperation<I extends SerializableStruct, O extends Serializab
     default ApiResource boundResource() {
         return null;
     }
+
+    /**
+     * Name of the Operation.
+     *
+     * @return Returns the name of the operation.
+     */
+    default String name() {
+        return schema().id().getName();
+    }
 }

--- a/server/server-api/build.gradle.kts
+++ b/server/server-api/build.gradle.kts
@@ -10,4 +10,5 @@ extra["moduleName"] = "software.amazon.smithy.java.server.api"
 dependencies {
     implementation(project(":logging"))
     implementation(project(":core"))
+    implementation(project(":framework-errors"))
 }

--- a/server/server-api/src/main/java/software/amazon/smithy/java/server/FilteredService.java
+++ b/server/server-api/src/main/java/software/amazon/smithy/java/server/FilteredService.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.server;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.java.framework.model.UnknownOperationException;
+
+/**
+ * A service implementation that filters operations based on a provided filter.
+ * <p>
+ * This class wraps an existing service and applies an operation filter to control
+ * which operations are exposed through this service.
+ */
+public final class FilteredService implements Service {
+
+    private final Service delegate;
+    private final Predicate<ApiOperation<? extends SerializableStruct, ? extends SerializableStruct>> filter;
+    private final Map<String, Operation<? extends SerializableStruct, ? extends SerializableStruct>> filteredOperations;
+    private final List<Operation<? extends SerializableStruct, ? extends SerializableStruct>> operationList;
+
+    /**
+     * Creates a new filtered service by applying the specified filter to the delegate service.
+     *
+     * @param delegate The underlying service to filter
+     * @param filter   The filter to apply to the service's operations
+     */
+    public FilteredService(
+            Service delegate,
+            Predicate<ApiOperation<? extends SerializableStruct, ? extends SerializableStruct>> filter
+    ) {
+        this.delegate = delegate;
+        this.filter = filter;
+        this.filteredOperations = delegate.getAllOperations()
+                .stream()
+                .filter(o -> filter.test(o.getApiOperation()))
+                .collect(Collectors.toMap(Operation::name, Function.identity()));
+        this.operationList = new ArrayList<>(filteredOperations.values());
+    }
+
+    /**
+     * Retrieves an operation by name, if it exists and passes the filter.
+     *
+     * @param operationName The name of the operation to retrieve
+     * @return The filtered operation with the specified name
+     * @throws UnknownOperationException if no matching operation is found, or it's filtered out
+     */
+    @Override
+    public <I extends SerializableStruct,
+            O extends SerializableStruct> Operation<I, O> getOperation(String operationName) {
+        var operation = filteredOperations.get(operationName);
+        if (operation == null) {
+            throw UnknownOperationException.builder().message("No matching operations found for request").build();
+        }
+        return (Operation<I, O>) operation;
+    }
+
+    /**
+     * Returns all operations that pass the filter.
+     *
+     * @return A list of all operations included by the filter
+     */
+    @Override
+    public List<Operation<? extends SerializableStruct, ? extends SerializableStruct>> getAllOperations() {
+        return operationList;
+    }
+
+    /**
+     * Returns the schema from the delegate service.
+     *
+     * @return The schema of the delegate service
+     */
+    @Override
+    public Schema schema() {
+        return delegate.schema(); //TODO this probably isn't accurate, we need to filter the schema too.
+    }
+
+    /**
+     * Returns the type registry from the delegate service.
+     *
+     * @return The type registry of the delegate service
+     */
+    @Override
+    public TypeRegistry typeRegistry() {
+        return delegate.typeRegistry();
+    }
+}

--- a/server/server-api/src/main/java/software/amazon/smithy/java/server/OperationFilters.java
+++ b/server/server-api/src/main/java/software/amazon/smithy/java/server/OperationFilters.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.server;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Predicate;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+
+public final class OperationFilters {
+
+    private OperationFilters() {}
+
+    /**
+     * Creates a {@link Predicate} that only includes operations with names in the provided set.
+     *
+     * @param operationNames Set of operation names to include
+     * @return A {@link Predicate} that only includes the specified operations
+     */
+    public static Predicate<ApiOperation<? extends SerializableStruct, ? extends SerializableStruct>> allowList(
+            Set<String> operationNames
+    ) {
+        return new OperationFilters.OperationNameFilter(operationNames, null);
+    }
+
+    /**
+     * Creates a {@link Predicate} that excludes operations with names in the provided set.
+     *
+     * @param operationNames Set of operation names to exclude
+     * @return A {@link Predicate} that excludes the specified operations
+     */
+    static Predicate<ApiOperation<? extends SerializableStruct, ? extends SerializableStruct>> blockList(
+            Set<String> operationNames
+    ) {
+        return new OperationNameFilter(null, operationNames);
+    }
+
+    static final class OperationNameFilter implements Predicate<ApiOperation<?, ?>> {
+        private final Set<String> allowlist;
+        private final Set<String> blocklist;
+
+        OperationNameFilter(Set<String> allowlist, Set<String> blocklist) {
+            this.allowlist = allowlist != null ? allowlist : Collections.emptySet();
+            this.blocklist = blocklist != null ? blocklist : Collections.emptySet();
+        }
+
+        @Override
+        public boolean test(ApiOperation<?, ?> operation) {
+            var operationName = operation.schema().id().getName();
+
+            if (blocklist.contains(operationName)) {
+                return false;
+            }
+
+            return allowlist.isEmpty() || allowlist.contains(operationName);
+        }
+    }
+}

--- a/server/server-api/src/test/java/software/amazon/smithy/java/server/FilteredServiceTest.java
+++ b/server/server-api/src/test/java/software/amazon/smithy/java/server/FilteredServiceTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static software.amazon.smithy.java.server.TestStructs.createMockOperation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.java.framework.model.UnknownOperationException;
+import software.amazon.smithy.java.server.TestStructs.MockStruct;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Tests for the {@link FilteredService} class.
+ */
+public class FilteredServiceTest {
+
+    private MockService delegateService;
+
+    @BeforeEach
+    public void setup() {
+        delegateService = new MockService();
+    }
+
+    /**
+     * Test implementation of Service for testing FilteredService.
+     */
+    private class MockService implements Service {
+        private final List<Operation<?, ?>> operations;
+        private final Schema mockSchema = Schema.createService(ShapeId.from("mock#MockService"));
+        private final TypeRegistry mockTypeRegistry = TypeRegistry.EMPTY;
+
+        public MockService() {
+            // Create a list of test operations
+            operations = new ArrayList<>();
+            operations.add(createMockOperation("GetItem"));
+            operations.add(createMockOperation("PutItem"));
+            operations.add(createMockOperation("UpdateItem"));
+            operations.add(createMockOperation("DeleteItem"));
+            operations.add(createMockOperation("ListItems"));
+        }
+
+        @Override
+        public <I extends SerializableStruct,
+                O extends SerializableStruct> Operation<I, O> getOperation(String operationName) {
+            return (Operation<I, O>) operations.stream()
+                    .filter(op -> op.name().equals(operationName))
+                    .findFirst()
+                    .orElseThrow(() -> UnknownOperationException.builder().build());
+        }
+
+        @Override
+        public List<Operation<? extends SerializableStruct, ? extends SerializableStruct>> getAllOperations() {
+            return operations;
+        }
+
+        @Override
+        public Schema schema() {
+            return mockSchema;
+        }
+
+        @Override
+        public TypeRegistry typeRegistry() {
+            return mockTypeRegistry;
+        }
+    }
+
+    @Test
+    public void testFilteredServiceWithAllowList() {
+        // Create a filtered service that only allows specific operations
+        var filter = OperationFilters.allowList(Set.of("GetItem", "PutItem"));
+        FilteredService filteredService = new FilteredService(delegateService, filter);
+
+        // Verify that getAllOperations returns only the allowed operations
+        List<Operation<?, ?>> filteredOperations = filteredService.getAllOperations();
+        assertThat(filteredOperations).hasSize(2);
+        assertThat(filteredOperations.stream().map(Operation::name).toList())
+                .containsExactlyInAnyOrder("GetItem", "PutItem");
+
+        // Verify that getOperation works for allowed operations
+        Operation<?, ?> getItemOp = filteredService.getOperation("GetItem");
+        assertThat(getItemOp).isNotNull();
+        assertThat(getItemOp.name()).isEqualTo("GetItem");
+
+        // Verify that getOperation throws for filtered-out operations
+        assertThatThrownBy(() -> filteredService.getOperation("DeleteItem"))
+                .isInstanceOf(UnknownOperationException.class);
+    }
+
+    @Test
+    public void testFilteredServiceWithBlockList() {
+        // Create a filtered service that blocks specific operations
+        var filter = OperationFilters.blockList(Set.of("DeleteItem", "UpdateItem"));
+        FilteredService filteredService = new FilteredService(delegateService, filter);
+
+        // Verify that getAllOperations returns only the non-blocked operations
+        List<Operation<?, ?>> filteredOperations = filteredService.getAllOperations();
+        assertThat(filteredOperations).hasSize(3);
+        assertThat(filteredOperations.stream().map(Operation::name).collect(Collectors.toList()))
+                .containsExactlyInAnyOrder("GetItem", "PutItem", "ListItems");
+
+        // Verify that getOperation works for non-blocked operations
+        Operation<?, ?> listItemsOp = filteredService.getOperation("ListItems");
+        assertThat(listItemsOp).isNotNull();
+        assertThat(listItemsOp.name()).isEqualTo("ListItems");
+
+        // Verify that getOperation throws for blocked operations
+        assertThatThrownBy(() -> filteredService.getOperation("DeleteItem"))
+                .isInstanceOf(UnknownOperationException.class);
+    }
+
+    @Test
+    public void testFilteredServiceWithCustomFilter() {
+        // Create a filtered service with a custom filter (only "Get" operations)
+        Predicate<ApiOperation<? extends SerializableStruct, ? extends SerializableStruct>> filter =
+                operation -> operation.name().startsWith("Get");
+        FilteredService filteredService = new FilteredService(delegateService, filter);
+
+        // Verify that getAllOperations returns only the matching operations
+        List<Operation<?, ?>> filteredOperations = filteredService.getAllOperations();
+        assertThat(filteredOperations).hasSize(1);
+        assertThat(filteredOperations.get(0).name()).isEqualTo("GetItem");
+
+        // Verify that getOperation throws for filtered-out operations
+        assertThatThrownBy(() -> filteredService.getOperation("PutItem"))
+                .isInstanceOf(UnknownOperationException.class);
+    }
+
+    @Test
+    public void testSchemaAndTypeRegistryDelegation() {
+        // Create a filtered service
+        var filter = OperationFilters.allowList(Set.of("GetItem"));
+        FilteredService filteredService = new FilteredService(delegateService, filter);
+
+        // Verify that schema and typeRegistry are delegated to the underlying service
+        assertThat(filteredService.schema()).isSameAs(delegateService.schema());
+        assertThat(filteredService.typeRegistry()).isSameAs(delegateService.typeRegistry());
+    }
+
+    @Test
+    public void testFilterThatRemovesAllOperations() {
+        // Create a filter that removes all operations
+        Predicate<ApiOperation<? extends SerializableStruct, ? extends SerializableStruct>> filter = operation -> false;
+        FilteredService filteredService = new FilteredService(delegateService, filter);
+
+        // Verify that getAllOperations returns an empty list
+        List<Operation<?, ?>> filteredOperations = filteredService.getAllOperations();
+        assertThat(filteredOperations).isEmpty();
+
+        // Verify that getOperation throws for any operation
+        assertThatThrownBy(() -> filteredService.getOperation("GetItem"))
+                .isInstanceOf(UnknownOperationException.class);
+    }
+
+    @Test
+    public void testOperationInvocation() {
+        // Create a filtered service
+        Predicate<ApiOperation<? extends SerializableStruct, ? extends SerializableStruct>> filter =
+                OperationFilters.allowList(Set.of("GetItem"));
+        FilteredService filteredService = new FilteredService(delegateService, filter);
+
+        // Get the operation and verify we can invoke it
+        Operation<MockStruct, MockStruct> op = filteredService.getOperation("GetItem");
+        var mockInput = new MockStruct();
+
+        // Verify the result is the same.
+        assertSame(mockInput, op.function().apply(mockInput, null));
+    }
+}

--- a/server/server-api/src/test/java/software/amazon/smithy/java/server/OperationFiltersTest.java
+++ b/server/server-api/src/test/java/software/amazon/smithy/java/server/OperationFiltersTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.smithy.java.server.TestStructs.MockApiOperation;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link OperationFilters} default filters.
+ */
+public class OperationFiltersTest {
+
+    /**
+     * Creates a mock operation with the given name.
+     */
+    @Test
+    public void testAllowListFilter() {
+        // Create an allowlist filter with specific operation names
+        var filter = OperationFilters.allowList(Set.of("GetItem", "PutItem"));
+
+        // Operations in the allowlist should be included
+        assertThat(filter.test(new MockApiOperation("GetItem"))).isTrue();
+        assertThat(filter.test(new MockApiOperation("PutItem"))).isTrue();
+
+        // Operations not in the allowlist should be excluded
+        assertThat(filter.test(new MockApiOperation("DeleteItem"))).isFalse();
+        assertThat(filter.test(new MockApiOperation("ListItems"))).isFalse();
+    }
+
+    @Test
+    public void testAllowListFilterWithEmptySet() {
+        // An empty allowlist should include all operations
+        var filter = OperationFilters.allowList(Set.of());
+
+        assertThat(filter.test(new MockApiOperation("GetItem"))).isTrue();
+        assertThat(filter.test(new MockApiOperation("PutItem"))).isTrue();
+        assertThat(filter.test(new MockApiOperation("DeleteItem"))).isTrue();
+    }
+
+    @Test
+    public void testBlockListFilter() {
+        // Create a blocklist filter with specific operation names
+        var filter = OperationFilters.blockList(Set.of("DeleteItem", "UpdateItem"));
+
+        // Operations in the blocklist should be excluded
+        assertThat(filter.test(new MockApiOperation("DeleteItem"))).isFalse();
+        assertThat(filter.test(new MockApiOperation("UpdateItem"))).isFalse();
+
+        // Operations not in the blocklist should be included
+        assertThat(filter.test(new MockApiOperation("GetItem"))).isTrue();
+        assertThat(filter.test(new MockApiOperation("PutItem"))).isTrue();
+    }
+}

--- a/server/server-api/src/test/java/software/amazon/smithy/java/server/TestStructs.java
+++ b/server/server-api/src/test/java/software/amazon/smithy/java/server/TestStructs.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.server;
+
+import java.util.List;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.ApiService;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+class TestStructs {
+
+    /**
+     * Mock implementation of SerializableStruct for testing.
+     */
+    static class MockStruct implements SerializableStruct {
+
+        @Override
+        public Schema schema() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class MockApiOperation implements ApiOperation<MockStruct, MockStruct> {
+
+        private final Schema schema;
+
+        MockApiOperation(String name) {
+            this.schema = Schema.createOperation(ShapeId.from("mock#" + name));
+        }
+
+        @Override
+        public ShapeBuilder inputBuilder() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ShapeBuilder outputBuilder() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Schema schema() {
+            return schema;
+        }
+
+        @Override
+        public Schema inputSchema() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Schema outputSchema() {
+            return null;
+        }
+
+        @Override
+        public TypeRegistry errorRegistry() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<ShapeId> effectiveAuthSchemes() {
+            return List.of();
+        }
+
+        @Override
+        public ApiService service() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static Operation<MockStruct, MockStruct> createMockOperation(String name) {
+        return Operation.<MockStruct, MockStruct>of(
+                name,
+                (input, context) -> input,
+                new MockApiOperation(name),
+                null);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add ability to create a filtered service which only exposes certain operations of a service.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
