### PR TITLE
Make PropertyDetails#description optional

### DIFF
--- a/mcp/mcp-schemas/model/main.smithy
+++ b/mcp/mcp-schemas/model/main.smithy
@@ -134,7 +134,6 @@ structure PropertyDetails {
     @required
     type: String
 
-    @required
     description: String
 }
 


### PR DESCRIPTION
This is not guaranteed to be present for MCP servers because documentation traits are optional