### PR TITLE
Move prompts trait to use `smithy.ai` namespace and`smithy-ai-traits` package for easier upstreaming.

### DIFF
--- a/examples/mcp-server/build.gradle.kts
+++ b/examples/mcp-server/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     val smithyJavaVersion: String by project
 
     smithyBuild("software.amazon.smithy.java:plugins:$smithyJavaVersion")
-    implementation("software.amazon.smithy.java:mcp-traits:$smithyJavaVersion")
+    implementation("software.amazon.smithy.java:smithy-ai-traits:$smithyJavaVersion")
     implementation("software.amazon.smithy.java:mcp-server:$smithyJavaVersion")
     implementation("software.amazon.smithy.java:server-proxy:$smithyJavaVersion")
     implementation("software.amazon.smithy.java:server-netty:$smithyJavaVersion")

--- a/examples/mcp-server/smithy-build.json
+++ b/examples/mcp-server/smithy-build.json
@@ -6,7 +6,7 @@
       "service": "smithy.example.mcp#EmployeeService",
       "namespace": "software.amazon.smithy.java.example.server.mcp",
       "headerFile": "license.txt",
-      "runtimeTraits": ["smithy.api#documentation", "smithy.api#examples", "amazon.smithy.llm#prompts" ]
+      "runtimeTraits": ["smithy.api#documentation", "smithy.api#examples", "smithy.ai#prompts" ]
     }
   }
 }

--- a/examples/mcp-server/src/main/resources/software/amazon/smithy/java/example/server/mcp/main.smithy
+++ b/examples/mcp-server/src/main/resources/software/amazon/smithy/java/example/server/mcp/main.smithy
@@ -3,7 +3,7 @@ $version: "2"
 namespace smithy.example.mcp
 
 use aws.protocols#restJson1
