### PR TITLE
Fix cross-branch pollution bug in SchemaConverter recursion detection

### DIFF
--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaConverter.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaConverter.java
@@ -101,7 +101,7 @@ public final class SchemaConverter {
             return true;
         }
 
-        return switch (shape.getType().getCategory()) {
+        var result = switch (shape.getType().getCategory()) {
             case SIMPLE, SERVICE -> false;
             case MEMBER -> isRecursive(visited, model.expectShape(shape.asMemberShape().orElseThrow().getTarget()));
             case AGGREGATE -> {
@@ -113,6 +113,10 @@ public final class SchemaConverter {
                 yield false;
             }
         };
+
+        // "Pop" the current node off the "stack" -- other branches are still allowed to contain this shape.
+        visited.remove(shape.getId());
+        return result;
     }
 
     private Schema createNonRecursiveSchema(Shape shape) {


### PR DESCRIPTION
*Issue #, if available:*
I did not file an issue.

*Description of changes:*
SchemaConverter would incorrectly identify member schemas as recursive when the shape graph contains multiple branches hitting the same target shape, downstream of the member shape.

This change "pops" the "top of stack" shape on the way out of isRecursive(), avoiding this cross-branch pollution.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
