### PR TITLE
Add validation to generic mcp creation and installation to avoid creating a self-referencing executable

### DIFF
--- a/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ConfigUtils.java
+++ b/mcp/mcp-cli-api/src/main/java/software/amazon/smithy/java/mcp/cli/ConfigUtils.java
@@ -312,6 +312,7 @@ public class ConfigUtils {
                     .build());
             case genericBundle -> {
                 GenericBundle genericBundle = bundle.getValue();
+                validate(genericBundle);
                 install(genericBundle.getInstall());
                 builder.genericConfig(
                         GenericToolBundleConfig.builder()
@@ -328,6 +329,15 @@ public class ConfigUtils {
         writeMcpBundle(id, bundle);
         addMcpBundleConfig(config, id, mcpBundleConfig);
         return mcpBundleConfig;
+    }
+
+    private static void validate(GenericBundle genericBundle) {
+        if (!genericBundle.isExecuteDirectly() &&
+                genericBundle.getRun().getExecutable().equals(genericBundle.getMetadata().getId())) {
+            throw new IllegalStateException(
+                    "The generic MCP run command has the same value as id which isn't allowed.");
+        }
+
     }
 
     private static void install(List<ExecSpec> execSpecs) {
@@ -511,7 +521,7 @@ public class ConfigUtils {
         boolean shouldCreateWrapper = true;
         List<String> args = List.of();
         String command = id;
-        if (bundle.getValue() instanceof GenericBundle genericBundle) {
+        if (bundle.getValue() instanceof GenericBundle genericBundle && genericBundle.isExecuteDirectly()) {
             command = genericBundle.getRun().getExecutable();
             args = genericBundle.getRun().getArgs();
             shouldCreateWrapper = false;

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/CreateGenericBundle.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/CreateGenericBundle.java
@@ -39,7 +39,7 @@ public class CreateGenericBundle extends AbstractCreateBundle<CreateGenericBundl
                         .description(input.description)
                         .build())
                 .artifact(new GenericArtifact.EmptyMember())
-                .executeDirectly(true);
+                .executeDirectly(input.executeDirectly);
 
         // Parse and add install commands
         if (input.installCommands != null && !input.installCommands.isEmpty()) {
@@ -52,6 +52,10 @@ public class CreateGenericBundle extends AbstractCreateBundle<CreateGenericBundl
 
         // Parse and add run command
         if (input.runCommand != null) {
+            if (!input.executeDirectly && input.runCommand.equals(input.id)) {
+                throw new IllegalArgumentException("Run command cannot be the same as the id for MCPs that are not " +
+                        "executed directly");
+            }
             genericBundleBuilder.run(parseExecSpec(input.runCommand));
         }
 
@@ -98,5 +102,8 @@ public class CreateGenericBundle extends AbstractCreateBundle<CreateGenericBundl
                         "Example: --run 'node server.js' or --run 'python main.py'",
                 required = true)
         protected String runCommand;
+
+        @Option(names = "--execute-directly", description = "Whether to execute the MCP server directly or via the CLI")
+        protected boolean executeDirectly = true; //TODO make this false once our MCP proxy is fully fleshed out.
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Re-adding back the change reverted in #822 but now we have additional checks in place avoid creating fork bombs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
