### PR TITLE
Add create command and have a concept of local bundles

### DIFF
--- a/aws/aws-mcp-cli-commands/build.gradle.kts
+++ b/aws/aws-mcp-cli-commands/build.gradle.kts
@@ -24,3 +24,7 @@ dependencies {
 tasks.compileJava {
     options.compilerArgs.add("-Aproject=${project.name}")
 }
+
+tasks.withType<JavaCompile> {
+    options.release.set(21)
+}

--- a/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/AddAwsServiceBundle.java
+++ b/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/AddAwsServiceBundle.java
@@ -17,7 +17,7 @@ import software.amazon.smithy.mcp.bundle.api.model.Bundle;
 import software.amazon.smithy.mcp.bundle.api.model.BundleMetadata;
 import software.amazon.smithy.mcp.bundle.api.model.SmithyMcpBundle;
 
-@Command(name = "add-aws-bundle")
+@Command(name = "add-aws-bundle", hidden = true, description = "Deprecated!. Use the create command.")
 public class AddAwsServiceBundle extends AbstractAddBundle {
 
     @Option(names = "--overwrite",

--- a/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/AddAwsServiceBundle.java
+++ b/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/AddAwsServiceBundle.java
@@ -35,7 +35,7 @@ public class AddAwsServiceBundle extends AbstractAddBundle {
     protected Set<String> blockedApis;
 
     @Option(names = "--read-only-apis",
-            description = "Include read only APIs in the MCP server")
+            description = "Include only read-only APIs in the MCP server")
     protected Boolean readOnlyApis;
 
     @Override

--- a/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/CreateAwsServiceBundle.java
+++ b/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/CreateAwsServiceBundle.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.mcp.cli.commands;
+
+import static picocli.CommandLine.ArgGroup;
+import static picocli.CommandLine.Parameters;
+
+import java.util.Set;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import software.amazon.smithy.java.aws.servicebundle.bundler.AwsServiceBundler;
+import software.amazon.smithy.java.mcp.cli.AbstractCreateBundle;
+import software.amazon.smithy.mcp.bundle.api.model.Bundle;
+import software.amazon.smithy.mcp.bundle.api.model.BundleMetadata;
+import software.amazon.smithy.mcp.bundle.api.model.SmithyMcpBundle;
+
+@Command(name = "aws-service-mcp", description = "Create an MCP for an AWS service.")
+public class CreateAwsServiceBundle extends AbstractCreateBundle<CreateAwsServiceBundle.CreateAwsServiceBundleInput> {
+
+    @ArgGroup(multiplicity = "1")
+    Input input;
+
+    @Override
+    protected CreateAwsServiceBundleInput getInput() {
+        return input.cliInput;
+    }
+
+    @Override
+    protected Bundle getNewBundle(CreateAwsServiceBundleInput input) {
+        var bundleBuilder = AwsServiceBundler.builder()
+                .serviceName(input.awsServiceName);
+        if (input.allowedApis != null) {
+            // User explicitly specified allowed APIs
+            bundleBuilder.exposedOperations(input.allowedApis);
+            // If readOnlyApis is also requested, include those as well
+            if (Boolean.TRUE.equals(input.readOnlyApis)) {
+                bundleBuilder.readOnlyOperations();
+            }
+        } else if (!Boolean.FALSE.equals(input.readOnlyApis)) {
+            //If nothing is specified then default to only readOnlyOperations.
+            bundleBuilder.readOnlyOperations();
+        } else {
+            throw new IllegalArgumentException("You have turned off readOnlyApis and also not specified any " +
+                    "allowedApis so there are no operations to create a bundle for.");
+        }
+
+        if (input.blockedApis != null) {
+            // Always apply blocked operations if specified
+            bundleBuilder.blockedOperations(input.blockedApis);
+        }
+        return Bundle.builder()
+                .smithyBundle(SmithyMcpBundle.builder()
+                        .bundle(bundleBuilder.build().bundle())
+                        .metadata(BundleMetadata.builder()
+                                .name(input.name)
+                                .description(input.description)
+                                .build())
+                        .build())
+                .build();
+    }
+
+    public static class Input {
+        @ArgGroup(exclusive = false)
+        CreateAwsServiceBundleInput cliInput;
+
+        @ArgGroup(multiplicity = "1")
+        JsonInput jsonInput;
+
+    }
+
+    public static class CreateAwsServiceBundleInput extends CreateBundleInput {
+        @Parameters(description = "Name of aws service to create the bundle for.")
+        String awsServiceName;
+
+        @Option(names = {"-a", "--allowed-apis"}, description = "List of APIs to expose in the MCP server")
+        protected Set<String> allowedApis;
+
+        @Option(names = {"-b", "--blocked-apis"}, description = "List of APIs to hide in the MCP server")
+        protected Set<String> blockedApis;
+
+        @Option(names = "--read-only-apis",
+                description = "Include read only APIs in the MCP server")
+        protected Boolean readOnlyApis;
+    }
+}

--- a/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/CreateAwsServiceBundle.java
+++ b/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/CreateAwsServiceBundle.java
@@ -73,7 +73,7 @@ public class CreateAwsServiceBundle extends AbstractCreateBundle<CreateAwsServic
     }
 
     public static class CreateAwsServiceBundleInput extends CreateBundleInput {
-        @Parameters(description = "Name of aws service to create the bundle for.")
+        @Parameters(description = "Name of AWS service to create the bundle for")
         String awsServiceName;
 
         @Option(names = {"-a", "--allowed-apis"}, description = "List of APIs to expose in the MCP server")
@@ -83,7 +83,7 @@ public class CreateAwsServiceBundle extends AbstractCreateBundle<CreateAwsServic
         protected Set<String> blockedApis;
 
         @Option(names = "--read-only-apis",
-                description = "Include read only APIs in the MCP server")
+                description = "Include only read-only APIs in the MCP server")
         protected Boolean readOnlyApis;
     }
 }

