### PR TITLE
added JDK8 compatibility for smithy-ai-traits

### DIFF
--- a/smithy-ai-traits/build.gradle.kts
+++ b/smithy-ai-traits/build.gradle.kts
@@ -42,6 +42,10 @@ spotbugs {
     ignoreFailures = true
 }
 
+tasks.compileJava {
+    options.release.set(8)
+}
+
 java.sourceSets["main"].java {
     srcDirs("model", "src/main/smithy")
 }

--- a/smithy-ai-traits/src/main/java/software/amazon/smithy/ai/PromptUniquenessValidator.java
+++ b/smithy-ai-traits/src/main/java/software/amazon/smithy/ai/PromptUniquenessValidator.java
@@ -46,17 +46,17 @@ public final class PromptUniquenessValidator extends AbstractValidator {
             }
         });
 
-        for (OperationShape operation : service.getOperations()
+        service.getOperations()
                 .stream()
                 .map(shapeId -> model.expectShape(shapeId, OperationShape.class))
-                .toList()) {
+                .forEach(operation -> {
 
-            operation.getTrait(PromptsTrait.class).ifPresent(promptsTrait -> {
-                for (String promptName : promptsTrait.getValues().keySet()) {
-                    checkPromptUniqueness(promptName, operation, seenPromptNames, events);
-                }
-            });
-        }
+                    operation.getTrait(PromptsTrait.class).ifPresent(promptsTrait -> {
+                        for (String promptName : promptsTrait.getValues().keySet()) {
+                            checkPromptUniqueness(promptName, operation, seenPromptNames, events);
+                        }
+                    });
+                });
     }
 
     private void checkPromptUniqueness(


### PR DESCRIPTION
We want to be able to consume the traits package in JDK 8 packages too. Fixed JDK 8 compatibility in validator tests.



Testing:
`./gradlew clean build` 

```
❯ javap -v 'jar:file:////Volumes/workplace/gateway-live/src/smithy-java/smithy-ai-traits/build/libs/smithy-ai-traits-0.0.2.jar!/software/amazon/smithy/ai/PromptsTrait.class' 'jar:file:////Volumes/workplace/gateway-live/src/smithy-java/smithy-ai-traits/build/libs/smithy-ai-traits-0.0.2.jar!/software/amazon/smithy/ai/PromptTemplateDefinition.class' | grep -B 2 "version:"
  Compiled from "PromptsTrait.java"
public final class software.amazon.smithy.ai.PromptsTrait extends software.amazon.smithy.model.traits.AbstractTrait implements software.amazon.smithy.utils.ToSmithyBuilder<software.amazon.smithy.ai.PromptsTrait>
  minor version: 0
  major version: 52
--
  Compiled from "PromptTemplateDefinition.java"
public final class software.amazon.smithy.ai.PromptTemplateDefinition extends java.lang.Object implements software.amazon.smithy.model.node.ToNode, software.amazon.smithy.utils.ToSmithyBuilder<software.amazon.smithy.ai.PromptTemplateDefinition>
  minor version: 0
  major version: 52
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
