### PR TITLE
Handle additionalInput without modifying the actual input model

### DIFF
--- a/aws/aws-service-bundle/src/main/java/software/amazon/smithy/java/aws/servicebundle/provider/AwsServiceBundle.java
+++ b/aws/aws-service-bundle/src/main/java/software/amazon/smithy/java/aws/servicebundle/provider/AwsServiceBundle.java
@@ -5,8 +5,9 @@
 
 package software.amazon.smithy.java.aws.servicebundle.provider;
 
+import static java.util.Objects.requireNonNull;
+
 import java.net.URI;
-import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,8 +26,8 @@ import software.amazon.smithy.java.client.core.auth.scheme.AuthScheme;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import software.amazon.smithy.java.client.core.interceptors.CallHook;
 import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
-import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.dynamicclient.DynamicClient;
+import software.amazon.smithy.java.server.ProxyService;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.modelbundle.api.BundlePlugin;
@@ -87,12 +88,11 @@ final class AwsServiceBundle implements BundlePlugin {
 
         @Override
         public ClientConfig modifyBeforeCall(CallHook<?, ?> hook) {
-            if (!(hook.input() instanceof Document d)) {
-                throw new IllegalArgumentException("Input must be a Document");
-            }
+            var d = requireNonNull(hook.config().context().get(ProxyService.PROXY_INPUT),
+                    "Expected additionalInput in the request");
             var input = d.asShape(PreRequest.builder());
 
-            var endpoint = URI.create(Objects.requireNonNull(serviceMetadata.getEndpoints().get(input.getAwsRegion()),
+            var endpoint = URI.create(requireNonNull(serviceMetadata.getEndpoints().get(input.getAwsRegion()),
                     "no endpoint for region " + input.getAwsRegion()));
 
             var identityResolver =

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
@@ -169,6 +169,8 @@ public class ClientTest {
                 .addPlugin(config -> config.addInterceptor(new ClientInterceptor() {
                     @Override
                     public ClientConfig modifyBeforeCall(CallHook<?, ?> hook) {
+                        //RequestOverrides config should be visible here.
+                        assertThat(hook.config().context().get(CallContext.APPLICATION_ID), equalTo(id));
                         // Note that the overrides given to the call itself will override interceptors.
                         var override = RequestOverrideConfig.builder()
                                 .putConfig(CallContext.APPLICATION_ID, "foo")

--- a/server/server-proxy/src/main/java/software/amazon/smithy/java/server/ProxyOperationTrait.java
+++ b/server/server-proxy/src/main/java/software/amazon/smithy/java/server/ProxyOperationTrait.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.server;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.Trait;
+
+/**
+ * A trait that marks operations as proxies to delegate operations.
+ * 
+ * <p>Operations annotated with this trait are treated as proxies to the 
+ * delegate operation specified by this trait. Proxy operations enable 
+ * additional input processing while maintaining compatibility with the 
+ * original operation interface.</p>
+ * 
+ * <h3>Proxy Operation Input Handling</h3>
+ * <p>Proxy operation inputs are expected to be a superset of the original 
+ * operation input. For operations with existing input, a new input structure 
+ * is created that contains all original input members plus an 
+ * {@code additionalInput} field containing the additional parameters. For 
+ * operations with no input, the additional input structure is used directly.</p>
+ * 
+ * <h3>Additional Input Access</h3>
+ * <p>The additional input data can be accessed in Dynamic client interceptors 
+ * using the {@code ProxyService.PROXY_INPUT} context key. This enables 
+ * interceptors to process the extra data before the request is forwarded 
+ * to the delegate service.</p>
+ * 
+ * <h3>Input Stripping</h3>
+ * <p>The proxy service automatically strips out the additional input before 
+ * sending the request to the delegate service, ensuring that only the 
+ * expected input parameters are forwarded to the original operation.</p>
+ * 
+ * @see ProxyService#PROXY_INPUT
+ */
+public final class ProxyOperationTrait implements Trait {
+
+    private static final ShapeId SHAPE_ID = ShapeId.from("smithy.server.api#proxyOperation");
+    private final ShapeId delegateOperation;
+
+    public ProxyOperationTrait(ShapeId delegateOperation) {
+        this.delegateOperation = delegateOperation;
+    }
+
+    @Override
+    public ShapeId toShapeId() {
+        return SHAPE_ID;
+    }
+
+    @Override
+    public Node toNode() {
+        return null;
+    }
+
+    public ShapeId getDelegateOperation() {
+        return delegateOperation;
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Modifying the actual input model has other side affects like affecting RestJson serialization. To avoid these we now create proxy operations which delegate to the actual operations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
