### PR TITLE
Print human-readable titles alongside MCP server identifiers in list subcommand

### DIFF
--- a/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/AwsMcpRegistry.java
+++ b/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/AwsMcpRegistry.java
@@ -17,21 +17,32 @@ import software.amazon.smithy.mcp.bundle.api.model.Bundle;
 import software.amazon.smithy.mcp.bundle.api.model.BundleMetadata;
 import software.amazon.smithy.mcp.bundle.api.model.SmithyMcpBundle;
 
-public class AwsMcpRegistry implements Registry {
+public final class AwsMcpRegistry implements Registry {
 
-    private final List<BundleMetadata> availableMcpBundles;
+    private final List<RegistryEntry> availableMcpBundles;
 
     public AwsMcpRegistry() {
         try (var models = new BufferedReader(new InputStreamReader(
                 Objects.requireNonNull(AwsMcpRegistry.class.getResourceAsStream("/models.txt")),
                 StandardCharsets.UTF_8))) {
             this.availableMcpBundles = models.lines()
-                    .map(line -> line.substring(0, line.indexOf("/")).toLowerCase(Locale.ROOT))
-                    .map(s -> BundleMetadata.builder().name(s).description("AWS MCP server for " + s).build())
+                    .map(AwsMcpRegistry::lineToEntry)
                     .toList();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static RegistryEntry lineToEntry(String line) {
+        // line format: Title (which may contain spaces)|sdk-id/service/YYYY/MM/DD/sdk-id-YYYY-MM-DD.json
+        // sdk title, pipe character, github url to download the model (of which the first component is the sdk id)
+        var parts = line.split("\\|");
+        // this is the SDK title
+        var title = parts[0];
+        // this is id we pass to start-server
+        var name = parts[1].split("/")[0].toLowerCase(Locale.ROOT);
+        var bundle = BundleMetadata.builder().name(name).description("AWS MCP server for " + name).build();
+        return new RegistryEntry(title, bundle);
     }
 
     @Override
@@ -40,7 +51,7 @@ public class AwsMcpRegistry implements Registry {
     }
 
     @Override
-    public List<BundleMetadata> listMcpBundles() {
+    public List<RegistryEntry> listMcpBundles() {
         return availableMcpBundles;
     }
 

--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
@@ -43,13 +43,18 @@ public final class AwsServiceBundler extends ModelBundler {
     static final Map<String, String> GH_URIS_BY_SERVICE = new HashMap<>();
 
     static {
-        // line is in the form fooService/service/version/fooService.json
+        // line format: Title (which may contain spaces)|sdk-id/service/YYYY/MM/DD/sdk-id-YYYY-MM-DD.json
+        // sdk title, pipe character, github url to download the model (of which the first component is the sdk id)
         try (var models = new BufferedReader(new InputStreamReader(
                 Objects.requireNonNull(AwsServiceBundler.class.getResourceAsStream("/models.txt")),
                 StandardCharsets.UTF_8))) {
             models.lines()
-                    .forEach(line -> GH_URIS_BY_SERVICE
-                            .put(line.substring(0, line.indexOf("/")).toLowerCase(Locale.ROOT), line));
+                    .forEach(line -> {
+                        var start = line.indexOf("|") + 1;
+                        var end = line.indexOf("/", start);
+                        GH_URIS_BY_SERVICE.put(line.substring(start, end).toLowerCase(Locale.ROOT),
+                                line.substring(start));
+                    });
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/aws/aws-service-bundler/src/main/resources/models.txt
+++ b/aws/aws-service-bundler/src/main/resources/models.txt
@@ -1,402 +1,402 @@
-oam/service/2022-06-10/oam-2022-06-10.json
-forecast/service/2018-06-26/forecast-2018-06-26.json
-bedrock-runtime/service/2023-09-30/bedrock-runtime-2023-09-30.json
-codebuild/service/2016-10-06/codebuild-2016-10-06.json
-iotdeviceadvisor/service/2020-09-18/iotdeviceadvisor-2020-09-18.json
-auto-scaling/service/2011-01-01/auto-scaling-2011-01-01.json
-database-migration-service/service/2016-01-01/database-migration-service-2016-01-01.json
-codeguruprofiler/service/2019-07-18/codeguruprofiler-2019-07-18.json
-kinesis/service/2013-12-02/kinesis-2013-12-02.json
-pinpoint/service/2016-12-01/pinpoint-2016-12-01.json
-chime/service/2018-05-01/chime-2018-05-01.json
-iottwinmaker/service/2021-11-29/iottwinmaker-2021-11-29.json
-organizations/service/2016-11-28/organizations-2016-11-28.json
-networkflowmonitor/service/2023-04-19/networkflowmonitor-2023-04-19.json
-shield/service/2016-06-02/shield-2016-06-02.json
-ssm/service/2014-11-06/ssm-2014-11-06.json
-arc-zonal-shift/service/2022-10-30/arc-zonal-shift-2022-10-30.json
-workspaces-thin-client/service/2023-08-22/workspaces-thin-client-2023-08-22.json
-partnercentral-selling/service/2022-07-26/partnercentral-selling-2022-07-26.json
-geo-places/service/2020-11-19/geo-places-2020-11-19.json
-signer/service/2017-08-25/signer-2017-08-25.json
-marketplace-reporting/service/2018-05-10/marketplace-reporting-2018-05-10.json
-lakeformation/service/2017-03-31/lakeformation-2017-03-31.json
-pcs/service/2023-02-10/pcs-2023-02-10.json
-kinesis-video-webrtc-storage/service/2018-05-10/kinesis-video-webrtc-storage-2018-05-10.json
-mediaconnect/service/2018-11-14/mediaconnect-2018-11-14.json
-secrets-manager/service/2017-10-17/secrets-manager-2017-10-17.json
-mwaa/service/2020-07-01/mwaa-2020-07-01.json
-kms/service/2014-11-01/kms-2014-11-01.json
-quicksight/service/2018-04-01/quicksight-2018-04-01.json
-workmail/service/2017-10-01/workmail-2017-10-01.json
-eventbridge/service/2015-10-07/eventbridge-2015-10-07.json
-frauddetector/service/2019-11-15/frauddetector-2019-11-15.json
-cloudwatch-events/service/2015-10-07/cloudwatch-events-2015-10-07.json
-cloudhsm-v2/service/2017-04-28/cloudhsm-v2-2017-04-28.json
-cloudsearch-domain/service/2013-01-01/cloudsearch-domain-2013-01-01.json
-lookoutequipment/service/2020-12-15/lookoutequipment-2020-12-15.json
-iot-events-data/service/2018-10-23/iot-events-data-2018-10-23.json
-securitylake/service/2018-05-10/securitylake-2018-05-10.json
-cloudwatch/service/2010-08-01/cloudwatch-2010-08-01.json
-glue/service/2017-03-31/glue-2017-03-31.json
-application-auto-scaling/service/2016-02-06/application-auto-scaling-2016-02-06.json
-personalize-events/service/2018-03-22/personalize-events-2018-03-22.json
-voice-id/service/2021-09-27/voice-id-2021-09-27.json
-s3/service/2006-03-01/s3-2006-03-01.json
-appintegrations/service/2020-07-29/appintegrations-2020-07-29.json
-lex-runtime-service/service/2016-11-28/lex-runtime-service-2016-11-28.json
-ssm-contacts/service/2021-05-03/ssm-contacts-2021-05-03.json
-chime-sdk-meetings/service/2021-07-15/chime-sdk-meetings-2021-07-15.json
-sesv2/service/2019-09-27/sesv2-2019-09-27.json
-emr/service/2009-03-31/emr-2009-03-31.json
-controltower/service/2018-05-10/controltower-2018-05-10.json
-iotfleethub/service/2020-11-03/iotfleethub-2020-11-03.json
-resource-explorer-2/service/2022-07-28/resource-explorer-2-2022-07-28.json
-s3-control/service/2018-08-20/s3-control-2018-08-20.json
-personalize/service/2018-05-22/personalize-2018-05-22.json
-marketplace-entitlement-service/service/2017-01-11/marketplace-entitlement-service-2017-01-11.json
-directory-service-data/service/2023-05-31/directory-service-data-2023-05-31.json
-ssm-sap/service/2018-05-10/ssm-sap-2018-05-10.json
-outposts/service/2019-12-03/outposts-2019-12-03.json
-workdocs/service/2016-05-01/workdocs-2016-05-01.json
-networkmanager/service/2019-07-05/networkmanager-2019-07-05.json
-kinesis-video-signaling/service/2019-12-04/kinesis-video-signaling-2019-12-04.json
-socialmessaging/service/2024-01-01/socialmessaging-2024-01-01.json
-omics/service/2022-11-28/omics-2022-11-28.json
-mediapackage/service/2017-10-12/mediapackage-2017-10-12.json
-sagemaker-featurestore-runtime/service/2020-07-01/sagemaker-featurestore-runtime-2020-07-01.json
-config-service/service/2014-11-12/config-service-2014-11-12.json
-cloudwatch-logs/service/2014-03-28/cloudwatch-logs-2014-03-28.json
-medialive/service/2017-10-14/medialive-2017-10-14.json
-backup-gateway/service/2021-01-01/backup-gateway-2021-01-01.json
-connect-contact-lens/service/2020-08-21/connect-contact-lens-2020-08-21.json
-mediaconvert/service/2017-08-29/mediaconvert-2017-08-29.json
-sns/service/2010-03-31/sns-2010-03-31.json
-datasync/service/2018-11-09/datasync-2018-11-09.json
-greengrassv2/service/2020-11-30/greengrassv2-2020-11-30.json
-cleanroomsml/service/2023-09-06/cleanroomsml-2023-09-06.json
-neptunedata/service/2023-08-01/neptunedata-2023-08-01.json
-acm-pca/service/2017-08-22/acm-pca-2017-08-22.json
-service-catalog/service/2015-12-10/service-catalog-2015-12-10.json
-b2bi/service/2022-06-23/b2bi-2022-06-23.json
-iotanalytics/service/2017-11-27/iotanalytics-2017-11-27.json
-lex-model-building-service/service/2017-04-19/lex-model-building-service-2017-04-19.json
-inspector2/service/2020-06-08/inspector2-2020-06-08.json
-groundstation/service/2019-05-23/groundstation-2019-05-23.json
-ecr-public/service/2020-10-30/ecr-public-2020-10-30.json
-fis/service/2020-12-01/fis-2020-12-01.json
-proton/service/2020-07-20/proton-2020-07-20.json
-api-gateway/service/2015-07-09/api-gateway-2015-07-09.json
-cloudhsm/service/2014-05-30/cloudhsm-2014-05-30.json
-sms/service/2016-10-24/sms-2016-10-24.json
-osis/service/2022-01-01/osis-2022-01-01.json
-privatenetworks/service/2021-12-03/privatenetworks-2021-12-03.json
-memorydb/service/2021-01-01/memorydb-2021-01-01.json
-inspector/service/2016-02-16/inspector-2016-02-16.json
-translate/service/2017-07-01/translate-2017-07-01.json
-mailmanager/service/2023-10-17/mailmanager-2023-10-17.json
-neptune-graph/service/2023-11-29/neptune-graph-2023-11-29.json
-chatbot/service/2017-10-11/chatbot-2017-10-11.json
-fms/service/2018-01-01/fms-2018-01-01.json
-qapps/service/2023-11-27/qapps-2023-11-27.json
-customer-profiles/service/2020-08-15/customer-profiles-2020-08-15.json
-geo-maps/service/2020-11-19/geo-maps-2020-11-19.json
-route-53-domains/service/2014-05-15/route-53-domains-2014-05-15.json
-service-catalog-appregistry/service/2020-06-24/service-catalog-appregistry-2020-06-24.json
-qbusiness/service/2023-11-27/qbusiness-2023-11-27.json
-synthetics/service/2017-10-11/synthetics-2017-10-11.json
-storage-gateway/service/2013-06-30/storage-gateway-2013-06-30.json
-elastic-transcoder/service/2012-09-25/elastic-transcoder-2012-09-25.json
-apptest/service/2022-12-06/apptest-2022-12-06.json
-bcm-data-exports/service/2023-11-26/bcm-data-exports-2023-11-26.json
-iotsecuretunneling/service/2018-10-05/iotsecuretunneling-2018-10-05.json
-cloudfront/service/2020-05-31/cloudfront-2020-05-31.json
-bedrock-data-automation/service/2023-07-26/bedrock-data-automation-2023-07-26.json
-location/service/2020-11-19/location-2020-11-19.json
-wafv2/service/2019-07-29/wafv2-2019-07-29.json
-opensearch/service/2021-01-01/opensearch-2021-01-01.json
-iotthingsgraph/service/2018-09-06/iotthingsgraph-2018-09-06.json
-security-ir/service/2018-05-10/security-ir-2018-05-10.json
-repostspace/service/2022-05-13/repostspace-2022-05-13.json
-health/service/2016-08-04/health-2016-08-04.json
-workmailmessageflow/service/2019-05-01/workmailmessageflow-2019-05-01.json
-mediastore-data/service/2017-09-01/mediastore-data-2017-09-01.json
-ec2-instance-connect/service/2018-04-02/ec2-instance-connect-2018-04-02.json
-comprehendmedical/service/2018-10-30/comprehendmedical-2018-10-30.json
-iotfleetwise/service/2021-06-17/iotfleetwise-2021-06-17.json
-route53profiles/service/2018-05-10/route53profiles-2018-05-10.json
-application-signals/service/2024-04-15/application-signals-2024-04-15.json
-resource-groups-tagging-api/service/2017-01-26/resource-groups-tagging-api-2017-01-26.json
-accessanalyzer/service/2019-11-01/accessanalyzer-2019-11-01.json
-glacier/service/2012-06-01/glacier-2012-06-01.json
-lightsail/service/2016-11-28/lightsail-2016-11-28.json
-rum/service/2018-05-10/rum-2018-05-10.json
-direct-connect/service/2012-10-25/direct-connect-2012-10-25.json
-elastic-beanstalk/service/2010-12-01/elastic-beanstalk-2010-12-01.json
-imagebuilder/service/2019-12-02/imagebuilder-2019-12-02.json
-simspaceweaver/service/2022-10-28/simspaceweaver-2022-10-28.json
-iot-jobs-data-plane/service/2017-09-29/iot-jobs-data-plane-2017-09-29.json
-freetier/service/2023-09-07/freetier-2023-09-07.json
-bedrock-agent-runtime/service/2023-07-26/bedrock-agent-runtime-2023-07-26.json
-neptune/service/2014-10-31/neptune-2014-10-31.json
-transfer/service/2018-11-05/transfer-2018-11-05.json
-deadline/service/2023-10-12/deadline-2023-10-12.json
-braket/service/2019-09-01/braket-2019-09-01.json
-verifiedpermissions/service/2021-12-01/verifiedpermissions-2021-12-01.json
-scheduler/service/2021-06-30/scheduler-2021-06-30.json
-waf-regional/service/2016-11-28/waf-regional-2016-11-28.json
-qldb/service/2019-01-02/qldb-2019-01-02.json
-marketplace-commerce-analytics/service/2015-07-01/marketplace-commerce-analytics-2015-07-01.json
-ecr/service/2015-09-21/ecr-2015-09-21.json
-cost-and-usage-report-service/service/2017-01-06/cost-and-usage-report-service-2017-01-06.json
-kinesis-video-media/service/2017-09-30/kinesis-video-media-2017-09-30.json
-dynamodb/service/2012-08-10/dynamodb-2012-08-10.json
-resiliencehub/service/2020-04-30/resiliencehub-2020-04-30.json
-macie2/service/2020-01-01/macie2-2020-01-01.json
-entityresolution/service/2018-05-10/entityresolution-2018-05-10.json
-s3outposts/service/2017-07-25/s3outposts-2017-07-25.json
-grafana/service/2020-08-18/grafana-2020-08-18.json
-kinesis-analytics/service/2015-08-14/kinesis-analytics-2015-08-14.json
-eks-auth/service/2023-11-26/eks-auth-2023-11-26.json
-rbin/service/2021-06-15/rbin-2021-06-15.json
-service-quotas/service/2019-06-24/service-quotas-2019-06-24.json
-ecs/service/2014-11-13/ecs-2014-11-13.json
-marketplace-metering/service/2016-01-14/marketplace-metering-2016-01-14.json
-timestream-write/service/2018-11-01/timestream-write-2018-11-01.json
-qconnect/service/2020-10-19/qconnect-2020-10-19.json
-cloudsearch/service/2013-01-01/cloudsearch-2013-01-01.json
-bcm-pricing-calculator/service/2024-06-19/bcm-pricing-calculator-2024-06-19.json
-appfabric/service/2023-05-19/appfabric-2023-05-19.json
-lookoutvision/service/2020-11-20/lookoutvision-2020-11-20.json
-route53resolver/service/2018-04-01/route53resolver-2018-04-01.json
-marketplace-agreement/service/2020-03-01/marketplace-agreement-2020-03-01.json
-workspaces/service/2015-04-08/workspaces-2015-04-08.json
-gameliftstreams/service/2018-05-10/gameliftstreams-2018-05-10.json
-taxsettings/service/2018-05-10/taxsettings-2018-05-10.json
-pinpoint-sms-voice/service/2018-09-05/pinpoint-sms-voice-2018-09-05.json
-fsx/service/2018-03-01/fsx-2018-03-01.json
-codepipeline/service/2015-07-09/codepipeline-2015-07-09.json
-schemas/service/2019-12-02/schemas-2019-12-02.json
-emr-serverless/service/2021-07-13/emr-serverless-2021-07-13.json
-sqs/service/2012-11-05/sqs-2012-11-05.json
-license-manager-user-subscriptions/service/2018-05-10/license-manager-user-subscriptions-2018-05-10.json
-route53-recovery-cluster/service/2019-12-02/route53-recovery-cluster-2019-12-02.json
-migrationhuborchestrator/service/2021-08-28/migrationhuborchestrator-2021-08-28.json
-iot/service/2015-05-28/iot-2015-05-28.json
-sso-oidc/service/2019-06-10/sso-oidc-2019-06-10.json
-codestar-notifications/service/2019-10-15/codestar-notifications-2019-10-15.json
-ebs/service/2019-11-02/ebs-2019-11-02.json
-amplify/service/2017-07-25/amplify-2017-07-25.json
-cloudcontrol/service/2021-09-30/cloudcontrol-2021-09-30.json
-wellarchitected/service/2020-03-31/wellarchitected-2020-03-31.json
-route-53/service/2013-04-01/route-53-2013-04-01.json
-ssm-incidents/service/2018-05-10/ssm-incidents-2018-05-10.json
-bedrock/service/2023-04-20/bedrock-2023-04-20.json
-ivs-realtime/service/2020-07-14/ivs-realtime-2020-07-14.json
-migrationhub-config/service/2019-06-30/migrationhub-config-2019-06-30.json
-redshift/service/2012-12-01/redshift-2012-12-01.json
-inspector-scan/service/2023-08-08/inspector-scan-2023-08-08.json
-connectcases/service/2022-10-03/connectcases-2022-10-03.json
-kinesis-video/service/2017-09-30/kinesis-video-2017-09-30.json
-pca-connector-scep/service/2018-05-10/pca-connector-scep-2018-05-10.json
-appflow/service/2020-08-23/appflow-2020-08-23.json
-gamelift/service/2015-10-01/gamelift-2015-10-01.json
-cloudtrail/service/2013-11-01/cloudtrail-2013-11-01.json
-resource-groups/service/2017-11-27/resource-groups-2017-11-27.json
-supplychain/service/2024-01-01/supplychain-2024-01-01.json
-timestream-influxdb/service/2023-01-27/timestream-influxdb-2023-01-27.json
-pipes/service/2015-10-07/pipes-2015-10-07.json
-evidently/service/2021-02-01/evidently-2021-02-01.json
-codeguru-security/service/2018-05-10/codeguru-security-2018-05-10.json
-cost-optimization-hub/service/2022-07-26/cost-optimization-hub-2022-07-26.json
-amplifyuibuilder/service/2021-08-11/amplifyuibuilder-2021-08-11.json
-route53-recovery-control-config/service/2020-11-02/route53-recovery-control-config-2020-11-02.json
-vpc-lattice/service/2022-11-30/vpc-lattice-2022-11-30.json
-managedblockchain-query/service/2023-05-04/managedblockchain-query-2023-05-04.json
-redshift-data/service/2019-12-20/redshift-data-2019-12-20.json
-mediatailor/service/2018-04-23/mediatailor-2018-04-23.json
-mediapackagev2/service/2022-12-25/mediapackagev2-2022-12-25.json
-pi/service/2018-02-27/pi-2018-02-27.json
-appconfig/service/2019-10-09/appconfig-2019-10-09.json
-networkmonitor/service/2023-08-01/networkmonitor-2023-08-01.json
-network-firewall/service/2020-11-12/network-firewall-2020-11-12.json
-connectparticipant/service/2018-09-07/connectparticipant-2018-09-07.json
-mgn/service/2020-02-26/mgn-2020-02-26.json
-sagemaker-edge/service/2020-09-23/sagemaker-edge-2020-09-23.json
-applicationcostprofiler/service/2020-09-10/applicationcostprofiler-2020-09-10.json
-keyspaces/service/2022-02-10/keyspaces-2022-02-10.json
-application-discovery-service/service/2015-11-01/application-discovery-service-2015-11-01.json
-iam/service/2010-05-08/iam-2010-05-08.json
-data-pipeline/service/2012-10-29/data-pipeline-2012-10-29.json
-chime-sdk-messaging/service/2021-05-15/chime-sdk-messaging-2021-05-15.json
-mediastore/service/2017-09-01/mediastore-2017-09-01.json
-iot-wireless/service/2020-11-22/iot-wireless-2020-11-22.json
-cloud9/service/2017-09-23/cloud9-2017-09-23.json
-wisdom/service/2020-10-19/wisdom-2020-10-19.json
-sagemaker-runtime/service/2017-05-13/sagemaker-runtime-2017-05-13.json
-sso/service/2019-06-10/sso-2019-06-10.json
-auditmanager/service/2017-07-25/auditmanager-2017-07-25.json
-snowball/service/2016-06-30/snowball-2016-06-30.json
-opsworks/service/2013-02-18/opsworks-2013-02-18.json
-migration-hub/service/2017-05-31/migration-hub-2017-05-31.json
-identitystore/service/2020-06-15/identitystore-2020-06-15.json
-elastic-load-balancing-v2/service/2015-12-01/elastic-load-balancing-v2-2015-12-01.json
-connectcampaigns/service/2021-01-30/connectcampaigns-2021-01-30.json
-textract/service/2018-06-27/textract-2018-06-27.json
-compute-optimizer/service/2019-11-01/compute-optimizer-2019-11-01.json
-s3tables/service/2018-05-10/s3tables-2018-05-10.json
-eks/service/2017-11-01/eks-2017-11-01.json
-support/service/2013-04-15/support-2013-04-15.json
-mturk/service/2017-01-17/mturk-2017-01-17.json
-apigatewayv2/service/2018-11-29/apigatewayv2-2018-11-29.json
-cognito-identity-provider/service/2016-04-18/cognito-identity-provider-2016-04-18.json
-bedrock-data-automation-runtime/service/2024-06-13/bedrock-data-automation-runtime-2024-06-13.json
-pinpoint-sms-voice-v2/service/2022-03-31/pinpoint-sms-voice-v2-2022-03-31.json
-amp/service/2020-08-01/amp-2020-08-01.json
-drs/service/2020-02-26/drs-2020-02-26.json
-payment-cryptography/service/2021-09-14/payment-cryptography-2021-09-14.json
-kafkaconnect/service/2021-09-14/kafkaconnect-2021-09-14.json
-kafka/service/2018-11-14/kafka-2018-11-14.json
-databrew/service/2017-07-25/databrew-2017-07-25.json
-support-app/service/2021-08-20/support-app-2021-08-20.json
-codedeploy/service/2014-10-06/codedeploy-2014-10-06.json
-batch/service/2016-08-10/batch-2016-08-10.json
-savingsplans/service/2019-06-28/savingsplans-2019-06-28.json
-bedrock-agent/service/2023-06-05/bedrock-agent-2023-06-05.json
-directory-service/service/2015-04-16/directory-service-2015-04-16.json
-chime-sdk-media-pipelines/service/2021-07-15/chime-sdk-media-pipelines-2021-07-15.json
-migrationhubstrategy/service/2020-02-19/migrationhubstrategy-2020-02-19.json
-timestream-query/service/2018-11-01/timestream-query-2018-11-01.json
-codeguru-reviewer/service/2019-09-19/codeguru-reviewer-2019-09-19.json
-appsync/service/2017-07-25/appsync-2017-07-25.json
-dlm/service/2018-01-12/dlm-2018-01-12.json
-iot-data-plane/service/2015-05-28/iot-data-plane-2015-05-28.json
-global-accelerator/service/2018-08-08/global-accelerator-2018-08-08.json
-amplifybackend/service/2020-08-11/amplifybackend-2020-08-11.json
-datazone/service/2018-05-10/datazone-2018-05-10.json
-connectcampaignsv2/service/2024-04-23/connectcampaignsv2-2024-04-23.json
-billingconductor/service/2021-07-30/billingconductor-2021-07-30.json
-budgets/service/2016-10-20/budgets-2016-10-20.json
-cloudtrail-data/service/2021-08-11/cloudtrail-data-2021-08-11.json
-geo-routes/service/2020-11-19/geo-routes-2020-11-19.json
-m2/service/2021-04-28/m2-2021-04-28.json
-pinpoint-email/service/2018-07-26/pinpoint-email-2018-07-26.json
-lex-models-v2/service/2020-08-07/lex-models-v2-2020-08-07.json
-finspace/service/2021-03-12/finspace-2021-03-12.json
-detective/service/2018-10-26/detective-2018-10-26.json
-lambda/service/2015-03-31/lambda-2015-03-31.json
-kinesis-analytics-v2/service/2018-05-23/kinesis-analytics-v2-2018-05-23.json
-panorama/service/2019-07-24/panorama-2019-07-24.json
-iot-events/service/2018-07-27/iot-events-2018-07-27.json
-app-mesh/service/2019-01-25/app-mesh-2019-01-25.json
-managedblockchain/service/2018-09-24/managedblockchain-2018-09-24.json
-servicediscovery/service/2017-03-14/servicediscovery-2017-03-14.json
-waf/service/2015-08-24/waf-2015-08-24.json
-ivs/service/2020-07-14/ivs-2020-07-14.json
-devops-guru/service/2020-12-01/devops-guru-2020-12-01.json
-cost-explorer/service/2017-10-25/cost-explorer-2017-10-25.json
-mq/service/2017-11-27/mq-2017-11-27.json
-route53-recovery-readiness/service/2019-12-02/route53-recovery-readiness-2019-12-02.json
-internetmonitor/service/2021-06-03/internetmonitor-2021-06-03.json
-license-manager/service/2018-08-01/license-manager-2018-08-01.json
-codestar-connections/service/2019-12-01/codestar-connections-2019-12-01.json
-artifact/service/2018-05-10/artifact-2018-05-10.json
-iotsitewise/service/2019-12-02/iotsitewise-2019-12-02.json
-serverlessapplicationrepository/service/2017-09-08/serverlessapplicationrepository-2017-09-08.json
-ssm-quicksetup/service/2018-05-10/ssm-quicksetup-2018-05-10.json
-docdb-elastic/service/2022-11-28/docdb-elastic-2022-11-28.json
-sagemaker-metrics/service/2022-09-30/sagemaker-metrics-2022-09-30.json
-license-manager-linux-subscriptions/service/2018-05-10/license-manager-linux-subscriptions-2018-05-10.json
-sagemaker-geospatial/service/2020-05-27/sagemaker-geospatial-2020-05-27.json
-personalize-runtime/service/2018-05-22/personalize-runtime-2018-05-22.json
-clouddirectory/service/2017-01-11/clouddirectory-2017-01-11.json
-chime-sdk-voice/service/2022-08-03/chime-sdk-voice-2022-08-03.json
-notificationscontacts/service/2018-05-10/notificationscontacts-2018-05-10.json
-backupsearch/service/2018-05-10/backupsearch-2018-05-10.json
-dynamodb-streams/service/2012-08-10/dynamodb-streams-2012-08-10.json
-iot-managed-integrations/service/2025-03-03/iot-managed-integrations-2025-03-03.json
-cognito-sync/service/2014-06-30/cognito-sync-2014-06-30.json
-codeartifact/service/2018-09-22/codeartifact-2018-09-22.json
-elastic-load-balancing/service/2012-06-01/elastic-load-balancing-2012-06-01.json
-guardduty/service/2017-11-28/guardduty-2017-11-28.json
-cleanrooms/service/2022-02-17/cleanrooms-2022-02-17.json
-trustedadvisor/service/2022-09-15/trustedadvisor-2022-09-15.json
-sagemaker-a2i-runtime/service/2019-11-07/sagemaker-a2i-runtime-2019-11-07.json
-dax/service/2017-04-19/dax-2017-04-19.json
-opsworkscm/service/2016-11-01/opsworkscm-2016-11-01.json
-docdb/service/2014-10-31/docdb-2014-10-31.json
-firehose/service/2015-08-04/firehose-2015-08-04.json
-ivschat/service/2020-07-14/ivschat-2020-07-14.json
-ses/service/2010-12-01/ses-2010-12-01.json
-application-insights/service/2018-11-25/application-insights-2018-11-25.json
-device-farm/service/2015-06-23/device-farm-2015-06-23.json
-account/service/2021-02-01/account-2021-02-01.json
-robomaker/service/2018-06-29/robomaker-2018-06-29.json
-launch-wizard/service/2018-05-10/launch-wizard-2018-05-10.json
-finspace-data/service/2020-07-13/finspace-data-2020-07-13.json
-appconfigdata/service/2021-11-11/appconfigdata-2021-11-11.json
-controlcatalog/service/2018-05-10/controlcatalog-2018-05-10.json
-greengrass/service/2017-06-07/greengrass-2017-06-07.json
-kendra-ranking/service/2022-10-19/kendra-ranking-2022-10-19.json
-snow-device-management/service/2021-08-04/snow-device-management-2021-08-04.json
-securityhub/service/2018-10-26/securityhub-2018-10-26.json
-workspaces-web/service/2020-07-08/workspaces-web-2020-07-08.json
-backup/service/2018-11-15/backup-2018-11-15.json
-opensearchserverless/service/2021-11-01/opensearchserverless-2021-11-01.json
-cloudformation/service/2010-05-15/cloudformation-2010-05-15.json
-kendra/service/2019-02-03/kendra-2019-02-03.json
-connect/service/2017-08-08/connect-2017-08-08.json
-machine-learning/service/2014-12-12/machine-learning-2014-12-12.json
-elasticache/service/2015-02-02/elasticache-2015-02-02.json
-sfn/service/2016-11-23/sfn-2016-11-23.json
-sso-admin/service/2020-07-20/sso-admin-2020-07-20.json
-auto-scaling-plans/service/2018-01-06/auto-scaling-plans-2018-01-06.json
-comprehend/service/2017-11-27/comprehend-2017-11-27.json
-rds-data/service/2018-08-01/rds-data-2018-08-01.json
-chime-sdk-identity/service/2021-04-20/chime-sdk-identity-2021-04-20.json
-rekognition/service/2016-06-27/rekognition-2016-06-27.json
-appstream/service/2016-12-01/appstream-2016-12-01.json
-polly/service/2016-06-10/polly-2016-06-10.json
-invoicing/service/2024-12-01/invoicing-2024-12-01.json
-rds/service/2014-10-31/rds-2014-10-31.json
-pricing/service/2017-10-15/pricing-2017-10-15.json
-swf/service/2012-01-25/swf-2012-01-25.json
-qldb-session/service/2019-07-11/qldb-session-2019-07-11.json
-cloudfront-keyvaluestore/service/2022-07-26/cloudfront-keyvaluestore-2022-07-26.json
-marketplace-deployment/service/2023-01-25/marketplace-deployment-2023-01-25.json
-medical-imaging/service/2023-07-19/medical-imaging-2023-07-19.json
-transcribe/service/2017-10-26/transcribe-2017-10-26.json
-observabilityadmin/service/2018-05-10/observabilityadmin-2018-05-10.json
-notifications/service/2018-05-10/notifications-2018-05-10.json
-codecommit/service/2015-04-13/codecommit-2015-04-13.json
-lex-runtime-v2/service/2020-08-07/lex-runtime-v2-2020-08-07.json
-pca-connector-ad/service/2018-05-10/pca-connector-ad-2018-05-10.json
-forecastquery/service/2018-06-26/forecastquery-2018-06-26.json
-healthlake/service/2017-07-01/healthlake-2017-07-01.json
-rolesanywhere/service/2018-05-10/rolesanywhere-2018-05-10.json
-marketplace-catalog/service/2018-09-17/marketplace-catalog-2018-09-17.json
-billing/service/2023-09-07/billing-2023-09-07.json
-emr-containers/service/2020-10-01/emr-containers-2020-10-01.json
-apigatewaymanagementapi/service/2018-11-29/apigatewaymanagementapi-2018-11-29.json
-xray/service/2016-04-12/xray-2016-04-12.json
-transcribe-streaming/service/2017-10-26/transcribe-streaming-2017-10-26.json
-ram/service/2018-01-04/ram-2018-01-04.json
-codeconnections/service/2023-12-01/codeconnections-2023-12-01.json
-efs/service/2015-02-01/efs-2015-02-01.json
-migration-hub-refactor-spaces/service/2021-10-26/migration-hub-refactor-spaces-2021-10-26.json
-elasticsearch-service/service/2015-01-01/elasticsearch-service-2015-01-01.json
-cognito-identity/service/2014-06-30/cognito-identity-2014-06-30.json
-payment-cryptography-data/service/2022-02-03/payment-cryptography-data-2022-02-03.json
-dataexchange/service/2017-07-25/dataexchange-2017-07-25.json
-sts/service/2011-06-15/sts-2011-06-15.json
-sagemaker/service/2017-07-24/sagemaker-2017-07-24.json
-kinesis-video-archived-media/service/2017-09-30/kinesis-video-archived-media-2017-09-30.json
-acm/service/2015-12-08/acm-2015-12-08.json
-athena/service/2017-05-18/athena-2017-05-18.json
-dsql/service/2018-05-10/dsql-2018-05-10.json
-mediapackage-vod/service/2018-11-07/mediapackage-vod-2018-11-07.json
-tnb/service/2008-10-21/tnb-2008-10-21.json
-ec2/service/2016-11-15/ec2-2016-11-15.json
-apprunner/service/2020-05-15/apprunner-2020-05-15.json
-lookoutmetrics/service/2017-07-25/lookoutmetrics-2017-07-25.json
-redshift-serverless/service/2021-04-21/redshift-serverless-2021-04-21.json
+AWS ARC - Zonal Shift|arc-zonal-shift/service/2022-10-30/arc-zonal-shift-2022-10-30.json
+AWS Account|account/service/2021-02-01/account-2021-02-01.json
+AWS Amplify|amplify/service/2017-07-25/amplify-2017-07-25.json
+AWS Amplify UI Builder|amplifyuibuilder/service/2021-08-11/amplifyuibuilder-2021-08-11.json
+AWS App Mesh|app-mesh/service/2019-01-25/app-mesh-2019-01-25.json
+AWS App Runner|apprunner/service/2020-05-15/apprunner-2020-05-15.json
+AWS AppConfig Data|appconfigdata/service/2021-11-11/appconfigdata-2021-11-11.json
+AWS AppSync|appsync/service/2017-07-25/appsync-2017-07-25.json
+AWS Application Cost Profiler|applicationcostprofiler/service/2020-09-10/applicationcostprofiler-2020-09-10.json
+AWS Application Discovery Service|application-discovery-service/service/2015-11-01/application-discovery-service-2015-11-01.json
+AWS Artifact|artifact/service/2018-05-10/artifact-2018-05-10.json
+AWS Audit Manager|auditmanager/service/2017-07-25/auditmanager-2017-07-25.json
+AWS Auto Scaling Plans|auto-scaling-plans/service/2018-01-06/auto-scaling-plans-2018-01-06.json
+AWS B2B Data Interchange|b2bi/service/2022-06-23/b2bi-2022-06-23.json
+AWS Backup|backup/service/2018-11-15/backup-2018-11-15.json
+AWS Backup Gateway|backup-gateway/service/2021-01-01/backup-gateway-2021-01-01.json
+AWS Backup Search|backupsearch/service/2018-05-10/backupsearch-2018-05-10.json
+AWS Batch|batch/service/2016-08-10/batch-2016-08-10.json
+AWS Billing|billing/service/2023-09-07/billing-2023-09-07.json
+AWS Billing and Cost Management Data Exports|bcm-data-exports/service/2023-11-26/bcm-data-exports-2023-11-26.json
+AWS Billing and Cost Management Pricing Calculator|bcm-pricing-calculator/service/2024-06-19/bcm-pricing-calculator-2024-06-19.json
+AWS Budgets|budgets/service/2016-10-20/budgets-2016-10-20.json
+AWS Certificate Manager|acm/service/2015-12-08/acm-2015-12-08.json
+AWS Certificate Manager Private Certificate Authority|acm-pca/service/2017-08-22/acm-pca-2017-08-22.json
+AWS Chatbot|chatbot/service/2017-10-11/chatbot-2017-10-11.json
+AWS Clean Rooms ML|cleanroomsml/service/2023-09-06/cleanroomsml-2023-09-06.json
+AWS Clean Rooms Service|cleanrooms/service/2022-02-17/cleanrooms-2022-02-17.json
+AWS Cloud Control API|cloudcontrol/service/2021-09-30/cloudcontrol-2021-09-30.json
+AWS Cloud Map|servicediscovery/service/2017-03-14/servicediscovery-2017-03-14.json
+AWS Cloud9|cloud9/service/2017-09-23/cloud9-2017-09-23.json
+AWS CloudFormation|cloudformation/service/2010-05-15/cloudformation-2010-05-15.json
+AWS CloudHSM V2|cloudhsm-v2/service/2017-04-28/cloudhsm-v2-2017-04-28.json
+AWS CloudTrail|cloudtrail/service/2013-11-01/cloudtrail-2013-11-01.json
+AWS CloudTrail Data Service|cloudtrail-data/service/2021-08-11/cloudtrail-data-2021-08-11.json
+AWS CodeBuild|codebuild/service/2016-10-06/codebuild-2016-10-06.json
+AWS CodeCommit|codecommit/service/2015-04-13/codecommit-2015-04-13.json
+AWS CodeConnections|codeconnections/service/2023-12-01/codeconnections-2023-12-01.json
+AWS CodeDeploy|codedeploy/service/2014-10-06/codedeploy-2014-10-06.json
+AWS CodePipeline|codepipeline/service/2015-07-09/codepipeline-2015-07-09.json
+AWS CodeStar Notifications|codestar-notifications/service/2019-10-15/codestar-notifications-2019-10-15.json
+AWS CodeStar connections|codestar-connections/service/2019-12-01/codestar-connections-2019-12-01.json
+AWS Comprehend Medical|comprehendmedical/service/2018-10-30/comprehendmedical-2018-10-30.json
+AWS Compute Optimizer|compute-optimizer/service/2019-11-01/compute-optimizer-2019-11-01.json
+AWS Config|config-service/service/2014-11-12/config-service-2014-11-12.json
+AWS Control Catalog|controlcatalog/service/2018-05-10/controlcatalog-2018-05-10.json
+AWS Control Tower|controltower/service/2018-05-10/controltower-2018-05-10.json
+AWS Cost Explorer Service|cost-explorer/service/2017-10-25/cost-explorer-2017-10-25.json
+AWS Cost and Usage Report Service|cost-and-usage-report-service/service/2017-01-06/cost-and-usage-report-service-2017-01-06.json
+AWS Data Exchange|dataexchange/service/2017-07-25/dataexchange-2017-07-25.json
+AWS Data Pipeline|data-pipeline/service/2012-10-29/data-pipeline-2012-10-29.json
+AWS DataSync|datasync/service/2018-11-09/datasync-2018-11-09.json
+AWS Database Migration Service|database-migration-service/service/2016-01-01/database-migration-service-2016-01-01.json
+AWS Device Farm|device-farm/service/2015-06-23/device-farm-2015-06-23.json
+AWS Direct Connect|direct-connect/service/2012-10-25/direct-connect-2012-10-25.json
+AWS Directory Service|directory-service/service/2015-04-16/directory-service-2015-04-16.json
+AWS Directory Service Data|directory-service-data/service/2023-05-31/directory-service-data-2023-05-31.json
+AWS EC2 Instance Connect|ec2-instance-connect/service/2018-04-02/ec2-instance-connect-2018-04-02.json
+AWS Elastic Beanstalk|elastic-beanstalk/service/2010-12-01/elastic-beanstalk-2010-12-01.json
+AWS Elemental MediaConvert|mediaconvert/service/2017-08-29/mediaconvert-2017-08-29.json
+AWS Elemental MediaLive|medialive/service/2017-10-14/medialive-2017-10-14.json
+AWS Elemental MediaPackage|mediapackage/service/2017-10-12/mediapackage-2017-10-12.json
+AWS Elemental MediaPackage VOD|mediapackage-vod/service/2018-11-07/mediapackage-vod-2018-11-07.json
+AWS Elemental MediaPackage v2|mediapackagev2/service/2022-12-25/mediapackagev2-2022-12-25.json
+AWS Elemental MediaStore|mediastore/service/2017-09-01/mediastore-2017-09-01.json
+AWS Elemental MediaStore Data Plane|mediastore-data/service/2017-09-01/mediastore-data-2017-09-01.json
+AWS End User Messaging Social|socialmessaging/service/2024-01-01/socialmessaging-2024-01-01.json
+AWS EntityResolution|entityresolution/service/2018-05-10/entityresolution-2018-05-10.json
+AWS Fault Injection Simulator|fis/service/2020-12-01/fis-2020-12-01.json
+AWS Free Tier|freetier/service/2023-09-07/freetier-2023-09-07.json
+AWS Global Accelerator|global-accelerator/service/2018-08-08/global-accelerator-2018-08-08.json
+AWS Glue|glue/service/2017-03-31/glue-2017-03-31.json
+AWS Glue DataBrew|databrew/service/2017-07-25/databrew-2017-07-25.json
+AWS Greengrass|greengrass/service/2017-06-07/greengrass-2017-06-07.json
+AWS Ground Station|groundstation/service/2019-05-23/groundstation-2019-05-23.json
+AWS Health APIs and Notifications|health/service/2016-08-04/health-2016-08-04.json
+AWS Health Imaging|medical-imaging/service/2023-07-19/medical-imaging-2023-07-19.json
+AWS Identity and Access Management|iam/service/2010-05-08/iam-2010-05-08.json
+AWS Invoicing|invoicing/service/2024-12-01/invoicing-2024-12-01.json
+AWS IoT|iot/service/2015-05-28/iot-2015-05-28.json
+AWS IoT Analytics|iotanalytics/service/2017-11-27/iotanalytics-2017-11-27.json
+AWS IoT Core Device Advisor|iotdeviceadvisor/service/2020-09-18/iotdeviceadvisor-2020-09-18.json
+AWS IoT Data Plane|iot-data-plane/service/2015-05-28/iot-data-plane-2015-05-28.json
+AWS IoT Events|iot-events/service/2018-07-27/iot-events-2018-07-27.json
+AWS IoT Events Data|iot-events-data/service/2018-10-23/iot-events-data-2018-10-23.json
+AWS IoT Fleet Hub|iotfleethub/service/2020-11-03/iotfleethub-2020-11-03.json
+AWS IoT FleetWise|iotfleetwise/service/2021-06-17/iotfleetwise-2021-06-17.json
+AWS IoT Greengrass V2|greengrassv2/service/2020-11-30/greengrassv2-2020-11-30.json
+AWS IoT Jobs Data Plane|iot-jobs-data-plane/service/2017-09-29/iot-jobs-data-plane-2017-09-29.json
+AWS IoT Secure Tunneling|iotsecuretunneling/service/2018-10-05/iotsecuretunneling-2018-10-05.json
+AWS IoT SiteWise|iotsitewise/service/2019-12-02/iotsitewise-2019-12-02.json
+AWS IoT Things Graph|iotthingsgraph/service/2018-09-06/iotthingsgraph-2018-09-06.json
+AWS IoT TwinMaker|iottwinmaker/service/2021-11-29/iottwinmaker-2021-11-29.json
+AWS IoT Wireless|iot-wireless/service/2020-11-22/iot-wireless-2020-11-22.json
+AWS Key Management Service|kms/service/2014-11-01/kms-2014-11-01.json
+AWS Lake Formation|lakeformation/service/2017-03-31/lakeformation-2017-03-31.json
+AWS Lambda|lambda/service/2015-03-31/lambda-2015-03-31.json
+AWS Launch Wizard|launch-wizard/service/2018-05-10/launch-wizard-2018-05-10.json
+AWS License Manager|license-manager/service/2018-08-01/license-manager-2018-08-01.json
+AWS License Manager Linux Subscriptions|license-manager-linux-subscriptions/service/2018-05-10/license-manager-linux-subscriptions-2018-05-10.json
+AWS License Manager User Subscriptions|license-manager-user-subscriptions/service/2018-05-10/license-manager-user-subscriptions-2018-05-10.json
+AWS Mainframe Modernization Application Testing|apptest/service/2022-12-06/apptest-2022-12-06.json
+AWS Marketplace Agreement Service|marketplace-agreement/service/2020-03-01/marketplace-agreement-2020-03-01.json
+AWS Marketplace Catalog Service|marketplace-catalog/service/2018-09-17/marketplace-catalog-2018-09-17.json
+AWS Marketplace Commerce Analytics|marketplace-commerce-analytics/service/2015-07-01/marketplace-commerce-analytics-2015-07-01.json
+AWS Marketplace Deployment Service|marketplace-deployment/service/2023-01-25/marketplace-deployment-2023-01-25.json
+AWS Marketplace Entitlement Service|marketplace-entitlement-service/service/2017-01-11/marketplace-entitlement-service-2017-01-11.json
+AWS Marketplace Reporting Service|marketplace-reporting/service/2018-05-10/marketplace-reporting-2018-05-10.json
+AWS MediaConnect|mediaconnect/service/2018-11-14/mediaconnect-2018-11-14.json
+AWS MediaTailor|mediatailor/service/2018-04-23/mediatailor-2018-04-23.json
+AWS Migration Hub|migration-hub/service/2017-05-31/migration-hub-2017-05-31.json
+AWS Migration Hub Config|migrationhub-config/service/2019-06-30/migrationhub-config-2019-06-30.json
+AWS Migration Hub Orchestrator|migrationhuborchestrator/service/2021-08-28/migrationhuborchestrator-2021-08-28.json
+AWS Migration Hub Refactor Spaces|migration-hub-refactor-spaces/service/2021-10-26/migration-hub-refactor-spaces-2021-10-26.json
+AWS Network Firewall|network-firewall/service/2020-11-12/network-firewall-2020-11-12.json
+AWS Network Manager|networkmanager/service/2019-07-05/networkmanager-2019-07-05.json
+AWS OpsWorks|opsworks/service/2013-02-18/opsworks-2013-02-18.json
+AWS OpsWorks CM|opsworkscm/service/2016-11-01/opsworkscm-2016-11-01.json
+AWS Organizations|organizations/service/2016-11-28/organizations-2016-11-28.json
+AWS Outposts|outposts/service/2019-12-03/outposts-2019-12-03.json
+AWS Panorama|panorama/service/2019-07-24/panorama-2019-07-24.json
+AWS Parallel Computing Service|pcs/service/2023-02-10/pcs-2023-02-10.json
+AWS Performance Insights|pi/service/2018-02-27/pi-2018-02-27.json
+AWS Price List Service|pricing/service/2017-10-15/pricing-2017-10-15.json
+AWS Private 5G|privatenetworks/service/2021-12-03/privatenetworks-2021-12-03.json
+AWS Proton|proton/service/2020-07-20/proton-2020-07-20.json
+AWS RDS DataService|rds-data/service/2018-08-01/rds-data-2018-08-01.json
+AWS Resilience Hub|resiliencehub/service/2020-04-30/resiliencehub-2020-04-30.json
+AWS Resource Access Manager|ram/service/2018-01-04/ram-2018-01-04.json
+AWS Resource Explorer|resource-explorer-2/service/2022-07-28/resource-explorer-2-2022-07-28.json
+AWS Resource Groups|resource-groups/service/2017-11-27/resource-groups-2017-11-27.json
+AWS Resource Groups Tagging API|resource-groups-tagging-api/service/2017-01-26/resource-groups-tagging-api-2017-01-26.json
+AWS RoboMaker|robomaker/service/2018-06-29/robomaker-2018-06-29.json
+AWS Route53 Recovery Control Config|route53-recovery-control-config/service/2020-11-02/route53-recovery-control-config-2020-11-02.json
+AWS Route53 Recovery Readiness|route53-recovery-readiness/service/2019-12-02/route53-recovery-readiness-2019-12-02.json
+AWS S3 Control|s3-control/service/2018-08-20/s3-control-2018-08-20.json
+AWS SSO Identity Store|identitystore/service/2020-06-15/identitystore-2020-06-15.json
+AWS SSO OIDC|sso-oidc/service/2019-06-10/sso-oidc-2019-06-10.json
+AWS Savings Plans|savingsplans/service/2019-06-28/savingsplans-2019-06-28.json
+AWS Secrets Manager|secrets-manager/service/2017-10-17/secrets-manager-2017-10-17.json
+AWS Security Token Service|sts/service/2011-06-15/sts-2011-06-15.json
+AWS SecurityHub|securityhub/service/2018-10-26/securityhub-2018-10-26.json
+AWS Server Migration Service|sms/service/2016-10-24/sms-2016-10-24.json
+AWS Service Catalog|service-catalog/service/2015-12-10/service-catalog-2015-12-10.json
+AWS Service Catalog App Registry|service-catalog-appregistry/service/2020-06-24/service-catalog-appregistry-2020-06-24.json
+AWS Shield|shield/service/2016-06-02/shield-2016-06-02.json
+AWS Signer|signer/service/2017-08-25/signer-2017-08-25.json
+AWS SimSpace Weaver|simspaceweaver/service/2022-10-28/simspaceweaver-2022-10-28.json
+AWS Single Sign-On|sso/service/2019-06-10/sso-2019-06-10.json
+AWS Single Sign-On Admin|sso-admin/service/2020-07-20/sso-admin-2020-07-20.json
+AWS Snow Device Management|snow-device-management/service/2021-08-04/snow-device-management-2021-08-04.json
+AWS Step Functions|sfn/service/2016-11-23/sfn-2016-11-23.json
+AWS Storage Gateway|storage-gateway/service/2013-06-30/storage-gateway-2013-06-30.json
+AWS Supply Chain|supplychain/service/2024-01-01/supplychain-2024-01-01.json
+AWS Support|support/service/2013-04-15/support-2013-04-15.json
+AWS Support App|support-app/service/2021-08-20/support-app-2021-08-20.json
+AWS Systems Manager Incident Manager|ssm-incidents/service/2018-05-10/ssm-incidents-2018-05-10.json
+AWS Systems Manager Incident Manager Contacts|ssm-contacts/service/2021-05-03/ssm-contacts-2021-05-03.json
+AWS Systems Manager QuickSetup|ssm-quicksetup/service/2018-05-10/ssm-quicksetup-2018-05-10.json
+AWS Systems Manager for SAP|ssm-sap/service/2018-05-10/ssm-sap-2018-05-10.json
+AWS Telco Network Builder|tnb/service/2008-10-21/tnb-2008-10-21.json
+AWS Transfer Family|transfer/service/2018-11-05/transfer-2018-11-05.json
+AWS User Notifications|notifications/service/2018-05-10/notifications-2018-05-10.json
+AWS User Notifications Contacts|notificationscontacts/service/2018-05-10/notificationscontacts-2018-05-10.json
+AWS WAF|waf/service/2015-08-24/waf-2015-08-24.json
+AWS WAF Regional|waf-regional/service/2016-11-28/waf-regional-2016-11-28.json
+AWS WAFV2|wafv2/service/2019-07-29/wafv2-2019-07-29.json
+AWS Well-Architected Tool|wellarchitected/service/2020-03-31/wellarchitected-2020-03-31.json
+AWS X-Ray|xray/service/2016-04-12/xray-2016-04-12.json
+AWS re:Post Private|repostspace/service/2022-05-13/repostspace-2022-05-13.json
+AWSBillingConductor|billingconductor/service/2021-07-30/billingconductor-2021-07-30.json
+AWSDeadlineCloud|deadline/service/2023-10-12/deadline-2023-10-12.json
+AWSKendraFrontendService|kendra/service/2019-02-03/kendra-2019-02-03.json
+AWSMainframeModernization|m2/service/2021-04-28/m2-2021-04-28.json
+AWSMarketplace Metering|marketplace-metering/service/2016-01-14/marketplace-metering-2016-01-14.json
+AWSServerlessApplicationRepository|serverlessapplicationrepository/service/2017-09-08/serverlessapplicationrepository-2017-09-08.json
+Access Analyzer|accessanalyzer/service/2019-11-01/accessanalyzer-2019-11-01.json
+Agents for Amazon Bedrock|bedrock-agent/service/2023-06-05/bedrock-agent-2023-06-05.json
+Agents for Amazon Bedrock Runtime|bedrock-agent-runtime/service/2023-07-26/bedrock-agent-runtime-2023-07-26.json
+Amazon API Gateway|api-gateway/service/2015-07-09/api-gateway-2015-07-09.json
+Amazon AppConfig|appconfig/service/2019-10-09/appconfig-2019-10-09.json
+Amazon AppIntegrations Service|appintegrations/service/2020-07-29/appintegrations-2020-07-29.json
+Amazon AppStream|appstream/service/2016-12-01/appstream-2016-12-01.json
+Amazon Appflow|appflow/service/2020-08-23/appflow-2020-08-23.json
+Amazon Athena|athena/service/2017-05-18/athena-2017-05-18.json
+Amazon Augmented AI Runtime|sagemaker-a2i-runtime/service/2019-11-07/sagemaker-a2i-runtime-2019-11-07.json
+Amazon Aurora DSQL|dsql/service/2018-05-10/dsql-2018-05-10.json
+Amazon Bedrock|bedrock/service/2023-04-20/bedrock-2023-04-20.json
+Amazon Bedrock Runtime|bedrock-runtime/service/2023-09-30/bedrock-runtime-2023-09-30.json
+Amazon Chime|chime/service/2018-05-01/chime-2018-05-01.json
+Amazon Chime SDK Identity|chime-sdk-identity/service/2021-04-20/chime-sdk-identity-2021-04-20.json
+Amazon Chime SDK Media Pipelines|chime-sdk-media-pipelines/service/2021-07-15/chime-sdk-media-pipelines-2021-07-15.json
+Amazon Chime SDK Meetings|chime-sdk-meetings/service/2021-07-15/chime-sdk-meetings-2021-07-15.json
+Amazon Chime SDK Messaging|chime-sdk-messaging/service/2021-05-15/chime-sdk-messaging-2021-05-15.json
+Amazon Chime SDK Voice|chime-sdk-voice/service/2022-08-03/chime-sdk-voice-2022-08-03.json
+Amazon CloudDirectory|clouddirectory/service/2017-01-11/clouddirectory-2017-01-11.json
+Amazon CloudFront|cloudfront/service/2020-05-31/cloudfront-2020-05-31.json
+Amazon CloudFront KeyValueStore|cloudfront-keyvaluestore/service/2022-07-26/cloudfront-keyvaluestore-2022-07-26.json
+Amazon CloudHSM|cloudhsm/service/2014-05-30/cloudhsm-2014-05-30.json
+Amazon CloudSearch|cloudsearch/service/2013-01-01/cloudsearch-2013-01-01.json
+Amazon CloudSearch Domain|cloudsearch-domain/service/2013-01-01/cloudsearch-domain-2013-01-01.json
+Amazon CloudWatch|cloudwatch/service/2010-08-01/cloudwatch-2010-08-01.json
+Amazon CloudWatch Application Insights|application-insights/service/2018-11-25/application-insights-2018-11-25.json
+Amazon CloudWatch Application Signals|application-signals/service/2024-04-15/application-signals-2024-04-15.json
+Amazon CloudWatch Events|cloudwatch-events/service/2015-10-07/cloudwatch-events-2015-10-07.json
+Amazon CloudWatch Evidently|evidently/service/2021-02-01/evidently-2021-02-01.json
+Amazon CloudWatch Internet Monitor|internetmonitor/service/2021-06-03/internetmonitor-2021-06-03.json
+Amazon CloudWatch Logs|cloudwatch-logs/service/2014-03-28/cloudwatch-logs-2014-03-28.json
+Amazon CloudWatch Network Monitor|networkmonitor/service/2023-08-01/networkmonitor-2023-08-01.json
+Amazon CodeGuru Profiler|codeguruprofiler/service/2019-07-18/codeguruprofiler-2019-07-18.json
+Amazon CodeGuru Reviewer|codeguru-reviewer/service/2019-09-19/codeguru-reviewer-2019-09-19.json
+Amazon CodeGuru Security|codeguru-security/service/2018-05-10/codeguru-security-2018-05-10.json
+Amazon Cognito Identity|cognito-identity/service/2014-06-30/cognito-identity-2014-06-30.json
+Amazon Cognito Identity Provider|cognito-identity-provider/service/2016-04-18/cognito-identity-provider-2016-04-18.json
+Amazon Cognito Sync|cognito-sync/service/2014-06-30/cognito-sync-2014-06-30.json
+Amazon Comprehend|comprehend/service/2017-11-27/comprehend-2017-11-27.json
+Amazon Connect Cases|connectcases/service/2022-10-03/connectcases-2022-10-03.json
+Amazon Connect Contact Lens|connect-contact-lens/service/2020-08-21/connect-contact-lens-2020-08-21.json
+Amazon Connect Customer Profiles|customer-profiles/service/2020-08-15/customer-profiles-2020-08-15.json
+Amazon Connect Participant Service|connectparticipant/service/2018-09-07/connectparticipant-2018-09-07.json
+Amazon Connect Service|connect/service/2017-08-08/connect-2017-08-08.json
+Amazon Connect Wisdom Service|wisdom/service/2020-10-19/wisdom-2020-10-19.json
+Amazon Data Lifecycle Manager|dlm/service/2018-01-12/dlm-2018-01-12.json
+Amazon DataZone|datazone/service/2018-05-10/datazone-2018-05-10.json
+Amazon Detective|detective/service/2018-10-26/detective-2018-10-26.json
+Amazon DevOps Guru|devops-guru/service/2020-12-01/devops-guru-2020-12-01.json
+Amazon DocumentDB Elastic Clusters|docdb-elastic/service/2022-11-28/docdb-elastic-2022-11-28.json
+Amazon DocumentDB with MongoDB compatibility|docdb/service/2014-10-31/docdb-2014-10-31.json
+Amazon DynamoDB|dynamodb/service/2012-08-10/dynamodb-2012-08-10.json
+Amazon DynamoDB Accelerator (DAX)|dax/service/2017-04-19/dax-2017-04-19.json
+Amazon DynamoDB Streams|dynamodb-streams/service/2012-08-10/dynamodb-streams-2012-08-10.json
+Amazon EC2 Container Service|ecs/service/2014-11-13/ecs-2014-11-13.json
+Amazon EKS Auth|eks-auth/service/2023-11-26/eks-auth-2023-11-26.json
+Amazon EMR|emr/service/2009-03-31/emr-2009-03-31.json
+Amazon EMR Containers|emr-containers/service/2020-10-01/emr-containers-2020-10-01.json
+Amazon ElastiCache|elasticache/service/2015-02-02/elasticache-2015-02-02.json
+Amazon Elastic Block Store|ebs/service/2019-11-02/ebs-2019-11-02.json
+Amazon Elastic Compute Cloud|ec2/service/2016-11-15/ec2-2016-11-15.json
+Amazon Elastic Container Registry|ecr/service/2015-09-21/ecr-2015-09-21.json
+Amazon Elastic Container Registry Public|ecr-public/service/2020-10-30/ecr-public-2020-10-30.json
+Amazon Elastic File System|efs/service/2015-02-01/efs-2015-02-01.json
+Amazon Elastic Kubernetes Service|eks/service/2017-11-01/eks-2017-11-01.json
+Amazon Elastic Transcoder|elastic-transcoder/service/2012-09-25/elastic-transcoder-2012-09-25.json
+Amazon Elasticsearch Service|elasticsearch-service/service/2015-01-01/elasticsearch-service-2015-01-01.json
+Amazon EventBridge|eventbridge/service/2015-10-07/eventbridge-2015-10-07.json
+Amazon EventBridge Pipes|pipes/service/2015-10-07/pipes-2015-10-07.json
+Amazon EventBridge Scheduler|scheduler/service/2021-06-30/scheduler-2021-06-30.json
+Amazon FSx|fsx/service/2018-03-01/fsx-2018-03-01.json
+Amazon Forecast Query Service|forecastquery/service/2018-06-26/forecastquery-2018-06-26.json
+Amazon Forecast Service|forecast/service/2018-06-26/forecast-2018-06-26.json
+Amazon Fraud Detector|frauddetector/service/2019-11-15/frauddetector-2019-11-15.json
+Amazon GameLift|gamelift/service/2015-10-01/gamelift-2015-10-01.json
+Amazon GameLift Streams|gameliftstreams/service/2018-05-10/gameliftstreams-2018-05-10.json
+Amazon Glacier|glacier/service/2012-06-01/glacier-2012-06-01.json
+Amazon GuardDuty|guardduty/service/2017-11-28/guardduty-2017-11-28.json
+Amazon HealthLake|healthlake/service/2017-07-01/healthlake-2017-07-01.json
+Amazon Import/Export Snowball|snowball/service/2016-06-30/snowball-2016-06-30.json
+Amazon Inspector|inspector/service/2016-02-16/inspector-2016-02-16.json
+Amazon Interactive Video Service|ivs/service/2020-07-14/ivs-2020-07-14.json
+Amazon Interactive Video Service Chat|ivschat/service/2020-07-14/ivschat-2020-07-14.json
+Amazon Interactive Video Service RealTime|ivs-realtime/service/2020-07-14/ivs-realtime-2020-07-14.json
+Amazon Kendra Intelligent Ranking|kendra-ranking/service/2022-10-19/kendra-ranking-2022-10-19.json
+Amazon Keyspaces|keyspaces/service/2022-02-10/keyspaces-2022-02-10.json
+Amazon Kinesis|kinesis/service/2013-12-02/kinesis-2013-12-02.json
+Amazon Kinesis Analytics|kinesis-analytics/service/2015-08-14/kinesis-analytics-2015-08-14.json
+Amazon Kinesis Analytics|kinesis-analytics-v2/service/2018-05-23/kinesis-analytics-v2-2018-05-23.json
+Amazon Kinesis Firehose|firehose/service/2015-08-04/firehose-2015-08-04.json
+Amazon Kinesis Video Signaling Channels|kinesis-video-signaling/service/2019-12-04/kinesis-video-signaling-2019-12-04.json
+Amazon Kinesis Video Streams|kinesis-video/service/2017-09-30/kinesis-video-2017-09-30.json
+Amazon Kinesis Video Streams Archived Media|kinesis-video-archived-media/service/2017-09-30/kinesis-video-archived-media-2017-09-30.json
+Amazon Kinesis Video Streams Media|kinesis-video-media/service/2017-09-30/kinesis-video-media-2017-09-30.json
+Amazon Kinesis Video WebRTC Storage|kinesis-video-webrtc-storage/service/2018-05-10/kinesis-video-webrtc-storage-2018-05-10.json
+Amazon Lex Model Building Service|lex-model-building-service/service/2017-04-19/lex-model-building-service-2017-04-19.json
+Amazon Lex Model Building V2|lex-models-v2/service/2020-08-07/lex-models-v2-2020-08-07.json
+Amazon Lex Runtime Service|lex-runtime-service/service/2016-11-28/lex-runtime-service-2016-11-28.json
+Amazon Lex Runtime V2|lex-runtime-v2/service/2020-08-07/lex-runtime-v2-2020-08-07.json
+Amazon Lightsail|lightsail/service/2016-11-28/lightsail-2016-11-28.json
+Amazon Location Service|location/service/2020-11-19/location-2020-11-19.json
+Amazon Location Service Maps V2|geo-maps/service/2020-11-19/geo-maps-2020-11-19.json
+Amazon Location Service Places V2|geo-places/service/2020-11-19/geo-places-2020-11-19.json
+Amazon Location Service Routes V2|geo-routes/service/2020-11-19/geo-routes-2020-11-19.json
+Amazon Lookout for Equipment|lookoutequipment/service/2020-12-15/lookoutequipment-2020-12-15.json
+Amazon Lookout for Metrics|lookoutmetrics/service/2017-07-25/lookoutmetrics-2017-07-25.json
+Amazon Lookout for Vision|lookoutvision/service/2020-11-20/lookoutvision-2020-11-20.json
+Amazon Machine Learning|machine-learning/service/2014-12-12/machine-learning-2014-12-12.json
+Amazon Macie 2|macie2/service/2020-01-01/macie2-2020-01-01.json
+Amazon Managed Blockchain|managedblockchain/service/2018-09-24/managedblockchain-2018-09-24.json
+Amazon Managed Blockchain Query|managedblockchain-query/service/2023-05-04/managedblockchain-query-2023-05-04.json
+Amazon Managed Grafana|grafana/service/2020-08-18/grafana-2020-08-18.json
+Amazon Mechanical Turk|mturk/service/2017-01-17/mturk-2017-01-17.json
+Amazon MemoryDB|memorydb/service/2021-01-01/memorydb-2021-01-01.json
+Amazon Neptune|neptune/service/2014-10-31/neptune-2014-10-31.json
+Amazon Neptune Graph|neptune-graph/service/2023-11-29/neptune-graph-2023-11-29.json
+Amazon NeptuneData|neptunedata/service/2023-08-01/neptunedata-2023-08-01.json
+Amazon Omics|omics/service/2022-11-28/omics-2022-11-28.json
+Amazon OpenSearch Ingestion|osis/service/2022-01-01/osis-2022-01-01.json
+Amazon OpenSearch Service|opensearch/service/2021-01-01/opensearch-2021-01-01.json
+Amazon Personalize|personalize/service/2018-05-22/personalize-2018-05-22.json
+Amazon Personalize Events|personalize-events/service/2018-03-22/personalize-events-2018-03-22.json
+Amazon Personalize Runtime|personalize-runtime/service/2018-05-22/personalize-runtime-2018-05-22.json
+Amazon Pinpoint|pinpoint/service/2016-12-01/pinpoint-2016-12-01.json
+Amazon Pinpoint Email Service|pinpoint-email/service/2018-07-26/pinpoint-email-2018-07-26.json
+Amazon Pinpoint SMS Voice V2|pinpoint-sms-voice-v2/service/2022-03-31/pinpoint-sms-voice-v2-2022-03-31.json
+Amazon Pinpoint SMS and Voice Service|pinpoint-sms-voice/service/2018-09-05/pinpoint-sms-voice-2018-09-05.json
+Amazon Polly|polly/service/2016-06-10/polly-2016-06-10.json
+Amazon Prometheus Service|amp/service/2020-08-01/amp-2020-08-01.json
+Amazon Q Connect|qconnect/service/2020-10-19/qconnect-2020-10-19.json
+Amazon QLDB|qldb/service/2019-01-02/qldb-2019-01-02.json
+Amazon QLDB Session|qldb-session/service/2019-07-11/qldb-session-2019-07-11.json
+Amazon QuickSight|quicksight/service/2018-04-01/quicksight-2018-04-01.json
+Amazon Recycle Bin|rbin/service/2021-06-15/rbin-2021-06-15.json
+Amazon Redshift|redshift/service/2012-12-01/redshift-2012-12-01.json
+Amazon Rekognition|rekognition/service/2016-06-27/rekognition-2016-06-27.json
+Amazon Relational Database Service|rds/service/2014-10-31/rds-2014-10-31.json
+Amazon Route 53|route-53/service/2013-04-01/route-53-2013-04-01.json
+Amazon Route 53 Domains|route-53-domains/service/2014-05-15/route-53-domains-2014-05-15.json
+Amazon Route 53 Resolver|route53resolver/service/2018-04-01/route53resolver-2018-04-01.json
+Amazon S3 Tables|s3tables/service/2018-05-10/s3tables-2018-05-10.json
+Amazon S3 on Outposts|s3outposts/service/2017-07-25/s3outposts-2017-07-25.json
+Amazon SageMaker Feature Store Runtime|sagemaker-featurestore-runtime/service/2020-07-01/sagemaker-featurestore-runtime-2020-07-01.json
+Amazon SageMaker Metrics Service|sagemaker-metrics/service/2022-09-30/sagemaker-metrics-2022-09-30.json
+Amazon SageMaker Runtime|sagemaker-runtime/service/2017-05-13/sagemaker-runtime-2017-05-13.json
+Amazon SageMaker Service|sagemaker/service/2017-07-24/sagemaker-2017-07-24.json
+Amazon SageMaker geospatial capabilities|sagemaker-geospatial/service/2020-05-27/sagemaker-geospatial-2020-05-27.json
+Amazon Sagemaker Edge Manager|sagemaker-edge/service/2020-09-23/sagemaker-edge-2020-09-23.json
+Amazon Security Lake|securitylake/service/2018-05-10/securitylake-2018-05-10.json
+Amazon Simple Email Service|sesv2/service/2019-09-27/sesv2-2019-09-27.json
+Amazon Simple Email Service|ses/service/2010-12-01/ses-2010-12-01.json
+Amazon Simple Notification Service|sns/service/2010-03-31/sns-2010-03-31.json
+Amazon Simple Queue Service|sqs/service/2012-11-05/sqs-2012-11-05.json
+Amazon Simple Storage Service|s3/service/2006-03-01/s3-2006-03-01.json
+Amazon Simple Systems Manager (SSM)|ssm/service/2014-11-06/ssm-2014-11-06.json
+Amazon Simple Workflow Service|swf/service/2012-01-25/swf-2012-01-25.json
+Amazon Textract|textract/service/2018-06-27/textract-2018-06-27.json
+Amazon Timestream Query|timestream-query/service/2018-11-01/timestream-query-2018-11-01.json
+Amazon Timestream Write|timestream-write/service/2018-11-01/timestream-write-2018-11-01.json
+Amazon Transcribe Service|transcribe/service/2017-10-26/transcribe-2017-10-26.json
+Amazon Transcribe Streaming Service|transcribe-streaming/service/2017-10-26/transcribe-streaming-2017-10-26.json
+Amazon Translate|translate/service/2017-07-01/translate-2017-07-01.json
+Amazon VPC Lattice|vpc-lattice/service/2022-11-30/vpc-lattice-2022-11-30.json
+Amazon Verified Permissions|verifiedpermissions/service/2021-12-01/verifiedpermissions-2021-12-01.json
+Amazon Voice ID|voice-id/service/2021-09-27/voice-id-2021-09-27.json
+Amazon WorkDocs|workdocs/service/2016-05-01/workdocs-2016-05-01.json
+Amazon WorkMail|workmail/service/2017-10-01/workmail-2017-10-01.json
+Amazon WorkMail Message Flow|workmailmessageflow/service/2019-05-01/workmailmessageflow-2019-05-01.json
+Amazon WorkSpaces|workspaces/service/2015-04-08/workspaces-2015-04-08.json
+Amazon WorkSpaces Thin Client|workspaces-thin-client/service/2023-08-22/workspaces-thin-client-2023-08-22.json
+Amazon WorkSpaces Web|workspaces-web/service/2020-07-08/workspaces-web-2020-07-08.json
+AmazonApiGatewayManagementApi|apigatewaymanagementapi/service/2018-11-29/apigatewaymanagementapi-2018-11-29.json
+AmazonApiGatewayV2|apigatewayv2/service/2018-11-29/apigatewayv2-2018-11-29.json
+AmazonConnectCampaignService|connectcampaigns/service/2021-01-30/connectcampaigns-2021-01-30.json
+AmazonConnectCampaignServiceV2|connectcampaignsv2/service/2024-04-23/connectcampaignsv2-2024-04-23.json
+AmazonMQ|mq/service/2017-11-27/mq-2017-11-27.json
+AmazonMWAA|mwaa/service/2020-07-01/mwaa-2020-07-01.json
+AmplifyBackend|amplifybackend/service/2020-08-11/amplifybackend-2020-08-11.json
+AppFabric|appfabric/service/2023-05-19/appfabric-2023-05-19.json
+Application Auto Scaling|application-auto-scaling/service/2016-02-06/application-auto-scaling-2016-02-06.json
+Application Migration Service|mgn/service/2020-02-26/mgn-2020-02-26.json
+Auto Scaling|auto-scaling/service/2011-01-01/auto-scaling-2011-01-01.json
+Braket|braket/service/2019-09-01/braket-2019-09-01.json
+CloudWatch Observability Access Manager|oam/service/2022-06-10/oam-2022-06-10.json
+CloudWatch Observability Admin Service|observabilityadmin/service/2018-05-10/observabilityadmin-2018-05-10.json
+CloudWatch RUM|rum/service/2018-05-10/rum-2018-05-10.json
+CodeArtifact|codeartifact/service/2018-09-22/codeartifact-2018-09-22.json
+Cost Optimization Hub|cost-optimization-hub/service/2022-07-26/cost-optimization-hub-2022-07-26.json
+Data Automation for Amazon Bedrock|bedrock-data-automation/service/2023-07-26/bedrock-data-automation-2023-07-26.json
+EC2 Image Builder|imagebuilder/service/2019-12-02/imagebuilder-2019-12-02.json
+EMR Serverless|emr-serverless/service/2021-07-13/emr-serverless-2021-07-13.json
+Elastic Disaster Recovery Service|drs/service/2020-02-26/drs-2020-02-26.json
+Elastic Load Balancing|elastic-load-balancing-v2/service/2015-12-01/elastic-load-balancing-v2-2015-12-01.json
+Elastic Load Balancing|elastic-load-balancing/service/2012-06-01/elastic-load-balancing-2012-06-01.json
+FinSpace Public API|finspace-data/service/2020-07-13/finspace-data-2020-07-13.json
+FinSpace User Environment Management service|finspace/service/2021-03-12/finspace-2021-03-12.json
+Firewall Management Service|fms/service/2018-01-01/fms-2018-01-01.json
+IAM Roles Anywhere|rolesanywhere/service/2018-05-10/rolesanywhere-2018-05-10.json
+Inspector Scan|inspector-scan/service/2023-08-08/inspector-scan-2023-08-08.json
+Inspector2|inspector2/service/2020-06-08/inspector2-2020-06-08.json
+MailManager|mailmanager/service/2023-10-17/mailmanager-2023-10-17.json
+Managed Streaming for Kafka|kafka/service/2018-11-14/kafka-2018-11-14.json
+Managed Streaming for Kafka Connect|kafkaconnect/service/2021-09-14/kafkaconnect-2021-09-14.json
+Managed integrations for AWS IoT Device Management|iot-managed-integrations/service/2025-03-03/iot-managed-integrations-2025-03-03.json
+Migration Hub Strategy Recommendations|migrationhubstrategy/service/2020-02-19/migrationhubstrategy-2020-02-19.json
+Network Flow Monitor|networkflowmonitor/service/2023-04-19/networkflowmonitor-2023-04-19.json
+OpenSearch Service Serverless|opensearchserverless/service/2021-11-01/opensearchserverless-2021-11-01.json
+Partner Central Selling API|partnercentral-selling/service/2022-07-26/partnercentral-selling-2022-07-26.json
+Payment Cryptography Control Plane|payment-cryptography/service/2021-09-14/payment-cryptography-2021-09-14.json
+Payment Cryptography Data Plane|payment-cryptography-data/service/2022-02-03/payment-cryptography-data-2022-02-03.json
+PcaConnectorAd|pca-connector-ad/service/2018-05-10/pca-connector-ad-2018-05-10.json
+Private CA Connector for SCEP|pca-connector-scep/service/2018-05-10/pca-connector-scep-2018-05-10.json
+QApps|qapps/service/2023-11-27/qapps-2023-11-27.json
+QBusiness|qbusiness/service/2023-11-27/qbusiness-2023-11-27.json
+Redshift Data API Service|redshift-data/service/2019-12-20/redshift-data-2019-12-20.json
+Redshift Serverless|redshift-serverless/service/2021-04-21/redshift-serverless-2021-04-21.json
+Route 53 Profiles|route53profiles/service/2018-05-10/route53profiles-2018-05-10.json
+Route53 Recovery Cluster|route53-recovery-cluster/service/2019-12-02/route53-recovery-cluster-2019-12-02.json
+Runtime for Amazon Bedrock Data Automation|bedrock-data-automation-runtime/service/2024-06-13/bedrock-data-automation-runtime-2024-06-13.json
+Schemas|schemas/service/2019-12-02/schemas-2019-12-02.json
+Security Incident Response|security-ir/service/2018-05-10/security-ir-2018-05-10.json
+Service Quotas|service-quotas/service/2019-06-24/service-quotas-2019-06-24.json
+Synthetics|synthetics/service/2017-10-11/synthetics-2017-10-11.json
+Tax Settings|taxsettings/service/2018-05-10/taxsettings-2018-05-10.json
+Timestream InfluxDB|timestream-influxdb/service/2023-01-27/timestream-influxdb-2023-01-27.json
+TrustedAdvisor Public API|trustedadvisor/service/2022-09-15/trustedadvisor-2022-09-15.json

--- a/mcp/mcp-bundle-api/src/main/java/software/amazon/smithy/mcp/bundle/api/Registry.java
+++ b/mcp/mcp-bundle-api/src/main/java/software/amazon/smithy/mcp/bundle/api/Registry.java
@@ -11,9 +11,35 @@ import software.amazon.smithy.mcp.bundle.api.model.BundleMetadata;
 
 public interface Registry {
 
+    final class RegistryEntry {
+        private final String title;
+        private final BundleMetadata bundleMetadata;
+
+        public RegistryEntry(String title, BundleMetadata bundleMetadata) {
+            this.title = title;
+            this.bundleMetadata = bundleMetadata;
+        }
+
+        /**
+         * Provides a human-readable title for the bundle for display purposes.
+         *
+         * @return the human-facing title of the registry entry
+         */
+        public String getTitle() {
+            return title;
+        }
+
+        /**
+         * @return the Bundle metadata
+         */
+        public BundleMetadata getBundleMetadata() {
+            return bundleMetadata;
+        }
+    }
+
     String name();
 
-    List<BundleMetadata> listMcpBundles();
+    List<RegistryEntry> listMcpBundles();
 
     Bundle getMcpBundle(String name);
 

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/ListBundles.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/ListBundles.java
@@ -13,7 +13,7 @@ import picocli.CommandLine.Spec;
 import software.amazon.smithy.java.mcp.cli.ExecutionContext;
 import software.amazon.smithy.java.mcp.cli.SmithyMcpCommand;
 import software.amazon.smithy.java.mcp.cli.model.Config;
-import software.amazon.smithy.mcp.bundle.api.model.BundleMetadata;
+import software.amazon.smithy.mcp.bundle.api.Registry;
 
 @Command(name = "list", description = "List all the MCP Bundles available in the Registry")
 public class ListBundles extends SmithyMcpCommand {
@@ -29,13 +29,14 @@ public class ListBundles extends SmithyMcpCommand {
     protected void execute(ExecutionContext context) {
         var registry = context.registry();
         var installedBundles = context.config().getToolBundles().keySet();
-        for (BundleMetadata bundle : registry
-                .listMcpBundles()) {
+        for (Registry.RegistryEntry entry : registry.listMcpBundles()) {
+            var bundle = entry.getBundleMetadata();
             boolean isInstalled = installedBundles.contains(bundle.getName());
             var commandLine = spec.commandLine();
             System.out.println(commandLine
                     .getColorScheme()
-                    .string("@|bold " + bundle.getName() + (isInstalled ? " [installed]" : "") + "|@"));
+                    .string("@|bold " + bundle.getName() + (isInstalled ? " [installed]" : "") + "|@: "
+                            + entry.getTitle()));
             var description = bundle.getDescription();
             if (description == null) {
                 description = "MCP server for " + bundle.getName();

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/StartServer.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/StartServer.java
@@ -197,6 +197,7 @@ public final class StartServer extends SmithyMcpCommand {
                     .listMcpBundles()
                     .stream()
                     .unordered()
+                    .map(Registry.RegistryEntry::getBundleMetadata)
                     .collect(Collectors.toMap(
                             BundleMetadata::getName,
                             bundle -> ServerEntry.builder()


### PR DESCRIPTION
We now print a friendly title with each server. The server identifier is bolded so users will know to use it with `start-server` and `install`. We can move the title into the body of the listing if we think we'll need additional clarity.