### PR TITLE
Ensure serializer is closed

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/core/serde/Codec.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/Codec.java
@@ -66,7 +66,6 @@ public interface Codec extends AutoCloseable {
         ByteBufferOutputStream baos = new ByteBufferOutputStream();
         try (var serializer = createSerializer(baos)) {
             shape.serialize(serializer);
-            serializer.flush();
         }
         return baos.toByteBuffer();
     }
@@ -99,9 +98,9 @@ public interface Codec extends AutoCloseable {
      */
     default String serializeToString(SerializableShape shape) {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        ShapeSerializer serializer = createSerializer(stream);
-        shape.serialize(serializer);
-        serializer.flush();
+        try (var serializer = createSerializer(stream)) {
+            shape.serialize(serializer);
+        }
         return stream.toString(StandardCharsets.UTF_8);
     }
 


### PR DESCRIPTION
We also don't need to call flush since it's done when calling close

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
