### PR TITLE
Allow .api.aws endpoints

### DIFF
--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
@@ -40,8 +40,8 @@ public final class ApiStandardTerminology {
             "Untag",
             "Update");
 
-    private  static final Set<String> READ_ONLY_API_PREFIXES = withCommonsPrefixes(READ_ONLY_TERMS);
-    private  static final Set<String> WRITE_API_PREFIXES = withCommonsPrefixes(WRITE_TERMS);
+    private static final Set<String> READ_ONLY_API_PREFIXES = withCommonsPrefixes(READ_ONLY_TERMS);
+    private static final Set<String> WRITE_API_PREFIXES = withCommonsPrefixes(WRITE_TERMS);
 
     public static Set<String> getReadOnlyApiPrefixes() {
         return READ_ONLY_API_PREFIXES;

--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
@@ -40,12 +40,15 @@ public final class ApiStandardTerminology {
             "Untag",
             "Update");
 
+    private  static final Set<String> READ_ONLY_API_PREFIXES = withCommonsPrefixes(READ_ONLY_TERMS);
+    private  static final Set<String> WRITE_API_PREFIXES = withCommonsPrefixes(WRITE_TERMS);
+
     public static Set<String> getReadOnlyApiPrefixes() {
-        return withCommonsPrefixes(READ_ONLY_TERMS);
+        return READ_ONLY_API_PREFIXES;
     }
 
     public static Set<String> getWriteApiPrefixes() {
-        return withCommonsPrefixes(WRITE_TERMS);
+        return WRITE_API_PREFIXES;
     }
 
     private ApiStandardTerminology() {}

--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
@@ -5,12 +5,14 @@
 
 package software.amazon.smithy.java.aws.servicebundle.bundler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public final class ApiStandardTerminology {
+final class ApiStandardTerminology {
 
     private static final Set<String> COMMON_PREFIXES = Set.of("Batch");
     private static final Set<String> READ_ONLY_TERMS =
@@ -43,10 +45,12 @@ public final class ApiStandardTerminology {
     private static final Set<String> READ_ONLY_API_PREFIXES = withCommonsPrefixes(READ_ONLY_TERMS);
     private static final Set<String> WRITE_API_PREFIXES = withCommonsPrefixes(WRITE_TERMS);
 
+    @SuppressFBWarnings(value = "MS", justification = "Internal representation already immutable")
     public static Set<String> getReadOnlyApiPrefixes() {
         return READ_ONLY_API_PREFIXES;
     }
 
+    @SuppressFBWarnings(value = "MS", justification = "Internal representation already immutable")
     public static Set<String> getWriteApiPrefixes() {
         return WRITE_API_PREFIXES;
     }

--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
@@ -6,7 +6,6 @@
 package software.amazon.smithy.java.aws.servicebundle.bundler;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;

--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-final class ApiStandardTerminology {
+public final class ApiStandardTerminology {
 
     private static final Set<String> COMMON_PREFIXES = Set.of("Batch");
     private static final Set<String> READ_ONLY_TERMS =
@@ -40,8 +40,8 @@ final class ApiStandardTerminology {
             "Untag",
             "Update");
 
-    static final Set<String> READ_ONLY_API_PREFIXES = withCommonsPrefixes(READ_ONLY_TERMS);
-    static final Set<String> WRITE_API_PREFIXES = withCommonsPrefixes(WRITE_TERMS);
+    public static final Set<String> READ_ONLY_API_PREFIXES = withCommonsPrefixes(READ_ONLY_TERMS);
+    public static final Set<String> WRITE_API_PREFIXES = withCommonsPrefixes(WRITE_TERMS);
 
     private ApiStandardTerminology() {}
 

--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/ApiStandardTerminology.java
@@ -40,8 +40,13 @@ public final class ApiStandardTerminology {
             "Untag",
             "Update");
 
-    public static final Set<String> READ_ONLY_API_PREFIXES = withCommonsPrefixes(READ_ONLY_TERMS);
-    public static final Set<String> WRITE_API_PREFIXES = withCommonsPrefixes(WRITE_TERMS);
+    public static Set<String> getReadOnlyApiPrefixes() {
+        return withCommonsPrefixes(READ_ONLY_TERMS);
+    }
+
+    public static Set<String> getWriteApiPrefixes() {
+        return withCommonsPrefixes(WRITE_TERMS);
+    }
 
     private ApiStandardTerminology() {}
 

--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
@@ -104,8 +104,8 @@ public final class AwsServiceBundler extends ModelBundler {
         }
 
         public Builder readOnlyOperations() {
-            this.allowedPrefixes(ApiStandardTerminology.READ_ONLY_API_PREFIXES);
-            this.blockedPrefixes(ApiStandardTerminology.WRITE_API_PREFIXES);
+            this.allowedPrefixes(ApiStandardTerminology.getReadOnlyApiPrefixes());
+            this.blockedPrefixes(ApiStandardTerminology.getWriteApiPrefixes());
             return this;
         }
 

--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
@@ -242,8 +242,7 @@ public final class AwsServiceBundler extends ModelBundler {
             if (endpoint.startsWith("https://")) {
                 if (endpoint.endsWith(region + ".amazonaws.com")
                         || endpoint.contains(region + ".amazonaws.com.")
-                        || endpoint.endsWith(region + ".api.aws")
-                ) {
+                        || endpoint.endsWith(region + ".api.aws")) {
                     var prev = endpoints.put(region, endpoint);
                     if (prev != null && !endpoint.equals(prev)) {
                         throw new RuntimeException(

--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
@@ -234,8 +234,11 @@ public final class AwsServiceBundler extends ModelBundler {
                 continue;
             }
 
-            if (endpoint.startsWith("https://") && endpoint.endsWith(region + ".amazonaws.com")) {
-                if (endpoint.endsWith(region + ".amazonaws.com") || endpoint.contains(region + ".amazonaws.com.")) {
+            if (endpoint.startsWith("https://")) {
+                if (endpoint.endsWith(region + ".amazonaws.com")
+                        || endpoint.contains(region + ".amazonaws.com.")
+                        || endpoint.endsWith(region + ".api.aws")
+                ) {
                     var prev = endpoints.put(region, endpoint);
                     if (prev != null && !endpoint.equals(prev)) {
                         throw new RuntimeException(

--- a/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
+++ b/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
@@ -64,8 +64,8 @@ public class AwsServiceBundlerTest {
         var bundler = AwsServiceBundler.builder()
                 .serviceName("dynamodb")
                 .resolver(serviceName -> getModel("dynamodb-2012-08-10.json"))
-                .allowedPrefixes(ApiStandardTerminology.READ_ONLY_API_PREFIXES)
-                .blockedPrefixes(ApiStandardTerminology.WRITE_API_PREFIXES)
+                .allowedPrefixes(ApiStandardTerminology.getReadOnlyApiPrefixes())
+                .blockedPrefixes(ApiStandardTerminology.getWriteApiPrefixes())
                 .build();
         var bundle = bundler.bundle();
         var bundleModel = new ModelAssembler().addUnparsedModel("model.json", bundle.getModel())


### PR DESCRIPTION
*Description of changes:*

Datazone endpoints end in [.api.aws](https://github.com/aws/api-models-aws/blob/main/models/datazone/service/2018-05-10/datazone-2018-05-10.json#L9486) instead of `.amazonaws.com`. 

ApiStandardTerminology made public for testing and convenience.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
