### PR TITLE
Add payloadCodec to ClientProtocol

### DIFF
--- a/aws/client/aws-client-awsjson/src/main/java/software/amazon/smithy/java/aws/client/awsjson/AwsJsonProtocol.java
+++ b/aws/client/aws-client-awsjson/src/main/java/software/amazon/smithy/java/aws/client/awsjson/AwsJsonProtocol.java
@@ -16,6 +16,7 @@ import software.amazon.smithy.java.client.http.HttpErrorDeserializer;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.java.http.api.HttpHeaders;
 import software.amazon.smithy.java.http.api.HttpRequest;
@@ -52,6 +53,11 @@ abstract sealed class AwsJsonProtocol extends HttpClientProtocol permits AwsJson
     }
 
     protected abstract String contentType();
+
+    @Override
+    public Codec payloadCodec() {
+        return codec;
+    }
 
     @Override
     public <I extends SerializableStruct, O extends SerializableStruct> HttpRequest createRequest(

--- a/aws/client/aws-client-restjson/src/main/java/software/amazon/smithy/java/aws/client/restjson/RestJsonClientProtocol.java
+++ b/aws/client/aws-client-restjson/src/main/java/software/amazon/smithy/java/aws/client/restjson/RestJsonClientProtocol.java
@@ -56,7 +56,7 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
     }
 
     @Override
-    protected Codec codec() {
+    public Codec payloadCodec() {
         return codec;
     }
 
@@ -82,7 +82,7 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
         // TODO: this is where you'd plumb through Sigv4 support, another frame transformer?
         return AwsEventEncoderFactory.forInputStream(
                 inputOperation,
-                codec(),
+                payloadCodec(),
                 payloadMediaType(),
                 (e) -> new EventStreamingException("InternalServerException", "Internal Server Error"));
     }
@@ -91,7 +91,7 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
     protected EventDecoderFactory<AwsEventFrame> getEventDecoderFactory(
             OutputEventStreamingApiOperation<?, ?, ?> outputOperation
     ) {
-        return AwsEventDecoderFactory.forOutputStream(outputOperation, codec(), f -> f);
+        return AwsEventDecoderFactory.forOutputStream(outputOperation, payloadCodec(), f -> f);
     }
 
     public static final class Factory implements ClientProtocolFactory<RestJson1Trait> {

--- a/aws/client/aws-client-restxml/src/main/java/software/amazon/smithy/java/aws/client/restxml/RestXmlClientProtocol.java
+++ b/aws/client/aws-client-restxml/src/main/java/software/amazon/smithy/java/aws/client/restxml/RestXmlClientProtocol.java
@@ -51,7 +51,7 @@ public final class RestXmlClientProtocol extends HttpBindingClientProtocol<AwsEv
     }
 
     @Override
-    protected Codec codec() {
+    public Codec payloadCodec() {
         return codec;
     }
 
@@ -77,7 +77,7 @@ public final class RestXmlClientProtocol extends HttpBindingClientProtocol<AwsEv
         // TODO: this is where you'd plumb through Sigv4 support, another frame transformer?
         return AwsEventEncoderFactory.forInputStream(
                 inputOperation,
-                codec(),
+                payloadCodec(),
                 payloadMediaType(),
                 (e) -> new EventStreamingException("InternalServerException", "Internal Server Error"));
     }
