### PR TITLE
Add a wrapper structure over the SmithyBundle to capture mcp specific information

### DIFF
--- a/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/AddAwsServiceBundle.java
+++ b/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/AddAwsServiceBundle.java
@@ -14,6 +14,8 @@ import software.amazon.smithy.java.mcp.cli.CliBundle;
 import software.amazon.smithy.java.mcp.cli.model.McpBundleConfig;
 import software.amazon.smithy.java.mcp.cli.model.SmithyModeledBundleConfig;
 import software.amazon.smithy.mcp.bundle.api.model.Bundle;
+import software.amazon.smithy.mcp.bundle.api.model.BundleMetadata;
+import software.amazon.smithy.mcp.bundle.api.model.SmithyMcpBundle;
 
 @Command(name = "add-aws-bundle")
 public class AddAwsServiceBundle extends AbstractAddBundle {
@@ -42,7 +44,14 @@ public class AddAwsServiceBundle extends AbstractAddBundle {
                         .bundleLocation(getBundleFileLocation())
                         .build())
                 .build();
-        return new CliBundle(Bundle.builder().smithyBundle(bundle).build(), bundleConfig);
+        return new CliBundle(
+                Bundle.builder()
+                        .smithyBundle(SmithyMcpBundle.builder()
+                                .bundle(bundle)
+                                .metadata(BundleMetadata.builder().name(awsServiceName).build())
+                                .build())
+                        .build(),
+                bundleConfig);
     }
 
     @Override

--- a/mcp/mcp-bundle-api/src/main/resources/META-INF/smithy/mcpbundle.smithy
+++ b/mcp/mcp-bundle-api/src/main/resources/META-INF/smithy/mcpbundle.smithy
@@ -5,14 +5,22 @@ namespace software.amazon.smithy.mcp.bundle.api
 use software.amazon.smithy.modelbundle.api#SmithyBundle
 
 union Bundle {
-    smithyBundle: SmithyBundle
+    smithyBundle: SmithyMcpBundle
+}
+
+structure SmithyMcpBundle with [CommonBundleConfig] {
+    bundle: SmithyBundle
+}
+
+@mixin
+structure CommonBundleConfig {
+    metadata: BundleMetadata
 }
 
 structure BundleMetadata {
     @required
     name: String
 
-    @required
     description: String
 
     version: String


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We need MCP specific information in the McpBundle structure, so having the SmithyBundle directly as a Union member doesn't work.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
