### PR TITLE
Fix plugin dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ by the Smithy build process:
 
 ```diff
 dependencies {
-+    smithyBuild("software.amazon.smithy.codegen:plugins:<replace with version>")
++    smithyBuild("software.amazon.smithy.java.codegen:plugins:<replace with version>")
 }
 ```
 


### PR DESCRIPTION
Weirdest rendering ever, but it makes sense since it's a "diff" snippet:

<img width="940" alt="image" src="https://github.com/user-attachments/assets/ebb395e9-38e1-4f74-bc55-ac9b61df6b44" />


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
