### PR TITLE
Add ability to override call config in interceptor

### DIFF
--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCall.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCall.java
@@ -110,6 +110,27 @@ final class ClientCall<I extends SerializableStruct, O extends SerializableStruc
 
         private Builder() {}
 
+        void withConfig(ClientConfig callConfig) {
+            context = Context.modifiableCopy(callConfig.context());
+            supportedAuthSchemes.addAll(callConfig.supportedAuthSchemes());
+
+            if (callConfig.endpointResolver() != null) {
+                endpointResolver = callConfig.endpointResolver();
+            }
+
+            if (callConfig.authSchemeResolver() != null) {
+                authSchemeResolver = callConfig.authSchemeResolver();
+            }
+
+            if (callConfig.retryScope() != null) {
+                retryScope = callConfig.retryScope();
+            }
+
+            if (callConfig.retryStrategy() != null) {
+                retryStrategy = callConfig.retryStrategy();
+            }
+        }
+
         ClientCall<I, O> build() {
             return new ClientCall<>(this);
         }

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/CallHook.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/CallHook.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.interceptors;
+
+import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.RequestOverrideConfig;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+
+/**
+ * Hook to add request level overrides to client calls using {@link RequestOverrideConfig}.
+ *
+ * @param <I> Input shape.
+ * @param <O> Output shape.
+ */
+public record CallHook<I extends SerializableStruct, O extends SerializableStruct>(
+        ApiOperation<I, O> operation,
+        ClientConfig config,
+        I input) {
+    /**
+     * Get the API operation being called.
+     *
+     * @return the operation being called.
+     */
+    @Override
+    public ApiOperation<I, O> operation() {
+        return operation;
+    }
+
+    /**
+     * Get the client config of the hook.
+     *
+     * @return the config.
+     */
+    @Override
+    public ClientConfig config() {
+        return config;
+    }
+
+    /**
+     * Get the always present input shape value.
+     *
+     * @return the input value.
+     */
+    @Override
+    public I input() {
+        return input;
+    }
+
+    /**
+     * Create a new CallHook using the given config.
+     *
+     * @param config Config to use.
+     * @return the new CallHook or the current hook if the config hasn't changed.
+     */
+    public CallHook<I, O> withConfig(ClientConfig config) {
+        if (config == this.config) {
+            return this;
+        } else {
+            return new CallHook<>(operation, config, input);
+        }
+    }
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/ClientInterceptor.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/ClientInterceptor.java
@@ -8,6 +8,8 @@ package software.amazon.smithy.java.client.core.interceptors;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.RequestOverrideConfig;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 
 /**
@@ -46,6 +48,19 @@ public interface ClientInterceptor {
      */
     static ClientInterceptor chain(List<ClientInterceptor> interceptors) {
         return interceptors.isEmpty() ? NOOP : new ClientInterceptorChain(interceptors);
+    }
+
+    /**
+     * The first hook called before executing a call, allowing modification of the {@link ClientConfig} used
+     * with the call.
+     *
+     * <p>Use {@link ClientConfig#withRequestOverride(RequestOverrideConfig)} to modify the given config.
+     *
+     * @param hook Hook data.
+     * @return the updated ClientConfig, or the ClientConfig given to the hook.
+     */
+    default ClientConfig modifyBeforeCall(CallHook<?, ?> hook) {
+        return hook.config();
     }
 
     /**

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/ClientInterceptorChain.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/interceptors/ClientInterceptorChain.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.client.core.interceptors;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import software.amazon.smithy.java.client.core.ClientConfig;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.logging.InternalLogger;
 
@@ -42,6 +43,15 @@ final class ClientInterceptorChain implements ClientInterceptor {
         if (error != null) {
             throw error;
         }
+    }
+
+    @Override
+    public ClientConfig modifyBeforeCall(CallHook<?, ?> hook) {
+        var config = hook.config();
+        for (var interceptor : interceptors) {
+            config = interceptor.modifyBeforeCall(hook.withConfig(config));
+        }
+        return config;
     }
 
     @Override

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
@@ -156,7 +156,7 @@ public class ClientTest {
     }
 
     @Test
-    public void allowsInterceptorRequestOverridesOnOtherOverrides() throws URISyntaxException {
+    public void requestOverridesPerCallTakePrecedence() throws URISyntaxException {
         var queue = new MockQueue();
         queue.enqueue(HttpResponse.builder().statusCode(200).build());
         var id = "abc";
@@ -169,8 +169,9 @@ public class ClientTest {
                 .addPlugin(config -> config.addInterceptor(new ClientInterceptor() {
                     @Override
                     public ClientConfig modifyBeforeCall(CallHook<?, ?> hook) {
+                        // Note that the overrides given to the call itself will override interceptors.
                         var override = RequestOverrideConfig.builder()
-                                .putConfig(CallContext.APPLICATION_ID, id)
+                                .putConfig(CallContext.APPLICATION_ID, "foo")
                                 .build();
                         return hook.config().withRequestOverride(override);
                     }
@@ -190,7 +191,7 @@ public class ClientTest {
                 Document.ofObject(new HashMap<>()),
                 RequestOverrideConfig.builder()
                         .putConfig(CallContext.API_CALL_TIMEOUT, Duration.ofMinutes(2))
-                        .putConfig(CallContext.APPLICATION_ID, "foo") // this will be overridden in the interceptor
+                        .putConfig(CallContext.APPLICATION_ID, id) // this will be take precedence
                         .build());
     }
 }


### PR DESCRIPTION
Interceptors now have a new hook, modifyBeforeCall that accepts the ApiOperation being called, input of the call, and ClientConfig. It is expected to return the same ClientConfig or an updated ClientConfig using ClientConfig#withRequestOverride.

This allows for much more dynamic calls with clients, like changing the protocol per/call, applying plugins per/call, and more.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
