### PR TITLE
Add validation for prompt name uniqueness across the service.

### DIFF
--- a/examples/mcp-server/src/main/resources/software/amazon/smithy/java/example/server/mcp/main.smithy
+++ b/examples/mcp-server/src/main/resources/software/amazon/smithy/java/example/server/mcp/main.smithy
@@ -19,7 +19,7 @@ use smithy.ai#prompts
         arguments: GetCodingStatisticsInput
         preferWhen: "User wants to analyze developer productivity, review coding activity, or understand technology usage patterns"
     }
-    employee_lookup: {
+    Test_employee: {
         description: "General employee lookup and information retrieval service"
         template: "This service provides employee information including personal details and coding statistics. Use get_employee_info for basic details or get_coding_stats for development metrics."
         preferWhen: "User needs any employee-related information or wants to understand available employee data"

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServer.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServer.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.java.mcp.server;
 
+import static software.amazon.smithy.java.mcp.server.PromptLoader.normalize;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -146,7 +148,7 @@ public final class McpServer implements Server {
                     var promptName = req.getParams().getMember("name").asString();
                     var promptArguments = req.getParams().getMember("arguments");
 
-                    var prompt = prompts.get(promptName);
+                    var prompt = prompts.get(normalize(promptName));
 
                     if (prompt == null) {
                         internalError(req, new RuntimeException("Prompt not found: " + promptName));

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/PromptLoader.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/PromptLoader.java
@@ -54,7 +54,7 @@ final class PromptLoader {
 
             });
             for (Map.Entry<String, PromptTemplateDefinition> entry : promptDefinitions.entrySet()) {
-                var promptName = entry.getKey().toLowerCase();
+                var promptName = entry.getKey();
                 var promptTemplateDefinition = entry.getValue();
                 var templateString = promptTemplateDefinition.getTemplate();
 
@@ -76,8 +76,20 @@ final class PromptLoader {
                                 : List.of())
                         .build();
 
+                var normalizedName = normalize(promptName);
+
+                if (prompts.containsKey(normalizedName)) {
+                    var existingPrompt = prompts.get(normalizedName);
+                    throw new RuntimeException(String.format(
+                            "Duplicate normalized prompt name '%s' found. " +
+                                    "Original name '%s' conflicts with previously registered name '%s'.",
+                            normalizedName,
+                            promptName,
+                            existingPrompt.promptInfo().getName()));
+                }
+
                 prompts.put(
-                        promptName,
+                        normalizedName,
                         new Prompt(promptInfo, finalTemplateString));
             }
         }
@@ -117,5 +129,9 @@ final class PromptLoader {
         }
 
         return promptArguments;
+    }
+
+    public static String normalize(String promptName) {
+        return promptName.toLowerCase();
     }
 }

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/PromptLoaderTest.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/PromptLoaderTest.java
@@ -5,10 +5,16 @@
 
 package software.amazon.smithy.java.mcp.server;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.server.ProxyService;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 class PromptLoaderTest {
 
@@ -17,4 +23,300 @@ class PromptLoaderTest {
         var prompts = PromptLoader.loadPrompts(Collections.emptyList());
         assertTrue(prompts.isEmpty());
     }
+
+    @Test
+    public void testLoadPromptsWithUniqueNormalizedNames() {
+        var model = Model.assembler()
+                .addUnparsedModel("test-unique.smithy", UNIQUE_PROMPTS_MODEL)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        var service = ProxyService.builder()
+                .service(ShapeId.from("smithy.test.unique#TestService"))
+                .proxyEndpoint("http://localhost")
+                .model(model)
+                .build();
+
+        var prompts = PromptLoader.loadPrompts(List.of(service));
+
+        // Should have 3 prompts with unique normalized names
+        assertEquals(3, prompts.size());
+        assertTrue(prompts.containsKey("getuser"));
+        assertTrue(prompts.containsKey("createuser"));
+        assertTrue(prompts.containsKey("deleteuser"));
+    }
+
+    @Test
+    public void testLoadPromptsWithDuplicateNormalizedNamesFromDifferentServices() {
+        var model1 = Model.assembler()
+                .addUnparsedModel("test-service1.smithy", SERVICE1_MODEL)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        var model2 = Model.assembler()
+                .addUnparsedModel("test-service2.smithy", SERVICE2_MODEL)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        var service1 = ProxyService.builder()
+                .service(ShapeId.from("smithy.test.service1#TestService1"))
+                .proxyEndpoint("http://localhost")
+                .model(model1)
+                .build();
+
+        var service2 = ProxyService.builder()
+                .service(ShapeId.from("smithy.test.service2#TestService2"))
+                .proxyEndpoint("http://localhost")
+                .model(model2)
+                .build();
+
+        var exception = assertThrows(RuntimeException.class, () -> {
+            PromptLoader.loadPrompts(List.of(service1, service2));
+        });
+
+        String message = exception.getMessage();
+        assertTrue(message.contains("Duplicate normalized prompt name 'getuser' found"));
+        assertTrue(message.contains("Original name 'getuser' conflicts with previously registered name 'GetUser'"));
+    }
+
+    @Test
+    public void testLoadPromptsWithCaseSensitivityVariationsAcrossServices() {
+        var model1 = Model.assembler()
+                .addUnparsedModel("test-case1.smithy", CASE_SERVICE1_MODEL)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        var model2 = Model.assembler()
+                .addUnparsedModel("test-case2.smithy", CASE_SERVICE2_MODEL)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        var service1 = ProxyService.builder()
+                .service(ShapeId.from("smithy.test.case1#TestService1"))
+                .proxyEndpoint("http://localhost")
+                .model(model1)
+                .build();
+
+        var service2 = ProxyService.builder()
+                .service(ShapeId.from("smithy.test.case2#TestService2"))
+                .proxyEndpoint("http://localhost")
+                .model(model2)
+                .build();
+
+        var exception = assertThrows(RuntimeException.class, () -> {
+            PromptLoader.loadPrompts(List.of(service1, service2));
+        });
+
+        String message = exception.getMessage();
+        assertTrue(message.contains("Duplicate normalized prompt name 'getuser' found"));
+        assertTrue(message.contains("Original name 'GETUSER' conflicts with previously registered name 'GetUser'"));
+    }
+
+    @Test
+    public void testLoadPromptsWithSingleCharacterNamesAcrossServices() {
+        var model1 = Model.assembler()
+                .addUnparsedModel("test-single1.smithy", SINGLE_SERVICE1_MODEL)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        var model2 = Model.assembler()
+                .addUnparsedModel("test-single2.smithy", SINGLE_SERVICE2_MODEL)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        var service1 = ProxyService.builder()
+                .service(ShapeId.from("smithy.test.single1#TestService1"))
+                .proxyEndpoint("http://localhost")
+                .model(model1)
+                .build();
+
+        var service2 = ProxyService.builder()
+                .service(ShapeId.from("smithy.test.single2#TestService2"))
+                .proxyEndpoint("http://localhost")
+                .model(model2)
+                .build();
+
+        var exception = assertThrows(RuntimeException.class, () -> {
+            PromptLoader.loadPrompts(List.of(service1, service2));
+        });
+
+        String message = exception.getMessage();
+        assertTrue(message.contains("Duplicate normalized prompt name 'a' found"));
+        assertTrue(message.contains("Original name 'a' conflicts with previously registered name 'A'"));
+    }
+
+    @Test
+    public void testNormalizeMethod() {
+        // Test the normalize method directly
+        assertEquals("getuser", PromptLoader.normalize("GetUser"));
+        assertEquals("getuser", PromptLoader.normalize("GETUSER"));
+        assertEquals("getuser", PromptLoader.normalize("getuser"));
+        assertEquals("getuser", PromptLoader.normalize("getUser"));
+        assertEquals("a", PromptLoader.normalize("A"));
+        assertEquals("a", PromptLoader.normalize("a"));
+        assertEquals("get-user", PromptLoader.normalize("Get-User"));
+        assertEquals("get_user", PromptLoader.normalize("Get_User"));
+    }
+
+    // Test model with unique normalized prompt names
+    private static final String UNIQUE_PROMPTS_MODEL =
+            """
+                    $version: "2"
+
+                    namespace smithy.test.unique
+
+                    use smithy.ai#prompts
+                    use aws.protocols#awsJson1_0
+
+                    @awsJson1_0
+                    @prompts({
+                        GetUser: { description: "Get a user", template: "Get user information" },
+                        CreateUser: { description: "Create a user", template: "Create new user" },
+                        DeleteUser: { description: "Delete a user", template: "Delete existing user" }
+                    })
+                    service TestService {
+                        operations: []
+                    }
+                    """;
+
+    // First service with GetUser prompt
+    private static final String SERVICE1_MODEL =
+            """
+                    $version: "2"
+
+                    namespace smithy.test.service1
+
+                    use smithy.ai#prompts
+                    use aws.protocols#awsJson1_0
+
+                    @awsJson1_0
+                    @prompts({
+                        GetUser: { description: "Get a user", template: "Get user information" }
+                    })
+                    service TestService1 {
+                        operations: []
+                    }
+                    """;
+
+    // Second service with getuser prompt (different case, same normalized name)
+    private static final String SERVICE2_MODEL =
+            """
+                    $version: "2"
+
+                    namespace smithy.test.service2
+
+                    use smithy.ai#prompts
+                    use aws.protocols#awsJson1_0
+
+                    @awsJson1_0
+                    @prompts({
+                        getuser: { description: "get a user", template: "get user information" }
+                    })
+                    service TestService2 {
+                        operations: []
+                    }
+                    """;
+
+    // First service with GetUser prompt for case sensitivity test
+    private static final String CASE_SERVICE1_MODEL =
+            """
+                    $version: "2"
+
+                    namespace smithy.test.case1
+
+                    use smithy.ai#prompts
+                    use aws.protocols#awsJson1_0
+
+                    @awsJson1_0
+                    @prompts({
+                        GetUser: { description: "Get a user", template: "Get user information" }
+                    })
+                    service TestService1 {
+                        operations: []
+                    }
+                    """;
+
+    // Second service with GETUSER prompt for case sensitivity test
+    private static final String CASE_SERVICE2_MODEL =
+            """
+                    $version: "2"
+
+                    namespace smithy.test.case2
+
+                    use smithy.ai#prompts
+                    use aws.protocols#awsJson1_0
+
+                    @awsJson1_0
+                    @prompts({
+                        GETUSER: { description: "GET A USER", template: "GET USER INFORMATION" }
+                    })
+                    service TestService2 {
+                        operations: []
+                    }
+                    """;
+
+    // First service with A prompt for single character test
+    private static final String SINGLE_SERVICE1_MODEL =
+            """
+                    $version: "2"
+
+                    namespace smithy.test.single1
+
+                    use smithy.ai#prompts
+                    use aws.protocols#awsJson1_0
+
+                    @awsJson1_0
+                    @prompts({
+                        A: { description: "Prompt A", template: "Template A" }
+                    })
+                    service TestService1 {
+                        operations: []
+                    }
+                    """;
+
+    // Second service with a prompt for single character test
+    private static final String SINGLE_SERVICE2_MODEL =
+            """
+                    $version: "2"
+
+                    namespace smithy.test.single2
+
+                    use smithy.ai#prompts
+                    use aws.protocols#awsJson1_0
+
+                    @awsJson1_0
+                    @prompts({
+                        a: { description: "prompt a", template: "template a" }
+                    })
+                    service TestService2 {
+                        operations: []
+                    }
+                    """;
+
+    // Test model with special characters in prompt names
+    private static final String SPECIAL_CHARS_MODEL =
+            """
+                    $version: "2"
+
+                    namespace smithy.test.special
+
+                    use smithy.ai#prompts
+                    use aws.protocols#awsJson1_0
+
+                    @awsJson1_0
+                    @prompts({
+                        "Get-User": { description: "Get a user", template: "Get user information" },
+                        "Get_Item": { description: "Get an item", template: "Get item information" }
+                    })
+                    service TestService {
+                        operations: []
+                    }
+                    """;
 }

