### PR TITLE
Add pretty printing support to JSON serialization

### DIFF
--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonCodec.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonCodec.java
@@ -151,6 +151,18 @@ public final class JsonCodec implements Codec {
             settingsBuilder.serializeTypeInDocuments(serializeTypeInDocuments);
             return this;
         }
+        
+        /**
+         * Whether to format the JSON output with pretty printing (indentation and line breaks).
+         * Default is false.
+         *
+         * @param prettyPrint true to enable pretty printing
+         * @return the builder
+         */
+        public Builder prettyPrint(boolean prettyPrint) {
+            settingsBuilder.prettyPrint(prettyPrint);
+            return this;
+        }
 
         /**
          * Uses a custom JSON serde provider.

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSettings.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSettings.java
@@ -44,6 +44,7 @@ public final class JsonSettings {
     private final String defaultNamespace;
     private final JsonSerdeProvider provider;
     private final boolean serializeTypeInDocuments;
+    private final boolean prettyPrint;
 
     private JsonSettings(Builder builder) {
         this.timestampResolver = builder.useTimestampFormat
@@ -56,6 +57,7 @@ public final class JsonSettings {
         this.defaultNamespace = builder.defaultNamespace;
         this.provider = builder.provider;
         this.serializeTypeInDocuments = builder.serializeTypeInDocuments;
+        this.prettyPrint = builder.prettyPrint;
     }
 
     /**
@@ -113,6 +115,15 @@ public final class JsonSettings {
         return serializeTypeInDocuments;
     }
 
+    /**
+     * Whether to format the JSON output with pretty printing (indentation and line breaks).
+     *
+     * @return true if pretty printing is enabled
+     */
+    public boolean prettyPrint() {
+        return prettyPrint;
+    }
+
     JsonSerdeProvider provider() {
         return provider;
     }
@@ -128,6 +139,7 @@ public final class JsonSettings {
             builder.useJsonName(true);
         }
         builder.serializeTypeInDocuments(serializeTypeInDocuments);
+        builder.prettyPrint(prettyPrint);
     }
 
     /**
@@ -152,6 +164,7 @@ public final class JsonSettings {
         private String defaultNamespace;
         private JsonSerdeProvider provider = PROVIDER;
         private boolean serializeTypeInDocuments = true;
+        private boolean prettyPrint = false;
 
         private Builder() {}
 
@@ -237,6 +250,18 @@ public final class JsonSettings {
          */
         public Builder serializeTypeInDocuments(boolean serializeTypeInDocuments) {
             this.serializeTypeInDocuments = serializeTypeInDocuments;
+            return this;
+        }
+
+        /**
+         * Whether to format the JSON output with pretty printing (indentation and line breaks).
+         * Default is false.
+         *
+         * @param prettyPrint true to enable pretty printing
+         * @return the builder
+         */
+        public Builder prettyPrint(boolean prettyPrint) {
+            this.prettyPrint = prettyPrint;
             return this;
         }
 

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerializer.java
@@ -36,6 +36,9 @@ final class JacksonJsonSerializer implements ShapeSerializer {
             JsonSettings settings
     ) {
         this.generator = generator;
+        if (settings.prettyPrint()) {
+            generator.useDefaultPrettyPrinter();
+        }
         this.settings = settings;
     }
 

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
@@ -254,6 +254,41 @@ public class JsonSerializerTest {
             assertThat(result, equalTo("{\"__type\":\"smithy.example#Nested\"}"));
         }
     }
+    
+    @Test
+    public void testPrettyPrinting() throws Exception {
+        try (var codec = JsonCodec.builder().prettyPrint(true).build(); var output = new ByteArrayOutputStream()) {
+            try (var serializer = codec.createSerializer(output)) {
+                serializer.writeStruct(
+                        JsonTestData.BIRD,
+                        new SerializableStruct() {
+                            @Override
+                            public Schema schema() {
+                                return JsonTestData.BIRD;
+                            }
+
+                            @Override
+                            public void serializeMembers(ShapeSerializer ser) {
+                                ser.writeString(schema().member("name"), "Toucan");
+                                ser.writeString(schema().member("color"), "red");
+                            }
+
+                            @Override
+                            public <T> T getMemberValue(Schema member) {
+                                return null;
+                            }
+                        });
+            }
+            var result = output.toString(StandardCharsets.UTF_8);
+            // Expected format with Jackson's default pretty printer
+            String expectedFormat = """
+                {
+                  "name" : "Toucan",
+                  "color" : "red"
+                }""";
+            assertThat(result, equalTo(expectedFormat));
+        }
+    }
 
     private static final class NestedStruct implements SerializableStruct {
         @Override


### PR DESCRIPTION
## Summary
- Adds a new  option to JsonSettings that can be used to format JSON output with indentation and line breaks
- The option is disabled by default to maintain backward compatibility
- Adds a test case to verify pretty printing functionality