### PR TITLE
Add support for search tools and dynamic tool loading

### DIFF
--- a/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/BundleMCPServerExample.java
+++ b/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/BundleMCPServerExample.java
@@ -14,7 +14,7 @@ public final class BundleMCPServerExample {
             var mcpServer = McpServer.builder()
                 .stdio()
                 .name("smithy-mcp-server")
-                .addService(McpBundles.getService(bundle.getValue()))
+                .addService("dynamodb-mcp", McpBundles.getService(bundle.getValue()))
                 .build();
 
             mcpServer.start();

--- a/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/MCPServerExample.java
+++ b/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/MCPServerExample.java
@@ -16,7 +16,7 @@ public class MCPServerExample {
         var mcpServer = McpServer.builder()
                 .stdio()
                 .name("smithy-mcp-server")
-                .addService(service)
+                .addService("employee-mcp", service)
                 .build();
 
         mcpServer.start();

--- a/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/ProxyMCPExample.java
+++ b/examples/mcp-server/src/main/java/software/amazon/smithy/java/example/server/mcp/ProxyMCPExample.java
@@ -41,7 +41,7 @@ public class ProxyMCPExample {
         var mcpServer = McpServer.builder()
                 .stdio()
                 .name("smithy-mcp-server")
-                .addService(mcpService)
+                .addService("employee-mcp", mcpService)
                 .build();
         mcpServer.start();
 

--- a/mcp/mcp-bundle-api/src/main/java/software/amazon/smithy/mcp/bundle/api/RegistryTool.java
+++ b/mcp/mcp-bundle-api/src/main/java/software/amazon/smithy/mcp/bundle/api/RegistryTool.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.mcp.bundle.api;
+
+public record RegistryTool(String serverId, String toolName) {}

--- a/mcp/mcp-bundle-api/src/main/java/software/amazon/smithy/mcp/bundle/api/SearchableRegistry.java
+++ b/mcp/mcp-bundle-api/src/main/java/software/amazon/smithy/mcp/bundle/api/SearchableRegistry.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.mcp.bundle.api;
+
+import java.util.List;
+
+public interface SearchableRegistry extends Registry {
+
+    List<RegistryTool> searchTools(String query, int numberOfTools);
+}

--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/StartServer.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/commands/StartServer.java
@@ -7,11 +7,14 @@ package software.amazon.smithy.java.mcp.cli.commands;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -24,22 +27,25 @@ import software.amazon.smithy.java.mcp.cli.model.Config;
 import software.amazon.smithy.java.mcp.cli.model.GenericToolBundleConfig;
 import software.amazon.smithy.java.mcp.cli.model.McpBundleConfig;
 import software.amazon.smithy.java.mcp.cli.model.SmithyModeledBundleConfig;
-import software.amazon.smithy.java.mcp.registry.model.InstallServerInput;
-import software.amazon.smithy.java.mcp.registry.model.InstallServerOutput;
-import software.amazon.smithy.java.mcp.registry.model.ListServersInput;
-import software.amazon.smithy.java.mcp.registry.model.ListServersOutput;
-import software.amazon.smithy.java.mcp.registry.model.ServerEntry;
-import software.amazon.smithy.java.mcp.registry.service.InstallServerOperation;
-import software.amazon.smithy.java.mcp.registry.service.ListServersOperation;
+import software.amazon.smithy.java.mcp.registry.model.InstallToolInput;
+import software.amazon.smithy.java.mcp.registry.model.InstallToolOutput;
+import software.amazon.smithy.java.mcp.registry.model.SearchToolsInput;
+import software.amazon.smithy.java.mcp.registry.model.SearchToolsOutput;
+import software.amazon.smithy.java.mcp.registry.model.Tool;
+import software.amazon.smithy.java.mcp.registry.service.InstallToolOperation;
 import software.amazon.smithy.java.mcp.registry.service.McpRegistry;
+import software.amazon.smithy.java.mcp.registry.service.SearchToolsOperation;
 import software.amazon.smithy.java.mcp.server.McpServer;
+import software.amazon.smithy.java.mcp.server.StdioProxy;
+import software.amazon.smithy.java.mcp.server.ToolFilter;
 import software.amazon.smithy.java.server.FilteredService;
 import software.amazon.smithy.java.server.OperationFilters;
 import software.amazon.smithy.java.server.RequestContext;
 import software.amazon.smithy.java.server.Service;
 import software.amazon.smithy.mcp.bundle.api.McpBundles;
 import software.amazon.smithy.mcp.bundle.api.Registry;
-import software.amazon.smithy.mcp.bundle.api.model.BundleMetadata;
+import software.amazon.smithy.mcp.bundle.api.SearchableRegistry;
+import software.amazon.smithy.mcp.bundle.api.model.Bundle;
 import software.amazon.smithy.mcp.bundle.api.model.GenericBundle;
 
 /**
@@ -111,7 +117,8 @@ public final class StartServer extends SmithyMcpCommand {
             toolBundleConfigs.add(toolBundleConfig);
         }
 
-        var services = new ArrayList<Service>();
+        var services = new HashMap<String, Service>();
+        var allowerServers = new HashSet<String>();
         //TODO Till we implement the full MCP spec in MCPServerProxy we can only start a single proxy server.
         ProcessIoProxy proxyServer = null;
         for (var toolBundleConfig : toolBundleConfigs) {
@@ -120,13 +127,17 @@ public final class StartServer extends SmithyMcpCommand {
                     if (proxyServer != null) {
                         throw new IllegalArgumentException("Generic MCP servers cannot be run with other MCP servers");
                     }
-                    services.add(bundleToService(toolBundleConfig.getValue()));
+                    SmithyModeledBundleConfig smithyConfig = toolBundleConfig.getValue();
+                    services.put(smithyConfig.getName(), bundleToService(smithyConfig));
+                    allowerServers.add(smithyConfig.getName());
                 }
                 case genericConfig -> {
                     if (!services.isEmpty() || proxyServer != null) {
                         throw new IllegalArgumentException("Generic MCP servers cannot be run with other MCP servers");
                     }
                     GenericToolBundleConfig genericToolBundleConfig = toolBundleConfig.getValue();
+                    allowerServers.add(genericToolBundleConfig.getName());
+
                     GenericBundle genericBundle =
                             ConfigUtils.getMcpBundle(genericToolBundleConfig.getName()).getValue();
                     List<String> combinedArgs = new ArrayList<>();
@@ -151,22 +162,36 @@ public final class StartServer extends SmithyMcpCommand {
 
         ThrowingRunnable awaitCompletion;
         Supplier<CompletableFuture<Void>> shutdownMethod;
+        Set<String> allowedTools = null;
         if (proxyServer != null) {
             proxyServer.start();
             awaitCompletion = proxyServer::awaitCompletion;
             shutdownMethod = proxyServer::shutdown;
         } else {
             if (registryServer) {
-                services.add(McpRegistry.builder()
-                        .addInstallServerOperation(new InstallOp(registry, config))
-                        .addListServersOperation(new ListOp(registry))
-                        .build());
+                allowedTools = new CopyOnWriteArraySet<>();
+                final SearchToolsOperation searchToolsOperation;
+                if (registry instanceof SearchableRegistry searchableRegistry) {
+                    searchToolsOperation = new SearchOp(searchableRegistry);
+                    allowedTools.add("SearchTools");
+                } else {
+                    searchToolsOperation = (ignored, ignored1) -> {
+                        throw new UnsupportedOperationException("This registry isn't searchable");
+                    };
+                }
+                allowedTools.add("InstallTool");
+                services.put("registry-mcp",
+                        McpRegistry.builder()
+                                .addInstallToolOperation(new InstallTool(registry, config, allowedTools))
+                                .addSearchToolsOperation(searchToolsOperation)
+                                .build());
             }
 
             this.mcpServer =
                     (McpServer) McpServer.builder()
                             .stdio()
-                            .addServices(services)
+                            .addService(services)
+                            .toolFilter(getToolFilter(allowerServers, allowedTools))
                             .name("smithy-mcp-server")
                             .build();
             mcpServer.start();
@@ -186,10 +211,17 @@ public final class StartServer extends SmithyMcpCommand {
         }
     }
 
-    private static Service bundleToService(SmithyModeledBundleConfig bundleConfig) {
-        Service service =
-                McpBundles.getService(ConfigUtils.getMcpBundle(bundleConfig.getName()));
+    private ToolFilter getToolFilter(Set<String> allowedServers, Set<String> tools) {
+        return (mcpServerName, toolName) -> {
+            if (allowedServers.contains(mcpServerName)) {
+                return true;
+            }
+            return tools == null || tools.contains(toolName);
+        };
+    }
 
+    private static Service bundleToService(SmithyModeledBundleConfig bundleConfig) {
+        var service = bundleToService(ConfigUtils.getMcpBundle(bundleConfig.getName()));
         if (bundleConfig.hasAllowListedTools() || bundleConfig.hasBlockListedTools()) {
             var filter = OperationFilters.allowList(bundleConfig.getAllowListedTools())
                     .and(OperationFilters.blockList(bundleConfig.getBlockListedTools()));
@@ -198,60 +230,86 @@ public final class StartServer extends SmithyMcpCommand {
         return service;
     }
 
-    private static final class ListOp implements ListServersOperation {
+    private static Service bundleToService(Bundle bundle) {
+        return McpBundles.getService(bundle);
+    }
 
-        private final Registry registry;
+    private static final class SearchOp implements SearchToolsOperation {
 
-        private ListOp(Registry registry) {
+        private final SearchableRegistry registry;
+
+        private SearchOp(SearchableRegistry registry) {
             this.registry = registry;
         }
 
         @Override
-        public ListServersOutput listServers(ListServersInput input, RequestContext context) {
-            var servers = registry
-                    .listMcpBundles()
-                    .stream()
-                    .unordered()
-                    .map(Registry.RegistryEntry::getBundleMetadata)
-                    .collect(Collectors.toMap(
-                            BundleMetadata::getName,
-                            bundle -> ServerEntry.builder()
-                                    .description(bundle.getDescription())
-                                    .build()));
-            return ListServersOutput.builder()
-                    .servers(servers)
+        public SearchToolsOutput searchTools(SearchToolsInput input, RequestContext context) {
+            var tools = registry.searchTools(input.getToolDescription(), input.getNumberOfTools());
+            return SearchToolsOutput.builder()
+                    .tools(tools.stream()
+                            .map(t -> Tool.builder()
+                                    .serverId(t.serverId())
+                                    .toolName(t.toolName())
+                                    .build())
+                            .toList())
                     .build();
         }
     }
 
-    private final class InstallOp implements InstallServerOperation {
+    private final class InstallTool implements InstallToolOperation {
 
         private final Registry registry;
         private final Config config;
+        private final Set<String> installedTools;
 
-        private InstallOp(Registry registry, Config config) {
+        private InstallTool(Registry registry, Config config, Set<String> installedTools) {
             this.registry = registry;
             this.config = config;
+            this.installedTools = installedTools;
         }
 
         @Override
-        public InstallServerOutput installServer(InstallServerInput input, RequestContext context) {
-            try {
-                if (!config.getToolBundles().containsKey(input.getServerName())) {
-                    var bundle = registry.getMcpBundle(input.getServerName());
-                    if (bundle == null) {
-                        throw new IllegalArgumentException(
-                                "Can't find a configured tool bundle for '" + input.getServerName() + "'.");
-                    } else {
-                        var mcpBundleConfig = ConfigUtils.addMcpBundle(config, input.getServerName(), bundle);
-                        mcpServer.addNewService(bundleToService(mcpBundleConfig.getValue()));
+        public InstallToolOutput installTool(InstallToolInput input, RequestContext context) {
+            var tool = input.getTool();
+            var toolName = tool.getToolName();
+            var serverId = tool.getServerId();
+            Bundle bundle;
+            if (!config.getToolBundles().containsKey(serverId)) {
+                bundle = registry.getMcpBundle(serverId);
+                if (bundle == null) {
+                    throw new IllegalArgumentException("Can't find a configured tool bundle for '" + serverId + "'.");
+                } else {
+                    try {
+                        ConfigUtils.addMcpBundle(config, serverId, bundle);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
                     }
                 }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            } else {
+                bundle = ConfigUtils.getMcpBundle(serverId);
             }
-
-            return InstallServerOutput.builder().build();
+            switch (bundle.type()) {
+                case genericBundle -> {
+                    GenericBundle genericBundle = bundle.getValue();
+                    if (!mcpServer.containsMcpServer(serverId)) {
+                        mcpServer.addNewProxy(StdioProxy.builder()
+                                .name(serverId)
+                                .command(genericBundle.getRun().getExecutable())
+                                .build());
+                    }
+                }
+                case smithyBundle -> {
+                    if (!mcpServer.containsMcpServer(serverId)) {
+                        mcpServer.addNewService(serverId, bundleToService(bundle));
+                    }
+                }
+                default -> throw new IllegalArgumentException("Unsupported bundle type: " + bundle.type());
+            }
+            mcpServer.refreshTools();
+            installedTools.add(toolName);
+            return InstallToolOutput.builder()
+                    .message("Tool " + toolName + " installed. Check your list of tools.")
+                    .build();
         }
     }
 

--- a/mcp/mcp-schemas/model/main.smithy
+++ b/mcp/mcp-schemas/model/main.smithy
@@ -59,6 +59,8 @@ structure InitializeResult with [BaseResult] {
 
     @required
     serverInfo: ServerInfo
+
+    instructions: String
 }
 
 structure Capabilities {

--- a/mcp/mcp-schemas/model/registry.smithy
+++ b/mcp/mcp-schemas/model/registry.smithy
@@ -2,38 +2,65 @@ $version: "2"
 
 namespace smithy.mcp.registry
 
-/// This service provides methods to list and install MCP servers. You can get a list of available servers with
-/// ListServers. Use a server from that method to install a new server with the InstallServer API.
+/// This service provides methods to search MCP Tools and install MCP servers. You can get a list of MCP tools that are most appropriate
+/// for the given task with SearchTools. If the given tool is not already available you can install using the InstallTool api.
+/// Be aware that tools installed using InstallTool are available as part of the ToolAssistant MCP server and the MCP serverId returned from search tool needs to be ignored while tool calling.
 service McpRegistry {
     operations: [
-        ListServers
-        InstallServer
+        SearchTools
+        InstallTool
     ]
 }
 
-/// List the available MCP servers that you can install
-operation ListServers {
+/// Search MCP Tools that can help to perform a current task or answer a query. This can be invoked multiple times
+operation SearchTools {
+    input := {
+        /// Tool Description based on the dialogue context. Include relevant information like urls, nouns, acronyms etc.
+        /// Example dialogue:
+        /// User: Hi, can you help me create a code review. I use code.amazon.com
+        /// Example Tool Description : "Create a code review on code.amazon.com"
+        toolDescription: String
+
+        /// Number of tools to return based on relevance in descending order of relevance. If not specified, the default is 1
+        @default(1)
+        numberOfTools: Integer
+    }
+
     output := {
-        /// A map of server name to details about that server
+        /// List of MCP tools most relevant for the query, sorted by order of relevance,
+        /// the first tool being the most relevant.
         @required
-        servers: ServerMap
+        tools: Tools
     }
 }
 
-map ServerMap {
-    key: String
-    value: ServerEntry
+list Tools {
+    member: Tool
+}
+
+structure Tool {
+    /// Id of the MCP server this Tool belongs to
+    @required
+    serverId: String
+
+    /// Name of the Tool
+    toolName: String
 }
 
 structure ServerEntry {
     description: String
 }
 
-/// Install a new MCP server for local use.
-operation InstallServer {
+/// Install a new MCP Tool for local use.
+/// Be aware that tools installed using InstallTool are available as part of the ToolAssistant MCP server and the MCP serverId returned from search tool needs to be ignored while tool calling.
+operation InstallTool {
     input := {
         /// The name of the MCP server to install
         @required
-        serverName: String
+        tool: Tool
+    }
+
+    output := {
+        message: String
     }
 }

--- a/mcp/mcp-schemas/smithy-build.json
+++ b/mcp/mcp-schemas/smithy-build.json
@@ -3,12 +3,14 @@
   "plugins": {
     "java-type-codegen": {
       "namespace": "software.amazon.smithy.java.mcp",
-      "headerFile": "license.txt"
+      "headerFile": "license.txt",
+      "runtimeTraits": ["smithy.api#documentation", "smithy.api#examples" ]
     },
     "java-server-codegen": {
       "service": "smithy.mcp.registry#McpRegistry",
       "namespace": "software.amazon.smithy.java.mcp.registry",
-      "headerFile": "license.txt"
+      "headerFile": "license.txt",
+      "runtimeTraits": ["smithy.api#documentation", "smithy.api#examples" ]
     }
   }
 }

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServerBuilder.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServerBuilder.java
@@ -9,7 +9,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import software.amazon.smithy.java.server.Server;
 import software.amazon.smithy.java.server.Service;
@@ -20,9 +22,10 @@ public final class McpServerBuilder {
 
     InputStream is;
     OutputStream os;
-    List<Service> serviceList = new ArrayList<>();
+    Map<String, Service> services = new HashMap<>();
     List<McpServerProxy> proxyList = new ArrayList<>();
     String name;
+    ToolFilter toolFilter = (server, tool) -> true;
 
     McpServerBuilder() {}
 
@@ -52,25 +55,30 @@ public final class McpServerBuilder {
         return new McpServer(this);
     }
 
-    public McpServerBuilder addService(Service... service) {
-        serviceList.addAll(Arrays.asList(service));
+    public McpServerBuilder addService(String id, Service service) {
+        services.put(id, service);
         return this;
     }
 
-    public McpServerBuilder addServices(List<Service> services) {
-        serviceList.addAll(services);
+    public McpServerBuilder addService(Map<String, Service> services) {
+        this.services.putAll(services);
         return this;
     }
 
-    public McpServerBuilder addMcpService(McpServerProxy proxy) {
-        proxyList.add(proxy);
+    public McpServerBuilder addService(McpServerProxy... proxy) {
+        proxyList.addAll(Arrays.asList(proxy));
+        return this;
+    }
+
+    public McpServerBuilder toolFilter(ToolFilter filter) {
+        this.toolFilter = filter;
         return this;
     }
 
     private void validate() {
         Objects.requireNonNull(is, "MCP server input stream is required");
         Objects.requireNonNull(os, "MCP server output stream is required");
-        if (serviceList.isEmpty() && proxyList.isEmpty()) {
+        if (services.isEmpty() && proxyList.isEmpty()) {
             throw new IllegalArgumentException("MCP server requires at least one service or proxy");
         }
     }

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServerProxy.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServerProxy.java
@@ -35,18 +35,17 @@ public abstract class McpServerProxy {
             if (response.getError() != null) {
                 throw new RuntimeException("Error listing tools: " + response.getError().getMessage());
             }
-            return response.getResult().asShape(ListToolsResult.builder()).getTools();
+            return response.getResult()
+                    .asShape(ListToolsResult.builder())
+                    .getTools()
+                    .stream()
+                    .toList();
         }).join();
     }
 
-    public void initialize(Consumer<JsonRpcResponse> notificationConsumer) {
-        JsonRpcRequest request = JsonRpcRequest.builder()
-                .method("initialize")
-                .id(generateRequestId())
-                .jsonrpc("2.0")
-                .build();
+    public void initialize(Consumer<JsonRpcResponse> notificationConsumer, JsonRpcRequest initializeRequest) {
 
-        var result = Objects.requireNonNull(rpc(request).join());
+        var result = Objects.requireNonNull(rpc(initializeRequest).join());
         if (result.getError() != null) {
             throw new RuntimeException("Error during initialization: " + result.getError().getMessage());
         }
@@ -82,4 +81,6 @@ public abstract class McpServerProxy {
     protected void notify(JsonRpcResponse response) {
         notificationConsumer.accept(response);
     }
+
+    public abstract String name();
 }

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/PromptLoader.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/PromptLoader.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.mcp.server;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -35,7 +36,7 @@ final class PromptLoader {
      *
      * @return Map of prompt names to PromptInfo objects
      */
-    public static Map<String, Prompt> loadPrompts(List<Service> services) {
+    public static Map<String, Prompt> loadPrompts(Collection<Service> services) {
         Map<String, Prompt> prompts = new LinkedHashMap<>();
 
         for (var service : services) {

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/ToolFilter.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/ToolFilter.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.mcp.server;
+
+public interface ToolFilter {
+
+    boolean allowTool(String mcpServerName, String toolName);
+}

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
@@ -63,11 +63,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test#TestService"))
-                        .proxyEndpoint("http://localhost")
-                        .model(MODEL)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
                 .build();
 
         server.start();
@@ -81,8 +82,7 @@ public class McpServerTest {
         var properties = inputSchema.get("properties").asStringMap();
 
         assertEquals("TestOperation", tool.get("name").asString());
-        assertEquals("This tool invokes TestOperation API of TestService.A TestOperation",
-                tool.get("description").asString());
+        assertEquals("A TestOperation", tool.get("description").asString());
         assertEquals("object", inputSchema.get("type").asString());
         assertEquals("An input for TestOperation with a nested member",
                 inputSchema.get("description").asString());
@@ -124,11 +124,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test#TestService"))
-                        .proxyEndpoint("http://localhost")
-                        .model(MODEL)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
                 .build();
 
         server.start();
@@ -168,11 +169,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test#TestService"))
-                        .proxyEndpoint("http://localhost")
-                        .model(MODEL)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
                 .build();
 
         server.start();
@@ -209,11 +211,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test#TestService"))
-                        .proxyEndpoint("http://localhost")
-                        .model(MODEL)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
                 .build();
 
         server.start();
@@ -231,18 +234,20 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test#TestService"))
-                        .proxyEndpoint("http://localhost")
-                        .clientConfigurator(
-                                clientConfigurator -> clientConfigurator.addInterceptor(new ClientInterceptor() {
-                                    @Override
-                                    public void readBeforeSerialization(InputHook<?, ?> hook) {
-                                        capturedInput.set((StructDocument) hook.input());
-                                    }
-                                }))
-                        .model(MODEL)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .clientConfigurator(
+                                        clientConfigurator -> clientConfigurator
+                                                .addInterceptor(new ClientInterceptor() {
+                                                    @Override
+                                                    public void readBeforeSerialization(InputHook<?, ?> hook) {
+                                                        capturedInput.set((StructDocument) hook.input());
+                                                    }
+                                                }))
+                                .model(MODEL)
+                                .build())
                 .build();
 
         server.start();
@@ -335,11 +340,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test#TestService"))
-                        .proxyEndpoint("http://localhost")
-                        .model(MODEL)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
                 .build();
 
         server.start();
@@ -363,11 +369,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test#TestService"))
-                        .proxyEndpoint("http://localhost")
-                        .model(MODEL)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
                 .build();
 
         server.start();
@@ -395,11 +402,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test#TestService"))
-                        .proxyEndpoint("http://localhost")
-                        .model(MODEL)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
                 .build();
 
         server.start();
@@ -427,11 +435,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test#TestService"))
-                        .proxyEndpoint("http://localhost")
-                        .model(MODEL)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
                 .build();
 
         server.start();
@@ -456,11 +465,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test.args#TestServiceWithArgs"))
-                        .proxyEndpoint("http://localhost")
-                        .model(modelWithArgs)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test.args#TestServiceWithArgs"))
+                                .proxyEndpoint("http://localhost")
+                                .model(modelWithArgs)
+                                .build())
                 .build();
 
         server.start();
@@ -496,11 +506,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test.args#TestServiceWithArgs"))
-                        .proxyEndpoint("http://localhost")
-                        .model(modelWithArgs)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test.args#TestServiceWithArgs"))
+                                .proxyEndpoint("http://localhost")
+                                .model(modelWithArgs)
+                                .build())
                 .build();
 
         server.start();
@@ -532,11 +543,12 @@ public class McpServerTest {
         server = McpServer.builder()
                 .input(input)
                 .output(output)
-                .addService(ProxyService.builder()
-                        .service(ShapeId.from("smithy.test.edge#TestServiceEdgeCases"))
-                        .proxyEndpoint("http://localhost")
-                        .model(modelEdgeCases)
-                        .build())
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test.edge#TestServiceEdgeCases"))
+                                .proxyEndpoint("http://localhost")
+                                .model(modelEdgeCases)
+                                .build())
                 .build();
 
         server.start();
@@ -629,7 +641,6 @@ public class McpServerTest {
 
     private JsonRpcResponse read() {
         var line = output.read();
-        System.out.println(line);
         return CODEC.deserializeShape(line, JsonRpcResponse.builder());
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add support for search tools and dynamic tool loading

  This PR enhances the MCP server implementation with dynamic tool discovery and installation capabilities:

  Key Changes

  - Search Tools API: Added searchTools operation to the registry service that allows finding relevant tools based on task descriptions
  - Dynamic Tool Installation: Implemented installTool operation to dynamically install MCP tools at runtime
  - Tool Filtering: Added configurable tool filtering support with predicate-based filtering
  - Server Architecture Updates:
    - Services now stored in a map structure for better management
    - Added support for both Smithy-modeled and generic MCP tool bundles
    - Enhanced proxy server initialization and tool refresh mechanisms
  - Registry Model Updates: Updated the registry schema to support tool search and installation workflows
  - CLI Enhancements: Updated StartServer command to handle dynamic tool loading and registry operations

  API Changes

  - Replaced ListServers/InstallServer operations with SearchTools/InstallTool
  - Added RegistryTool record for tool identification
  - Enhanced InitializeResult to include optional instructions field

  Implementation Details

  - Tools can now be installed on-demand from the registry
  - Supports both direct service integration and proxy-based tool execution
  - Maintains backward compatibility with existing tool bundle configurations
  - Added proper error handling and validation for tool installation

  This enables a more flexible and discoverable tool ecosystem where clients can search for and install relevant tools based on their current tasks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
