### PR TITLE
Handle recursive schemas in tool definitions

### DIFF
--- a/mcp/mcp-schemas/model/main.smithy
+++ b/mcp/mcp-schemas/model/main.smithy
@@ -109,11 +109,18 @@ list ToolInfoList {
     member: ToolInfo
 }
 
-structure JsonObjectSchema {
+@mixin
+structure Description {
+    description: String
+}
+
+structure JsonObjectSchema with [Description] {
     @required
     type: String = "object"
 
     properties: PropertiesMap
+
+    definitions: PropertiesMap
 
     required: StringList
 
@@ -126,26 +133,28 @@ structure JsonObjectSchema {
     schema: String = "http://json-schema.org/draft-07/schema#"
 }
 
-structure JsonArraySchema {
+structure SchemaRef with [Description] {
+    @required
+    @jsonName("$ref")
+    ref: String
+}
+
+structure JsonArraySchema with [Description] {
     @required
     type: String = "array"
 
-    /// one of JsonObjectSchema | JsonArraySchema | JsonPrimitiveSchema
+    /// one of JsonObjectSchema | JsonArraySchema | JsonPrimitiveSchema | SchemaRef
     @required
     items: Document
 
     uniqueItems: PrimitiveBoolean = false
 
-    description: String
-
     default: Document
 }
 
-structure JsonPrimitiveSchema {
+structure JsonPrimitiveSchema with [Description] {
     @required
     type: JsonPrimitiveType
-
-    description: String
 }
 
 enum JsonPrimitiveType {
@@ -158,7 +167,7 @@ enum JsonPrimitiveType {
 map PropertiesMap {
     key: String
 
-    /// one of JsonObjectSchema | JsonArraySchema | JsonPrimitiveSchema
+    /// one of JsonObjectSchema | JsonArraySchema | JsonPrimitiveSchema | SchemaRef
     value: Document
 }
 


### PR DESCRIPTION
We put shape definitions into the `#/definitions` path wherever possible now to break definition cycles.

```
{
  "jsonrpc": "2.0",
  "result": {
    "tools": [
      {
        "name": "TestOperation",
        "description": "This tool invokes TestOperation API of TestService.A TestOperation",
        "inputSchema": {
          "description": "An input for TestOperation with a nested member",
          "type": "object",
          "properties": {
            "str": {
              "type": "string"
            },
            "bool": {
              "type": "boolean"
            },
            "booleanList": {
              "type": "array",
              "items": {
                "type": "boolean"
              },
              "uniqueItems": false
            },
            "list": {
              "description": "A list of Nested",
              "type": "array",
              "items": {
                "description": "member member",
                "$ref": "#/definitions/smithy.test#Nested"
              },
              "uniqueItems": false
            },
            "nested": {
              "description": "nested member",
              "$ref": "#/definitions/smithy.test#Nested"
            },
            "doubleNestedList": {
              "description": "A double-nested list of Nested",
              "type": "array",
              "items": {
                "description": "A list of Nested",
                "type": "array",
                "items": {
                  "description": "member member",
                  "$ref": "#/definitions/smithy.test#Nested"
                },
                "uniqueItems": false
              },
              "uniqueItems": false
            }
          },
          "definitions": {
            "smithy.api#Document": {
              "type": "object",
              "additionalProperties": true,
              "$schema": "http://json-schema.org/draft-07/schema#"
            },
            "smithy.test#Nested": {
              "description": "A structure that can be nested",
              "type": "object",
              "properties": {
                "nestedStr": {
                  "type": "string"
                },
                "nestedDocument": {
                  "description": "nestedDocument member",
                  "$ref": "#/definitions/smithy.api#Document"
                },
                "recursive": {
                  "description": "recursive member",
                  "$ref": "#/definitions/smithy.test#Recursive"
                }
              },
              "additionalProperties": false,
              "$schema": "http://json-schema.org/draft-07/schema#"
            },
            "smithy.test#Recursive": {
              "description": "A structure that's recursively referenced",
              "type": "object",
              "properties": {
                "recurseNested": {
                  "description": "A structure that can be nested",
                  "$ref": "#/definitions/smithy.test#Nested"
                }
              },
              "additionalProperties": false,
              "$schema": "http://json-schema.org/draft-07/schema#"
            }
          },
          "additionalProperties": false,
          "$schema": "http://json-schema.org/draft-07/schema#"
        }
      }
    ]
  },
  "id": 0
}
```