### PR TITLE
Make jars reproducible

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-java.java-conventions.gradle.kts
@@ -28,6 +28,11 @@ tasks.withType<Javadoc>() {
     options.encoding = "UTF-8"
 }
 
+tasks.withType<AbstractArchiveTask> {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+}
+
 /*
  * Common test configuration
  * ===============================


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This makes jars reproducible to an extent. Spot checked MD5 sum of some jars remain same across clean builds and on different machines.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
