### PR TITLE
Fix missing new line in the generated code

### DIFF
--- a/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
+++ b/codegen/plugins/client-codegen/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientImplementationGenerator.java
@@ -108,8 +108,8 @@ public final class ClientImplementationGenerator
             var template =
                     """
                             @Override
-                            public ${?async}${future:T}<${/async}${output:T}${?async}>${/async} ${name:L}(${input:T} input, ${overrideConfig:T} overrideConfig) {${^async}
-                                try {
+                            public ${?async}${future:T}<${/async}${output:T}${?async}>${/async} ${name:L}(${input:T} input, ${overrideConfig:T} overrideConfig) {
+                                ${^async}try {
                                     ${/async}return call(input, ${operation:T}.instance(), overrideConfig)${^async}.join()${/async};${^async}
                                 } catch (${completionException:T} e) {
                                     throw unwrapAndThrow(e);


### PR DESCRIPTION
### Notes

Fixes a missing new line in the async client implementation, currently for DDB

```

    @Override
    public CompletableFuture<BatchExecuteStatementOutput> batchExecuteStatement(BatchExecuteStatementInput input, RequestOverrideConfig overrideConfig) {return call(input, BatchExecuteStatement.instance(), overrideConfig);
    }

```

to 

```

    @Override
    public CompletableFuture<BatchExecuteStatementOutput> batchExecuteStatement(BatchExecuteStatementInput input, RequestOverrideConfig overrideConfig) {
        return call(input, BatchExecuteStatement.instance(), overrideConfig);
    }
```
