### PR TITLE
Don't regenerate Schemas of external types

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/integrations/externaltypes/ExternalTypesIntegration.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/integrations/externaltypes/ExternalTypesIntegration.java
@@ -31,9 +31,9 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class ExternalTypesIntegration implements JavaCodegenIntegration {
     private static final String PROPERTY_FILE = "META-INF/smithy-java/type-mappings.properties";
-    private static final Map<ShapeId, Symbol> TYPE_MAPPINGS = getErrorMappings();
+    private static final Map<ShapeId, Symbol> TYPE_MAPPINGS = getTypeMappings();
 
-    private static Map<ShapeId, Symbol> getErrorMappings() {
+    private static Map<ShapeId, Symbol> getTypeMappings() {
         try {
             Map<ShapeId, Symbol> result = new HashMap<>();
             var classLoader = ExternalTypesIntegration.class.getClassLoader();
@@ -49,7 +49,7 @@ public final class ExternalTypesIntegration implements JavaCodegenIntegration {
                     var symbol = CodegenUtils.fromClass(shapeClass)
                             .toBuilder()
                             .putProperty(SymbolProperties.EXTERNAL_TYPE, true)
-                            .build();;
+                            .build();
                     var existing = result.put(shapeId, symbol);
                     if (existing != null) {
                         throw new CodegenException(

--- a/examples/standalone-types/build.gradle.kts
+++ b/examples/standalone-types/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
 
     smithyBuild("software.amazon.smithy.java:plugins:$smithyJavaVersion")
     api("software.amazon.smithy.java:core:$smithyJavaVersion")
+    api("software.amazon.smithy.java:framework-errors:$smithyJavaVersion")
 
     testImplementation("org.hamcrest:hamcrest:3.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")

--- a/examples/standalone-types/model/person.smithy
+++ b/examples/standalone-types/model/person.smithy
@@ -2,6 +2,8 @@ $version: "2"
 
 namespace smithy.example
 
+use smithy.framework#ValidationException
+
 structure Human {
     children: HumanList
 
@@ -28,4 +30,8 @@ structure Parents {
 
 structure Address {
     city: String
+}
+
+structure HumanValidationException {
+    cause: ValidationException
 }

--- a/examples/standalone-types/src/test/java/software/amazon/smithy/java/example/ExternalTypesTest.java
+++ b/examples/standalone-types/src/test/java/software/amazon/smithy/java/example/ExternalTypesTest.java
@@ -1,0 +1,22 @@
+package software.amazon.smithy.java.example;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.SpecificShapeSerializer;
+import software.amazon.smithy.java.example.standalone.model.HumanValidationException;
+import software.amazon.smithy.java.framework.model.ValidationException;
+
+class ExternalTypesTest {
+
+    @Test
+    void verifySchemasAreNotRegenerated() {
+        HumanValidationException.builder().cause(ValidationException.builder().message("Test").build()).build().serializeMembers(new SpecificShapeSerializer() {
+
+            @Override
+            public void writeStruct(Schema schema, SerializableStruct struct) {
+               schema.assertMemberTargetIs(ValidationException.$SCHEMA);
+            }
+        });
+    }
+}

--- a/jmespath/src/main/java/software/amazon/smithy/java/jmespath/JMESPathFunction.java
+++ b/jmespath/src/main/java/software/amazon/smithy/java/jmespath/JMESPathFunction.java
@@ -429,7 +429,7 @@ enum JMESPathFunction {
                     }
                 }
                 case SHORT, BYTE, INTEGER, INT_ENUM, LONG, FLOAT, DOUBLE, BIG_DECIMAL, BIG_INTEGER ->
-                        Document.ofNumber(argument.asNumber());
+                    Document.ofNumber(argument.asNumber());
                 default -> null;
             };
         }

--- a/jmespath/src/test/java/software/amazon/smithy/java/jmespath/ComplianceTestRunner.java
+++ b/jmespath/src/test/java/software/amazon/smithy/java/jmespath/ComplianceTestRunner.java
@@ -168,16 +168,21 @@ class ComplianceTestRunner {
         } else if (isNumeric(expected) && isNumeric(actual)) {
             // Normalize all numbers to BigDecimal to make comparisons work.
             return new BigDecimal(expected.asNumber().toString())
-                           .compareTo(new BigDecimal(actual.asNumber().toString())) == 0;
+                    .compareTo(new BigDecimal(actual.asNumber().toString())) == 0;
         }
         return Objects.equals(expected, actual);
     }
 
     private static boolean isNumeric(Document doc) {
         var type = doc.type();
-        return type == ShapeType.BYTE || type == ShapeType.SHORT || type == ShapeType.INTEGER
-                || type == ShapeType.LONG || type == ShapeType.BIG_INTEGER || type == ShapeType.BIG_DECIMAL
-                || type == ShapeType.FLOAT || type == ShapeType.DOUBLE || type == ShapeType.INT_ENUM;
+        return type == ShapeType.BYTE || type == ShapeType.SHORT
+                || type == ShapeType.INTEGER
+                || type == ShapeType.LONG
+                || type == ShapeType.BIG_INTEGER
+                || type == ShapeType.BIG_DECIMAL
+                || type == ShapeType.FLOAT
+                || type == ShapeType.DOUBLE
+                || type == ShapeType.INT_ENUM;
     }
 
     private static final class NodeToDocumentConverter implements NodeVisitor<Document> {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We should not re-generate schema in our Schema's class for external types. This currently only does it for external structures but not external list/maps.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
