### PR TITLE
Enable jar protocol for URL access

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -81,7 +81,7 @@ graalvmNative {
 
         buildArgs.addAll(listOf(
             "-H:ResourceConfigurationFiles=${projectDir}/src/resource-config.json",
-            "--enable-url-protocols=http,https",
+            "--enable-url-protocols=http,https,jar",
         ))
 
         // Debug info


### PR DESCRIPTION
Added the 'jar' URL protocol to the list of enabled protocols in our GraalVM native image configuration. Without this protocol enabled, the native CLI was failing with "ModelImportException" as it requires access to resources packaged in JAR files.