### PR TITLE
Revert "Add service name suffix to tool operation name"

### DIFF
--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServer.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServer.java
@@ -181,16 +181,15 @@ public final class McpServer implements Server {
             var serviceName = service.schema().id().getName();
             for (var operation : service.getAllOperations()) {
                 var operationName = operation.name();
-                var toolName = serviceName + "_" + operationName;
                 Schema schema = operation.getApiOperation().schema();
                 var toolInfo = ToolInfo.builder()
-                        .name(toolName)
+                        .name(operationName)
                         .description(createDescription(serviceName,
                                 operationName,
                                 schema))
                         .inputSchema(createInputSchema(operation.getApiOperation().inputSchema()))
                         .build();
-                tools.put(toolName, new Tool(toolInfo, operation));
+                tools.put(operation.name(), new Tool(toolInfo, operation));
             }
         }
         return tools;


### PR DESCRIPTION
This reverts commit 3219d78446d53ca9f8e41b5c1077a225ce114fc7.

*Issue #, if available:*

*Description of changes:*

This is causing some clients like Q to fail validation on the tool names. Reverting for now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
