### PR TITLE
Expose framework error classes to server dependencies

### DIFF
--- a/server/server-api/build.gradle.kts
+++ b/server/server-api/build.gradle.kts
@@ -10,5 +10,5 @@ extra["moduleName"] = "software.amazon.smithy.java.server.api"
 dependencies {
     implementation(project(":logging"))
     implementation(project(":core"))
-    implementation(project(":framework-errors"))
+    api(project(":framework-errors"))
 }


### PR DESCRIPTION
When compiling a project that uses the server-rpcv2-cbor package we get an error that Exception classes declared in the framework-error package cannot be found. server-rpcv2-cbor declares an api dependency on server-api which is a common package for server related code. If framework-errors are intended to be common server logic then server-api should declare an api dependency on framework-errors so that consumers will be able to access those classes (which are used in code generation).

An alternative is to declare that api dependency on framework-errors in the server-rpcv2-cbor package; however, considering that these errors are intended to be common across server implementations, it should ostensibly go in the the common server-api package.