### PR TITLE
Resolve AWS services in the AWS bundler by sigv4 signing name

### DIFF
--- a/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
+++ b/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
@@ -20,7 +20,8 @@ public class AwsServiceBundlerTest {
 
     @Test
     public void accessAnalyzer() {
-        var bundler = new AwsServiceBundler("accessanalyzer-2019-11-01.json", AwsServiceBundlerTest::getModel);
+        var bundler = new AwsServiceBundler("access-analyzer",
+                serviceName -> getModel("accessanalyzer-2019-11-01.json"));
         var bundle = bundler.bundle();
         var config = bundle.getConfig().asShape(AwsServiceMetadata.builder());
 
@@ -33,8 +34,8 @@ public class AwsServiceBundlerTest {
     @Test
     public void testFilteringApis() {
         var filteredOperations = Set.of("GetFindingsStatistics", "GetFindingRecommendation");
-        var bundler = new AwsServiceBundler("accessanalyzer-2019-11-01.json",
-                AwsServiceBundlerTest::getModel,
+        var bundler = new AwsServiceBundler("access-analyzer",
+                serviceName -> getModel("accessanalyzer-2019-11-01.json"),
                 filteredOperations,
                 Set.of());
         var bundle = bundler.bundle();


### PR DESCRIPTION
Now, we input the sigv4 signing name to the bundler and use that to produce the bundles. This doesn't _exactly_ align with the experience we want but it's closer than we were before.