### PR TITLE
Fix model path for additional input in Aws bundles

### DIFF
--- a/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
+++ b/aws/aws-service-bundler/src/main/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundler.java
@@ -176,7 +176,7 @@ public final class AwsServiceBundler extends ModelBundler {
                             blockedPrefixes)))
                     .additionalInput(AdditionalInput.builder()
                             .identifier(PreRequest.$ID.toString())
-                            .model(loadModel("/META-INF/smithy/bundle.smithy"))
+                            .model(loadModel("/META-INF/smithy/awsmcp.smithy"))
                             .build())
                     .build();
         } catch (Exception e) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

After #790 we remove the unused shaped so PreRequest was getting removed from the main model. And we pack the incorrect model in additional input.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
