### PR TITLE
Fix ResourceGenerator to handle resources with more than 10 properties

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ResourceGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ResourceGenerator.java
@@ -153,9 +153,9 @@ public final class ResourceGenerator
             writer.putContext("props", properties);
             writer.write(
                     """
-                            private static final ${map:T}<${string:T}, ${sdkSchema:T}> $$IDENTIFIERS = ${map:T}.of(${#ids}${key:S}, ${value:L}${^key.last},
+                            private static final ${map:T}<${string:T}, ${sdkSchema:T}> $$IDENTIFIERS = ${map:T}.ofEntries(${#ids}Map.entry(${key:S}, ${value:L})${^key.last},
                                 ${/key.last}${/ids});
-                            private static final ${map:T}<${string:T}, ${sdkSchema:T}> $$PROPERTIES = ${map:T}.of(${#props}${key:S}, ${value:L}${^key.last},
+                            private static final ${map:T}<${string:T}, ${sdkSchema:T}> $$PROPERTIES = ${map:T}.ofEntries(${#props}Map.entry(${key:S}, ${value:L})${^key.last},
                                 ${/key.last}${/props});
                             """);
             writer.popState();


### PR DESCRIPTION
Java's Map.of(...) only supports overloads up to 10 key-value pairs. Since resources can have more than 10 properties the Map.ofEntries(...) factory method must be used in instead to prevent compilation errors.

 ### Compilation error:
 ```
 method Map.<K#1,V#1>of() is not applicable
        (cannot infer type-variable(s) K#1,V#1
          (actual and formal argument lists differ in length))
      method Map.<K#2,V#2>of(K#2,V#2) is not applicable
        (cannot infer type-variable(s) K#2,V#2
          (actual and formal argument lists differ in length))
      method Map.<K#3,V#3>of(K#3,V#3,K#3,V#3) is not applicable
        (cannot infer type-variable(s) K#3,V#3
          (actual and formal argument lists differ in length))
      method Map.<K#4,V#4>of(K#4,V#4,K#4,V#4,K#4,V#4) is not applicable
        (cannot infer type-variable(s) K#4,V#4
          (actual and formal argument lists differ in length))
      method Map.<K#5,V#5>of(K#5,V#5,K#5,V#5,K#5,V#5,K#5,V#5) is not applicable
        (cannot infer type-variable(s) K#5,V#5
          (actual and formal argument lists differ in length))
      method Map.<K#6,V#6>of(K#6,V#6,K#6,V#6,K#6,V#6,K#6,V#6,K#6,V#6) is not applicable
        (cannot infer type-variable(s) K#6,V#6
          (actual and formal argument lists differ in length))
      method Map.<K#7,V#7>of(K#7,V#7,K#7,V#7,K#7,V#7,K#7,V#7,K#7,V#7,K#7,V#7) is not applicable
        (cannot infer type-variable(s) K#7,V#7
          (actual and formal argument lists differ in length))
      method Map.<K#8,V#8>of(K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8) is not applicable
        (cannot infer type-variable(s) K#8,V#8
          (actual and formal argument lists differ in length))
      method Map.<K#9,V#9>of(K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9) is not applicable
        (cannot infer type-variable(s) K#9,V#9
          (actual and formal argument lists differ in length))
      method Map.<K#10,V#10>of(K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10) is not applicable
        (cannot infer type-variable(s) K#10,V#10
          (actual and formal argument lists differ in length))
      method Map.<K#11,V#11>of(K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11) is not applicable
        (cannot infer type-variable(s) K#11,V#11
          (actual and formal argument lists differ in length))
    where K#1,V#1,K#2,V#2,K#3,V#3,K#4,V#4,K#5,V#5,K#6,V#6,K#7,V#7,K#8,V#8,K#9,V#9,K#10,V#10,K#11,V#11 are type-variables:
      K#1 extends Object declared in method <K#1,V#1>of()
      V#1 extends Object declared in method <K#1,V#1>of()
      K#2 extends Object declared in method <K#2,V#2>of(K#2,V#2)
      V#2 extends Object declared in method <K#2,V#2>of(K#2,V#2)
      K#3 extends Object declared in method <K#3,V#3>of(K#3,V#3,K#3,V#3)
      V#3 extends Object declared in method <K#3,V#3>of(K#3,V#3,K#3,V#3)
      K#4 extends Object declared in method <K#4,V#4>of(K#4,V#4,K#4,V#4,K#4,V#4)
      V#4 extends Object declared in method <K#4,V#4>of(K#4,V#4,K#4,V#4,K#4,V#4)
      K#5 extends Object declared in method <K#5,V#5>of(K#5,V#5,K#5,V#5,K#5,V#5,K#5,V#5)
      V#5 extends Object declared in method <K#5,V#5>of(K#5,V#5,K#5,V#5,K#5,V#5,K#5,V#5)
      K#6 extends Object declared in method <K#6,V#6>of(K#6,V#6,K#6,V#6,K#6,V#6,K#6,V#6,K#6,V#6)
      V#6 extends Object declared in method <K#6,V#6>of(K#6,V#6,K#6,V#6,K#6,V#6,K#6,V#6,K#6,V#6)
      K#7 extends Object declared in method <K#7,V#7>of(K#7,V#7,K#7,V#7,K#7,V#7,K#7,V#7,K#7,V#7,K#7,V#7)
      V#7 extends Object declared in method <K#7,V#7>of(K#7,V#7,K#7,V#7,K#7,V#7,K#7,V#7,K#7,V#7,K#7,V#7)
      K#8 extends Object declared in method <K#8,V#8>of(K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8)
      V#8 extends Object declared in method <K#8,V#8>of(K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8,K#8,V#8)
      K#9 extends Object declared in method <K#9,V#9>of(K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9)
      V#9 extends Object declared in method <K#9,V#9>of(K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9,K#9,V#9)
      K#10 extends Object declared in method <K#10,V#10>of(K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10)
      V#10 extends Object declared in method <K#10,V#10>of(K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10,K#10,V#10)
      K#11 extends Object declared in method <K#11,V#11>of(K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11)
      V#11 extends Object declared in method <K#11,V#11>of(K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11,K#11,V#11)
```