### PR TITLE
Event stream implementation for RPCv2

### DIFF
--- a/aws/aws-event-streams/build.gradle.kts
+++ b/aws/aws-event-streams/build.gradle.kts
@@ -9,5 +9,6 @@ extra["moduleName"] = "software.amazon.smithy.java.aws.events"
 
 dependencies {
     api(project(":core"))
+    api(project(":http:http-api"))
     api("software.amazon.eventstream:eventstream:1.0.1")
 }

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventDecoderFactory.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventDecoderFactory.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.aws.events;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 import software.amazon.smithy.java.core.schema.InputEventStreamingApiOperation;
 import software.amazon.smithy.java.core.schema.OutputEventStreamingApiOperation;
@@ -17,43 +18,79 @@ import software.amazon.smithy.java.core.serde.event.EventDecoderFactory;
 import software.amazon.smithy.java.core.serde.event.FrameDecoder;
 import software.amazon.smithy.java.core.serde.event.FrameTransformer;
 
-public class AwsEventDecoderFactory<E extends SerializableStruct> implements EventDecoderFactory<AwsEventFrame> {
+/**
+ * A {@link EventDecoderFactory} for AWS events.
+ *
+ * @param <E>  The event shape type
+ * @param <IR> The initial request shape type
+ */
+public final class AwsEventDecoderFactory<E extends SerializableStruct, IR extends SerializableStruct>
+        implements EventDecoderFactory<AwsEventFrame> {
 
-    private final Schema schema;
+    private final String initialEventType;
+    private final Supplier<ShapeBuilder<IR>> initialEventBuilder;
+    private final Schema eventSchema;
     private final Codec codec;
     private final Supplier<ShapeBuilder<E>> eventBuilder;
     private final FrameTransformer<AwsEventFrame> transformer;
 
     private AwsEventDecoderFactory(
-            Schema schema,
+            String initialEventType,
+            Supplier<ShapeBuilder<IR>> initialEventBuilder,
+            Schema eventSchema,
             Codec codec,
             Supplier<ShapeBuilder<E>> eventBuilder,
             FrameTransformer<AwsEventFrame> transformer
     ) {
-        this.schema = schema.isMember() ? schema.memberTarget() : schema;
-        this.codec = codec;
-        this.eventBuilder = eventBuilder;
-        this.transformer = transformer;
+        this.initialEventType = Objects.requireNonNull(initialEventType, "initialEventType");
+        this.initialEventBuilder = Objects.requireNonNull(initialEventBuilder, "initialEventBuilder");
+        this.eventSchema = Objects.requireNonNull(eventSchema, "eventSchema").isMember() ? eventSchema.memberTarget()
+                : eventSchema;
+        this.codec = Objects.requireNonNull(codec, "codec");
+        this.eventBuilder = Objects.requireNonNull(eventBuilder, "eventBuilder");
+        this.transformer = Objects.requireNonNull(transformer, "transformer");
     }
 
-    public static <IE extends SerializableStruct> AwsEventDecoderFactory<IE> forInputStream(
+    /**
+     * Creates a new input stream decoder factory.
+     *
+     * @param operation   The input operation for the factory
+     * @param codec       The protocol codec to decode the payload
+     * @param transformer The frame transformer
+     * @param <IE>        The output event type
+     * @return A new event decoder factory
+     */
+    public static <IE extends SerializableStruct> AwsEventDecoderFactory<IE, ?> forInputStream(
             InputEventStreamingApiOperation<?, ?, IE> operation,
             Codec codec,
             FrameTransformer<AwsEventFrame> transformer
     ) {
         return new AwsEventDecoderFactory<>(
+                "initial-request",
+                operation::inputBuilder,
                 operation.inputStreamMember(),
                 codec,
                 operation.inputEventBuilderSupplier(),
                 transformer);
     }
 
-    public static <OE extends SerializableStruct> AwsEventDecoderFactory<OE> forOutputStream(
+    /**
+     * Creates a new output stream decoder factory.
+     *
+     * @param operation   The output operation for the factory
+     * @param codec       The protocol codec to decode the payload
+     * @param transformer The frame transformer
+     * @param <OE>        The output event type
+     * @return A new event decoder factory
+     */
+    public static <OE extends SerializableStruct> AwsEventDecoderFactory<OE, ?> forOutputStream(
             OutputEventStreamingApiOperation<?, ?, OE> operation,
             Codec codec,
             FrameTransformer<AwsEventFrame> transformer
     ) {
         return new AwsEventDecoderFactory<>(
+                "initial-response",
+                operation::outputBuilder,
                 operation.outputStreamMember(),
                 codec,
                 operation.outputEventBuilderSupplier(),
@@ -62,7 +99,7 @@ public class AwsEventDecoderFactory<E extends SerializableStruct> implements Eve
 
     @Override
     public EventDecoder<AwsEventFrame> newEventDecoder() {
-        return new AwsEventShapeDecoder<>(eventBuilder, schema, codec);
+        return new AwsEventShapeDecoder<>(initialEventType, initialEventBuilder, eventBuilder, eventSchema, codec);
     }
 
     @Override

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventEncoderFactory.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventEncoderFactory.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.aws.events;
 
+import java.util.Objects;
 import java.util.function.Function;
 import software.amazon.smithy.java.core.schema.InputEventStreamingApiOperation;
 import software.amazon.smithy.java.core.schema.OutputEventStreamingApiOperation;
@@ -15,46 +16,77 @@ import software.amazon.smithy.java.core.serde.event.EventEncoderFactory;
 import software.amazon.smithy.java.core.serde.event.EventStreamingException;
 import software.amazon.smithy.java.core.serde.event.FrameEncoder;
 
-public class AwsEventEncoderFactory implements EventEncoderFactory<AwsEventFrame> {
-
+/**
+ * A {@link EventEncoderFactory} for AWS events.
+ */
+public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEventFrame> {
+    private final String initialEventType;
     private final Schema schema;
     private final Codec codec;
     private final String payloadMediaType;
     private final Function<Throwable, EventStreamingException> exceptionHandler;
 
     private AwsEventEncoderFactory(
+            String initialEventType,
             Schema schema,
             Codec codec,
             String payloadMediaType,
             Function<Throwable, EventStreamingException> exceptionHandler
     ) {
-        this.schema = schema.isMember() ? schema.memberTarget() : schema;
-        this.codec = codec;
-        this.payloadMediaType = payloadMediaType;
-        this.exceptionHandler = exceptionHandler;
+        this.initialEventType = Objects.requireNonNull(initialEventType, "initialEventType");
+        this.schema = Objects.requireNonNull(schema, "schema").isMember() ? schema.memberTarget() : schema;
+        this.codec = Objects.requireNonNull(codec, "codec");
+        this.payloadMediaType = Objects.requireNonNull(payloadMediaType, "payloadMediaType");
+        this.exceptionHandler = Objects.requireNonNull(exceptionHandler, "exceptionHandler");
     }
 
+    /**
+     * Creates a new input stream encoder factory.
+     *
+     * @param operation        The input operation for the factory
+     * @param codec            The protocol codec to decode the payload
+     * @param payloadMediaType The payload media type
+     * @param exceptionHandler The handler to convert exceptions for event streaming
+     * @return A new event encoder factory
+     */
     public static AwsEventEncoderFactory forInputStream(
             InputEventStreamingApiOperation<?, ?, ?> operation,
             Codec codec,
             String payloadMediaType,
             Function<Throwable, EventStreamingException> exceptionHandler
     ) {
-        return new AwsEventEncoderFactory(operation.inputStreamMember(), codec, payloadMediaType, exceptionHandler);
+        return new AwsEventEncoderFactory("initial-request",
+                operation.inputStreamMember(),
+                codec,
+                payloadMediaType,
+                exceptionHandler);
     }
 
+    /**
+     * Creates a new output stream encoder factory.
+     *
+     * @param operation        The output operation for the factory
+     * @param codec            The protocol codec to decode the payload
+     * @param payloadMediaType The payload media type
+     * @param exceptionHandler The handler to convert exceptions for event streaming
+     * @return A new event encoder factory
+     */
     public static AwsEventEncoderFactory forOutputStream(
             OutputEventStreamingApiOperation<?, ?, ?> operation,
             Codec codec,
             String payloadMediaType,
             Function<Throwable, EventStreamingException> exceptionHandler
     ) {
-        return new AwsEventEncoderFactory(operation.outputStreamMember(), codec, payloadMediaType, exceptionHandler);
+        return new AwsEventEncoderFactory("initial-response",
+                operation.outputStreamMember(),
+                codec,
+                payloadMediaType,
+                exceptionHandler);
     }
 
     @Override
     public EventEncoder<AwsEventFrame> newEventEncoder() {
-        return new AwsEventShapeEncoder(schema, codec, payloadMediaType, exceptionHandler);
+        return new AwsEventShapeEncoder(initialEventType, schema, codec, payloadMediaType, exceptionHandler);
     }
 
     @Override
@@ -66,5 +98,4 @@ public class AwsEventEncoderFactory implements EventEncoderFactory<AwsEventFrame
     public String contentType() {
         return "application/vnd.amazon.eventstream";
     }
-
 }

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeDecoder.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeDecoder.java
@@ -5,56 +5,118 @@
 
 package software.amazon.smithy.java.aws.events;
 
+import java.util.Objects;
+import java.util.concurrent.Flow;
 import java.util.function.Supplier;
 import software.amazon.eventstream.Message;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.SpecificShapeDeserializer;
 import software.amazon.smithy.java.core.serde.event.EventDecoder;
 
-public final class AwsEventShapeDecoder<E extends SerializableStruct> implements EventDecoder<AwsEventFrame> {
+/**
+ * A decoder for AWS events
+ *
+ * @param <E>  The type of the event
+ * @param <IR> The type of the initial event
+ */
+public final class AwsEventShapeDecoder<E extends SerializableStruct, IR extends SerializableStruct>
+        implements EventDecoder<AwsEventFrame> {
 
+    private final String initialEventType;
+    private final Supplier<ShapeBuilder<IR>> initialEventBuilder;
     private final Supplier<ShapeBuilder<E>> eventBuilder;
     private final Schema eventSchema;
     private final Codec codec;
+    private volatile Flow.Publisher<SerializableStruct> publisher;
 
-    public AwsEventShapeDecoder(
+    AwsEventShapeDecoder(
+            String initialEventType,
+            Supplier<ShapeBuilder<IR>> initialEventBuilder,
             Supplier<ShapeBuilder<E>> eventBuilder,
             Schema eventSchema,
             Codec codec
     ) {
-        this.eventBuilder = eventBuilder;
-        this.eventSchema = eventSchema;
-        this.codec = codec;
+        this.initialEventType = Objects.requireNonNull(initialEventType, "initialEventType");
+        this.initialEventBuilder = Objects.requireNonNull(initialEventBuilder, "initialEventBuilder");
+        this.eventBuilder = Objects.requireNonNull(eventBuilder, "eventBuilder");
+        this.eventSchema = Objects.requireNonNull(eventSchema, "eventSchema");
+        this.codec = Objects.requireNonNull(codec, "codec");
     }
 
     @Override
-    public E decode(AwsEventFrame frame) {
-        Message message = frame.unwrap();
-        String messageType = getMessageType(message);
-        if (!messageType.equals("event")) {
-            throw new UnsupportedOperationException("Unsupported frame type: " + messageType);
+    public SerializableStruct decode(AwsEventFrame frame) {
+        var message = frame.unwrap();
+        var eventType = getEventType(message);
+        if (initialEventType.equals(eventType)) {
+            return decodeInitialResponse(frame);
         }
-        String eventType = getEventType(message);
-        Schema memberSchema = eventSchema.member(eventType);
+        return decodeEvent(frame);
+    }
+
+    @Override
+    public void onPrepare(Flow.Publisher<SerializableStruct> publisher) {
+        this.publisher = publisher;
+    }
+
+    private E decodeEvent(AwsEventFrame frame) {
+        var message = frame.unwrap();
+        var eventType = getEventType(message);
+        var memberSchema = eventSchema.member(eventType);
         if (memberSchema == null) {
             throw new IllegalArgumentException("Unsupported event type: " + eventType);
         }
+        var codecDeserializer = codec.createDeserializer(message.getPayload());
+        var eventDeserializer = new AwsEventDeserializer(memberSchema, codecDeserializer);
+        var builder = eventBuilder.get();
+        return builder.deserialize(eventDeserializer).build();
+    }
 
-        return eventBuilder.get()
-                .deserialize(
-                        new AwsEventDeserializer(
-                                memberSchema,
-                                codec.createDeserializer(message.getPayload())))
-                .build();
+    private IR decodeInitialResponse(AwsEventFrame frame) {
+        var message = frame.unwrap();
+        var codecDeserializer = codec.createDeserializer(message.getPayload());
+        var builder = initialEventBuilder.get();
+        builder.deserialize(codecDeserializer);
+        var publisherMember = getPublisherMember(builder.schema());
+        var responseDeserializer = new EventStreamDeserializer(publisherMember, publisher);
+        builder.deserialize(responseDeserializer);
+        return builder.build();
+    }
+
+    private Schema getPublisherMember(Schema schema) {
+        for (var member : schema.members()) {
+            if (member.memberTarget().hasTrait(TraitKey.STREAMING_TRAIT)) {
+                return member;
+            }
+        }
+        throw new IllegalArgumentException("cannot find streaming member");
     }
 
     private String getEventType(Message message) {
         return message.getHeaders().get(":event-type").getString();
     }
 
-    private String getMessageType(Message message) {
-        return message.getHeaders().get(":message-type").getString();
+    static class EventStreamDeserializer extends SpecificShapeDeserializer {
+        private final Schema publisherMember;
+        private final Flow.Publisher<? extends SerializableStruct> publisher;
+
+        EventStreamDeserializer(Schema publisherMember, Flow.Publisher<? extends SerializableStruct> publisher) {
+            this.publisherMember = publisherMember;
+            this.publisher = publisher;
+        }
+
+        @Override
+        public Flow.Publisher<? extends SerializableStruct> readEventStream(Schema schema) {
+            return publisher;
+        }
+
+        @Override
+        public <T> void readStruct(Schema schema, T state, ShapeDeserializer.StructMemberConsumer<T> consumer) {
+            consumer.accept(state, publisherMember, this);
+        }
     }
 }

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoder.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoder.java
@@ -6,16 +6,19 @@
 package software.amazon.smithy.java.aws.events;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import software.amazon.eventstream.HeaderValue;
 import software.amazon.eventstream.Message;
 import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
@@ -26,7 +29,7 @@ import software.amazon.smithy.model.shapes.ShapeId;
 
 public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
 
-    private final Schema eventSchema;
+    private final String initialEventType;
     private final Codec codec;
     private final String payloadMediaType;
     private final Set<String> possibleTypes;
@@ -34,29 +37,48 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
     private final Function<Throwable, EventStreamingException> exceptionHandler;
 
     public AwsEventShapeEncoder(
+            String initialEventType,
             Schema eventSchema,
             Codec codec,
             String payloadMediaType,
             Function<Throwable, EventStreamingException> exceptionHandler
     ) {
-        this.eventSchema = eventSchema;
-        this.codec = codec;
-        this.payloadMediaType = payloadMediaType;
-        this.possibleTypes = eventSchema.members().stream().map(Schema::memberName).collect(Collectors.toSet());
-        this.possibleExceptions = eventSchema.members()
-                .stream()
-                .filter(s -> s.hasTrait(TraitKey.ERROR_TRAIT))
-                .collect(Collectors.toMap(s -> s.memberTarget().id(), Function.identity()));
-        this.exceptionHandler = exceptionHandler;
+        this.initialEventType = Objects.requireNonNull(initialEventType, "initialEventType");
+        this.codec = Objects.requireNonNull(codec, "codec");
+        this.payloadMediaType = Objects.requireNonNull(payloadMediaType, "payloadMediaType");
+        this.possibleTypes = possibleTypes(Objects.requireNonNull(eventSchema, "eventSchema"));
+        this.possibleExceptions = possibleExceptions(Objects.requireNonNull(eventSchema, "eventSchema"));
+        this.exceptionHandler = Objects.requireNonNull(exceptionHandler, "exceptionHandler");
     }
 
     @Override
     public AwsEventFrame encode(SerializableStruct item) {
-        var os = new ByteArrayOutputStream();
         var typeHolder = new AtomicReference<String>();
-        try (var baseSerializer = codec.createSerializer(os)) {
+        var payload = encodeInput(item, typeHolder);
+        var headers = Map.of(
+                ":message-type",
+                HeaderValue.fromString("event"),
+                ":event-type",
+                HeaderValue.fromString(typeHolder.get()),
+                ":content-type",
+                HeaderValue.fromString(payloadMediaType));
+        return new AwsEventFrame(new Message(headers, payload));
+    }
 
-            item.serializeMembers(new SpecificShapeSerializer() {
+    private byte[] encodeInput(SerializableStruct item, AtomicReference<String> typeHolder) {
+        if (isInitialRequest(item.schema())) {
+            // The initial event is serialized fully instead of just a single member as for events.
+            typeHolder.compareAndSet(null, initialEventType);
+            var os = new ByteArrayOutputStream();
+            try (var baseSerializer = codec.createSerializer(os)) {
+                SchemaUtils.withFilteredMembers(item.schema(), item, this::excludeEventStreamMember)
+                        .serialize(baseSerializer);
+            }
+            return os.toByteArray();
+        }
+        var os = new ByteArrayOutputStream();
+        try (var baseSerializer = codec.createSerializer(os)) {
+            var serializer = new SpecificShapeSerializer() {
                 @Override
                 public void writeStruct(Schema schema, SerializableStruct struct) {
                     if (possibleTypes.contains(schema.memberName())) {
@@ -64,43 +86,82 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
                     }
                     baseSerializer.writeStruct(schema, struct);
                 }
-            });
+            };
+            item.serializeMembers(serializer);
         }
+        return os.toByteArray();
+    }
 
-        var headers = new HashMap<String, HeaderValue>();
-        headers.put(":event-type", HeaderValue.fromString(typeHolder.get()));
-        headers.put(":message-type", HeaderValue.fromString("event"));
-        headers.put(":content-type", HeaderValue.fromString(payloadMediaType));
+    private boolean isInitialRequest(Schema schema) {
+        for (var member : schema.members()) {
+            if (isEventStreamMember(member)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-        return new AwsEventFrame(new Message(headers, os.toByteArray()));
+    private boolean excludeEventStreamMember(Schema schema) {
+        return !isEventStreamMember(schema);
+    }
+
+    private boolean isEventStreamMember(Schema schema) {
+        if (schema.isMember() && schema.memberTarget().hasTrait(TraitKey.STREAMING_TRAIT)) {
+            return true;
+        }
+        return false;
     }
 
     @Override
     public AwsEventFrame encodeFailure(Throwable exception) {
         AwsEventFrame frame;
         Schema exceptionSchema;
-        if (exception instanceof ModeledException me && (exceptionSchema = possibleExceptions.get(
-                me.schema().id())) != null) {
-            var headers = new HashMap<String, HeaderValue>();
-            headers.put(":message-type", HeaderValue.fromString("exception"));
-            headers.put(
+        if (exception instanceof ModeledException me
+                && (exceptionSchema = possibleExceptions.get(me.schema().id())) != null) {
+            var headers = Map.of(
+                    ":message-type",
+                    HeaderValue.fromString("exception"),
                     ":exception-type",
-                    HeaderValue.fromString(exceptionSchema.memberName()));
-            headers.put(":content-type", HeaderValue.fromString(payloadMediaType));
+                    HeaderValue.fromString(exceptionSchema.memberName()),
+                    ":content-type",
+                    HeaderValue.fromString(payloadMediaType));
             var payload = codec.serialize(me);
             var bytes = new byte[payload.remaining()];
             payload.get(bytes);
             frame = new AwsEventFrame(new Message(headers, bytes));
         } else {
             EventStreamingException es = exceptionHandler.apply(exception);
-            var headers = new HashMap<String, HeaderValue>();
-            headers.put(":message-type", HeaderValue.fromString("error"));
-            headers.put(":error-code", HeaderValue.fromString(es.getErrorCode()));
-            headers.put(":error-message", HeaderValue.fromString(es.getMessage()));
-
+            var headers = Map.of(
+                    ":message-type",
+                    HeaderValue.fromString("error"),
+                    ":error-code",
+                    HeaderValue.fromString(es.getErrorCode()),
+                    ":error-message",
+                    HeaderValue.fromString(es.getMessage()));
             frame = new AwsEventFrame(new Message(headers, new byte[0]));
         }
         return frame;
 
+    }
+
+    static Set<String> possibleTypes(Schema eventSchema) {
+        var result = new HashSet<String>();
+        for (var memberSchema : eventSchema.members()) {
+            String memberName = memberSchema.memberName();
+            result.add(memberName);
+        }
+        return Collections.unmodifiableSet(result);
+    }
+
+    static Map<ShapeId, Schema> possibleExceptions(Schema eventSchema) {
+        var result = new HashMap<ShapeId, Schema>();
+        for (var memberSchema : eventSchema.members()) {
+            if (memberSchema.hasTrait(TraitKey.ERROR_TRAIT)) {
+                if (result.put(memberSchema.memberTarget().id(), memberSchema) != null) {
+                    throw new IllegalStateException("Duplicate key");
+                }
+            }
+        }
+        return Collections.unmodifiableMap(result);
     }
 }

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsFrameDecoder.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsFrameDecoder.java
@@ -6,8 +6,8 @@
 package software.amazon.smithy.java.aws.events;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import software.amazon.eventstream.MessageDecoder;
 import software.amazon.smithy.java.core.serde.event.FrameDecoder;
 import software.amazon.smithy.java.core.serde.event.FrameTransformer;
@@ -23,11 +23,15 @@ public final class AwsFrameDecoder implements FrameDecoder<AwsEventFrame> {
     @Override
     public List<AwsEventFrame> decode(ByteBuffer buffer) {
         decoder.feed(buffer);
-        return decoder.getDecodedMessages()
-                .stream()
-                .map(AwsEventFrame::new)
-                .map(transformer)
-                .filter(Objects::nonNull)
-                .toList();
+        var messages = decoder.getDecodedMessages();
+        var result = new ArrayList<AwsEventFrame>();
+        for (var message : messages) {
+            var event = new AwsEventFrame(message);
+            var transformed = transformer.apply(event);
+            if (transformed != null) {
+                result.add(transformed);
+            }
+        }
+        return result;
     }
 }

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/RpcEventStreamResponse.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/RpcEventStreamResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.event.EventDecoderFactory;
+import software.amazon.smithy.java.core.serde.event.EventStreamFrameDecodingProcessor;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.io.datastream.DataStream;
+
+/**
+ * A util class to deserialize event streams responses for RPC protocols.
+ */
+public final class RpcEventStreamResponse {
+
+    private RpcEventStreamResponse() {}
+
+    public static <O extends SerializableStruct> CompletableFuture<O> deserializeResponse(
+            EventDecoderFactory<AwsEventFrame> eventDecoderFactory,
+            HttpResponse response
+    ) {
+        var bodyDataStream = bodyDataStream(response);
+        var result = new CompletableFuture<O>();
+        var processor = EventStreamFrameDecodingProcessor.create(bodyDataStream, eventDecoderFactory);
+
+        // A subscriber to serialize the initial event.
+        processor.subscribe(new Flow.Subscriber<>() {
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(1);
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void onNext(SerializableStruct item) {
+                result.complete((O) item);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                result.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                result.completeExceptionally(new RuntimeException("Unexpected vent stream completion"));
+            }
+        });
+
+        return result;
+    }
+
+    private static DataStream bodyDataStream(HttpResponse response) {
+        var contentType = response.headers().contentType();
+        var contentLength = response.headers().contentLength();
+        return DataStream.withMetadata(response.body(), contentType, contentLength, null);
+    }
+}

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/RpcEventStreamsRequest.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/RpcEventStreamsRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.Flow;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.TraitKey;
+import software.amazon.smithy.java.core.serde.event.EventEncoderFactory;
+import software.amazon.smithy.java.core.serde.event.EventStreamFrameEncodingProcessor;
+
+/**
+ * A util class to serialize event streams requests for RPC protocols.
+ */
+public final class RpcEventStreamsRequest {
+
+    private RpcEventStreamsRequest() {}
+
+    public static Flow.Publisher<ByteBuffer> bodyForEventStreaming(
+            EventEncoderFactory<AwsEventFrame> eventStreamEncodingFactory,
+            SerializableStruct input
+    ) {
+        Flow.Publisher<SerializableStruct> eventStream = input.getMemberValue(streamingMember(input.schema()));
+        var publisher = EventStreamFrameEncodingProcessor.create(eventStream, eventStreamEncodingFactory);
+        // Queue the input as the initial-request.
+        publisher.onNext(input);
+        return publisher;
+    }
+
+    private static Schema streamingMember(Schema schema) {
+        for (var member : schema.members()) {
+            if (member.isMember() && member.memberTarget().hasTrait(TraitKey.STREAMING_TRAIT)) {
+                return member;
+            }
+        }
+        throw new IllegalArgumentException("No streaming member found");
+    }
+}

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientTransport.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientTransport.java
@@ -160,7 +160,7 @@ public class JavaHttpClientTransport implements ClientTransport<HttpRequest, Htt
 
         var headers = HttpHeaders.of(headerMap);
         var length = headers.contentLength();
-        long adaptedLength = length == null ? -1 : length;
+        var adaptedLength = length == null ? -1 : length;
 
         return HttpResponse.builder()
                 .httpVersion(javaToSmithyVersion(response.version()))
@@ -192,10 +192,18 @@ public class JavaHttpClientTransport implements ClientTransport<HttpRequest, Htt
             return "http-java";
         }
 
-        // TODO: Determine what configuration is actually needed.
         @Override
         public JavaHttpClientTransport createTransport(Document node) {
-            return new JavaHttpClientTransport();
+            setHostProperties();
+            var versionNode = node.asStringMap().get("version");
+            HttpClient httpClient;
+            if (versionNode != null) {
+                var version = HttpVersion.from(versionNode.asString());
+                httpClient = HttpClient.newBuilder().version(smithyToHttpVersion(version)).build();
+            } else {
+                httpClient = HttpClient.newHttpClient();
+            }
+            return new JavaHttpClientTransport(httpClient);
         }
 
         @Override

--- a/client/client-rpcv2-cbor/build.gradle.kts
+++ b/client/client-rpcv2-cbor/build.gradle.kts
@@ -11,6 +11,7 @@ extra["moduleName"] = "software.amazon.smithy.java.client.rpcv2cbor"
 dependencies {
     api(project(":client:client-http"))
     api(project(":codecs:cbor-codec"))
+    api(project(":aws:aws-event-streams"))
     api(libs.smithy.aws.traits)
 
     implementation(libs.smithy.protocol.traits)

--- a/client/client-rpcv2-cbor/src/main/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocol.java
+++ b/client/client-rpcv2-cbor/src/main/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocol.java
@@ -10,6 +10,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import software.amazon.smithy.java.aws.events.AwsEventDecoderFactory;
+import software.amazon.smithy.java.aws.events.AwsEventEncoderFactory;
+import software.amazon.smithy.java.aws.events.AwsEventFrame;
+import software.amazon.smithy.java.aws.events.RpcEventStreamResponse;
+import software.amazon.smithy.java.aws.events.RpcEventStreamsRequest;
 import software.amazon.smithy.java.cbor.Rpcv2CborCodec;
 import software.amazon.smithy.java.client.core.ClientProtocol;
 import software.amazon.smithy.java.client.core.ClientProtocolFactory;
@@ -18,13 +23,19 @@ import software.amazon.smithy.java.client.http.HttpClientProtocol;
 import software.amazon.smithy.java.client.http.HttpErrorDeserializer;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.InputEventStreamingApiOperation;
+import software.amazon.smithy.java.core.schema.OutputEventStreamingApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.Unit;
 import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.java.core.serde.event.EventDecoderFactory;
+import software.amazon.smithy.java.core.serde.event.EventEncoderFactory;
+import software.amazon.smithy.java.core.serde.event.EventStreamingException;
 import software.amazon.smithy.java.http.api.HttpHeaders;
 import software.amazon.smithy.java.http.api.HttpRequest;
 import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.http.api.HttpVersion;
 import software.amazon.smithy.java.io.ByteBufferOutputStream;
 import software.amazon.smithy.java.io.datastream.DataStream;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -32,7 +43,8 @@ import software.amazon.smithy.protocol.traits.Rpcv2CborTrait;
 
 public final class RpcV2CborProtocol extends HttpClientProtocol {
     private static final Codec CBOR_CODEC = Rpcv2CborCodec.builder().build();
-    private static final List<String> CONTENT_TYPE = List.of("application/cbor");
+    private static final String PAYLOAD_MEDIA_TYPE = "application/cbor";
+    private static final List<String> CONTENT_TYPE = List.of(PAYLOAD_MEDIA_TYPE);
     private static final List<String> SMITHY_PROTOCOL = List.of("rpc-v2-cbor");
 
     private final ShapeId service;
@@ -41,10 +53,7 @@ public final class RpcV2CborProtocol extends HttpClientProtocol {
     public RpcV2CborProtocol(ShapeId service) {
         super(Rpcv2CborTrait.ID);
         this.service = service;
-        this.errorDeserializer = HttpErrorDeserializer.builder()
-                .codec(CBOR_CODEC)
-                .serviceId(service)
-                .build();
+        this.errorDeserializer = HttpErrorDeserializer.builder().codec(CBOR_CODEC).serviceId(service).build();
     }
 
     @Override
@@ -60,38 +69,25 @@ public final class RpcV2CborProtocol extends HttpClientProtocol {
             URI endpoint
     ) {
         var target = "/service/" + service.getName() + "/operation/" + operation.schema().id().getName();
+        var builder = HttpRequest.builder().method("POST").uri(endpoint.resolve(target));
 
-        Map<String, List<String>> headers;
-        DataStream body;
+        builder.httpVersion(HttpVersion.HTTP_2);
         if (Unit.ID.equals(operation.inputSchema().id())) {
             // Top-level Unit types do not get serialized
-            headers = Map.of(
-                    "smithy-protocol",
-                    SMITHY_PROTOCOL,
-                    "Accept",
-                    CONTENT_TYPE);
-            body = DataStream.ofEmpty();
+            builder.headers(HttpHeaders.of(headersForEmptyBody()))
+                    .body(DataStream.ofEmpty());
+        } else if (operation instanceof InputEventStreamingApiOperation<?, ?, ?> i) {
+            // Event streaming
+            var encoderFactory = getEventEncoderFactory(i);
+            var body = RpcEventStreamsRequest.bodyForEventStreaming(encoderFactory, input);
+            builder.headers(HttpHeaders.of(headersForEventStreaming()))
+                    .body(body);
         } else {
-            var sink = new ByteBufferOutputStream();
-            try (var serializer = CBOR_CODEC.createSerializer(sink)) {
-                input.serialize(serializer);
-            }
-            headers = Map.of(
-                    "Content-Type",
-                    CONTENT_TYPE,
-                    "smithy-protocol",
-                    SMITHY_PROTOCOL,
-                    "Accept",
-                    CONTENT_TYPE);
-            body = DataStream.ofByteBuffer(sink.toByteBuffer(), "application/cbor");
+            // Regular request
+            builder.headers(HttpHeaders.of(headers()))
+                    .body(getBody(input));
         }
-
-        return HttpRequest.builder()
-                .method("POST")
-                .uri(endpoint.resolve(target))
-                .headers(HttpHeaders.of(headers))
-                .body(body)
-                .build();
+        return builder.build();
     }
 
     @Override
@@ -109,6 +105,11 @@ public final class RpcV2CborProtocol extends HttpClientProtocol {
                     });
         }
 
+        if (operation instanceof OutputEventStreamingApiOperation<I, O, ?> o) {
+            var eventDecoderFactory = getEventDecoderFactory(o);
+            return RpcEventStreamResponse.deserializeResponse(eventDecoderFactory, response);
+        }
+
         var builder = operation.outputBuilder();
         var content = response.body();
         if (content.contentLength() == 0) {
@@ -120,6 +121,50 @@ public final class RpcV2CborProtocol extends HttpClientProtocol {
                 .toCompletableFuture();
     }
 
+    private DataStream getBody(SerializableStruct input) {
+        var sink = new ByteBufferOutputStream();
+        try (var serializer = CBOR_CODEC.createSerializer(sink)) {
+            input.serialize(serializer);
+        }
+        return DataStream.ofByteBuffer(sink.toByteBuffer(), PAYLOAD_MEDIA_TYPE);
+    }
+
+    private Map<String, List<String>> headers() {
+        return Map.of("smithy-protocol", SMITHY_PROTOCOL, "Content-Type", CONTENT_TYPE, "Accept", CONTENT_TYPE);
+    }
+
+    private Map<String, List<String>> headersForEmptyBody() {
+        return Map.of("smithy-protocol", SMITHY_PROTOCOL, "Accept", CONTENT_TYPE);
+    }
+
+    private Map<String, List<String>> headersForEventStreaming() {
+        return Map.of("smithy-protocol",
+                SMITHY_PROTOCOL,
+                "Content-Type",
+                List.of("application/vnd.amazon.eventstream"),
+                "Accept",
+                CONTENT_TYPE);
+    }
+
+    private EventEncoderFactory<AwsEventFrame> getEventEncoderFactory(
+            InputEventStreamingApiOperation<?, ?, ?> inputOperation
+    ) {
+
+        // TODO: this is where you'd plumb through Sigv4 support, another frame transformer?
+        return AwsEventEncoderFactory.forInputStream(inputOperation,
+                payloadCodec(),
+                PAYLOAD_MEDIA_TYPE,
+                (e) -> new EventStreamingException("InternalServerException", "Internal Server Error"));
+    }
+
+    private EventDecoderFactory<AwsEventFrame> getEventDecoderFactory(
+            OutputEventStreamingApiOperation<?, ?, ?> outputOperation
+    ) {
+        return AwsEventDecoderFactory.forOutputStream(outputOperation,
+                payloadCodec(),
+                f -> f);
+    }
+
     public static final class Factory implements ClientProtocolFactory<Rpcv2CborTrait> {
         @Override
         public ShapeId id() {
@@ -129,9 +174,7 @@ public final class RpcV2CborProtocol extends HttpClientProtocol {
         @Override
         public ClientProtocol<?, ?> createProtocol(ProtocolSettings settings, Rpcv2CborTrait trait) {
             return new RpcV2CborProtocol(
-                    Objects.requireNonNull(
-                            settings.service(),
-                            "service is a required protocol setting"));
+                    Objects.requireNonNull(settings.service(), "service is a required protocol setting"));
         }
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/SchemaUtils.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/SchemaUtils.java
@@ -44,7 +44,7 @@ public final class SchemaUtils {
 
             @Override
             public <T> T getMemberValue(Schema member) {
-                return memberPredicate.test(schema()) ? getMemberValue(member) : null;
+                return memberPredicate.test(schema()) ? struct.getMemberValue(member) : null;
             }
         };
     }

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/BufferingFlatMapProcessor.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/BufferingFlatMapProcessor.java
@@ -65,26 +65,33 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
     @Override
     public final void onNext(I item) {
         try {
-            map(item).forEach(queue::add);
+            map(item).forEach(this::addToQueue);
         } catch (Exception e) {
             onError(new SerializationException("Malformed input", e));
             return;
         }
-
         flush();
+    }
+
+    private void addToQueue(O item) {
+        queue.add(item);
     }
 
     @Override
     public final void onError(Throwable t) {
         upstreamSubscription.cancel();
         terminalEvent.compareAndSet(null, t);
-        flush();
+        if (upstreamSubscription != null && downstream != null) {
+            flush();
+        }
     }
 
     @Override
     public final void onComplete() {
         terminalEvent.compareAndSet(null, COMPLETE_SENTINEL);
-        flush();
+        if (upstreamSubscription != null && downstream != null) {
+            flush();
+        }
     }
 
     @Override
@@ -234,5 +241,4 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
     private static long accumulate(AtomicLong l, long n) {
         return l.accumulateAndGet(n, BufferingFlatMapProcessor::accumulate);
     }
-
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/event/EventDecoder.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/event/EventDecoder.java
@@ -5,10 +5,20 @@
 
 package software.amazon.smithy.java.core.serde.event;
 
+import java.util.concurrent.Flow;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 
 public interface EventDecoder<F extends Frame<?>> {
 
     SerializableStruct decode(F frame);
 
+    /**
+     * Called once after building the publisher to allow the decoder to do any one-time setup prior to start processing
+     * events.
+     *
+     * @param publisher The events publisher.
+     */
+    default void onPrepare(Flow.Publisher<SerializableStruct> publisher) {
+        // does nothing by default.
+    }
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/event/EventStreamFrameDecodingProcessor.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/event/EventStreamFrameDecodingProcessor.java
@@ -11,33 +11,58 @@ import java.util.stream.Stream;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.BufferingFlatMapProcessor;
 
+/**
+ * Processor to pipe raw byte arrays to frame encoders and then to event encoders.
+ *
+ * @param <F> The frame type.
+ */
 public final class EventStreamFrameDecodingProcessor<F extends Frame<?>>
         extends BufferingFlatMapProcessor<ByteBuffer, SerializableStruct> {
-    private final FrameDecoder<F> decoder;
+    private final FrameDecoder<F> frameDecoder;
     private final EventDecoder<F> eventDecoder;
 
-    public EventStreamFrameDecodingProcessor(
+    EventStreamFrameDecodingProcessor(
             Flow.Publisher<ByteBuffer> publisher,
-            FrameDecoder<F> decoder,
+            FrameDecoder<F> frameDecoder,
             EventDecoder<F> eventDecoder
     ) {
         super(publisher);
-        this.decoder = decoder;
+        this.frameDecoder = frameDecoder;
         this.eventDecoder = eventDecoder;
     }
 
+    /**
+     * Creates a new processor with the given publisher and decoder factory. This method calls prepare to setup the
+     * decoders prior to start processing events.
+     *
+     * @param publisher           The publisher generating the events
+     * @param eventDecoderFactory The decoder factory to decode the raw bytes
+     * @param <F>                 The type of the frame
+     * @return A new processor
+     */
     public static <F extends Frame<?>> EventStreamFrameDecodingProcessor<F> create(
             Flow.Publisher<ByteBuffer> publisher,
             EventDecoderFactory<F> eventDecoderFactory
     ) {
-        return new EventStreamFrameDecodingProcessor<>(
+        var result = new EventStreamFrameDecodingProcessor<>(
                 publisher,
                 eventDecoderFactory.newFrameDecoder(),
                 eventDecoderFactory.newEventDecoder());
+        result.prepare();
+        return result;
+    }
+
+    /**
+     * Called once after building the frame processor to allow decoders to do any one-time setup prior to start
+     * processing events.
+     */
+    void prepare() {
+        frameDecoder.onPrepare(this);
+        eventDecoder.onPrepare(this);
     }
 
     @Override
     protected Stream<SerializableStruct> map(ByteBuffer item) {
-        return decoder.decode(item).stream().map(eventDecoder::decode);
+        return frameDecoder.decode(item).stream().map(eventDecoder::decode);
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/event/EventStreamFrameEncodingProcessor.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/event/EventStreamFrameEncodingProcessor.java
@@ -16,7 +16,7 @@ public final class EventStreamFrameEncodingProcessor<F extends Frame<?>, T exten
     private final EventEncoder<F> eventEncoder;
     private final FrameEncoder<F> encoder;
 
-    public EventStreamFrameEncodingProcessor(
+    private EventStreamFrameEncodingProcessor(
             Flow.Publisher<T> publisher,
             EventEncoder<F> eventEncoder,
             FrameEncoder<F> encoder
@@ -26,8 +26,8 @@ public final class EventStreamFrameEncodingProcessor<F extends Frame<?>, T exten
         this.encoder = encoder;
     }
 
-    public static <F extends Frame<?>> EventStreamFrameEncodingProcessor<F, ?> create(
-            Flow.Publisher<? extends SerializableStruct> publisher,
+    public static <F extends Frame<?>> EventStreamFrameEncodingProcessor<F, SerializableStruct> create(
+            Flow.Publisher<SerializableStruct> publisher,
             EventEncoderFactory<F> encoderFactory
     ) {
         return new EventStreamFrameEncodingProcessor<>(

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/event/FrameDecoder.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/event/FrameDecoder.java
@@ -7,6 +7,8 @@ package software.amazon.smithy.java.core.serde.event;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.Flow;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
 
 /**
  * Decodes frames from bytes.
@@ -19,4 +21,14 @@ public interface FrameDecoder<F extends Frame<?>> {
      * @return all the frames readable from this pass
      */
     List<F> decode(ByteBuffer buffer);
+
+    /**
+     * Called once after building the publisher to allow the decoder to do any one-time setup prior to start processing
+     * events.
+     *
+     * @param publisher The events publisher.
+     */
+    default void onPrepare(Flow.Publisher<SerializableStruct> publisher) {
+        // does nothing by default.
+    }
 }

--- a/examples/event-streaming-client/src/it/java/software/amazon/smithy/java/example/eventstreaming/EventStreamTest.java
+++ b/examples/event-streaming-client/src/it/java/software/amazon/smithy/java/example/eventstreaming/EventStreamTest.java
@@ -12,16 +12,18 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import software.amazon.smithy.java.example.eventstreaming.client.FizzBuzzServiceClient;
+import software.amazon.smithy.java.example.eventstreaming.model.BuzzEvent;
 import software.amazon.smithy.java.example.eventstreaming.model.FizzBuzzInput;
 import software.amazon.smithy.java.example.eventstreaming.model.FizzBuzzOutput;
 import software.amazon.smithy.java.example.eventstreaming.model.FizzBuzzStream;
+import software.amazon.smithy.java.example.eventstreaming.model.FizzEvent;
 import software.amazon.smithy.java.example.eventstreaming.model.Value;
 import software.amazon.smithy.java.example.eventstreaming.model.ValueStream;
 
@@ -46,6 +48,7 @@ public class EventStreamTest {
 
         AtomicLong receivedEvents = new AtomicLong();
         Set<Long> unbuzzed = new HashSet<>();
+        AtomicBoolean done = new AtomicBoolean();
         output.getStream().subscribe(new Flow.Subscriber<>() {
 
             private Flow.Subscription subscription;
@@ -62,7 +65,7 @@ public class EventStreamTest {
                 long value;
                 switch (item.type()) {
                     case fizz:
-                        value = item.getValue();
+                        value = item.<FizzEvent>getValue().getValue();
                         System.out.println("received fizz: " + value);
                         assertEquals(0, value % 3);
                         if (value % 5 == 0) {
@@ -70,7 +73,7 @@ public class EventStreamTest {
                         }
                         break;
                     case buzz:
-                        value = item.getValue();
+                        value = item.<BuzzEvent>getValue().getValue();
                         System.out.println("received buzz: " + value);
                         assertEquals(0, value % 5);
                         if (value % 3 == 0) {
@@ -85,16 +88,26 @@ public class EventStreamTest {
             }
 
             @Override
-            public void onError(Throwable throwable) {}
+            public void onError(Throwable throwable) {
+                System.out.println("Error: " + throwable.getMessage());
+                throwable.printStackTrace();
+            }
 
             @Override
             public void onComplete() {
+                done.set(true);
                 System.out.println("output stream completed");
             }
         });
 
         // wait to receive events in the response stream
-        Thread.sleep(100);
+        var waits = 10;
+        do {
+            Thread.sleep(100);
+            if (--waits <= 0) {
+                throw new RuntimeException("Timed out waiting for completion");
+            }
+        } while (!done.get());
 
         assertTrue(unbuzzed.isEmpty(), unbuzzed.size() + " unbuzzed fizzes");
         assertEquals((range / 3) + (range / 5), receivedEvents.get());

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpVersion.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpVersion.java
@@ -5,9 +5,26 @@
 
 package software.amazon.smithy.java.http.api;
 
+/**
+ * Enumeration of the HTTP protocol versions.
+ */
 public enum HttpVersion {
     HTTP_1_1,
     HTTP_2;
+
+    /**
+     * Returns the enum value that the version represents.
+     *
+     * @param version The string to convert to enum value
+     * @return The enum value that the version represents.
+     */
+    public static HttpVersion from(String version) {
+        return switch (version) {
+            case "HTTP/1.1" -> HTTP_1_1;
+            case "HTTP/2.0" -> HTTP_2;
+            default -> throw new UnsupportedOperationException("Unsupported HTTP version: " + version);
+        };
+    }
 
     @Override
     public String toString() {

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/RequestSerializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/RequestSerializer.java
@@ -8,10 +8,12 @@ package software.amazon.smithy.java.http.binding;
 import java.net.URI;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Flow;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.InputEventStreamingApiOperation;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.event.EventEncoderFactory;
@@ -157,7 +159,7 @@ public final class RequestSerializer {
                 .method(httpTrait.getMethod())
                 .uri(targetEndpoint);
 
-        var eventStream = serializer.getEventStream();
+        var eventStream = (Flow.Publisher<SerializableStruct>) serializer.getEventStream();
         if (eventStream != null && operation instanceof InputEventStreamingApiOperation<?, ?, ?>) {
             builder.body(EventStreamFrameEncodingProcessor.create(eventStream, eventStreamEncodingFactory));
             serializer.setContentType(eventStreamEncodingFactory.contentType());

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseSerializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseSerializer.java
@@ -7,10 +7,12 @@ package software.amazon.smithy.java.http.binding;
 
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Flow;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.OutputEventStreamingApiOperation;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.event.EventEncoderFactory;
@@ -126,7 +128,7 @@ public final class ResponseSerializer {
         Objects.requireNonNull(payloadMediaType, "payloadMediaType is not set");
 
         Schema schema;
-        boolean isFailure = errorSchema != null;
+        var isFailure = errorSchema != null;
         if (isFailure) {
             schema = errorSchema;
         } else {
@@ -147,7 +149,7 @@ public final class ResponseSerializer {
         var builder = HttpResponse.builder()
                 .statusCode(serializer.getResponseStatus());
 
-        var eventStream = serializer.getEventStream();
+        var eventStream = (Flow.Publisher<SerializableStruct>) serializer.getEventStream();
         if (eventStream != null && operation instanceof OutputEventStreamingApiOperation<?, ?, ?>) {
             builder.body(
                     EventStreamFrameEncodingProcessor.create(eventStream, eventEncoderFactory));


### PR DESCRIPTION

*Description of changes:*

Initial wire of event streams for RPC protocols, and H2 support. This change only includes RPCv2, and a follow up change will add support for the other RPC protocols.

This change **does not** include any of:

1. Support for `@eventPayload` trait
2. Support for `@eventHeader` trait
3. Event signing

These will be added in follow up changes.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
