### PR TITLE
Add a way to set CUSTOM_ENDPOINT and use with EP 2

### DIFF
--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/CallContext.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/CallContext.java
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.java.client.core;
 
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 import software.amazon.smithy.java.auth.api.identity.Identity;
@@ -15,30 +14,26 @@ import software.amazon.smithy.java.context.Context;
 
 /**
  * Context parameters made available to underlying transports like HTTP clients.
+ *
+ * <p>Settings that can be applied client-wide can be found in {@link ClientContext}.
  */
 public final class CallContext {
     /**
-     * The total amount of time to wait for an API call to complete, including retries, and serialization.
-     */
-    public static final Context.Key<Duration> API_CALL_TIMEOUT = Context.key("API call timeout");
-
-    /**
-     * The amount of time to wait for a single, underlying network request to complete before giving up and timing out.
-     */
-    public static final Context.Key<Duration> API_CALL_ATTEMPT_TIMEOUT = Context.key("API call attempt timeout");
-
-    /**
-     * The endpoint resolver used to resolve the destination endpoint for a request.
-     */
-    public static final Context.Key<EndpointResolver> ENDPOINT_RESOLVER = Context.key("EndpointResolver");
-
-    /**
-     * The read-only resolved endpoint for the request.
+     * The read-only endpoint for the request.
      */
     public static final Context.Key<Endpoint> ENDPOINT = Context.key("Endpoint of the request");
 
     /**
-     * The identity resolved for the request.
+     * The endpoint resolver used to resolve the destination endpoint for a request.
+     *
+     * <p>This is a read-only value; modifying this value has no effect on a request.
+     */
+    public static final Context.Key<EndpointResolver> ENDPOINT_RESOLVER = Context.key("EndpointResolver");
+
+    /**
+     * The read-only identity resolved for the request.
+     *
+     * <p>This is a read-only value; modifying this value has no effect on a request.
      */
     public static final Context.Key<Identity> IDENTITY = Context.key("Identity of the caller");
 
@@ -73,17 +68,6 @@ public final class CallContext {
     public static final Context.Key<Set<FeatureId>> FEATURE_IDS = Context.key(
             "Feature IDs used with a request",
             HashSet::new);
-
-    /**
-     * The name of the application, used in things like user-agent headers.
-     *
-     * <p>This value is used by AWS SDKs, but can be used generically for any client.
-     * See <a href="https://docs.aws.amazon.com/sdkref/latest/guide/feature-appid.html">Application ID</a> for more
-     * information.
-     *
-     * <p>This value should be less than 50 characters.
-     */
-    public static final Context.Key<String> APPLICATION_ID = Context.key("Application ID");
 
     private CallContext() {}
 }

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
@@ -13,6 +13,7 @@ import software.amazon.smithy.java.auth.api.identity.IdentityResolver;
 import software.amazon.smithy.java.auth.api.identity.IdentityResolvers;
 import software.amazon.smithy.java.client.core.auth.scheme.AuthScheme;
 import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
+import software.amazon.smithy.java.client.core.endpoint.Endpoint;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import software.amazon.smithy.java.client.core.interceptors.CallHook;
 import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
@@ -221,6 +222,34 @@ public abstract class Client {
         @SuppressWarnings("unchecked")
         public B endpointResolver(EndpointResolver endpointResolver) {
             this.configBuilder.endpointResolver(endpointResolver);
+            return (B) this;
+        }
+
+        /**
+         * Set a custom endpoint for the client to use.
+         *
+         * <p>Note that things like "hostLabel" traits may still cause the endpoint to change. For a completely
+         * static endpoint that never changes, use {@link EndpointResolver#staticHost}.
+         *
+         * @param customEndpoint Endpoint to use with the client.
+         * @return the builder.
+         */
+        @SuppressWarnings("unchecked")
+        public B endpoint(Endpoint customEndpoint) {
+            putConfig(ClientContext.CUSTOM_ENDPOINT, customEndpoint);
+            return (B) this;
+        }
+
+        /**
+         * Set a custom endpoint for the client to use.
+         *
+         * @param customEndpoint Endpoint to use with the client.
+         * @return the builder.
+         * @see #endpoint(Endpoint)
+         */
+        @SuppressWarnings("unchecked")
+        public B endpoint(String customEndpoint) {
+            putConfig(ClientContext.CUSTOM_ENDPOINT, Endpoint.builder().uri(customEndpoint).build());
             return (B) this;
         }
 

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCall.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCall.java
@@ -64,6 +64,8 @@ final class ClientCall<I extends SerializableStruct, O extends SerializableStruc
         supportedAuthSchemes = builder.supportedAuthSchemes.stream()
                 .collect(Collectors.toMap(AuthScheme::schemeId, Function.identity(), (key1, key2) -> key1));
 
+        context.put(CallContext.ENDPOINT_RESOLVER, endpointResolver);
+
         // Retries
         retryStrategy = Objects.requireNonNull(builder.retryStrategy, "retryStrategy is null");
         retryScope = Objects.requireNonNullElse(builder.retryScope, "");

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientConfig.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientConfig.java
@@ -70,7 +70,19 @@ public final class ClientConfig {
         this.transport = builder.transport;
         ClientPipeline.validateProtocolAndTransport(protocol, transport);
 
-        this.endpointResolver = Objects.requireNonNull(builder.endpointResolver, "endpointResolver is null");
+        // Use an explicitly given resolver if one was set.
+        if (builder.endpointResolver != null) {
+            this.endpointResolver = builder.endpointResolver;
+        } else {
+            // Use a custom endpoint and static endpoint resolver if a custom endpoint was given.
+            // Things like the Smithy rules engine based resolver look for this property to know if a custom endpoint
+            // was provided in this manner.
+            var customEndpoint = builder.context.get(ClientContext.CUSTOM_ENDPOINT);
+            if (customEndpoint == null) {
+                throw new NullPointerException("Both endpointResolver and ClientContext.CUSTOM_ENDPOINT are not set");
+            }
+            this.endpointResolver = EndpointResolver.staticEndpoint(customEndpoint);
+        }
 
         this.interceptors = List.copyOf(builder.interceptors);
 

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientContext.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientContext.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core;
+
+import java.time.Duration;
+import software.amazon.smithy.java.client.core.endpoint.Endpoint;
+import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
+import software.amazon.smithy.java.context.Context;
+
+/**
+ * Context parameters that can be provided on a client config and take effect on each request.
+ *
+ * <p>Other per/call settings can be found in {@link CallContext}.
+ */
+public final class ClientContext {
+    /**
+     * A custom endpoint used in each request.
+     *
+     * <p>This can be used in lieu of setting something like {@link EndpointResolver#staticEndpoint}, allowing
+     * endpoint resolvers like the Smithy Rules Engine resolver to still process and validate endpoints even when a
+     * custom endpoint is provided.
+     */
+    public static final Context.Key<Endpoint> CUSTOM_ENDPOINT = Context.key("Custom endpoint to use with requests");
+
+    /**
+     * The name of the application, used in things like user-agent headers.
+     *
+     * <p>This value is used by AWS SDKs, but can be used generically for any client.
+     * See <a href="https://docs.aws.amazon.com/sdkref/latest/guide/feature-appid.html">Application ID</a> for more
+     * information.
+     *
+     * <p>This value should be less than 50 characters.
+     */
+    public static final Context.Key<String> APPLICATION_ID = Context.key("Application ID");
+
+    /**
+     * The total amount of time to wait for an API call to complete, including retries, and serialization.
+     *
+     * <p>This can be overridden per/call too.
+     */
+    public static final Context.Key<Duration> API_CALL_TIMEOUT = Context.key("API call timeout");
+
+    /**
+     * The amount of time to wait for a single, underlying network request to complete before giving up and timing out.
+     *
+     * <p>This can be overridden per/call too.
+     */
+    public static final Context.Key<Duration> API_CALL_ATTEMPT_TIMEOUT = Context.key("API call attempt timeout");
+
+    private ClientContext() {}
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/endpoint/Endpoint.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/endpoint/Endpoint.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.client.core.endpoint;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.java.context.Context;
 
@@ -16,11 +15,6 @@ import software.amazon.smithy.java.context.Context;
  * A resolved endpoint.
  */
 public interface Endpoint {
-    /**
-     * Assigns headers to an endpoint. These are typically HTTP headers.
-     */
-    Context.Key<Map<String, List<String>>> HEADERS = Context.key("Endpoint headers");
-
     /**
      * The endpoint URI.
      *

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/endpoint/EndpointContext.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/endpoint/EndpointContext.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.endpoint;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.java.context.Context;
+
+/**
+ * Context parameters specifically relevant to a resolved {@link Endpoint} property.
+ */
+public final class EndpointContext {
+
+    private EndpointContext() {}
+
+    /**
+     * Assigns headers to an endpoint. These are typically HTTP headers.
+     */
+    public static final Context.Key<Map<String, List<String>>> HEADERS = Context.key("Endpoint headers");
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/endpoint/EndpointResolver.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/endpoint/EndpointResolver.java
@@ -72,7 +72,7 @@ public interface EndpointResolver {
      */
     static EndpointResolver staticHost(Endpoint endpoint) {
         Objects.requireNonNull(endpoint);
-        return params -> CompletableFuture.completedFuture(endpoint);
+        return new StaticHostResolver(endpoint);
     }
 
     /**
@@ -83,8 +83,7 @@ public interface EndpointResolver {
      */
     static EndpointResolver staticHost(String endpoint) {
         Objects.requireNonNull(endpoint);
-        var ep = Endpoint.builder().uri(endpoint).build();
-        return params -> CompletableFuture.completedFuture(ep);
+        return staticHost(Endpoint.builder().uri(endpoint).build());
     }
 
     /**
@@ -95,7 +94,6 @@ public interface EndpointResolver {
      */
     static EndpointResolver staticHost(URI endpoint) {
         Objects.requireNonNull(endpoint);
-        var ep = Endpoint.builder().uri(endpoint).build();
-        return params -> CompletableFuture.completedFuture(ep);
+        return staticHost(Endpoint.builder().uri(endpoint).build());
     }
 }

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/endpoint/StaticHostResolver.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/endpoint/StaticHostResolver.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core.endpoint;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An endpoint resolver that always returns the same endpoint.
+ *
+ * @param endpoint Endpoint to return exactly.
+ */
+record StaticHostResolver(Endpoint endpoint) implements EndpointResolver {
+    @Override
+    public CompletableFuture<Endpoint> resolveEndpoint(EndpointResolverParams params) {
+        return CompletableFuture.completedFuture(endpoint);
+    }
+}

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
@@ -138,14 +138,14 @@ public class ClientTest {
                     @Override
                     public ClientConfig modifyBeforeCall(CallHook<?, ?> hook) {
                         var override = RequestOverrideConfig.builder()
-                                .putConfig(CallContext.APPLICATION_ID, id)
+                                .putConfig(ClientContext.APPLICATION_ID, id)
                                 .build();
                         return hook.config().withRequestOverride(override);
                     }
 
                     @Override
                     public void readBeforeExecution(InputHook<?, ?> hook) {
-                        assertThat(hook.context().get(CallContext.APPLICATION_ID), equalTo(id));
+                        assertThat(hook.context().get(ClientContext.APPLICATION_ID), equalTo(id));
                     }
                 }))
                 .endpointResolver(EndpointResolver.staticEndpoint(new URI("http://localhost")))
@@ -171,15 +171,15 @@ public class ClientTest {
                     public ClientConfig modifyBeforeCall(CallHook<?, ?> hook) {
                         // Note that the overrides given to the call itself will override interceptors.
                         var override = RequestOverrideConfig.builder()
-                                .putConfig(CallContext.APPLICATION_ID, "foo")
+                                .putConfig(ClientContext.APPLICATION_ID, "foo")
                                 .build();
                         return hook.config().withRequestOverride(override);
                     }
 
                     @Override
                     public void readBeforeExecution(InputHook<?, ?> hook) {
-                        assertThat(hook.context().get(CallContext.APPLICATION_ID), equalTo(id));
-                        assertThat(hook.context().get(CallContext.API_CALL_TIMEOUT), equalTo(Duration.ofMinutes(2)));
+                        assertThat(hook.context().get(ClientContext.APPLICATION_ID), equalTo(id));
+                        assertThat(hook.context().get(ClientContext.API_CALL_TIMEOUT), equalTo(Duration.ofMinutes(2)));
                     }
                 }))
                 .endpointResolver(EndpointResolver.staticEndpoint(new URI("http://localhost")))
@@ -190,8 +190,32 @@ public class ClientTest {
         c.call("GetSprocket",
                 Document.ofObject(new HashMap<>()),
                 RequestOverrideConfig.builder()
-                        .putConfig(CallContext.API_CALL_TIMEOUT, Duration.ofMinutes(2))
-                        .putConfig(CallContext.APPLICATION_ID, id) // this will be take precedence
+                        .putConfig(ClientContext.API_CALL_TIMEOUT, Duration.ofMinutes(2))
+                        .putConfig(ClientContext.APPLICATION_ID, id) // this will be take precedence
                         .build());
+    }
+
+    @Test
+    public void setsCustomEndpoint() {
+        var queue = new MockQueue();
+        queue.enqueue(HttpResponse.builder().statusCode(200).build());
+
+        DynamicClient c = DynamicClient.builder()
+                .model(MODEL)
+                .service(SERVICE)
+                .protocol(new RestJsonClientProtocol(SERVICE))
+                .addPlugin(MockPlugin.builder().addQueue(queue).build())
+                .addPlugin(config -> config.addInterceptor(new ClientInterceptor() {
+                    @Override
+                    public void readBeforeExecution(InputHook<?, ?> hook) {
+                        assertThat(hook.context().get(ClientContext.CUSTOM_ENDPOINT).uri().toString(),
+                                equalTo("https://example.com"));
+                    }
+                }))
+                .endpoint("https://example.com")
+                .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+                .build();
+
+        c.call("GetSprocket");
     }
 }

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/plugins/UserAgentPlugin.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/plugins/UserAgentPlugin.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import software.amazon.smithy.java.client.core.CallContext;
 import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.ClientContext;
 import software.amazon.smithy.java.client.core.ClientPlugin;
 import software.amazon.smithy.java.client.core.ClientTransport;
 import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
@@ -109,7 +110,7 @@ public final class UserAgentPlugin implements ClientPlugin {
         }
 
         private static String resolveAppId(Context context) {
-            var appId = context.get(CallContext.APPLICATION_ID);
+            var appId = context.get(ClientContext.APPLICATION_ID);
             if (appId == null) {
                 appId = System.getenv(SYSTEM_APP_ID);
             }

--- a/client/client-http/src/test/java/software/amazon/smithy/java/client/http/plugins/UserAgentPluginTest.java
+++ b/client/client-http/src/test/java/software/amazon/smithy/java/client/http/plugins/UserAgentPluginTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.client.core.CallContext;
+import software.amazon.smithy.java.client.core.ClientContext;
 import software.amazon.smithy.java.client.core.FeatureId;
 import software.amazon.smithy.java.client.core.interceptors.RequestHook;
 import software.amazon.smithy.java.context.Context;
@@ -49,7 +50,7 @@ public class UserAgentPluginTest {
     public void addsApplicationId() throws Exception {
         UserAgentPlugin.UserAgentInterceptor interceptor = new UserAgentPlugin.UserAgentInterceptor();
         var context = Context.create();
-        context.put(CallContext.APPLICATION_ID, "hello there");
+        context.put(ClientContext.APPLICATION_ID, "hello there");
         var req = HttpRequest.builder().uri(new URI("/")).method("GET").build();
         var foo = new Foo();
         var updated = interceptor.modifyBeforeSigning(new RequestHook<>(createOperation(), context, foo, req));

--- a/client/client-rulesengine/src/main/java/software/amazon/smithy/java/client/rulesengine/EndpointRulesPlugin.java
+++ b/client/client-rulesengine/src/main/java/software/amazon/smithy/java/client/rulesengine/EndpointRulesPlugin.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.client.rulesengine;
 
 import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.ClientContext;
 import software.amazon.smithy.java.client.core.ClientPlugin;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.rulesengine.traits.ContextParamTrait;
@@ -69,8 +70,9 @@ public final class EndpointRulesPlugin implements ClientPlugin {
 
     @Override
     public void configureClient(ClientConfig.Builder config) {
-        // Only modify the endpoint resolver if it isn't set already and if a program was provided.
-        if (config.endpointResolver() == null) {
+        // Only modify the endpoint resolver if it isn't set already or if CUSTOM_ENDPOINT is set,
+        // and if a program was provided.
+        if (config.endpointResolver() == null || config.context().get(ClientContext.CUSTOM_ENDPOINT) != null) {
             if (program != null) {
                 applyResolver(program, config);
             } else if (config.service() != null) {

--- a/client/client-rulesengine/src/main/java/software/amazon/smithy/java/client/rulesengine/EndpointRulesResolver.java
+++ b/client/client-rulesengine/src/main/java/software/amazon/smithy/java/client/rulesengine/EndpointRulesResolver.java
@@ -44,7 +44,6 @@ final class EndpointRulesResolver implements EndpointResolver {
         var staticParams = getStaticParams(operation);
         // TODO: Grab input from RulesEnginePlugin.OPERATION_CONTEXT_PARAMS_TRAIT
         // TODO: Grab input from RulesEnginePlugin.CONTEXT_PARAM_TRAIT
-        // TODO: We need some way to provide the SDK::Endpoint builtin.
         return new HashMap<>(staticParams);
     }
 

--- a/client/client-rulesengine/src/main/java/software/amazon/smithy/java/client/rulesengine/RulesVm.java
+++ b/client/client-rulesengine/src/main/java/software/amazon/smithy/java/client/rulesengine/RulesVm.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import software.amazon.smithy.java.client.core.endpoint.Endpoint;
+import software.amazon.smithy.java.client.core.endpoint.EndpointContext;
 import software.amazon.smithy.java.context.Context;
 
 final class RulesVm {
@@ -257,7 +258,7 @@ final class RulesVm {
         var builder = Endpoint.builder().uri(createUri(urlString));
 
         if (!headers.isEmpty()) {
-            builder.putProperty(Endpoint.HEADERS, headers);
+            builder.putProperty(EndpointContext.HEADERS, headers);
         }
 
         for (var extension : program.extensions) {

--- a/client/client-rulesengine/src/main/java/software/amazon/smithy/java/client/rulesengine/Stdlib.java
+++ b/client/client-rulesengine/src/main/java/software/amazon/smithy/java/client/rulesengine/Stdlib.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.client.rulesengine;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
+import software.amazon.smithy.java.client.core.ClientContext;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.io.uri.URLEncoding;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.IsValidHostLabel;
@@ -105,7 +106,10 @@ enum Stdlib implements RulesFunction {
 
     static Object standardBuiltins(String name, Context context) {
         if (name.equals("SDK::Endpoint")) {
-            // TODO: grab statically set endpoint via a config key.
+            var result = context.get(ClientContext.CUSTOM_ENDPOINT);
+            if (result != null) {
+                return result.uri().toString();
+            }
         }
         return null;
     }

--- a/client/client-rulesengine/src/test/java/software/amazon/smithy/java/client/rulesengine/EndpointRulesPluginTest.java
+++ b/client/client-rulesengine/src/test/java/software/amazon/smithy/java/client/rulesengine/EndpointRulesPluginTest.java
@@ -11,6 +11,8 @@ import static org.hamcrest.Matchers.not;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.ClientContext;
+import software.amazon.smithy.java.client.core.endpoint.Endpoint;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import software.amazon.smithy.java.core.schema.ApiService;
 import software.amazon.smithy.java.core.schema.Schema;
@@ -43,6 +45,19 @@ public class EndpointRulesPluginTest {
         plugin.configureClient(builder);
 
         assertThat(builder.endpointResolver(), not(instanceOf(EndpointRulesResolver.class)));
+    }
+
+    @Test
+    public void modifiesResolverIfCustomEndpointSet() {
+        var contents = IoUtils.readUtf8Resource(getClass(), "example-complex-ruleset.json");
+        var program = new RulesEngine().compile(EndpointRuleSet.fromNode(Node.parse(contents)));
+        var plugin = EndpointRulesPlugin.from(program);
+        var builder = ClientConfig.builder()
+                .endpointResolver(EndpointResolver.staticHost("foo.com"))
+                .putConfig(ClientContext.CUSTOM_ENDPOINT, Endpoint.builder().uri("https://example.com").build());
+        plugin.configureClient(builder);
+
+        assertThat(builder.endpointResolver(), instanceOf(EndpointRulesResolver.class));
     }
 
     @Test

--- a/client/client-rulesengine/src/test/java/software/amazon/smithy/java/client/rulesengine/RulesCompilerTest.java
+++ b/client/client-rulesengine/src/test/java/software/amazon/smithy/java/client/rulesengine/RulesCompilerTest.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import software.amazon.smithy.java.client.core.endpoint.Endpoint;
+import software.amazon.smithy.java.client.core.endpoint.EndpointContext;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -53,7 +53,7 @@ public class RulesCompilerTest {
             expected.getEndpoint().ifPresent(expectedEndpoint -> {
                 var result = plugin.getProgram().resolveEndpoint(ctx, input);
                 assertThat(result.uri().toString(), equalTo(expectedEndpoint.getUrl()));
-                var actualHeaders = result.property(Endpoint.HEADERS);
+                var actualHeaders = result.property(EndpointContext.HEADERS);
                 if (expectedEndpoint.getHeaders().isEmpty()) {
                     assertThat(actualHeaders, nullValue());
                 } else {

--- a/client/client-rulesengine/src/test/java/software/amazon/smithy/java/client/rulesengine/RulesVmTest.java
+++ b/client/client-rulesengine/src/test/java/software/amazon/smithy/java/client/rulesengine/RulesVmTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.java.client.core.endpoint.Endpoint;
+import software.amazon.smithy.java.client.core.endpoint.EndpointContext;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.Template;
 
@@ -269,7 +269,7 @@ public class RulesVmTest {
         var endpoint = program.resolveEndpoint(Context.create(), Map.of());
 
         assertThat(endpoint.toString(), containsString("https://hi.bar"));
-        assertThat(endpoint.property(Endpoint.HEADERS), equalTo(Map.of("abc", List.of("def"))));
+        assertThat(endpoint.property(EndpointContext.HEADERS), equalTo(Map.of("abc", List.of("def"))));
     }
 
     @Test

--- a/client/client-rulesengine/src/test/java/software/amazon/smithy/java/client/rulesengine/StdlibTest.java
+++ b/client/client-rulesengine/src/test/java/software/amazon/smithy/java/client/rulesengine/StdlibTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.client.rulesengine;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 import java.net.URI;
@@ -14,6 +15,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import software.amazon.smithy.java.client.core.ClientContext;
+import software.amazon.smithy.java.client.core.endpoint.Endpoint;
+import software.amazon.smithy.java.context.Context;
 
 public class StdlibTest {
     @Test
@@ -83,5 +87,16 @@ public class StdlibTest {
     })
     public void testsForValidHostLabels(String input, boolean allowDots, boolean isValid) {
         assertThat(input, Stdlib.IS_VALID_HOST_LABEL.apply2(input, allowDots), is(isValid));
+    }
+
+    @Test
+    public void resolvesSdkEndpointBuiltins() {
+        var ctx = Context.create();
+        var endpoint = Endpoint.builder().uri("https://foo.com").build();
+        ctx.put(ClientContext.CUSTOM_ENDPOINT, endpoint);
+        var result = Stdlib.standardBuiltins("SDK::Endpoint", ctx);
+
+        assertThat(result, instanceOf(String.class));
+        assertThat(result, equalTo(endpoint.uri().toString()));
     }
 }


### PR DESCRIPTION
Client builder now has new `endpoint` builder methods that are used to more easily set a custom endpoint for the client. This also sets the ClientContext.CUSTOM_ENDPOINT setting that the rules engine plugin looks for two (1) know if it should override the currently set endpoint provider of the client (2) what the SDK::Endpoint builtin should return when called.

This commit also breaks up some of the context properties that were all stored in CallContext and moves some that can be client-wide to ClientContext.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
