### PR TITLE
Make Document#discriminator nullable, add registry

### DIFF
--- a/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborDocumentTest.java
+++ b/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborDocumentTest.java
@@ -35,7 +35,6 @@ import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
-import software.amazon.smithy.java.core.serde.document.DiscriminatorException;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.json.JsonCodec;
 import software.amazon.smithy.java.json.JsonSettings;
@@ -401,11 +400,11 @@ public class CborDocumentTest {
     }
 
     @Test
-    public void throwsWhenGettingDisciminatorOfWrongType() {
+    public void returnsNullWhenGettingDisciminatorOfWrongType() {
         var de = toCbor("\"hi\"");
-        var json = de.readDocument();
+        var cbor = de.readDocument();
 
-        Assertions.assertThrows(DiscriminatorException.class, json::discriminator);
+        assertThat(cbor.discriminator(), nullValue());
     }
 
     @Test

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDocumentTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDocumentTest.java
@@ -40,7 +40,6 @@ import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.TimestampFormatter;
-import software.amazon.smithy.java.core.serde.document.DiscriminatorException;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -470,12 +469,12 @@ public class JsonDocumentTest {
     }
 
     @Test
-    public void throwsWhenGettingDisciminatorOfWrongType() {
+    public void returnsNullWhenGettingDisciminatorOfWrongType() {
         var codec = JsonCodec.builder().build();
         var de = codec.createDeserializer("\"hi\"".getBytes(StandardCharsets.UTF_8));
         var json = de.readDocument();
 
-        Assertions.assertThrows(DiscriminatorException.class, json::discriminator);
+        assertThat(json.discriminator(), nullValue());
     }
 
     @Test

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/document/Document.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/document/Document.java
@@ -86,17 +86,32 @@ public interface Document extends SerializableShape {
     ShapeType type();
 
     /**
+     * Attempts to find and parse a shape ID from the document in the document's discriminator field and throws a
+     * {@link DiscriminatorException} if no discriminator is found.
+     *
+     * @return the non-null, parsed shape ID.
+     * @throws DiscriminatorException if the document doesn't have a valid discriminator.
+     * @see #discriminator()
+     */
+    default ShapeId expectDiscriminator() {
+        var result = discriminator();
+        if (result != null) {
+            return result;
+        }
+        throw new DiscriminatorException(type() + " document has no discriminator");
+    }
+
+    /**
      * Attempts to find and parse a shape ID from the document in the document's discriminator field.
      *
      * <p>Typed documents must return the shape ID of the enclosed shape. When possible, document implementations
      * should account for protocol-specific differences in how a discriminator is serialized. For example, a JSON codec
      * should override this method, check __type, and parse a shape ID when this is called.
      *
-     * @return the non-null, parsed shape ID.
-     * @throws DiscriminatorException if the document doesn't have a valid discriminator.
+     * @return the parsed shape ID, or null if not found.
      */
     default ShapeId discriminator() {
-        throw new DiscriminatorException(type() + " document has no discriminator");
+        return null;
     }
 
     /**

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/document/DocumentDeserializer.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/document/DocumentDeserializer.java
@@ -29,12 +29,12 @@ public class DocumentDeserializer implements ShapeDeserializer {
      *
      * @param text Discriminator value to parse.
      * @param defaultNamespace The default namespace to use if one is not in {@code text}. Use null for no default.
-     * @return the parsed shape ID discriminator.
-     * @throws DiscriminatorException if a discriminator cannot be parsed.
+     * @return the parsed shape ID discriminator, or null if not found.
+     * @throws DiscriminatorException if a discriminator is found, but cannot be parsed.
      */
     public static ShapeId parseDiscriminator(String text, String defaultNamespace) {
         if (text == null) {
-            throw new DiscriminatorException("Unable to find a document discriminator");
+            return null;
         }
 
         try {

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentDeserializerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentDeserializerTest.java
@@ -9,6 +9,7 @@ import static java.nio.ByteBuffer.wrap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -61,12 +62,8 @@ public class DocumentDeserializerTest {
     }
 
     @Test
-    public void discriminatorThrowsWithNiceMessageWhenTextIsNull() {
-        var e = Assertions.assertThrows(
-                DiscriminatorException.class,
-                () -> DocumentDeserializer.parseDiscriminator(null, null));
-
-        assertThat(e.getMessage(), equalTo("Unable to find a document discriminator"));
+    public void discriminatorReturnsNullWhenMissing() {
+        assertThat(DocumentDeserializer.parseDiscriminator(null, "foo"), is(nullValue()));
     }
 
     @Test

--- a/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/serde/document/DocumentTest.java
@@ -512,14 +512,21 @@ public class DocumentTest {
     public void returnsNullForNonStructures() {
         var document = Document.of("Hi");
 
-        Assertions.assertThrows(DiscriminatorException.class, document::discriminator);
+        assertThat(document.discriminator(), nullValue());
+    }
+
+    @Test
+    public void throwsForMissingDiscriminatorWhenExpected() {
+        var document = Document.of("Hi");
+
+        Assertions.assertThrows(DiscriminatorException.class, document::expectDiscriminator);
     }
 
     @Test
     public void returnsNullForMapsMissingType() {
         var document = Document.of(Map.of("hi", Document.of("bye")));
 
-        Assertions.assertThrows(DiscriminatorException.class, document::discriminator);
+        assertThat(document.discriminator(), nullValue());
     }
 
     @Test

--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/StructDocument.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/StructDocument.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
-import software.amazon.smithy.java.core.serde.document.DiscriminatorException;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.core.serde.document.DocumentUtils;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -163,11 +162,7 @@ public final class StructDocument implements Document, SerializableStruct {
 
     @Override
     public ShapeId discriminator() {
-        if (schema.type() == ShapeType.STRUCTURE) {
-            return schema.id();
-        } else {
-            throw new DiscriminatorException(type() + " document has no discriminator");
-        }
+        return schema.type() == ShapeType.STRUCTURE ? schema.id() : null;
     }
 
     @Override

--- a/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/StructDocumentTest.java
+++ b/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/StructDocumentTest.java
@@ -79,7 +79,7 @@ public class StructDocumentTest {
         var sd = StructDocument.of(schema, document, ShapeId.from("smithy.example#S"));
 
         assertThat(sd.type(), is(ShapeType.STRUCTURE));
-        assertThat(sd.discriminator().toString(), equalTo("foo#Bar"));
+        assertThat(sd.expectDiscriminator().toString(), equalTo("foo#Bar"));
         assertThat(sd.size(), equalTo(1));
     }
 
@@ -91,7 +91,7 @@ public class StructDocumentTest {
         var document = Document.ofObject(Map.of("foo", "bar"));
         var sd = StructDocument.of(schema, document, ShapeId.from("smithy.example#S"));
 
-        Assertions.assertThrows(DiscriminatorException.class, sd::discriminator);
+        Assertions.assertThrows(DiscriminatorException.class, sd::expectDiscriminator);
     }
 
     @Test


### PR DESCRIPTION
Document#discriminator is now nullable, and returns null if no discriminator is found. This method still throws if a string is found but cannot be parsed. Making this nullable allows us to compose type registries so that they can check multiple registries to attempt to create a builder for a document.

Added a new api to TypeRegistry: createBuilder(Document). This API attempts to find a builder for a document based on its discriminator or returns null if the document has none, or no matching builder is found. This matches the behavior of createBuilder(ShapeId).

Added a new api to TypeRegistry: deserializeString(Document). This API deserializes a document into a builder from the registry but does not use error correction, ensuring that missing defaults are not filled in with zero values, and deserialization fails when members are missing (predicated on the resolved builder performing the required-ness check).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
