### PR TITLE
Tweak documentation and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ by the Smithy build process:
 
 ```diff
 dependencies {
-+    smithyBuild("software.amazon.smithy.java.codegen:plugins:<replace with version>")
++    smithyBuild("software.amazon.smithy.java:plugins:<replace with version>")
 }
 ```
 

--- a/codegen/plugins/server-codegen/src/main/java/software/amazon/smithy/java/codegen/server/JavaServerCodegenPlugin.java
+++ b/codegen/plugins/server-codegen/src/main/java/software/amazon/smithy/java/codegen/server/JavaServerCodegenPlugin.java
@@ -36,7 +36,7 @@ public final class JavaServerCodegenPlugin implements SmithyBuildPlugin {
                 new CodegenDirector<>();
 
         var settings = JavaCodegenSettings.fromNode(context.getSettings());
-        LOGGER.info("Generating Smithy-Java client for service [{}]...", settings.service());
+        LOGGER.info("Generating Smithy-Java server for service [{}]...", settings.service());
         runner.settings(settings);
         runner.directedCodegen(new DirectedJavaServerCodegen());
         runner.fileManifest(context.getFileManifest());

--- a/server/server-core/build.gradle.kts
+++ b/server/server-core/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     api(project(":http:http-api"))
     api(project(":core"))
     api(project(":context"))
-    api(project(":framework-errors"))
     implementation(libs.smithy.model)
     implementation(project(":io"))
     implementation(project(":logging"))

--- a/server/server-proxy/build.gradle.kts
+++ b/server/server-proxy/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     api(project(":http:http-api"))
     api(project(":core"))
     api(project(":context"))
-    api(project(":framework-errors"))
     api(project(":client:dynamic-client"))
     implementation(libs.smithy.model)
     implementation(project(":io"))


### PR DESCRIPTION
Small changes to documentation and dependencies:
* Remove redundant declaration on `framework-errors` package for config files that declare an `api` dependency on `server-api` (which already exports the `framework-errors` package) 
* Update README to use correct java codegen plugin dependency. [software.amazon.smithy.java.codegen:plugins](https://mvnrepository.com/artifact/software.amazon.smithy.java.codegen/plugins) is outdated compared to [software.amazon.smithy.java:plugins](https://mvnrepository.com/artifact/software.amazon.smithy.java/plugins)
* Fix copy paste documentation error
