### PR TITLE
Mark integrationTest sourcesets as test in IntelliJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jreleaser.model.Active
 plugins {
     base
     alias(libs.plugins.jreleaser)
+    idea
 }
 
 task("addGitHooks") {
@@ -72,6 +73,23 @@ jreleaser {
                     releaseRepository.set(true)
                     verifyPom.set(true)
                     stagingRepository(rootProject.layout.buildDirectory.dir("staging").get().asFile.path)
+                }
+            }
+        }
+    }
+}
+
+
+subprojects {
+    plugins.withId("java") {
+        apply(plugin = "idea")
+        afterEvaluate {
+            val sourceSets = the<SourceSetContainer>()
+            sourceSets.findByName("it")?.let {
+                idea {
+                    module {
+                        testSources.from(sourceSets["it"].java.srcDirs)
+                    }
                 }
             }
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently IntelliJ marks all the integration test sourcesets as source which messes with IntelliJ's 
code analysis tools like finding usages outside tests. 

After this change,

<img width="492" alt="Screenshot 2025-06-04 at 8 36 48 PM" src="https://github.com/user-attachments/assets/05fa0244-7219-427a-9541-54038ccbe582" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
