### PR TITLE
Add support for starting an McpServer from a GenericBundle

### DIFF
--- a/mcp/mcp-bundle-api/src/main/resources/META-INF/smithy/mcpbundle.smithy
+++ b/mcp/mcp-bundle-api/src/main/resources/META-INF/smithy/mcpbundle.smithy
@@ -29,8 +29,12 @@ structure BundleMetadata {
 
 structure GenericBundle with [CommonBundleConfig] {
     artifact: GenericArtifact
-    install: String
-    command: String
+    install: ExecSpec
+    run: ExecSpec
+}
+
+structure ExecSpec {
+    executable: String
     args: ArgList
 }
 

--- a/mcp/mcp-cli-api/model/main.smithy
+++ b/mcp/mcp-cli-api/model/main.smithy
@@ -22,8 +22,13 @@ union McpBundleConfig {
 @mixin
 structure CommonToolConfig {
     name: String
+
     allowListedTools: ToolNames
+
     blockListedTools: ToolNames
+
+    @required
+    bundleLocation: Location
 }
 
 map Registries {
@@ -44,10 +49,7 @@ structure CommonRegistryConfig {
     name: String
 }
 
-structure SmithyModeledBundleConfig with [CommonToolConfig] {
-    @required
-    bundleLocation: Location
-}
+structure SmithyModeledBundleConfig with [CommonToolConfig] {}
 
 list Locations {
     member: Location

--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ConfigUtils.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ConfigUtils.java
@@ -10,6 +10,7 @@ import static software.amazon.smithy.java.io.ByteBufferUtils.getBytes;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -175,6 +176,7 @@ public class ConfigUtils {
                 builder.genericConfig(
                         GenericToolBundleConfig.builder().name(toolBundleName).bundleLocation(location).build());
             }
+            default -> throw new IllegalStateException("Unexpected bundle type: " + bundle.type());
         }
 
         var mcpBundleConfig = builder.build();
@@ -230,7 +232,8 @@ public class ConfigUtils {
     }
 
     private static String captureProcessOutput(Process process) throws IOException {
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+        try (BufferedReader in =
+                new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
             return in.lines().collect(Collectors.joining(System.lineSeparator()));
         }
     }

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/ProcessIoProxy.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/ProcessIoProxy.java
@@ -191,7 +191,7 @@ public final class ProcessIoProxy {
      * @throws RuntimeException If there is an error starting the process
      */
     public synchronized void start() {
-        if (running.compareAndSet(false, true)) {
+        if (!running.compareAndSet(false, true)) {
             return;
         }
         try {

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/StartServer.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/StartServer.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -133,6 +132,7 @@ public final class StartServer extends SmithyMcpCommand {
                             .environmentVariables(System.getenv())
                             .build();
                 }
+                default -> throw new IllegalArgumentException("Unknown tool bundle type: " + toolBundleConfig.type());
             }
 
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add support for starting generic mcp server configs. Till we implement the full MCP spec in MCPServerProxy we can only start a single proxy server.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