@@ -86,7 +86,7 @@ public final class RestXmlClientProtocol extends HttpBindingClientProtocol<AwsEv
     protected EventDecoderFactory<AwsEventFrame> getEventDecoderFactory(
             OutputEventStreamingApiOperation<?, ?, ?> outputOperation
     ) {
-        return AwsEventDecoderFactory.forOutputStream(outputOperation, codec(), f -> f);
+        return AwsEventDecoderFactory.forOutputStream(outputOperation, payloadCodec(), f -> f);
     }
 
     public static final class Factory implements ClientProtocolFactory<RestXmlTrait> {

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientProtocol.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientProtocol.java
@@ -12,6 +12,7 @@ import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.error.CallException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.model.shapes.ShapeId;
 
@@ -28,6 +29,13 @@ public interface ClientProtocol<RequestT, ResponseT> {
      * @return the protocol ID.
      */
     ShapeId id();
+
+    /**
+     * Get the {@link Codec} used for serializing and deserializing the payloads of requests and responses.
+     *
+     * @return the payload codec of the protocol, or null if the protocol has no payload codec.
+     */
+    Codec payloadCodec();
 
     /**
      * Get the message exchange.

--- a/client/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
+++ b/client/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
@@ -31,6 +31,8 @@ import software.amazon.smithy.model.shapes.ShapeId;
 /**
  * An HTTP-based protocol that uses HTTP binding traits.
  *
+ * <p>Subclasses MUST implement a {@link #payloadCodec()} method that returns a non-null {@link Codec}.
+ *
  * @param <F> the framing type for event streams.
  */
 public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends HttpClientProtocol {
@@ -41,8 +43,6 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
     public HttpBindingClientProtocol(ShapeId id) {
         super(id);
     }
-
-    abstract protected Codec codec();
 
     abstract protected String payloadMediaType();
 
@@ -73,7 +73,7 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
     ) {
         RequestSerializer serializer = httpBinding.requestSerializer()
                 .operation(operation)
-                .payloadCodec(codec())
+                .payloadCodec(payloadCodec())
                 .payloadMediaType(payloadMediaType())
                 .shapeValue(input)
                 .endpoint(endpoint)
@@ -104,7 +104,7 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
 
         var outputBuilder = operation.outputBuilder();
         ResponseDeserializer deser = httpBinding.responseDeserializer()
-                .payloadCodec(codec())
+                .payloadCodec(payloadCodec())
                 .payloadMediaType(payloadMediaType())
                 .outputShapeBuilder(outputBuilder)
                 .response(response);

--- a/client/client-mock-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockPlugin.java
+++ b/client/client-mock-plugin/src/main/java/software/amazon/smithy/java/client/http/mock/MockPlugin.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.java.client.http.HttpMessageExchange;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.java.http.api.HttpHeaders;
 import software.amazon.smithy.java.http.api.HttpRequest;
@@ -165,6 +166,11 @@ public final class MockPlugin implements ClientPlugin {
         @Override
         public MessageExchange<HttpRequest, HttpResponse> messageExchange() {
             return delegate.messageExchange();
+        }
+
+        @Override
+        public Codec payloadCodec() {
+            return delegate.payloadCodec();
         }
 
         @Override

--- a/client/client-rpcv2-cbor/src/main/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocol.java
+++ b/client/client-rpcv2-cbor/src/main/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocol.java
@@ -48,6 +48,11 @@ public final class RpcV2CborProtocol extends HttpClientProtocol {
     }
 
     @Override
+    public Codec payloadCodec() {
+        return CBOR_CODEC;
+    }
+
+    @Override
     public <I extends SerializableStruct, O extends SerializableStruct> HttpRequest createRequest(
             ApiOperation<I, O> operation,
             I input,

--- a/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
+++ b/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/MockClient.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -93,6 +94,11 @@ final class MockClient extends Client {
         @Override
         public ShapeId id() {
             return PreludeSchemas.DOCUMENT.id();
+        }
+
+        @Override
+        public Codec payloadCodec() {
+            throw new UnsupportedOperationException("Placeholder protocol must be overridden");
         }
 
         @Override


### PR DESCRIPTION
ClientProtocol now exposes a payloadCoded method that can be used to get the Codec configured for the protocol. So a RestJson1 protocol would be able to return Codec configured to correctly serialize and deserialize RestJSON1 payloads. If a protocol ever comes along that has no payload codec or perhaps multiple, null may be returned.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
