### PR TITLE
Add dynamic tool loading

### DIFF
--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ConfigUtils.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ConfigUtils.java
@@ -148,6 +148,7 @@ public class ConfigUtils {
                 serializedBundle,
                 StandardOpenOption.TRUNCATE_EXISTING,
                 StandardOpenOption.CREATE);
+        addMcpBundleConfig(config, toolBundleName, mcpBundleConfig.mcpBundleConfig());
     }
 
     public static McpBundleConfig addMcpBundle(Config config, String toolBundleName, Bundle bundle)

--- a/mcp/mcp-cli/build.gradle.kts
+++ b/mcp/mcp-cli/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project(":codecs:json-codec", configuration = "shadow"))
     implementation(libs.picocli)
     api(project(":mcp:mcp-cli-api"))
+    api(project(":mcp:mcp-schemas"))
     implementation(libs.smithy.utils)
 
     // TODO these need to be dynamically loaded

--- a/mcp/mcp-schemas/build.gradle.kts
+++ b/mcp/mcp-schemas/build.gradle.kts
@@ -11,7 +11,9 @@ extra["moduleName"] = "software.amazon.smithy.mcp.schemas"
 dependencies {
     api(project(":core"))
     api(libs.smithy.model)
+    api(project(":server:server-api"))
     smithyBuild(project(":codegen:plugins:types-codegen"))
+    smithyBuild(project(":codegen:plugins:server-codegen"))
 }
 
 sourceSets {
@@ -24,14 +26,17 @@ sourceSets {
 
 afterEvaluate {
     val typePath = smithy.getPluginProjectionPath(smithy.sourceProjection.get(), "java-type-codegen")
+    val serverPath = smithy.getPluginProjectionPath(smithy.sourceProjection.get(), "java-server-codegen")
     sourceSets {
         main {
             java {
                 srcDir(typePath)
+                srcDir(serverPath)
                 include("software/**")
             }
             resources {
                 srcDir(typePath)
+                srcDir(serverPath)
                 include("META-INF/**")
             }
         }

--- a/mcp/mcp-schemas/model/registry.smithy
+++ b/mcp/mcp-schemas/model/registry.smithy
@@ -1,0 +1,39 @@
+$version: "2"
+
+namespace smithy.mcp.registry
+
+/// This service provides methods to list and install MCP servers. You can get a list of available servers with
+/// ListServers. Use a server from that method to install a new server with the InstallServer API.
+service McpRegistry {
+    operations: [
+        ListServers
+        InstallServer
+    ]
+}
+
+/// List the available MCP servers that you can install
+operation ListServers {
+    output := {
+        /// A map of server name to details about that server
+        @required
+        servers: ServerMap
+    }
+}
+
+map ServerMap {
+    key: String
+    value: ServerEntry
+}
+
+structure ServerEntry {
+    description: String
+}
+
+/// Install a new MCP server for local use.
+operation InstallServer {
+    input := {
+        /// The name of the MCP server to install
+        @required
+        serverName: String
+    }
+}

--- a/mcp/mcp-schemas/smithy-build.json
+++ b/mcp/mcp-schemas/smithy-build.json
@@ -4,6 +4,11 @@
     "java-type-codegen": {
       "namespace": "software.amazon.smithy.java.mcp",
       "headerFile": "license.txt"
+    },
+    "java-server-codegen": {
+      "service": "smithy.mcp.registry#McpRegistry",
+      "namespace": "software.amazon.smithy.java.mcp.registry",
+      "headerFile": "license.txt"
     }
   }
 }


### PR DESCRIPTION
This change serves the local registry itself as an MCP server, allowing tools to be dynamically located and installed during a session. To support this, we now support the `listChanged` server capability.

Additionally, I fixed a bug in ConfigUtils that did not cause the local registry to be updated on installation.