### PR TITLE
fix: Add missing comma to smithy-build.json diff in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ add the following to our `smithy-build.json`:
     ...
     "plugins": {
 +       "java-client-codegen": {
-+            "service": "com.example#CoffeeShop"
++            "service": "com.example#CoffeeShop",
 +            "namespace": "software.amazon.smithy.java.examples",
 +            "headerFile": "license.txt"
 +       }


### PR DESCRIPTION
Add a comma after the `"service"` key in `smithy-build.json`'s diff. Otherwise the JSON is not syntactically valid.

*Issue #, if available:* N/A

*Description of changes:*

Currently, in the README.md file, there is a syntax error in the diff for `smithy-build.json`. Fix it by adding the missing comma.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
