### PR TITLE
Fix CSV header parsing to not include quotes

### DIFF
--- a/aws/client/aws-client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
+++ b/aws/client/aws-client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
@@ -67,7 +67,6 @@ public class RestJson1ProtocolTests {
     @HttpClientResponseTests
     @ProtocolTestFilter(
             skipTests = {
-                    "RestJsonInputAndOutputWithQuotedStringHeaders",
                     "RestJsonFooErrorUsingCode",
                     "RestJsonFooErrorUsingCodeAndNamespace",
                     "RestJsonFooErrorUsingCodeUriAndNamespace",

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpHeaderListDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpHeaderListDeserializer.java
@@ -84,7 +84,6 @@ final class HttpHeaderListDeserializer extends SpecificShapeDeserializer {
                 escaping = true;
             } else if (c == '"') {
                 inQuotes = !inQuotes;
-                currentEntry.append(c);
             } else if (c == ',' && !inQuotes) {
                 // If we encounter a comma outside quotes, finalize the current entry.
                 accumulator.add(currentEntry.toString().trim());


### PR DESCRIPTION
We're splitting based on commas and quotes, but were including quotes as part of each parsed value. The quotes shouldn't be part of the parsed value, and removing it fixes a restJson1 protocol test.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
