### PR TITLE
Use gradle caches in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -17,13 +20,25 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v4
-
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'
+
+      - name: Cache compiled buildscripts
+        uses: actions/cache@v4
+        with:
+            key: ${{ runner.os }}-gradle-${{ hashFiles('buildSrc/**/*.kts') }}
+            path: |
+              ./buildSrc/build
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle-home-cache-includes: |
+            caches
 
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Our CI builds are too slow. The [avg build times are 14 and 17 mins](https://github.com/smithy-lang/smithy-java/actions/metrics/performance?tab=jobs). With this we will start storing Gradle caches in Github Action Caches.

[Example run](https://github.com/adwsingh/smithy-java/actions/runs/15460671192) from my fork with this change completed in 3m53s.

We also encrypt the caches to not leak any sensitive info that maybe produced during build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