--- a/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/CreateAwsServiceBundle.java
+++ b/aws/aws-mcp-cli-commands/src/main/java/software/amazon/smithy/java/aws/mcp/cli/commands/CreateAwsServiceBundle.java
@@ -55,6 +55,7 @@ public class CreateAwsServiceBundle extends AbstractCreateBundle<CreateAwsServic
                 .smithyBundle(SmithyMcpBundle.builder()
                         .bundle(bundleBuilder.build().bundle())
                         .metadata(BundleMetadata.builder()
+                                .id(input.id)
                                 .name(input.name)
                                 .description(input.description)
                                 .build())

--- a/aws/aws-mcp-cli-commands/src/main/resources/META-INF/services/software.amazon.smithy.java.mcp.cli.AbstractCreateBundle
+++ b/aws/aws-mcp-cli-commands/src/main/resources/META-INF/services/software.amazon.smithy.java.mcp.cli.AbstractCreateBundle
@@ -1,0 +1,1 @@
+software.amazon.smithy.java.aws.mcp.cli.commands.CreateAwsServiceBundle

--- a/mcp/mcp-bundle-api/src/main/java/software/amazon/smithy/mcp/bundle/api/ModifiableRegistry.java
+++ b/mcp/mcp-bundle-api/src/main/java/software/amazon/smithy/mcp/bundle/api/ModifiableRegistry.java
@@ -7,6 +7,6 @@ package software.amazon.smithy.mcp.bundle.api;
 
 import software.amazon.smithy.mcp.bundle.api.model.Bundle;
 
-public interface ModifiableRegistry extends Registry {
-    void publishBundle(Bundle bundle);
+public interface ModifiableRegistry<T> extends Registry {
+    void publishBundle(Bundle bundle, T args);
 }

--- a/mcp/mcp-bundle-api/src/main/resources/META-INF/smithy/mcpbundle.smithy
+++ b/mcp/mcp-bundle-api/src/main/resources/META-INF/smithy/mcpbundle.smithy
@@ -19,6 +19,9 @@ structure CommonBundleConfig {
 }
 
 structure BundleMetadata {
+    // Do not mark required for backward compatibility.
+    id: String
+
     @required
     name: String
 

--- a/mcp/mcp-cli-api/build.gradle.kts
+++ b/mcp/mcp-cli-api/build.gradle.kts
@@ -51,6 +51,10 @@ tasks.named("compileJava") {
     dependsOn("smithyBuild")
 }
 
+tasks.withType<JavaCompile> {
+    options.release.set(21)
+}
+
 // Needed because sources-jar needs to run after smithy-build is done
 tasks.sourcesJar {
     mustRunAfter(tasks.compileJava)

--- a/mcp/mcp-cli-api/model/main.smithy
+++ b/mcp/mcp-cli-api/model/main.smithy
@@ -2,6 +2,8 @@ $version: "2"
 
 namespace smithy.mcp.cli
 
+use software.amazon.smithy.mcp.bundle.api#BundleMetadata
+
 structure Config {
     toolBundles: McpBundleConfigs
 
@@ -36,8 +38,8 @@ structure CommonToolConfig {
 
     @default(false)
     local: PrimitiveBoolean
-
-    description: String
+    
+    metadata: BundleMetadata
 }
 
 map Registries {

--- a/mcp/mcp-cli-api/model/main.smithy
+++ b/mcp/mcp-cli-api/model/main.smithy
@@ -33,6 +33,11 @@ structure CommonToolConfig {
 
     @required
     bundleLocation: Location
+
+    @default(false)
+    local: PrimitiveBoolean
+
+    description: String
 }
 
 map Registries {

--- a/mcp/mcp-cli-api/model/main.smithy
+++ b/mcp/mcp-cli-api/model/main.smithy
@@ -38,7 +38,7 @@ structure CommonToolConfig {
 
     @default(false)
     local: PrimitiveBoolean
-    
+
     metadata: BundleMetadata
 }
 

--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/AbstractCreateBundle.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/AbstractCreateBundle.java
@@ -18,11 +18,15 @@ public abstract class AbstractCreateBundle<T extends AbstractCreateBundle.Create
                 defaultValue = "false")
         boolean overwrite;
 
-        @Option(names = {"-n", "--name"}, description = "Name to assign to the MCP server. Eg: (aws-dynamodb-mcp)",
+        @Option(names = {"--id"},
+                description = "Id to assign to the MCP server. This id needs to end in mcp. Eg: (aws-dynamodb-mcp)",
                 required = true)
+        public String id;
+
+        @Option(names = {"--name"}, description = "Name for this MCP server. Eg: (Pipelines MCP Server)")
         public String name;
 
-        @Option(names = {"-d", "--description"}, description = "Description of this mcp server", required = true)
+        @Option(names = {"-d", "--description"}, description = "Description of this mcp server.", required = true)
         public String description;
 
         @ArgGroup
@@ -42,15 +46,22 @@ public abstract class AbstractCreateBundle<T extends AbstractCreateBundle.Create
     protected void execute(ExecutionContext context) throws Exception {
         var input = getInput();
         var config = context.config();
-        if (!input.overwrite && config.getToolBundles().containsKey(input.name)) {
-            throw new IllegalArgumentException("Tool bundle " + input.name
+        if (!input.overwrite && config.getToolBundles().containsKey(input.id)) {
+            throw new IllegalArgumentException("Tool bundle " + input.id
                     + " already exists. Either choose a new name or pass --overwrite to overwrite the existing tool bundle");
         }
 
+        if (input.name == null) {
+            input.name = input.id;
+        }
+        if (input.description == null) {
+            input.description = "[" + input.id + "]" + " MCP Server";
+        }
+
         var bundle = getNewBundle(input);
-        ConfigUtils.addMcpBundle(config, input.name, bundle, true);
-        ConfigUtils.createWrapperAndUpdateClientConfigs(input.name, bundle, config, input.clientsInput);
-        System.out.println("Successfully created bundle " + input.name);
+        ConfigUtils.addMcpBundle(config, input.id, bundle, true);
+        ConfigUtils.createWrapperAndUpdateClientConfigs(input.id, bundle, config, input.clientsInput);
+        System.out.println("Successfully created bundle " + input.id);
     }
 
     protected abstract T getInput();

--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/AbstractCreateBundle.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/AbstractCreateBundle.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.mcp.cli;
+
+import static picocli.CommandLine.Option;
+
+import picocli.CommandLine.ArgGroup;
+import software.amazon.smithy.mcp.bundle.api.model.Bundle;
+
+public abstract class AbstractCreateBundle<T extends AbstractCreateBundle.CreateBundleInput> extends SmithyMcpCommand {
+
+    public abstract static class CreateBundleInput {
+        @Option(names = "--overwrite",
+                description = "Overwrite existing MCP server.",
+                defaultValue = "false")
+        boolean overwrite;
+
+        @Option(names = {"-n", "--name"}, description = "Name to assign to the MCP server. Eg: (aws-dynamodb-mcp)",
+                required = true)
+        public String name;
+
+        @Option(names = {"-d", "--description"}, description = "Description of this mcp server", required = true)
+        public String description;
+
+        @ArgGroup
+        ClientsInput clientsInput;
+    }
+
+    public static class JsonInput {
+        @Option(names = {"--input"}, description = "Provide the input in json format.", required = true)
+        String inputJson;
+
+        @Option(names = {"--input-file"}, description = "Provide path to a file which contains input in json format.",
+                required = true)
+        String inputJsonFile;
+    }
+
+    @Override
+    protected void execute(ExecutionContext context) throws Exception {
+        var input = getInput();
+        var config = context.config();
+        if (!input.overwrite && config.getToolBundles().containsKey(input.name)) {
+            throw new IllegalArgumentException("Tool bundle " + input.name
+                    + " already exists. Either choose a new name or pass --overwrite to overwrite the existing tool bundle");
+        }
+
+        var bundle = getNewBundle(input);
+        ConfigUtils.addMcpBundle(config, input.name, bundle, true);
+        ConfigUtils.createWrapperAndUpdateClientConfigs(input.name, bundle, config, input.clientsInput);
+        System.out.println("Successfully created bundle " + input.name);
+    }
+
+    protected abstract T getInput();
+
+    protected abstract Bundle getNewBundle(T input);
+}

--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/AbstractCreateBundle.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/AbstractCreateBundle.java
@@ -26,7 +26,7 @@ public abstract class AbstractCreateBundle<T extends AbstractCreateBundle.Create
         @Option(names = {"--name"}, description = "Name for this MCP server. Eg: (Pipelines MCP Server)")
         public String name;
 
-        @Option(names = {"-d", "--description"}, description = "Description of this mcp server.", required = true)
+        @Option(names = {"-d", "--description"}, description = "Description of this mcp server.")
         public String description;
 
         @ArgGroup
@@ -61,7 +61,7 @@ public abstract class AbstractCreateBundle<T extends AbstractCreateBundle.Create
         var bundle = getNewBundle(input);
         ConfigUtils.addMcpBundle(config, input.id, bundle, true);
         ConfigUtils.createWrapperAndUpdateClientConfigs(input.id, bundle, config, input.clientsInput);
-        System.out.println("Successfully created bundle " + input.id);
+        System.out.println("Successfully created mcp server " + input.id);
     }
 
     protected abstract T getInput();

--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ClientsInput.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ClientsInput.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.mcp.cli;
+
+import java.util.Set;
+import picocli.CommandLine.Option;
+
+public final class ClientsInput {
+    @Option(names = {"--clients"},
+            description = "Names of client configs to update. If not specified all client configs registered would be updated")
+    public Set<String> clients = Set.of();
+
+    @Option(names = "--print-client-config",
+            description = "If specified will not edit the client configs and only print to console.")
+    public Boolean print;
+}

--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ClientsInput.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ClientsInput.java
@@ -15,5 +15,5 @@ public final class ClientsInput {
 
     @Option(names = "--print-client-config",
             description = "If specified will not edit the client configs and only print to console.")
-    public Boolean print;
+    public boolean print = false;
 }

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/Configure.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/Configure.java
@@ -14,7 +14,6 @@ import picocli.CommandLine.Command;
  * the MCP CLI, such as adding tool bundles.
  */
 @Command(name = "configure", description = "Configure the Smithy MCP CLI", subcommands = {
-        AddSmithyBundle.class,
         ClientConfigCommand.class
 })
 public final class Configure {

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/CreateBundle.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/CreateBundle.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.mcp.cli.commands;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "create", description = "Create a MCP Bundle.")
+public final class CreateBundle {}

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/CreateGenericBundle.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/CreateGenericBundle.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.mcp.cli.commands;
+
+import static picocli.CommandLine.ArgGroup;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import software.amazon.smithy.java.mcp.cli.AbstractCreateBundle;
+import software.amazon.smithy.mcp.bundle.api.model.Bundle;
+import software.amazon.smithy.mcp.bundle.api.model.BundleMetadata;
+import software.amazon.smithy.mcp.bundle.api.model.ExecSpec;
+import software.amazon.smithy.mcp.bundle.api.model.GenericArtifact;
+import software.amazon.smithy.mcp.bundle.api.model.GenericBundle;
+
+@Command(name = "generic-mcp", description = "Create a generic MCP server with custom executable commands.")
+public class CreateGenericBundle extends AbstractCreateBundle<CreateGenericBundle.CreateGenericBundleInput> {
+
+    @ArgGroup(multiplicity = "1")
+    Input input;
+
+    @Override
+    protected CreateGenericBundleInput getInput() {
+        return input.cliInput;
+    }
+
+    @Override
+    protected Bundle getNewBundle(CreateGenericBundleInput input) {
+        var genericBundleBuilder = GenericBundle.builder()
+                .metadata(BundleMetadata.builder()
+                        .name(input.name)
+                        .description(input.description)
+                        .build())
+                .artifact(new GenericArtifact.EmptyMember())
+                .executeDirectly(true);
+
+        // Parse and add install commands
+        if (input.installCommands != null && !input.installCommands.isEmpty()) {
+            List<ExecSpec> installSpecs = new ArrayList<>();
+            for (String installCommand : input.installCommands) {
+                installSpecs.add(parseExecSpec(installCommand));
+            }
+            genericBundleBuilder.install(installSpecs);
+        }
+
+        // Parse and add run command
+        if (input.runCommand != null) {
+            genericBundleBuilder.run(parseExecSpec(input.runCommand));
+        }
+
+        return Bundle.builder()
+                .genericBundle(genericBundleBuilder.build())
+                .build();
+    }
+
+    private ExecSpec parseExecSpec(String command) {
+        String[] parts = command.trim().split("\\s+");
+        if (parts.length == 0) {
+            throw new IllegalArgumentException("Empty command provided");
+        }
+
+        String executable = parts[0];
+        List<String> args = new ArrayList<>();
+        if (parts.length > 1) {
+            args.addAll(Arrays.asList(Arrays.copyOfRange(parts, 1, parts.length)));
+        }
+
+        return ExecSpec.builder()
+                .executable(executable)
+                .args(args.isEmpty() ? null : args)
+                .build();
+    }
+
+    public static class Input {
+        @ArgGroup(exclusive = false)
+        CreateGenericBundleInput cliInput;
+
+        @ArgGroup(multiplicity = "1")
+        JsonInput jsonInput;
+    }
+
+    public static class CreateGenericBundleInput extends CreateBundleInput {
+        @Option(names = {"-i", "--install"},
+                arity = "1..*",
+                description = "Install commands to run during setup. " +
+                        "Example: --install 'npm install' 'pip install -r requirements.txt'")
+        protected List<String> installCommands;
+
+        @Option(names = {"-r", "--run"},
+                description = "The main command to run the MCP server. " +
+                        "Example: --run 'node server.js' or --run 'python main.py'",
+                required = true)
+        protected String runCommand;
+    }
+}

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/InstallBundle.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/InstallBundle.java
@@ -9,7 +9,7 @@ import static picocli.CommandLine.Command;
 
 import java.io.IOException;
 import java.util.Set;
-import picocli.CommandLine.Mixin;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import software.amazon.smithy.java.mcp.cli.ClientsInput;
@@ -28,7 +28,7 @@ public class InstallBundle extends SmithyMcpCommand {
     @Parameters(description = "Names of the MCP bundles to install.")
     Set<String> names;
 
-    @Mixin
+    @ArgGroup
     ClientsInput clientsInput;
 
     @Override

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/InstallBundle.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/InstallBundle.java
@@ -8,16 +8,15 @@ package software.amazon.smithy.java.mcp.cli.commands;
 import static picocli.CommandLine.Command;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Set;
+import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import software.amazon.smithy.java.mcp.cli.ClientsInput;
 import software.amazon.smithy.java.mcp.cli.ConfigUtils;
 import software.amazon.smithy.java.mcp.cli.ExecutionContext;
 import software.amazon.smithy.java.mcp.cli.SmithyMcpCommand;
 import software.amazon.smithy.java.mcp.cli.model.Config;
-import software.amazon.smithy.java.mcp.cli.model.McpServerConfig;
-import software.amazon.smithy.mcp.bundle.api.model.GenericBundle;
 
 @Command(name = "install", description = "Downloads and adds a bundle from the MCP registry.")
 public class InstallBundle extends SmithyMcpCommand {
@@ -29,13 +28,8 @@ public class InstallBundle extends SmithyMcpCommand {
     @Parameters(description = "Names of the MCP bundles to install.")
     Set<String> names;
 
-    @Option(names = {"--clients"},
-            description = "Names of client configs to update. If not specified all client configs registered would be updated")
-    Set<String> clients = Set.of();
-
-    @Option(names = "--print-only",
-            description = "If specified will not edit the client configs and only print to console.")
-    Boolean print;
+    @Mixin
+    ClientsInput clientsInput;
 
     @Override
     protected void execute(ExecutionContext context) throws IOException {
@@ -44,38 +38,8 @@ public class InstallBundle extends SmithyMcpCommand {
         for (var name : names) {
             var bundle = registry.getMcpBundle(name);
             ConfigUtils.addMcpBundle(config, name, bundle);
-
-            var command = name;
-            List<String> args = null;
-            boolean shouldCreateWrapper = true;
-
-            if (bundle.getValue() instanceof GenericBundle genericBundle && genericBundle.isExecuteDirectly()) {
-                command = genericBundle.getRun().getExecutable();
-                args = genericBundle.getRun().getArgs();
-                shouldCreateWrapper = false;
-            }
-
-            if (shouldCreateWrapper) {
-                ConfigUtils.createWrapperScript(name);
-                ConfigUtils.ensureMcpServersDirInPath();
-            }
-
-            var newClientConfig = McpServerConfig.builder()
-                    .command(command)
-                    .args(args)
-                    .build();
-            if (print == null) {
-                //By default, print the output if there are no configured client configs.
-                print = !config.hasClientConfigs();
-            }
-            ConfigUtils.addToClientConfigs(config, name, clients, newClientConfig);
-
+            ConfigUtils.createWrapperAndUpdateClientConfigs(name, bundle, config, clientsInput);
             System.out.println("Successfully installed " + name);
-
-            if (print) {
-                System.out.println("You can add the following to your MCP Servers config to use " + name);
-                System.out.println(newClientConfig);
-            }
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

  - Add create command infrastructure with pluggable bundle creation support
  - Implement local bundle concept to distinguish between registry and locally created bundles
  - Add AWS service bundle creation via create aws-service-mcp subcommand
  - Add generic MCP bundle creation via create generic-mcp subcommand


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
