### PR TITLE
Do not require the bundle model to have a single service

### DIFF
--- a/model-bundle/model-bundle-api/src/main/java/software/amazon/smithy/modelbundle/api/ModelBundles.java
+++ b/model-bundle/model-bundle-api/src/main/java/software/amazon/smithy/modelbundle/api/ModelBundles.java
@@ -53,17 +53,9 @@ public final class ModelBundles {
         }
         var b = model.toBuilder();
 
-        var serviceShapes = model.getServiceShapes();
-
-        if (serviceShapes.size() != 1) {
-            throw new IllegalStateException("Expected exactly one service shape but got "
-                    + serviceShapes.stream().map(ServiceShape::getId).toList());
-        }
-
-        var service = serviceShapes.iterator().next();
+        var serviceShape = model.expectShape(ShapeId.from(bundle.getServiceName()), ServiceShape.class);
 
         // mix in the generic arg members
-        var serviceShape = service.asServiceShape().get();
         var serviceBuilder = serviceShape.toBuilder();
         for (var opId : serviceShape.getAllOperations()) {
             var op = model.expectShape(opId, OperationShape.class);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Before #790, we weren’t removing unrelated services from the generated bundle model if they were present in the original model. We added a check in #787 to handle that, but any bundles created via the CLI before that change are now broken. So we're removing the check and instead assuming that the bundle model already contains the intended Service shape by ID.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
