### PR TITLE
Shut down local MCP server when the client disconnects

### DIFF
--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/SmithyMcpCommand.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/SmithyMcpCommand.java
@@ -54,7 +54,7 @@ public abstract class SmithyMcpCommand implements Callable<Integer> {
     protected String registryToUse(Config config) {
         return config.getDefaultRegistry();
     }
-  
+
     protected final CommandLine.Model.CommandSpec commandSpec() {
         return commandSpec;
     }


### PR DESCRIPTION
For some reason, Q chat isn't attempting to terminate our process when it exits. [It looks like it should](https://github.com/aws/amazon-q-developer-cli/blob/main/crates/cli/src/util/process/unix.rs#L6), but [they also expect local servers that are "implemented well" to exit when the input pipe closes](https://github.com/aws/amazon-q-developer-cli/blob/main/crates/cli/src/mcp_client/client.rs#L205-L206). We will now follow that expectation.