### PR TITLE
Change generated Getters to have a 'get' prefix

### DIFF
--- a/aws/aws-service-bundle/src/main/java/software/amazon/smithy/java/aws/servicebundle/provider/AwsAuthProvider.java
+++ b/aws/aws-service-bundle/src/main/java/software/amazon/smithy/java/aws/servicebundle/provider/AwsAuthProvider.java
@@ -42,15 +42,16 @@ final class AwsAuthProvider implements ConfigProvider<PreRequest> {
 
     @Override
     public IdentityResolver<?> identityResolver(PreRequest input) {
-        return new SdkCredentialsResolver(ProfileCredentialsProvider.create(input.awsProfileName()));
+        return new SdkCredentialsResolver(ProfileCredentialsProvider.create(input.getAwsProfileName()));
     }
 
     @Override
     public EndpointResolver endpointResolver(PreRequest input) {
         // TODO: error reporting
         return ignore -> {
-            var endpoint = URI.create(Objects.requireNonNull(serviceMetadata.endpoints().get(input.awsRegion()),
-                    "no endpoint for region " + input.awsRegion()));
+            var endpoint =
+                    URI.create(Objects.requireNonNull(serviceMetadata.getEndpoints().get(input.getAwsProfileName()),
+                            "no endpoint for region " + input.getAwsRegion()));
             return CompletableFuture.completedFuture(Endpoint.builder()
                     .uri(endpoint)
                     .build());
@@ -59,13 +60,13 @@ final class AwsAuthProvider implements ConfigProvider<PreRequest> {
 
     @Override
     public AuthScheme<?, ?> authScheme(PreRequest input) {
-        return new SigV4AuthScheme(serviceMetadata.sigv4SigningName());
+        return new SigV4AuthScheme(serviceMetadata.getSigv4SigningName());
     }
 
     @Override
     public RequestOverrideConfig.Builder adaptConfig(PreRequest args) {
         return ConfigProvider.super.adaptConfig(args)
-                .putConfig(RegionSetting.REGION, args.awsRegion());
+                .putConfig(RegionSetting.REGION, args.getAwsRegion());
     }
 
 }

--- a/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
+++ b/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
@@ -17,12 +17,12 @@ public class AwsServiceBundlerTest {
     @Test
     public void accessAnalyzer() {
         var bundler = new AwsServiceBundler("accessanalyzer-2019-11-01.json", AwsServiceBundlerTest::getModel);
-        var bundle = bundler.bundle().config().asShape(AwsServiceMetadata.builder());
+        var bundle = bundler.bundle().getConfig().asShape(AwsServiceMetadata.builder());
 
-        assertEquals("access-analyzer", bundle.sigv4SigningName());
-        assertEquals("AccessAnalyzer", bundle.serviceName());
+        assertEquals("access-analyzer", bundle.getSigv4SigningName());
+        assertEquals("AccessAnalyzer", bundle.getServiceName());
 
-        assertNotEquals(0, bundle.endpoints().size());
+        assertNotEquals(0, bundle.getEndpoints().size());
     }
 
     private static String getModel(String path) {

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/BuilderTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/BuilderTest.java
@@ -22,8 +22,8 @@ public class BuilderTest {
                 .build();
         var copy = original.toBuilder().optionalList(List.of("1")).build();
         assertThat(copy)
-                .returns(original.requiredList(), ListMembersInput::requiredList)
-                .returns(List.of("1"), ListMembersInput::optionalList);
+                .returns(original.getRequiredList(), ListMembersInput::getRequiredList)
+                .returns(List.of("1"), ListMembersInput::getOptionalList);
     }
 
     @Test
@@ -33,7 +33,7 @@ public class BuilderTest {
                 .build();
         var copy = original.toBuilder().optionalMap(Map.of("1", "2")).build();
         assertThat(copy)
-                .returns(original.requiredMap(), MapMembersInput::requiredMap)
-                .returns(Map.of("1", "2"), MapMembersInput::optionalMap);
+                .returns(original.getRequiredMap(), MapMembersInput::getRequiredMap)
+                .returns(Map.of("1", "2"), MapMembersInput::getOptionalMap);
     }
 }

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/ClientErrorCorrectionTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/ClientErrorCorrectionTest.java
@@ -28,15 +28,15 @@ public class ClientErrorCorrectionTest {
                 .errorCorrection()
                 .build();
 
-        assertFalse(corrected.getBooleanMember());
+        assertFalse(corrected.isBoolean());
         assertEquals(corrected.getBigDecimal(), BigDecimal.ZERO);
         assertEquals(corrected.getBigInteger(), BigInteger.ZERO);
-        assertEquals(corrected.getByteMember(), (byte) 0);
-        assertEquals(corrected.getDoubleMember(), 0);
-        assertEquals(corrected.getFloatMember(), 0);
+        assertEquals(corrected.getByte(), (byte) 0);
+        assertEquals(corrected.getDouble(), 0);
+        assertEquals(corrected.getFloat(), 0);
         assertEquals(corrected.getInteger(), 0);
-        assertEquals(corrected.getLongMember(), 0);
-        assertEquals(corrected.getShortMember(), (short) 0);
+        assertEquals(corrected.getLong(), 0);
+        assertEquals(corrected.getShort(), (short) 0);
         assertEquals(corrected.getBlob(), ByteBuffer.allocate(0));
         assertEquals(corrected.getStreamingBlob().contentLength(), 0);
         corrected.getStreamingBlob().asByteBuffer().thenAccept(bytes -> assertEquals(0, bytes.remaining()));
@@ -44,8 +44,8 @@ public class ClientErrorCorrectionTest {
         assertEquals(corrected.getList(), List.of());
         assertEquals(corrected.getMap(), Map.of());
         assertEquals(corrected.getTimestamp(), Instant.EPOCH);
-        assertEquals(corrected.getEnumMember().getType(), NestedEnum.Type.$UNKNOWN);
-        assertEquals(corrected.getEnumMember().getValue(), "");
+        assertEquals(corrected.getEnum().getType(), NestedEnum.Type.$UNKNOWN);
+        assertEquals(corrected.getEnum().getValue(), "");
         assertEquals(corrected.getIntEnum().getType(), NestedIntEnum.Type.$UNKNOWN);
         assertEquals(corrected.getIntEnum().getValue(), 0);
     }

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/ClientErrorCorrectionTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/ClientErrorCorrectionTest.java
@@ -21,31 +21,32 @@ import software.amazon.smithy.java.codegen.test.model.NestedEnum;
 import software.amazon.smithy.java.codegen.test.model.NestedIntEnum;
 
 public class ClientErrorCorrectionTest {
+
     @Test
     void correctsErrors() {
         var corrected = ClientErrorCorrectionInput.builder()
                 .errorCorrection()
                 .build();
 
-        assertFalse(corrected.booleanMember());
-        assertEquals(corrected.bigDecimal(), BigDecimal.ZERO);
-        assertEquals(corrected.bigInteger(), BigInteger.ZERO);
-        assertEquals(corrected.byteMember(), (byte) 0);
-        assertEquals(corrected.doubleMember(), 0);
-        assertEquals(corrected.floatMember(), 0);
-        assertEquals(corrected.integer(), 0);
-        assertEquals(corrected.longMember(), 0);
-        assertEquals(corrected.shortMember(), (short) 0);
-        assertEquals(corrected.blob(), ByteBuffer.allocate(0));
-        assertEquals(corrected.streamingBlob().contentLength(), 0);
-        corrected.streamingBlob().asByteBuffer().thenAccept(bytes -> assertEquals(0, bytes.remaining()));
-        assertNull(corrected.document());
-        assertEquals(corrected.list(), List.of());
-        assertEquals(corrected.map(), Map.of());
-        assertEquals(corrected.timestamp(), Instant.EPOCH);
-        assertEquals(corrected.enumMember().type(), NestedEnum.Type.$UNKNOWN);
-        assertEquals(corrected.enumMember().value(), "");
-        assertEquals(corrected.intEnum().type(), NestedIntEnum.Type.$UNKNOWN);
-        assertEquals(corrected.intEnum().value(), 0);
+        assertFalse(corrected.getBooleanMember());
+        assertEquals(corrected.getBigDecimal(), BigDecimal.ZERO);
+        assertEquals(corrected.getBigInteger(), BigInteger.ZERO);
+        assertEquals(corrected.getByteMember(), (byte) 0);
+        assertEquals(corrected.getDoubleMember(), 0);
+        assertEquals(corrected.getFloatMember(), 0);
+        assertEquals(corrected.getInteger(), 0);
+        assertEquals(corrected.getLongMember(), 0);
+        assertEquals(corrected.getShortMember(), (short) 0);
+        assertEquals(corrected.getBlob(), ByteBuffer.allocate(0));
+        assertEquals(corrected.getStreamingBlob().contentLength(), 0);
+        corrected.getStreamingBlob().asByteBuffer().thenAccept(bytes -> assertEquals(0, bytes.remaining()));
+        assertNull(corrected.getDocument());
+        assertEquals(corrected.getList(), List.of());
+        assertEquals(corrected.getMap(), Map.of());
+        assertEquals(corrected.getTimestamp(), Instant.EPOCH);
+        assertEquals(corrected.getEnumMember().getType(), NestedEnum.Type.$UNKNOWN);
+        assertEquals(corrected.getEnumMember().getValue(), "");
+        assertEquals(corrected.getIntEnum().getType(), NestedIntEnum.Type.$UNKNOWN);
+        assertEquals(corrected.getIntEnum().getValue(), 0);
     }
 }

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
@@ -27,15 +27,15 @@ public class DefaultsTest {
     void setsCorrectDefault() {
         var defaults = DefaultsInput.builder().build();
 
-        assertTrue(defaults.getBooleanMember());
+        assertTrue(defaults.isBoolean());
         assertEquals(defaults.getBigDecimal(), BigDecimal.valueOf(1.0));
         assertEquals(defaults.getBigInteger(), BigInteger.valueOf(1));
-        assertEquals(defaults.getByteMember(), (byte) 1);
-        assertEquals(defaults.getDoubleMember(), 1.0);
-        assertEquals(defaults.getFloatMember(), 1f);
+        assertEquals(defaults.getByte(), (byte) 1);
+        assertEquals(defaults.getDouble(), 1.0);
+        assertEquals(defaults.getFloat(), 1f);
         assertEquals(defaults.getInteger(), 1);
-        assertEquals(defaults.getLongMember(), 1);
-        assertEquals(defaults.getShortMember(), (short) 1);
+        assertEquals(defaults.getLong(), 1);
+        assertEquals(defaults.getShort(), (short) 1);
         assertEquals(defaults.getBlob(), ByteBuffer.wrap(Base64.getDecoder().decode("YmxvYg==")));
         defaults.getStreamingBlob()
                 .asByteBuffer()
@@ -49,7 +49,7 @@ public class DefaultsTest {
         assertEquals(defaults.getList(), List.of());
         assertEquals(defaults.getMap(), Map.of());
         assertEquals(defaults.getTimestamp(), Instant.parse("1985-04-12T23:20:50.52Z"));
-        assertEquals(defaults.getEnumMember(), NestedEnum.A);
+        assertEquals(defaults.getEnum(), NestedEnum.A);
         assertEquals(defaults.getIntEnum(), NestedIntEnum.A);
     }
 }

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
@@ -27,29 +27,29 @@ public class DefaultsTest {
     void setsCorrectDefault() {
         var defaults = DefaultsInput.builder().build();
 
-        assertTrue(defaults.booleanMember());
-        assertEquals(defaults.bigDecimal(), BigDecimal.valueOf(1.0));
-        assertEquals(defaults.bigInteger(), BigInteger.valueOf(1));
-        assertEquals(defaults.byteMember(), (byte) 1);
-        assertEquals(defaults.doubleMember(), 1.0);
-        assertEquals(defaults.floatMember(), 1f);
-        assertEquals(defaults.integer(), 1);
-        assertEquals(defaults.longMember(), 1);
-        assertEquals(defaults.shortMember(), (short) 1);
-        assertEquals(defaults.blob(), ByteBuffer.wrap(Base64.getDecoder().decode("YmxvYg==")));
-        defaults.streamingBlob()
+        assertTrue(defaults.getBooleanMember());
+        assertEquals(defaults.getBigDecimal(), BigDecimal.valueOf(1.0));
+        assertEquals(defaults.getBigInteger(), BigInteger.valueOf(1));
+        assertEquals(defaults.getByteMember(), (byte) 1);
+        assertEquals(defaults.getDoubleMember(), 1.0);
+        assertEquals(defaults.getFloatMember(), 1f);
+        assertEquals(defaults.getInteger(), 1);
+        assertEquals(defaults.getLongMember(), 1);
+        assertEquals(defaults.getShortMember(), (short) 1);
+        assertEquals(defaults.getBlob(), ByteBuffer.wrap(Base64.getDecoder().decode("YmxvYg==")));
+        defaults.getStreamingBlob()
                 .asByteBuffer()
                 .thenAccept(b -> assertEquals(b, ByteBuffer.wrap(Base64.getDecoder().decode("c3RyZWFtaW5n"))));
-        assertEquals(defaults.boolDoc(), Document.of(true));
-        assertEquals(defaults.stringDoc(), Document.of("string"));
-        assertEquals(defaults.numberDoc(), Document.of(1));
-        assertEquals(defaults.floatingPointnumberDoc(), Document.of(1.2));
-        assertEquals(defaults.listDoc(), Document.of(Collections.emptyList()));
-        assertEquals(defaults.mapDoc(), Document.of(Collections.emptyMap()));
-        assertEquals(defaults.list(), List.of());
-        assertEquals(defaults.map(), Map.of());
-        assertEquals(defaults.timestamp(), Instant.parse("1985-04-12T23:20:50.52Z"));
-        assertEquals(defaults.enumMember(), NestedEnum.A);
-        assertEquals(defaults.intEnum(), NestedIntEnum.A);
+        assertEquals(defaults.getBoolDoc(), Document.of(true));
+        assertEquals(defaults.getStringDoc(), Document.of("string"));
+        assertEquals(defaults.getNumberDoc(), Document.of(1));
+        assertEquals(defaults.getFloatingPointnumberDoc(), Document.of(1.2));
+        assertEquals(defaults.getListDoc(), Document.of(Collections.emptyList()));
+        assertEquals(defaults.getMapDoc(), Document.of(Collections.emptyMap()));
+        assertEquals(defaults.getList(), List.of());
+        assertEquals(defaults.getMap(), Map.of());
+        assertEquals(defaults.getTimestamp(), Instant.parse("1985-04-12T23:20:50.52Z"));
+        assertEquals(defaults.getEnumMember(), NestedEnum.A);
+        assertEquals(defaults.getIntEnum(), NestedIntEnum.A);
     }
 }

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/EnumTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/EnumTest.java
@@ -19,6 +19,6 @@ public class EnumTest {
         try (var codec = JsonCodec.builder().useJsonName(true).useTimestampFormat(true).build()) {
             output = codec.deserializeShape("\"option-n\"", EnumType.builder());
         }
-        assertEquals(output.type(), EnumType.Type.$UNKNOWN);
+        assertEquals(output.getType(), EnumType.Type.$UNKNOWN);
     }
 }

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/ListsTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/ListsTest.java
@@ -223,8 +223,8 @@ public class ListsTest {
         assertTrue(emptyInput.hasListOfBoolean());
         assertFalse(nullInput.hasListOfBoolean());
         // Collections should return empty collections for access
-        assertEquals(emptyInput.listOfBoolean(), Collections.emptyList());
-        assertEquals(emptyInput.listOfBoolean(), nullInput.listOfBoolean());
+        assertEquals(emptyInput.getListOfBoolean(), Collections.emptyList());
+        assertEquals(emptyInput.getListOfBoolean(), nullInput.getListOfBoolean());
         var emptyDocument = Document.of(emptyInput);
         var nullDocument = Document.of(nullInput);
         assertNotNull(emptyDocument.getMember("listOfBoolean"));

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/MapsTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/MapsTest.java
@@ -248,8 +248,8 @@ public class MapsTest {
         assertTrue(emptyInput.hasStringBooleanMap());
         assertFalse(nullInput.hasStringBooleanMap());
         // Collections should return empty collections for access
-        assertEquals(emptyInput.stringBooleanMap(), Collections.emptyMap());
-        assertEquals(emptyInput.stringBooleanMap(), nullInput.stringBooleanMap());
+        assertEquals(emptyInput.getStringBooleanMap(), Collections.emptyMap());
+        assertEquals(emptyInput.getStringBooleanMap(), nullInput.getStringBooleanMap());
 
         var emptyDocument = Document.of(emptyInput);
         var nullDocument = Document.of(nullInput);

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -256,6 +256,33 @@ public final class CodegenUtils {
     }
 
     /**
+     * Gets the name to use when defining the default value of a member.
+     *
+     * @param memberShape memberShape.
+     * @return Upper snake case name of default
+     */
+    public static String toGetterName(MemberShape memberShape, String memberName) {
+        var prefix = memberShape.isBooleanShape() ? "is" : "get";
+        var suffix =
+                Character.toUpperCase(memberName.charAt(0)) + (memberName.length() == 1 ? "" : memberName.substring(1));
+        return prefix + suffix;
+    }
+
+    /**
+     * Gets the name to use when defining the default value of a member.
+     *
+     * @param memberShape memberShape.
+     * @return Upper snake case name of default
+     */
+    public static String toUnionGetterName(MemberShape memberShape, String memberName) {
+        var getterName = toGetterName(memberShape, memberName);
+        if (getterName.equals("getValue")) {
+            getterName += "Member";
+        }
+        return getterName;
+    }
+
+    /**
      * Gets the file name to use for the SharedSerde utility class
      *
      * @param settings Settings to use for package namespace

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -269,20 +269,6 @@ public final class CodegenUtils {
     }
 
     /**
-     * Gets the name to use when defining the default value of a member.
-     *
-     * @param memberShape memberShape.
-     * @return Upper snake case name of default
-     */
-    public static String toUnionGetterName(MemberShape memberShape, String memberName) {
-        var getterName = toGetterName(memberShape, memberName);
-        if (getterName.equals("getValue")) {
-            getterName += "Member";
-        }
-        return getterName;
-    }
-
-    /**
      * Gets the file name to use for the SharedSerde utility class
      *
      * @param settings Settings to use for package namespace

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/CodegenUtils.java
@@ -46,6 +46,10 @@ public final class CodegenUtils {
             CodegenUtils.class.getResource("object-reserved-members.txt"));
     private static final URL SMITHY_RESERVED_MEMBERS_FILE = Objects.requireNonNull(
             CodegenUtils.class.getResource("smithy-reserved-members.txt"));
+    private static final URL SMITHY_RESERVED_METHODS_FILE = Objects.requireNonNull(
+            CodegenUtils.class.getResource("smithy-reserved-methods.txt"));
+
+    private static final List<String> DELIMITERS = List.of("_", "-", " ");
 
     public static final ReservedWords SHAPE_ESCAPER = new ReservedWordsBuilder()
             .loadCaseInsensitiveWords(RESERVED_WORDS_FILE, word -> word + "Shape")
@@ -54,6 +58,9 @@ public final class CodegenUtils {
             .loadCaseInsensitiveWords(RESERVED_WORDS_FILE, word -> word + "Member")
             .loadCaseInsensitiveWords(OBJECT_RESERVED_MEMBERS_FILE, word -> word + "Member")
             .loadCaseInsensitiveWords(SMITHY_RESERVED_MEMBERS_FILE, word -> word + "Member")
+            .build();
+    public static final ReservedWords METHODS_ESCAPER = new ReservedWordsBuilder()
+            .loadCaseInsensitiveWords(SMITHY_RESERVED_METHODS_FILE, word -> word + "Member")
             .build();
 
     private static final String SCHEMA_STATIC_NAME = "$SCHEMA";
@@ -256,16 +263,30 @@ public final class CodegenUtils {
     }
 
     /**
-     * Gets the name to use when defining the default value of a member.
      *
-     * @param memberShape memberShape.
-     * @return Upper snake case name of default
+     * Gets the name to use when defining a member as instance variable in a class.
+     *
+     * @param memberShape MemberShape
+     * @param model Model
+     * @return Instance variable name of a member.
      */
-    public static String toGetterName(MemberShape memberShape, String memberName) {
-        var prefix = memberShape.isBooleanShape() ? "is" : "get";
+    public static String toMemberName(MemberShape memberShape, Model model) {
+        return getMemberName(memberShape, model, true);
+    }
+
+    /**
+     * Gets the name to use when defining the getter method of a member.
+     *
+     * @param  memberShape memberShape.
+     * @return Getter method name of a member.
+     */
+    public static String toGetterName(MemberShape memberShape, Model model) {
+        var target = model.expectShape(memberShape.getTarget());
+        var prefix = target.isBooleanShape() ? "is" : "get";
+        var memberName = getMemberName(memberShape, model, false);
         var suffix =
                 Character.toUpperCase(memberName.charAt(0)) + (memberName.length() == 1 ? "" : memberName.substring(1));
-        return prefix + suffix;
+        return METHODS_ESCAPER.escape(prefix + suffix);
     }
 
     /**
@@ -462,4 +483,46 @@ public final class CodegenUtils {
                 .declarationFile(filename)
                 .build();
     }
+
+    private static String getMemberName(MemberShape shape, Model model, boolean escape) {
+        Shape containerShape = model.expectShape(shape.getContainer());
+        if (containerShape.isEnumShape() || containerShape.isIntEnumShape()) {
+            return CaseUtils.toSnakeCase(shape.getMemberName()).toUpperCase(Locale.ENGLISH);
+        }
+
+        // If a member name contains an underscore, space, or dash, convert to camel case using Smithy utility
+        var memberName = shape.getMemberName();
+        if (DELIMITERS.stream().anyMatch(memberName::contains)) {
+            memberName = CaseUtils.toCamelCase(memberName);
+        } else {
+            memberName = uncapitalizeAcronymAware(memberName);
+        }
+
+        if (escape) {
+            memberName = CodegenUtils.MEMBER_ESCAPER.escape(memberName);
+        }
+        return memberName;
+    }
+
+    private static String uncapitalizeAcronymAware(String str) {
+        if (Character.isLowerCase(str.charAt(0))) {
+            return str;
+        } else if (str.equals(str.toUpperCase())) {
+            return str.toLowerCase();
+        }
+        int strLen = str.length();
+        StringBuilder sb = new StringBuilder(strLen);
+        boolean nextIsUpperCase;
+        for (int idx = 0; idx < strLen; idx++) {
+            var currentChar = str.charAt(idx);
+            nextIsUpperCase = (idx + 1 < strLen) && Character.isUpperCase(str.charAt(idx + 1));
+            if (Character.isUpperCase(currentChar) && (nextIsUpperCase || idx == 0)) {
+                sb.append(Character.toLowerCase(currentChar));
+            } else {
+                sb.append(currentChar);
+            }
+        }
+        return sb.toString();
+    }
+
 }

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
@@ -174,14 +174,14 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
                     /**
                      * Value contained by this Enum.
                      */
-                    public ${value:N} value() {
+                    public ${value:N} getValue() {
                         return value;
                     }
 
                     /**
                      * Type of this Enum variant.
                      */
-                    public ${type:N} type() {
+                    public ${type:N} getType() {
                         return type;
                     }
 

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
@@ -60,7 +60,7 @@ public final class MapGenerator
                                                     for (var valueEntry : values.entrySet()) {
                                                         serializer.writeEntry(
                                                             ${keySchema:L}.mapKeyMember(),
-                                                            valueEntry.getKey()${?enumKey}.value()${/enumKey},
+                                                            valueEntry.getKey()${?enumKey}.getValue()${/enumKey},
                                                             valueEntry.getValue(),
                                                             ${name:U}$$ValueSerializer.INSTANCE
                                                         );

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/SerializerMemberGenerator.java
@@ -125,7 +125,7 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
 
     @Override
     public Void intEnumShape(IntEnumShape shape) {
-        writer.write("serializer.writeInteger(${schema:L}, ${state:L}.value())");
+        writer.write("serializer.writeInteger(${schema:L}, ${state:L}.getValue())");
         return null;
     }
 
@@ -177,7 +177,7 @@ final class SerializerMemberGenerator extends ShapeVisitor.DataShapeVisitor<Void
 
     @Override
     public Void enumShape(EnumShape shape) {
-        writer.write("serializer.writeString(${schema:L}, ${state:L}.value())");
+        writer.write("serializer.writeString(${schema:L}, ${state:L}.getValue())");
         return null;
     }
 

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -286,7 +286,7 @@ public final class StructureGenerator<
                 writer.putContext("memberName", memberName);
                 writer.putContext("member", symbolProvider.toSymbol(member));
                 writer.putContext("isNullable", CodegenUtils.isNullableMember(model, member));
-                writer.putContext("getterName", CodegenUtils.toGetterName(member, memberName));
+                writer.putContext("getterName", CodegenUtils.toGetterName(member, model));
                 this.member = member;
                 member.accept(this);
                 writer.popState();

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -282,9 +282,11 @@ public final class StructureGenerator<
                     continue;
                 }
                 writer.pushState();
-                writer.putContext("memberName", symbolProvider.toMemberName(member));
+                var memberName = symbolProvider.toMemberName(member);
+                writer.putContext("memberName", memberName);
                 writer.putContext("member", symbolProvider.toSymbol(member));
                 writer.putContext("isNullable", CodegenUtils.isNullableMember(model, member));
+                writer.putContext("getterName", CodegenUtils.toGetterName(member, memberName));
                 this.member = member;
                 member.accept(this);
                 writer.popState();
@@ -298,7 +300,7 @@ public final class StructureGenerator<
 
             writer.write(
                     """
-                            public ${?isNullable}${member:B}${/isNullable}${^isNullable}${member:N}${/isNullable} ${memberName:L}() {
+                            public ${?isNullable}${member:B}${/isNullable}${^isNullable}${member:N}${/isNullable} ${getterName:L}() {
                                 return ${memberName:L};
                             }
                             """);
@@ -325,7 +327,7 @@ public final class StructureGenerator<
             writer.putContext("collections", Collections.class);
             writer.write(
                     """
-                            public ${member:T} ${memberName:L}() {${?isNullable}
+                            public ${member:T} ${getterName:L}() {${?isNullable}
                                 if (${memberName:L} == null) {
                                     return ${collections:T}.${empty:L};
                                 }${/isNullable}

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -180,8 +180,9 @@ public final class UnionGenerator
                                 }
                                 """;
                 var memberSymbol = symbolProvider.toSymbol(member);
+                var target = model.expectShape(member.getTarget());
                 var memberName = symbolProvider.toMemberName(member);
-                var getterName = CodegenUtils.toGetterName(member, memberName);
+                var getterName = CodegenUtils.toGetterName(member, model);
                 if (getterName.equals("getValue")) {
                     getterName += "Member";
                 }
@@ -196,7 +197,6 @@ public final class UnionGenerator
                 writer.putContext(
                         "wrap",
                         memberSymbol.getProperty(SymbolProperties.COLLECTION_IMMUTABLE_WRAPPER).orElse(null));
-                var target = model.expectShape(member.getTarget());
                 writer.putContext("unit", target.hasTrait(UnitTypeTrait.class));
                 writer.putContext("col", target.isMapShape() || target.isListShape());
                 writer.write(template);

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -168,7 +168,7 @@ public final class UnionGenerator
                                         ${serializeMember:C};
                                     }${^unit}
 
-                                    public ${member:N} ${memberName:L}() {
+                                    public ${member:N} ${getterName:L}() {
                                         return value;
                                     }${/unit}
 
@@ -180,9 +180,15 @@ public final class UnionGenerator
                                 }
                                 """;
                 var memberSymbol = symbolProvider.toSymbol(member);
+                var memberName = symbolProvider.toMemberName(member);
+                var getterName = CodegenUtils.toGetterName(member, memberName);
+                if (getterName.equals("getValue")) {
+                    getterName += "Member";
+                }
                 writer.putContext("hasBoxed", memberSymbol.getProperty(SymbolProperties.BOXED_TYPE).isPresent());
                 writer.putContext("member", memberSymbol);
-                writer.putContext("memberName", symbolProvider.toMemberName(member));
+                writer.putContext("memberName", memberName);
+                writer.putContext("getterName", getterName);
                 writer.putContext(
                         "serializeMember",
                         new SerializerMemberGenerator(directive, writer, member, "value"));

--- a/codegen/codegen-core/src/main/resources/software/amazon/smithy/java/codegen/smithy-reserved-methods.txt
+++ b/codegen/codegen-core/src/main/resources/software/amazon/smithy/java/codegen/smithy-reserved-methods.txt
@@ -1,0 +1,10 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Member names reserved for Smithy interfaces or fields that are generated into
+# customer-defined objects. Member getters with any of these names will attempt
+# to override APIs reserved for Smithy's use unless escaped.
+#
+# Note: Only zero-args methods are a problem here.
+getClass

--- a/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/NamingTest.java
+++ b/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/NamingTest.java
@@ -31,13 +31,13 @@ public class NamingTest extends AbstractCodegenFileTest {
         var fileStr = getFileStringForClass("NamingConflictsInput");
         // Java map uses fully qualified name
         var expectedJavaMapGetter = """
-                    public java.util.Map<String, String> javaMap() {
+                    public java.util.Map<String, String> getJavaMap() {
                 """;
         assertTrue(fileStr.contains(expectedJavaMapGetter));
 
         // Custom map does not use fully qualified name
         var expectedCustomMap = """
-                    public Map map() {
+                    public Map getMap() {
                         return map;
                     }
                 """;
@@ -49,13 +49,13 @@ public class NamingTest extends AbstractCodegenFileTest {
         var fileStr = getFileStringForClass("NamingConflictsInput");
         // Java map uses fully qualified name
         var expectedJavaListGetter = """
-                    public java.util.List<String> javaList() {
+                    public java.util.List<String> getJavaList() {
                 """;
         assertTrue(fileStr.contains(expectedJavaListGetter));
 
         // Custom map does not use fully qualified name
         var expectedCustomList = """
-                    public List list() {
+                    public List getList() {
                         return list;
                     }
                 """;
@@ -122,14 +122,14 @@ public class NamingTest extends AbstractCodegenFileTest {
     void acronymMemberName() {
         var fileStr = getFileStringForClass("CasingInput");
         assertTrue(fileStr.contains("private final transient String acronymMemberName"));
-        assertTrue(fileStr.contains("public String acronymMemberName() {"));
+        assertTrue(fileStr.contains("public String getAcronymMemberName() {"));
     }
 
     @Test
     void allCapsMemberName() {
         var fileStr = getFileStringForClass("CasingInput");
         assertTrue(fileStr.contains("private final transient String allcaps"));
-        assertTrue(fileStr.contains("public String allcaps() {"));
+        assertTrue(fileStr.contains("public String getAllcaps() {"));
     }
 
     static List<Arguments> enumCaseArgs() {

--- a/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/NonNullAnnotationTest.java
+++ b/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/NonNullAnnotationTest.java
@@ -38,7 +38,7 @@ public class NonNullAnnotationTest extends AbstractCodegenFileTest {
     void nonNullAnnotationsOnFieldsAndGetter() {
         var fileStr = getFileStringForClass("NonNullAnnotationStructInput");
         var expectedField = "private final transient @TestNonNullAnnotation RequiredStruct requiredStruct;";
-        var expectedGetter = "public @TestNonNullAnnotation RequiredStruct requiredStruct()";
+        var expectedGetter = "public @TestNonNullAnnotation RequiredStruct getRequiredStruct()";
         var expectedImport = "import software.amazon.smithy.java.codegen.utils.TestNonNullAnnotation;";
         var expectedToString = "public @TestNonNullAnnotation String toString() {";
 
@@ -53,7 +53,7 @@ public class NonNullAnnotationTest extends AbstractCodegenFileTest {
         var fileStr = getFileStringForClass("NonNullAnnotationStructInput");
 
         var expectedField = "private final transient boolean requiredPrimitive;";
-        var expectedGetter = "public boolean requiredPrimitive() {";
+        var expectedGetter = "public boolean getRequiredPrimitive() {";
         var expectedToString = "public @TestNonNullAnnotation String toString() {";
 
         assertTrue(fileStr.contains(expectedField));
@@ -63,24 +63,25 @@ public class NonNullAnnotationTest extends AbstractCodegenFileTest {
     @Test
     void nonNullAnnotationAddedForUnionVariant() {
         var fileStr = getFileStringForClass("TestUnion");
-        var expectedGetterBoxed = "public @TestNonNullAnnotation String boxedVariant() {";
-        var expectedGetterPrimitive = "public @TestNonNullAnnotation String primitiveVariant() {";
+        var expectedGetterBoxed = "public @TestNonNullAnnotation String getBoxedVariant() {";
+        var expectedGetterPrimitive = "public @TestNonNullAnnotation String getPrimitiveVariant() {";
         var expectedToString = "public @TestNonNullAnnotation String toString() {";
         var expectedTypeGetter = "public @TestNonNullAnnotation Type type() {";
 
         assertTrue(fileStr.contains(expectedGetterBoxed));
         assertTrue(fileStr.contains(expectedGetterPrimitive));
         assertTrue(fileStr.contains(expectedToString));
+        System.out.println(fileStr);
         assertTrue(fileStr.contains(expectedTypeGetter));
     }
 
     @Test
     void nonNullAnnotationAddedForEnumVariant() {
         var fileStr = getFileStringForClass("TestEnum");
-        var expectedValueGetter = "public @TestNonNullAnnotation String value() {";
+        var expectedValueGetter = "public @TestNonNullAnnotation String getValue() {";
         var expectedValueField = "private final @TestNonNullAnnotation String value;";
         var expectedToString = "public @TestNonNullAnnotation String toString() {";
-        var expectedTypeGetter = "public @TestNonNullAnnotation Type type() {";
+        var expectedTypeGetter = "public @TestNonNullAnnotation Type getType() {";
 
         assertTrue(fileStr.contains(expectedValueGetter));
         assertTrue(fileStr.contains(expectedValueField));

--- a/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/NonNullAnnotationTest.java
+++ b/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/NonNullAnnotationTest.java
@@ -53,7 +53,7 @@ public class NonNullAnnotationTest extends AbstractCodegenFileTest {
         var fileStr = getFileStringForClass("NonNullAnnotationStructInput");
 
         var expectedField = "private final transient boolean requiredPrimitive;";
-        var expectedGetter = "public boolean getRequiredPrimitive() {";
+        var expectedGetter = "public boolean isRequiredPrimitive() {";
         var expectedToString = "public @TestNonNullAnnotation String toString() {";
 
         assertTrue(fileStr.contains(expectedField));

--- a/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -50,7 +50,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                                      *     <li> Lorem ipsum dolor sit amet, consectetur adipiscing elit Lorem ipsum dolor sit amet, consectetur adipiscing elit </li>
                                      * </ul>
                                      */
-                                    public String shouldNotBeWrapped() {
+                                    public String getShouldNotBeWrapped() {
                                 """));
     }
 
@@ -74,7 +74,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                      * @deprecated As of 1.2.
                      */
                     @Deprecated(since = "1.2")
-                    public String deprecatedMember() {
+                    public String getDeprecatedMember() {
                         return deprecatedMember;
                     }
                 """));
@@ -91,7 +91,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                      * @deprecated
                      */
                     @Deprecated
-                    public String deprecatedWithDocs() {
+                    public String getDeprecatedWithDocs() {
                         return deprecatedWithDocs;
                     }
                 """));
@@ -120,7 +120,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                     /**
                      * @since 1.2
                      */
-                    public String sinceMember() {
+                    public String getSinceMember() {
                 """));
     }
 
@@ -139,7 +139,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                     /**
                      * @see <a href="https://en.wikipedia.org/wiki/Puffin">Puffins are also neat</a>
                      */
-                    public String memberWithExternalDocumentation() {
+                    public String getMemberWithExternalDocumentation() {
                 """));
     }
 
@@ -153,7 +153,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                 """));
         assertThat(fileContents, containsString("""
                     @SmithyUnstableApi
-                    public String unstableMember() {
+                    public String getUnstableMember() {
                         return unstableMember;
                     }
                 """));
@@ -185,7 +185,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                      */
                     @SmithyUnstableApi
                     @Deprecated(since = "sometime")
-                    public String rollupMember() {
+                    public String getRollupMember() {
                 """));
     }
 

--- a/codegen/plugins/client-codegen/src/it/java/software/amazon/smithy/java/codegen/client/AuthSchemeTest.java
+++ b/codegen/plugins/client-codegen/src/it/java/software/amazon/smithy/java/codegen/client/AuthSchemeTest.java
@@ -58,6 +58,6 @@ public class AuthSchemeTest {
         var value = "hello world";
         var input = EchoInput.builder().string(value).build();
         var output = client.echo(input);
-        assertEquals(value, output.string());
+        assertEquals(value, output.getString());
     }
 }

--- a/codegen/plugins/client-codegen/src/it/java/software/amazon/smithy/java/codegen/client/GenericClientTest.java
+++ b/codegen/plugins/client-codegen/src/it/java/software/amazon/smithy/java/codegen/client/GenericClientTest.java
@@ -55,7 +55,7 @@ public class GenericClientTest {
         var value = "hello world";
         var input = EchoInput.builder().string(value).build();
         var output = client.echo(input);
-        assertEquals(value, output.string());
+        assertEquals(value, output.getString());
     }
 
     @Test
@@ -89,7 +89,7 @@ public class GenericClientTest {
         var echoedString = "hello world";
         var input = EchoInput.builder().string(echoedString).build();
         var output = client.echo(input);
-        assertEquals(echoedString, output.string());
+        assertEquals(echoedString, output.getString());
     }
 
     @Test
@@ -157,7 +157,7 @@ public class GenericClientTest {
         var value = "hello world";
         var input = EchoInput.builder().string(value).build();
         var output = client.echo(input);
-        assertEquals(value, output.string());
+        assertEquals(value, output.getString());
     }
 
     @Test

--- a/codegen/plugins/server-codegen/src/it/java/software/amazon/smithy/java/codegen/server/ServiceBuilderTest.java
+++ b/codegen/plugins/server-codegen/src/it/java/software/amazon/smithy/java/codegen/server/ServiceBuilderTest.java
@@ -36,7 +36,7 @@ public class ServiceBuilderTest {
     private static final class EchoImpl implements EchoOperation {
         @Override
         public EchoOutput echo(EchoInput input, RequestContext context) {
-            var output = input.value().toBuilder().echoCount(input.value().echoCount() + 1).build();
+            var output = input.getValue().toBuilder().echoCount(input.getValue().getEchoCount() + 1).build();
             return EchoOutput.builder().value(output).build();
         }
     }
@@ -46,7 +46,7 @@ public class ServiceBuilderTest {
         public CompletableFuture<GetBeerOutput> getBeer(GetBeerInput input, RequestContext context) {
             return CompletableFuture.completedFuture(
                     GetBeerOutput.builder()
-                            .value(List.of(Beer.builder().id(input.id()).name("TestBeer").build()))
+                            .value(List.of(Beer.builder().id(input.getId()).name("TestBeer").build()))
                             .build());
         }
     }
@@ -56,15 +56,15 @@ public class ServiceBuilderTest {
         public CompletableFuture<GetErrorOutput> getError(GetErrorInput input, RequestContext context) {
             Throwable exception;
             try {
-                Class<?> clazz = Class.forName(input.exceptionClass());
+                Class<?> clazz = Class.forName(input.getExceptionClass());
                 if (ModeledException.class.isAssignableFrom(clazz)) {
                     Object builderInstance = clazz.getDeclaredMethod("builder").invoke(null);
                     builderInstance = builderInstance.getClass()
                             .getMethod("message")
-                            .invoke(builderInstance, input.message());
+                            .invoke(builderInstance, input.getMessage());
                     exception = (Throwable) builderInstance.getClass().getMethod("build").invoke(builderInstance);
                 } else {
-                    exception = (Throwable) clazz.getConstructor().newInstance(input.message());
+                    exception = (Throwable) clazz.getConstructor().newInstance(input.getMessage());
                 }
             } catch (ClassNotFoundException
                     | NoSuchMethodException
@@ -88,7 +88,7 @@ public class ServiceBuilderTest {
         Operation<GetBeerInput, GetBeerOutput> getBeer = service.getOperation("GetBeer");
         assertThat("GetBeer").isEqualTo(getBeer.name());
         var output = getBeer.asyncFunction().apply(GetBeerInput.builder().id(1).build(), null);
-        assertThat(output.get().value())
+        assertThat(output.get().getValue())
                 .hasSize(1)
                 .containsExactly(Beer.builder().id(1).name("TestBeer").build());
 
@@ -96,8 +96,8 @@ public class ServiceBuilderTest {
         assertThat("Echo").isEqualTo(echo.name());
         var echoOutput = echo.function()
                 .apply(EchoInput.builder().value(EchoPayload.builder().string("A").build()).build(), null);
-        assertThat(echoOutput.value().echoCount()).isEqualTo(1);
-        assertThat(echoOutput.value().string()).isEqualTo("A");
+        assertThat(echoOutput.getValue().getEchoCount()).isEqualTo(1);
+        assertThat(echoOutput.getValue().getString()).isEqualTo("A");
     }
 
     @Test

--- a/examples/basic-server/src/main/java/software/amazon/smithy/java/server/example/BasicServerExample.java
+++ b/examples/basic-server/src/main/java/software/amazon/smithy/java/server/example/BasicServerExample.java
@@ -46,7 +46,7 @@ public class BasicServerExample {
         @Override
         public AddBeerOutput addBeer(AddBeerInput input, RequestContext context) {
             long id = ID_GEN.incrementAndGet();
-            FRIDGE.put(id, input.beer());
+            FRIDGE.put(id, input.getBeer());
             return AddBeerOutput.builder().id(id).build();
         }
     }
@@ -56,7 +56,7 @@ public class BasicServerExample {
         @Override
         public CompletableFuture<GetBeerOutput> getBeer(GetBeerInput input, RequestContext context) {
             return CompletableFuture.supplyAsync(
-                    () -> GetBeerOutput.builder().beer(FRIDGE.get(input.id())).build(),
+                    () -> GetBeerOutput.builder().beer(FRIDGE.get(input.getId())).build(),
                     CompletableFuture.delayedExecutor(100, TimeUnit.MILLISECONDS));
         }
     }

--- a/examples/end-to-end/src/it/java/software/amazon/smithy/java/server/example/RoundTripTests.java
+++ b/examples/end-to-end/src/it/java/software/amazon/smithy/java/server/example/RoundTripTests.java
@@ -60,7 +60,7 @@ public class RoundTripTests {
     @Test
     void executesCorrectly() throws InterruptedException {
         var menu = client.getMenu(GetMenuInput.builder().build());
-        var hasEspresso = menu.getItems().stream().anyMatch(item -> item.getTypeMember().equals(CoffeeType.ESPRESSO));
+        var hasEspresso = menu.getItems().stream().anyMatch(item -> item.getType().equals(CoffeeType.ESPRESSO));
         assertTrue(hasEspresso);
 
         var createRequest = CreateOrderInput.builder().coffeeType(CoffeeType.COLD_BREW).build();

--- a/examples/end-to-end/src/it/java/software/amazon/smithy/java/server/example/RoundTripTests.java
+++ b/examples/end-to-end/src/it/java/software/amazon/smithy/java/server/example/RoundTripTests.java
@@ -60,23 +60,23 @@ public class RoundTripTests {
     @Test
     void executesCorrectly() throws InterruptedException {
         var menu = client.getMenu(GetMenuInput.builder().build());
-        var hasEspresso = menu.items().stream().anyMatch(item -> item.typeMember().equals(CoffeeType.ESPRESSO));
+        var hasEspresso = menu.getItems().stream().anyMatch(item -> item.getTypeMember().equals(CoffeeType.ESPRESSO));
         assertTrue(hasEspresso);
 
         var createRequest = CreateOrderInput.builder().coffeeType(CoffeeType.COLD_BREW).build();
         var createResponse = client.createOrder(createRequest);
-        assertEquals(CoffeeType.COLD_BREW, createResponse.coffeeType());
-        System.out.println("Created request with id = " + createResponse.id());
+        assertEquals(CoffeeType.COLD_BREW, createResponse.getCoffeeType());
+        System.out.println("Created request with id = " + createResponse.getId());
 
-        var getRequest = GetOrderInput.builder().id(createResponse.id()).build();
+        var getRequest = GetOrderInput.builder().id(createResponse.getId()).build();
         var getResponse1 = client.getOrder(getRequest);
-        assertEquals(getResponse1.status(), OrderStatus.IN_PROGRESS);
+        assertEquals(getResponse1.getStatus(), OrderStatus.IN_PROGRESS);
 
         // Complete the order
-        OrderTracker.completeOrder(getResponse1.id());
+        OrderTracker.completeOrder(getResponse1.getId());
 
         var getResponse2 = client.getOrder(getRequest);
-        assertEquals(getResponse2.status(), OrderStatus.COMPLETED);
+        assertEquals(getResponse2.getStatus(), OrderStatus.COMPLETED);
         System.out.println("Completed Order :" + getResponse2);
     }
 
@@ -84,7 +84,7 @@ public class RoundTripTests {
     void errorsOutIfOrderDoesNotExist() throws InterruptedException {
         var getRequest = GetOrderInput.builder().id(UUID.randomUUID().toString()).build();
         var orderNotFound = assertThrows(OrderNotFound.class, () -> client.getOrder(getRequest));
-        assertEquals(orderNotFound.orderId(), getRequest.id());
+        assertEquals(orderNotFound.getOrderId(), getRequest.getId());
     }
 
     @AfterAll

--- a/examples/end-to-end/src/main/java/software/amazon/smithy/java/server/example/CreateOrder.java
+++ b/examples/end-to-end/src/main/java/software/amazon/smithy/java/server/example/CreateOrder.java
@@ -20,11 +20,11 @@ final class CreateOrder implements CreateOrderOperation {
     public CreateOrderOutput createOrder(CreateOrderInput input, RequestContext context) {
         var id = UUID.randomUUID();
 
-        OrderTracker.putOrder(new Order(id, input.coffeeType(), OrderStatus.IN_PROGRESS));
+        OrderTracker.putOrder(new Order(id, input.getCoffeeType(), OrderStatus.IN_PROGRESS));
 
         return CreateOrderOutput.builder()
                 .id(id.toString())
-                .coffeeType(input.coffeeType())
+                .coffeeType(input.getCoffeeType())
                 .status(OrderStatus.IN_PROGRESS)
                 .build();
     }

--- a/examples/end-to-end/src/main/java/software/amazon/smithy/java/server/example/GetOrder.java
+++ b/examples/end-to-end/src/main/java/software/amazon/smithy/java/server/example/GetOrder.java
@@ -15,15 +15,15 @@ import software.amazon.smithy.java.server.RequestContext;
 final class GetOrder implements GetOrderOperation {
     @Override
     public GetOrderOutput getOrder(GetOrderInput input, RequestContext context) {
-        var order = OrderTracker.getOrderById(UUID.fromString(input.id()));
+        var order = OrderTracker.getOrderById(UUID.fromString(input.getId()));
         if (order == null) {
             throw OrderNotFound.builder()
-                    .orderId(input.id())
+                    .orderId(input.getId())
                     .message("Order not found")
                     .build();
         }
         return GetOrderOutput.builder()
-                .id(input.id())
+                .id(input.getId())
                 .coffeeType(order.type())
                 .status(order.status())
                 .build();

--- a/examples/event-streaming-client/src/it/java/software/amazon/smithy/java/example/eventstreaming/EventStreamTest.java
+++ b/examples/event-streaming-client/src/it/java/software/amazon/smithy/java/example/eventstreaming/EventStreamTest.java
@@ -46,7 +46,7 @@ public class EventStreamTest {
 
         AtomicLong receivedEvents = new AtomicLong();
         Set<Long> unbuzzed = new HashSet<>();
-        output.stream().subscribe(new Flow.Subscriber<>() {
+        output.getStream().subscribe(new Flow.Subscriber<>() {
 
             private Flow.Subscription subscription;
 

--- a/examples/lambda/src/main/java/software/amazon/smithy/java/example/BeerServiceProvider.java
+++ b/examples/lambda/src/main/java/software/amazon/smithy/java/example/BeerServiceProvider.java
@@ -55,8 +55,8 @@ public final class BeerServiceProvider implements SmithyServiceProvider {
         @Override
         public AddBeerOutput addBeer(AddBeerInput input, RequestContext context) {
             LOGGER.info("AddBeer - " + input);
-            String id = ENCODER.encodeToString(input.beer().name().getBytes(StandardCharsets.UTF_8));
-            FRIDGE.put(id, input.beer());
+            String id = ENCODER.encodeToString(input.getBeer().getName().getBytes(StandardCharsets.UTF_8));
+            FRIDGE.put(id, input.getBeer());
             return AddBeerOutput.builder().id(id).build();
         }
     }
@@ -65,7 +65,7 @@ public final class BeerServiceProvider implements SmithyServiceProvider {
         @Override
         public GetBeerOutput getBeer(GetBeerInput input, RequestContext context) {
             LOGGER.info("GetBeer - " + input);
-            return GetBeerOutput.builder().beer(FRIDGE.get(input.id())).build();
+            return GetBeerOutput.builder().beer(FRIDGE.get(input.getId())).build();
         }
     }
 }

--- a/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/operations/GetCodingStatistics.java
+++ b/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/operations/GetCodingStatistics.java
@@ -12,7 +12,7 @@ public class GetCodingStatistics implements GetCodingStatisticsOperation {
 
     @Override
     public GetCodingStatisticsOutput getCodingStatistics(GetCodingStatisticsInput input, RequestContext context) {
-        return switch (input.login()) {
+        return switch (input.getLogin()) {
             case "janedoe" -> GetCodingStatisticsOutput.builder().commits(Map.of()).build();
             case "johndoe" -> GetCodingStatisticsOutput.builder().commits(Map.of("Java", 100)).build();
             default -> throw NoSuchUserException.builder().message("User doesn't exist in the system").build();

--- a/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/operations/GetEmployeeDetails.java
+++ b/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/operations/GetEmployeeDetails.java
@@ -11,7 +11,7 @@ public class GetEmployeeDetails implements GetEmployeeDetailsOperation {
 
     @Override
     public GetEmployeeDetailsOutput getEmployeeDetails(GetEmployeeDetailsInput input, RequestContext context) {
-        return switch (input.loginId()) {
+        return switch (input.getLoginId()) {
             case "janedoe" -> GetEmployeeDetailsOutput.builder().name("Jane Doe").build();
             case "johndoe" -> GetEmployeeDetailsOutput.builder().name("John Doe").managerAlias("janedoe").build();
             default -> throw NoSuchUserException.builder().message("User doesn't exist in the system").build();

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/server/mcp/MCPServer.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/server/mcp/MCPServer.java
@@ -91,8 +91,8 @@ public final class MCPServer implements Server {
 
     private void handleRequest(JsonRpcRequest req) {
         try {
-            switch (req.method()) {
-                case "initialize" -> writeResponse(req.id(),
+            switch (req.getMethod()) {
+                case "initialize" -> writeResponse(req.getId(),
                         InitializeResult.builder()
                                 .capabilities(Capabilities.builder()
                                         .tools(Tools.builder().listChanged(false).build())
@@ -102,13 +102,13 @@ public final class MCPServer implements Server {
                                         .version("1.0.0")
                                         .build())
                                 .build());
-                case "tools/list" -> writeResponse(req.id(),
+                case "tools/list" -> writeResponse(req.getId(),
                         ListToolsResult.builder().tools(tools.values().stream().map(Tool::toolInfo).toList()).build());
                 case "tools/call" -> {
-                    var operationName = req.params().getMember("name").asString();
+                    var operationName = req.getParams().getMember("name").asString();
                     var tool = tools.get(operationName);
                     var operation = tool.operation();
-                    var input = req.params()
+                    var input = req.getParams()
                             .getMember("arguments")
                             .asShape(operation.getApiOperation().inputBuilder());
                     var output = operation.function().apply(input, null);
@@ -117,7 +117,7 @@ public final class MCPServer implements Server {
                                     .text(CODEC.serializeToString((SerializableShape) output))
                                     .build()))
                             .build();
-                    writeResponse(req.id(), result);
+                    writeResponse(req.getId(), result);
                 }
                 default -> {
                     //For now don't do anything
@@ -161,7 +161,7 @@ public final class MCPServer implements Server {
                 .message(s)
                 .build();
         var response = JsonRpcResponse.builder()
-                .id(req.id())
+                .id(req.getId())
                 .error(error)
                 .jsonrpc("2.0")
                 .build();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding the get prefix to method names to enable Kotlin property access syntax. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
