### PR TITLE
Add uninstall command

### DIFF
--- a/mcp/mcp-cli-api/model/main.smithy
+++ b/mcp/mcp-cli-api/model/main.smithy
@@ -4,8 +4,12 @@ namespace smithy.mcp.cli
 
 structure Config {
     toolBundles: McpBundleConfigs
+
     defaultRegistry: String
+
     registries: Registries
+
+    @default([])
     clientConfigs: ClientConfigs
 }
 
@@ -72,6 +76,7 @@ list ToolNames {
     member: ToolName
 }
 
+@uniqueItems
 list ClientConfigs {
     member: ClientConfig
 }

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/McpCli.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/McpCli.java
@@ -13,6 +13,7 @@ import software.amazon.smithy.java.mcp.cli.commands.Configure;
 import software.amazon.smithy.java.mcp.cli.commands.InstallBundle;
 import software.amazon.smithy.java.mcp.cli.commands.ListBundles;
 import software.amazon.smithy.java.mcp.cli.commands.StartServer;
+import software.amazon.smithy.java.mcp.cli.commands.UninstallBundle;
 
 /**
  * Main entry point for the Smithy MCP Command Line Interface.
@@ -32,6 +33,7 @@ public class McpCli {
                 .addSubcommand(new StartServer())
                 .addSubcommand(new ListBundles())
                 .addSubcommand(new InstallBundle())
+                .addSubcommand(new UninstallBundle())
                 .addSubcommand(configureCommand);
         commandLine.execute(args);
     }

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/InstallBundle.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/InstallBundle.java
@@ -8,41 +8,29 @@ package software.amazon.smithy.java.mcp.cli.commands;
 import static picocli.CommandLine.Command;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 import picocli.CommandLine.Option;
-import software.amazon.smithy.java.io.ByteBufferUtils;
-import software.amazon.smithy.java.json.JsonCodec;
-import software.amazon.smithy.java.json.JsonSettings;
+import picocli.CommandLine.Parameters;
 import software.amazon.smithy.java.mcp.cli.ConfigUtils;
 import software.amazon.smithy.java.mcp.cli.ExecutionContext;
 import software.amazon.smithy.java.mcp.cli.SmithyMcpCommand;
 import software.amazon.smithy.java.mcp.cli.model.Config;
 import software.amazon.smithy.java.mcp.cli.model.McpServerConfig;
-import software.amazon.smithy.java.mcp.cli.model.McpServersClientConfig;
 
 @Command(name = "install", description = "Downloads and adds a bundle from the MCP registry.")
 public class InstallBundle extends SmithyMcpCommand {
-
-    private static final JsonCodec JSON_CODEC = JsonCodec.builder()
-            .settings(JsonSettings.builder()
-                    .prettyPrint(true)
-                    .build())
-            .build();
 
     @Option(names = {"-r", "--registry"},
             description = "Name of the registry to list the bundles from. If not provided it will use the default registry.")
     String registryName;
 
-    @Option(names = {"-n", "--name"}, description = "Name of the MCP Bundle to install.")
+    @Parameters(description = "Name of the MCP bundle to install.")
     String name;
 
     @Option(names = {"--clients"},
             description = "Names of client configs to update. If not specified all client configs registered would be updated")
-    List<String> clients;
+    Set<String> clients = Set.of();
 
     @Option(names = "--print-only",
             description = "If specified will not edit the client configs and only print to console.")
@@ -56,34 +44,11 @@ public class InstallBundle extends SmithyMcpCommand {
         ConfigUtils.addMcpBundle(config, name, bundle);
         var newConfig = McpServerConfig.builder().command("mcp-registry").args(List.of("start-server", name)).build();
         if (print == null) {
-            //By default print the output if there are no configured client configs.
+            //By default, print the output if there are no configured client configs.
             print = !config.hasClientConfigs();
         }
-        for (var clientConfigs : config.getClientConfigs()) {
-            var filePath = Path.of(clientConfigs.getFilePath());
-            if (Files.notExists(filePath)) {
-                System.out.printf("Skipping updating Mcp config file for %s as the file path '%s' does not exist.",
-                        name,
-                        filePath);
-                continue;
-            }
-            var currentConfig = Files.readAllBytes(filePath);
-            McpServersClientConfig currentMcpConfig;
-            if (currentConfig.length == 0) {
-                currentMcpConfig = McpServersClientConfig.builder().build();
-            } else {
-                currentMcpConfig =
-                        McpServersClientConfig.builder()
-                                .deserialize(JSON_CODEC.createDeserializer(currentConfig))
-                                .build();
-            }
-            var map = new LinkedHashMap<>(currentMcpConfig.getMcpServers());
-            map.put(name, newConfig);
-            var newMcpConfig = McpServersClientConfig.builder().mcpServers(map).build();
-            Files.write(filePath,
-                    ByteBufferUtils.getBytes(JSON_CODEC.serialize(newMcpConfig)),
-                    StandardOpenOption.TRUNCATE_EXISTING);
-        }
+        ConfigUtils.addToClientConfigs(config, name, clients, newConfig);
+
         System.out.println("Successfully installed " + name);
         if (print) {
             System.out.println("You can add the following to your MCP Servers config to use " + name);

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/UninstallBundle.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/UninstallBundle.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.mcp.cli.commands;
+
+import java.util.Set;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import software.amazon.smithy.java.mcp.cli.ConfigUtils;
+import software.amazon.smithy.java.mcp.cli.ExecutionContext;
+import software.amazon.smithy.java.mcp.cli.SmithyMcpCommand;
+
+@Command(name = "uninstall", description = "Uninstall a MCP bundle.")
+public class UninstallBundle extends SmithyMcpCommand {
+
+    @Parameters(description = "Name of the MCP bundle to uninstall.")
+    String name;
+
+    @CommandLine.Option(names = {"--clients"},
+            description = "Names of client configs to update. If not specified all client configs registered would be updated.")
+    Set<String> clients = Set.of();
+
+    @Override
+    protected void execute(ExecutionContext context) throws Exception {
+        var config = context.config();
+        if (!config.getToolBundles().containsKey(name)) {
+            System.out.println("No such MCP bundle exists. Nothing to do.");
+            return;
+        }
+        ConfigUtils.removeMcpBundle(config, name);
+        System.out.println("Uninstalled MCP bundle: " + name);
+        ConfigUtils.removeFromClientConfigs(config, name, clients);
+        System.out.println("Updated client configs");
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

 Introduces an UninstallBundle command that allows users to remove previously installed MCP bundles from their configuration. The command removes bundle entries from configuration files and updates client configs as needed. Complements the existing InstallBundle command to provide complete bundle lifecycle management.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
