### PR TITLE
Remove fluctuating constants from jar manifest which is added by smithy jar task

### DIFF
--- a/framework-errors/build.gradle.kts
+++ b/framework-errors/build.gradle.kts
@@ -45,6 +45,14 @@ tasks.named("sourcesJar") {
     mustRunAfter("compileJava")
 }
 
+tasks.jar {
+    doFirst {
+        manifest.attributes.remove("Build-Timestamp")
+        manifest.attributes.remove("Build-OS")
+        manifest.attributes.remove("Build-Jdk")
+    }
+}
+
 // Helps Intellij plugin identify models
 sourceSets {
     main {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is required to make framework-errors jar reproducible. I checked the smithy-gradle plugin and these seem to be only informational. The Smithy-Tags attribute in the only relevant attribute in the manifest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