--- a/smithy-ai-traits/model/prompts.smithy
+++ b/smithy-ai-traits/model/prompts.smithy
@@ -2,15 +2,17 @@ $version: "2"
 
 namespace smithy.ai
 
-// Prompt template trait - applied at operation level to provide guidance to LLMs
-@trait(selector: ":is(service, resource, operation)")
+@trait(selector: ":is(service, operation)")
 map prompts {
     /// Name of the prompt template
-    key: String
+    key: PromptName
 
     /// Definition of the prompt template
     value: PromptTemplateDefinition
 }
+
+@pattern("^[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*$")
+string PromptName
 
 /// Defines the structure of the prompt
 @private

--- a/smithy-ai-traits/src/main/java/software/amazon/smithy/ai/PromptUniquenessValidator.java
+++ b/smithy-ai-traits/src/main/java/software/amazon/smithy/ai/PromptUniquenessValidator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.ai;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+/**
+ * Validates that prompt names are unique within each service when compared case-insensitively.
+ * This validator checks both service-level and operation-level prompts to ensure no conflicts.
+ * 
+ * For example, "search_users" and "Search_Users" would be considered conflicting prompt names
+ * because they are identical when compared case-insensitively.
+ */
+public final class PromptUniquenessValidator extends AbstractValidator {
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        List<ValidationEvent> events = new ArrayList<>();
+
+        for (ServiceShape service : model.getServiceShapes()) {
+            validatePrompts(service, model, events);
+        }
+
+        return events;
+    }
+
+    private void validatePrompts(ServiceShape service, Model model, List<ValidationEvent> events) {
+        // Track prompt names to detect case-insensitive conflicts
+        Map<String, Shape> seenPromptNames = new HashMap<>();
+
+        service.getTrait(PromptsTrait.class).ifPresent(promptsTrait -> {
+            for (String promptName : promptsTrait.getValues().keySet()) {
+                checkPromptUniqueness(promptName, service, seenPromptNames, events);
+            }
+        });
+
+        for (OperationShape operation : service.getOperations()
+                .stream()
+                .map(shapeId -> model.expectShape(shapeId, OperationShape.class))
+                .toList()) {
+
+            operation.getTrait(PromptsTrait.class).ifPresent(promptsTrait -> {
+                for (String promptName : promptsTrait.getValues().keySet()) {
+                    checkPromptUniqueness(promptName, operation, seenPromptNames, events);
+                }
+            });
+        }
+    }
+
+    private void checkPromptUniqueness(
+            String promptName,
+            Shape shape,
+            Map<String, Shape> seenPromptNames,
+            List<ValidationEvent> events
+    ) {
+        String normalizedName = promptName.toLowerCase();
+
+        if (seenPromptNames.containsKey(normalizedName)) {
+            Shape conflictingShape = seenPromptNames.get(normalizedName);
+            events.add(error(shape,
+                    String.format(
+                            "Duplicate prompt name detected: '%s' conflicts with an existing prompt " +
+                                    "defined on %s when compared case-insensitively. Prompt names must be unique " +
+                                    "within a service regardless of case.",
+                            promptName,
+                            conflictingShape.getId())));
+        } else {
+            seenPromptNames.put(normalizedName, shape);
+        }
+    }
+}

