### PR TITLE
Use JReleaser 'MavenCentral' deployer for releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,14 +64,10 @@ jreleaser {
     // https://jreleaser.org/guide/latest/examples/maven/maven-central.html#_gradle
     deploy {
         maven {
-            nexus2 {
+            mavenCentral {
                 create("maven-central") {
                     active = Active.ALWAYS
-                    url = "https://aws.oss.sonatype.org/service/local"
-                    snapshotUrl = "https://aws.oss.sonatype.org/content/repositories/snapshots"
-                    closeRepository.set(true)
-                    releaseRepository.set(true)
-                    verifyPom.set(true)
+                    url = "https://central.sonatype.com/api/v1/publisher"
                     stagingRepository(rootProject.layout.buildDirectory.dir("staging").get().asFile.path)
                 }
             }


### PR DESCRIPTION
- Nexus2 deployer is sunsetting on June 30th

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
