### PR TITLE
Improve formatting of mcp-registry list output

### DIFF
--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/SmithyMcpCommand.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/SmithyMcpCommand.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.mcp.cli;
 import static software.amazon.smithy.java.mcp.cli.ConfigUtils.loadOrCreateConfig;
 
 import java.util.concurrent.Callable;
-
 import picocli.CommandLine;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.mcp.cli.model.Config;

--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/SmithyMcpCommand.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/SmithyMcpCommand.java
@@ -8,6 +8,8 @@ package software.amazon.smithy.java.mcp.cli;
 import static software.amazon.smithy.java.mcp.cli.ConfigUtils.loadOrCreateConfig;
 
 import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
 import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.java.mcp.cli.model.Config;
 
@@ -19,6 +21,9 @@ import software.amazon.smithy.java.mcp.cli.model.Config;
  * and providing appropriate error handling.
  */
 public abstract class SmithyMcpCommand implements Callable<Integer> {
+
+    @CommandLine.Spec
+    CommandLine.Model.CommandSpec commandSpec;
 
     InternalLogger LOG = InternalLogger.getLogger(SmithyMcpCommand.class);
 
@@ -46,4 +51,8 @@ public abstract class SmithyMcpCommand implements Callable<Integer> {
      * @throws Exception If an error occurs during execution
      */
     protected abstract void execute(Config config) throws Exception;
+
+    protected final CommandLine.Model.CommandSpec commandSpec() {
+        return commandSpec;
+    }
 }

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/ListBundles.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/ListBundles.java
@@ -5,14 +5,12 @@
 
 package software.amazon.smithy.java.mcp.cli.commands;
 
-import picocli.CommandLine;
+import static picocli.CommandLine.Command;
+
 import picocli.CommandLine.Option;
 import software.amazon.smithy.java.mcp.cli.RegistryUtils;
 import software.amazon.smithy.java.mcp.cli.SmithyMcpCommand;
 import software.amazon.smithy.java.mcp.cli.model.Config;
-import software.amazon.smithy.java.mcp.cli.model.SmithyModeledBundleConfig;
-
-import static picocli.CommandLine.Command;
 
 @Command(name = "list", description = "List all the MCP Bundles available in the Registry")
 public class ListBundles extends SmithyMcpCommand {
@@ -31,8 +29,9 @@ public class ListBundles extends SmithyMcpCommand {
         registry
                 .listMcpBundles()
                 .forEach(bundle -> {
-                    System.out.println(commandSpec().commandLine().getColorScheme()
-                        .string("@|bold " + bundle.getName() + "|@"));
+                    System.out.println(commandSpec().commandLine()
+                            .getColorScheme()
+                            .string("@|bold " + bundle.getName() + "|@"));
                     var description = bundle.getDescription();
                     if (description == null) {
                         description = "MCP server for " + bundle.getName();

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/ListBundles.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/ListBundles.java
@@ -5,12 +5,14 @@
 
 package software.amazon.smithy.java.mcp.cli.commands;
 
-import static picocli.CommandLine.Command;
-
+import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import software.amazon.smithy.java.mcp.cli.RegistryUtils;
 import software.amazon.smithy.java.mcp.cli.SmithyMcpCommand;
 import software.amazon.smithy.java.mcp.cli.model.Config;
+import software.amazon.smithy.java.mcp.cli.model.SmithyModeledBundleConfig;
+
+import static picocli.CommandLine.Command;
 
 @Command(name = "list", description = "List all the MCP Bundles available in the Registry")
 public class ListBundles extends SmithyMcpCommand {
@@ -29,13 +31,14 @@ public class ListBundles extends SmithyMcpCommand {
         registry
                 .listMcpBundles()
                 .forEach(bundle -> {
-                    StringBuilder builder = new StringBuilder(bundle.getName());
-                    if (bundle.getDescription() != null) {
-                        builder.append("\n").append("Description: ").append(bundle.getDescription());
-                    } else {
-                        builder.append("\n").append("MCP for ").append(bundle.getName());
+                    System.out.println(commandSpec().commandLine().getColorScheme()
+                        .string("@|bold " + bundle.getName() + "|@"));
+                    var description = bundle.getDescription();
+                    if (description == null) {
+                        description = "MCP server for " + bundle.getName();
                     }
-                    System.out.println(builder);
+                    System.out.print("\tDescription: ");
+                    System.out.println(description);
                 });
 
     }


### PR DESCRIPTION
New look:

<img width="498" alt="image" src="https://github.com/user-attachments/assets/06453d2f-264e-4eef-914f-798b4f4f5653" />
