### PR TITLE
Default to aws-json-1.0 for AWS services with unsupported protocols

### DIFF
--- a/aws/aws-service-bundle/src/main/java/software/amazon/smithy/java/aws/servicebundle/provider/AwsServiceBundle.java
+++ b/aws/aws-service-bundle/src/main/java/software/amazon/smithy/java/aws/servicebundle/provider/AwsServiceBundle.java
@@ -7,6 +7,9 @@ package software.amazon.smithy.java.aws.servicebundle.provider;
 
 import java.net.URI;
 import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.smithy.awsmcp.model.AwsServiceMetadata;
 import software.amazon.smithy.awsmcp.model.PreRequest;
@@ -15,16 +18,42 @@ import software.amazon.smithy.java.aws.client.core.settings.RegionSetting;
 import software.amazon.smithy.java.aws.sdkv2.auth.SdkCredentialsResolver;
 import software.amazon.smithy.java.client.core.Client;
 import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.ClientProtocolFactory;
+import software.amazon.smithy.java.client.core.ProtocolSettings;
 import software.amazon.smithy.java.client.core.RequestOverrideConfig;
 import software.amazon.smithy.java.client.core.auth.scheme.AuthScheme;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import software.amazon.smithy.java.client.core.interceptors.CallHook;
 import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
 import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.dynamicclient.DynamicClient;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.modelbundle.api.BundlePlugin;
 import software.amazon.smithy.modelbundle.api.StaticAuthSchemeResolver;
 
 final class AwsServiceBundle implements BundlePlugin {
+    private static final Set<ShapeId> GOOD_PROTOCOLS = Set.of(
+            "aws.protocols#restJson1",
+            "aws.protocols#awsJson1_0",
+            "aws.protocols#awsJson1_1",
+            "aws.protocols#restXml",
+            "smithy.protocols#rpcv2Cbor")
+            .stream()
+            .map(ShapeId::from)
+            .collect(Collectors.toSet());
+
+    private static final ClientProtocolFactory<?> AWS_JSON_1 = findAwsJson();
+    private static ClientProtocolFactory<?> findAwsJson() {
+        var awsJson1 = ShapeId.from("aws.protocols#awsJson1_0");
+        for (var protocolImpl : ServiceLoader.load(ClientProtocolFactory.class)) {
+            if (protocolImpl.id().equals(awsJson1)) {
+                return protocolImpl;
+            }
+        }
+        throw new RuntimeException("Couldn't find AWS-JSON 1.0 implementation");
+    }
+
     private final AwsServiceMetadata serviceMetadata;
     private final AuthScheme<?, ?> authScheme;
 
@@ -37,6 +66,19 @@ final class AwsServiceBundle implements BundlePlugin {
     public <C extends Client, B extends Client.Builder<C, B>> B configureClient(B clientBuilder) {
         clientBuilder.addInterceptor(new AwsServiceClientInterceptor(serviceMetadata, authScheme));
         clientBuilder.endpointResolver(EndpointResolver.staticEndpoint("http://localhost"));
+        clientBuilder.authSchemeResolver(StaticAuthSchemeResolver.getInstance());
+        clientBuilder.putSupportedAuthSchemes(StaticAuthSchemeResolver.staticScheme(authScheme));
+        if (clientBuilder instanceof DynamicClient.Builder dynamicBuilder) {
+            var index = ServiceIndex.of(dynamicBuilder.model());
+            var protocols = index.getProtocols(dynamicBuilder.service());
+            if (protocols.keySet().stream().noneMatch(GOOD_PROTOCOLS::contains)) {
+                // TODO: implement better protocol fallback behavior.
+                // If we don't have the service's supported protocol, let's just
+                // try AWS/JSON 1.0 and hope it works.
+                var settings = ProtocolSettings.builder().service(dynamicBuilder.service()).build();
+                dynamicBuilder.protocol(AWS_JSON_1.createProtocol(settings, null));
+            }
+        }
         return clientBuilder;
     }
 
@@ -61,8 +103,6 @@ final class AwsServiceBundle implements BundlePlugin {
                             .putConfig(RegionSetting.REGION, input.getAwsRegion())
                             .endpointResolver(EndpointResolver.staticEndpoint(endpoint))
                             .addIdentityResolver(identityResolver)
-                            .authSchemeResolver(StaticAuthSchemeResolver.getInstance())
-                            .putSupportedAuthSchemes(StaticAuthSchemeResolver.staticScheme(authScheme))
                             .build());
         }
     }

--- a/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
+++ b/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
@@ -50,6 +50,11 @@ public class AwsServiceBundlerTest {
                 .isEmpty();
     }
 
+    @Test
+    public void cw() {
+        var bundler = new AwsServiceBundler("cloudwatch").bundle();
+    }
+
     private static String getModel(String path) {
         try (var stream = new InputStreamReader(Objects
                 .requireNonNull(AwsServiceBundlerTest.class.getResourceAsStream(path), "No model named " + path))) {

--- a/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicClient.java
+++ b/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/DynamicClient.java
@@ -320,6 +320,16 @@ public final class DynamicClient extends Client {
         }
 
         /**
+         * Returns the model that this client will use, or {@code null} if
+         * {@link #model(Model)} has not yet been invoked.
+         *
+         * @return the client's model, or {@code null} if none is configured yet
+         */
+        public Model model() {
+            return this.model;
+        }
+
+        /**
          * <stong>Required</stong>: Set the service shape ID to call.
          *
          * <p>The given shape ID <em>MUST</em> be present in the model given in {@link #model(Model)}.
@@ -330,6 +340,15 @@ public final class DynamicClient extends Client {
         public Builder service(ShapeId service) {
             this.service = service;
             return this;
+        }
+
+        /**
+         * Returns the ID of the service that will be called by the client, or {@code null} if {@link #service(ShapeId)} has not yet been invoked.
+         *
+         * @return the service shape ID, or {@code null} if none is configured yet
+         */
+        public ShapeId service() {
+            return this.service;
         }
     }
 }


### PR DESCRIPTION
Notably, this adds getter methods to the DynamicClient builder for `model` and `service`.