--- a/smithy-ai-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-ai-traits/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -1,0 +1,1 @@
+software.amazon.smithy.ai.PromptUniquenessValidator

--- a/smithy-ai-traits/src/test/java/software/amazon/smithy/ai/PromptUniquenessValidatorTest.java
+++ b/smithy-ai-traits/src/test/java/software/amazon/smithy/ai/PromptUniquenessValidatorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.validation.ValidatedResult;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+public class PromptUniquenessValidatorTest {
+
+    /**
+     * Test case record for prompt uniqueness validation scenarios.
+     * 
+     * @param testName descriptive name for the test scenario
+     * @param resourcePath path to the Smithy model file
+     * @param expectedErrorCount number of validation errors expected
+     * @param expectedErrorContent specific content to verify in error messages (null if no errors expected)
+     */
+    public record ValidationTestCase(
+            String testName,
+            String resourcePath,
+            int expectedErrorCount,
+            String expectedErrorContent) {
+        @Override
+        public String toString() {
+            return testName;
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideValidationTestCases")
+    @DisplayName("Prompt uniqueness validation scenarios")
+    public void testPromptUniquenessValidation(ValidationTestCase testCase) {
+        var result = assembleModelFromResource(testCase.resourcePath());
+        List<ValidationEvent> duplicateEvents = filterDuplicatePromptEvents(result.getValidationEvents());
+
+        assertEquals(testCase.expectedErrorCount(),
+                duplicateEvents.size(),
+                String.format("Test '%s': Expected %d validation errors",
+                        testCase.testName(),
+                        testCase.expectedErrorCount()));
+
+        if (testCase.expectedErrorCount() > 0) {
+            ValidationEvent event = duplicateEvents.get(0);
+            assertTrue(event.getMessage().contains("Duplicate prompt name detected"),
+                    String.format("Test '%s': Should contain duplicate prompt error message", testCase.testName()));
+
+            if (testCase.expectedErrorContent() != null) {
+                assertTrue(event.getMessage().contains(testCase.expectedErrorContent()),
+                        String.format("Test '%s': Should contain expected error content: %s",
+                                testCase.testName(),
+                                testCase.expectedErrorContent()));
+            }
+
+            assertTrue(event.getMessage().contains("case-insensitively"),
+                    String.format("Test '%s': Should mention case-insensitive comparison", testCase.testName()));
+        }
+    }
+
+    /**
+     * Provides test cases for prompt uniqueness validation scenarios.
+     * Each test case includes: test name, resource path, expected error count, and expected error content.
+     */
+    private static Stream<ValidationTestCase> provideValidationTestCases() {
+        return Stream.of(
+                new ValidationTestCase(
+                        "No duplicate prompts",
+                        "/unique-prompts.smithy",
+                        0,
+                        null),
+                new ValidationTestCase(
+                        "Duplicate prompts within service",
+                        "/service-level-duplicates.smithy",
+                        1,
+                        "Search_Users"),
+                new ValidationTestCase(
+                        "Duplicate prompts between service and operation",
+                        "/duplicate-prompts.smithy",
+                        1,
+                        "Search_Users"),
+                new ValidationTestCase(
+                        "Same prompt names across different services (should be allowed)",
+                        "/cross-service-unique.smithy",
+                        0,
+                        null));
+    }
+
+    private ValidatedResult<Model> assembleModelFromResource(String resourcePath) {
+        return Model.assembler()
+                .addImport(Objects.requireNonNull(getClass().getResource(resourcePath)))
+                .discoverModels(getClass().getClassLoader())
+                .assemble();
+    }
+
+    private List<ValidationEvent> filterDuplicatePromptEvents(List<ValidationEvent> events) {
+        return events.stream()
+                .filter(event -> event.getMessage().contains("Duplicate prompt name detected"))
+                .toList();
+    }
+}

--- a/smithy-ai-traits/src/test/resources/cross-service-unique.smithy
+++ b/smithy-ai-traits/src/test/resources/cross-service-unique.smithy
@@ -1,0 +1,26 @@
+$version: "2.0"
+
+namespace com.example.test.cross
+
+use smithy.ai#prompts
+
+// Test model for validating that same prompt names are allowed across different services
+@prompts(
+    "search_users": {
+        template: "Search for users in ServiceOne"
+        description: "ServiceOne search template"
+    }
+)
+service ServiceOne {
+    operations: []
+}
+
+@prompts(
+    "search_users": {
+        template: "Search for users in ServiceTwo"
+        description: "ServiceTwo search template"
+    }
+)
+service ServiceTwo {
+    operations: []
+}

--- a/smithy-ai-traits/src/test/resources/duplicate-prompts.smithy
+++ b/smithy-ai-traits/src/test/resources/duplicate-prompts.smithy
@@ -1,0 +1,30 @@
+$version: "2.0"
+
+namespace com.example.test
+
+use smithy.ai#prompts
+
+@prompts(
+    "search_users": {
+        template: "Search for users in the system"
+        description: "Service-level search template"
+    }
+    "list_items": {
+        template: "List all items"
+        description: "List template"
+    }
+)
+service TestService {
+    operations: [SearchOperation]
+}
+
+@prompts(
+    "Search_Users": {
+        template: "Search for users from operation"
+        description: "Operation-level search template (conflicts with service-level)"
+    }
+)
+operation SearchOperation {
+    input := {}
+    output := {}
+}

--- a/smithy-ai-traits/src/test/resources/service-level-duplicates.smithy
+++ b/smithy-ai-traits/src/test/resources/service-level-duplicates.smithy
@@ -1,0 +1,20 @@
+$version: "2.0"
+
+namespace com.example.test.service
+
+use smithy.ai#prompts
+
+// Test model for validating service-level prompt name conflicts
+@prompts(
+    "search_users": {
+        template: "Search for users in the system"
+        description: "Service-level search template"
+    }
+    "Search_Users": {
+        template: "DUPLICATE: Search for users again (intentional case conflict)"
+        description: "Duplicate search template with different case for testing validation"
+    }
+)
+service TestService {
+    operations: []
+}

--- a/smithy-ai-traits/src/test/resources/unique-prompts.smithy
+++ b/smithy-ai-traits/src/test/resources/unique-prompts.smithy
@@ -1,0 +1,31 @@
+$version: "2.0"
+
+namespace com.example.test.unique
+
+use smithy.ai#prompts
+
+// Test model for validating that unique prompt names do not trigger validation errors
+@prompts(
+    "search_users": {
+        template: "Search for users in the system"
+        description: "Service-level search template"
+    }
+    "list_items": {
+        template: "List all items"
+        description: "List template"
+    }
+)
+service TestService {
+    operations: [SearchOperation]
+}
+
+@prompts(
+    "get_details": {
+        template: "Get detailed information"
+        description: "Operation-level details template"
+    }
+)
+operation SearchOperation {
+    input := {}
+    output := {}
+}


### PR DESCRIPTION
## Add validation for prompt name uniqueness across services

- Implements validation to prevent prompt naming conflicts within Smithy services. Prompts are now validated for case-insensitive uniqueness across both service-level and operation-level definitions. 

### Changes
- Added a validator for model level uniqueness when the prompt is used to have unique names.
- Added a check in MCP Server to have validation when prompts are loaded for normalized name to be unique.

The prompts are checked for uniqueness of name case-insensitively following same rules as defined for ShapeIds in the [semantics](https://smithy.io/2.0/spec/model.html#shape-id-conflicts) of a Smithy Model. 
> While shape ID references within the semantic model are case-sensitive, no two shapes in the semantic model can have the same case-insensitive shape ID. This restriction makes it easier to use Smithy models for code generation in programming languages that do not support case-sensitive identifiers or that perform some kind of normalization on generated identifiers (for example, a Python code generator might convert all member names to lower snake case). To illustrate, com.Foo#baz and com.foo#BAZ are not allowed in the same semantic model. This restriction also extends to member names: com.foo#Baz$bar and com.foo#Baz$BAR are in conflict.


### Examples of conflict

### Invalid - would cause validation errors
```smithy
@prompts({
    get_employee_info: {
        description: "Service-level prompt"
        template: "Get employee info"
    }
})
service EmployeeService {
    operations: [GetEmployeeDetails]
}

@prompts({
    Get_Employee_Info: {  // Same name, different case
        description: "Operation-level prompt"
        template: "Get employee details"
    }
})
operation GetEmployeeDetails {
    // ...
}
```

**Validation Error**: `Prompt name 'Get_Employee_Info' conflicts with existing prompt 'get_employee_info' in service EmployeeService (case-insensitive comparison)`

### After (Valid - unique names):
```smithy
@prompts({
    get_employee_info: {
        description: "Service-level prompt"
        template: "Get employee info"
    }
})
service EmployeeService {
    operations: [GetEmployeeDetails]
}

@prompts({
    get_employee_details_operation: {  // Unique name
        description: "Operation-level prompt"
        template: "Get employee details"
    }
})
operation GetEmployeeDetails {
    // ...
}
```



### Testing

- SmithyBuild on the invalid model now throws error:

#### Validation changes
<img width="1275" height="341" alt="Screenshot 2025-07-30 at 5 23 12 PM" src="https://github.com/user-attachments/assets/94bbf256-157f-4642-984e-f0f81a4fb2ff" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