-use amazon.smithy.llm#prompts
+use smithy.ai#prompts
 
 @restJson1
 @prompts({

--- a/examples/mcp-traits-example/README.md
+++ b/examples/mcp-traits-example/README.md
@@ -45,7 +45,7 @@ service UserService {
 ```smithy
 namespace com.example
 
-use amazon.smithy.llm#prompts
+use smithy.ai#prompts
 
 @prompts({
     search_users: { 

--- a/examples/mcp-traits-example/build.gradle.kts
+++ b/examples/mcp-traits-example/build.gradle.kts
@@ -8,8 +8,7 @@ dependencies {
     val smithyVersion: String by project
 
     // Include the mcp-traits module for the @prompts trait
-    smithyBuild(project(":mcp:mcp-traits"))
-    implementation(project(":mcp:mcp-traits"))
+    implementation(project(":smithy-ai-traits"))
     
     // Standard Smithy dependencies
     smithyBuild("software.amazon.smithy.java:plugins:$smithyJavaVersion")

--- a/examples/mcp-traits-example/model/main.smithy
+++ b/examples/mcp-traits-example/model/main.smithy
@@ -1,6 +1,6 @@
 namespace com.example
 
-use amazon.smithy.llm#prompts
+use smithy.ai#prompts
 
 @prompts({
     search_users: { description: "Search for users in the system by various criteria", template: "Search for users where {{searchCriteria}}. Use pagination with limit={{limit}} if many results expected.", arguments: SearchUsersInput, preferWhen: "User wants to find specific users or browse user lists" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit5 = "5.13.4"
 hamcrest = "3.0"
-smithy = "1.60.3"
+smithy = "1.61.0"
 jmh = "0.7.3"
 test-logger-plugin = "4.0.0"
 spotbugs = "6.0.22"

--- a/mcp/mcp-server/build.gradle.kts
+++ b/mcp/mcp-server/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation(project(":codecs:json-codec", configuration = "shadow"))
     implementation(project(":mcp:mcp-schemas"))
     implementation(project(":mcp:mcp-bundle-api"))
-    implementation(project(":mcp:mcp-traits"))
+    implementation(project(":smithy-ai-traits"))
     testRuntimeOnly(libs.smithy.aws.traits)
     testRuntimeOnly(project(":aws:client:aws-client-awsjson"))
 }

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
@@ -660,7 +660,7 @@ public class McpServerTest {
 
                     namespace smithy.test
 
-                    use amazon.smithy.llm#prompts
+                    use smithy.ai#prompts
 
                     /// A TestService
                     @aws.protocols#awsJson1_0
@@ -752,7 +752,7 @@ public class McpServerTest {
 
                     namespace smithy.test.args
 
-                    use amazon.smithy.llm#prompts
+                    use smithy.ai#prompts
                     use aws.protocols#awsJson1_0
 
                     @awsJson1_0
@@ -780,7 +780,7 @@ public class McpServerTest {
 
                     namespace smithy.test.edge
 
-                    use amazon.smithy.llm#prompts
+                    use smithy.ai#prompts
                     use aws.protocols#awsJson1_0
 
                     @awsJson1_0

--- a/mcp/mcp-server/src/test/resources/prompts/basic-prompt.smithy
+++ b/mcp/mcp-server/src/test/resources/prompts/basic-prompt.smithy
@@ -1,6 +1,6 @@
 namespace com.example
 
-use amazon.smithy.llm#prompts
+use smithy.ai#prompts
 
 @prompts({
     test_prompt: {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,9 @@ pluginManagement {
 
 rootProject.name = "smithy-java"
 
+// AI
+include(":smithy-ai-traits")
+
 // Common modules
 include(":context")
 include(":core")
@@ -105,7 +108,6 @@ include(":mcp:mcp-server")
 include(":mcp:mcp-cli")
 include(":mcp:mcp-cli-api")
 include(":mcp:mcp-bundle-api")
-include(":mcp:mcp-traits")
 
 include(":model-bundle")
 include(":model-bundle:model-bundle-api")

--- a/smithy-ai-traits/build.gradle.kts
+++ b/smithy-ai-traits/build.gradle.kts
@@ -3,10 +3,10 @@ plugins {
     alias(libs.plugins.smithy.gradle.jar)
 }
 
-description = "MCP Traits"
+description = "Smithy AI Traits"
 
-extra["displayName"] = "Smithy :: Java :: MCP Traits"
-extra["moduleName"] = "software.amazon.smithy.java.mcp.traits"
+extra["displayName"] = "Smithy :: Java :: AI Traits"
+extra["moduleName"] = "software.amazon.smithy.ai.traits"
 
 dependencies {
     api(libs.smithy.model)

--- a/smithy-ai-traits/model/prompts.smithy
+++ b/smithy-ai-traits/model/prompts.smithy
@@ -1,6 +1,6 @@
 $version: "2"
 
-namespace amazon.smithy.llm
+namespace smithy.ai
 
 // Prompt template trait - applied at operation level to provide guidance to LLMs
 @trait(selector: ":is(service, resource, operation)")
@@ -13,6 +13,7 @@ map prompts {
 }
 
 /// Defines the structure of the prompt
+@private
 structure PromptTemplateDefinition {
     /// Description of when to use this operation
     @required
@@ -29,5 +30,6 @@ structure PromptTemplateDefinition {
     preferWhen: String
 }
 
+@private
 @idRef(failWhenMissing: true, selector: "structure")
 string ArgumentShape

--- a/smithy-ai-traits/smithy-build.json
+++ b/smithy-ai-traits/smithy-build.json
@@ -4,7 +4,7 @@
   "plugins": {
     "trait-codegen": {
       "package": "software.amazon.smithy.ai",
-      "namespace": "amazon.smithy.llm",
+      "namespace": "smithy.ai",
       "header": []
     }
   }


### PR DESCRIPTION

## Description
This PR contains  pending changes as discussed in #817 about placement of trait definition and the namespace so that future upstreaming to `smithy-lang/smithy` is easier.
• Renamed namespace from amazon.smithy.llm to smithy.ai in prompts trait definition
• Moved mcp/mcp-traits module to smithy-ai-traits to reflect the new namespace
• Updated all references across examples, tests, and build configurations
• Modified dependency declarations in gradle files and version catalog



## Testing
- `./gradlew clean build`
- Validated that prompts list and get still works as before.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
