### PR TITLE
Fix default start-server behavior

### DIFF
--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/StartServer.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/StartServer.java
@@ -78,17 +78,16 @@ public final class StartServer extends SmithyMcpCommand {
         var config = context.config();
         // By default, load all available tools
         if (toolBundles == null || toolBundles.isEmpty()) {
-            toolBundles = new ArrayList<>(config.getToolBundles()
+            toolBundles = config.getToolBundles()
                     .entrySet()
                     .stream()
                     .filter(entry -> {
                         // By default, only include smithy bundles if no bundles are specified.
                         // We can undo this once we have fanout support for generic bundles.
-                        var bundle = entry.getValue();
-                        return bundle.getValue() instanceof McpBundleConfig.SmithyModeledMember;
+                        return entry.getValue().type() == McpBundleConfig.Type.smithyModeled;
                     })
                     .map(Map.Entry::getKey)
-                    .toList());
+                    .toList();
         }
 
         if (toolBundles.isEmpty() && !registryServer) {


### PR DESCRIPTION
The code currently looks at the type of the nested value instead of the type of the union variant.
