### PR TITLE
Add missing Id in GenericBundle metadata

### DIFF
--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/CreateGenericBundle.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/CreateGenericBundle.java
@@ -34,6 +34,7 @@ public class CreateGenericBundle extends AbstractCreateBundle<CreateGenericBundl
     protected Bundle getNewBundle(CreateGenericBundleInput input) {
         var genericBundleBuilder = GenericBundle.builder()
                 .metadata(BundleMetadata.builder()
+                        .id(input.id)
                         .name(input.name)
                         .description(input.description)
                         .build())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
BundleMetadata doesn't include Id in the config stored. Without this id, we will get NullPointerException when trying to publish the bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
