### PR TITLE
Fix gradle to generate javadoc and sources jar for publishing

### DIFF
--- a/codecs/json-codec/build.gradle.kts
+++ b/codecs/json-codec/build.gradle.kts
@@ -43,3 +43,14 @@ tasks {
 configurePublishing {
     customComponent = components["shadow"] as SoftwareComponent
 }
+
+// Ensure sources and javadocs jars are included in shadow component
+afterEvaluate {
+    val shadowComponent = components["shadow"] as AdhocComponentWithVariants
+    shadowComponent.addVariantsFromConfiguration(configurations.sourcesElements.get()) {
+        mapToMavenScope("runtime")
+    }
+    shadowComponent.addVariantsFromConfiguration(configurations.javadocElements.get()) {
+        mapToMavenScope("runtime")
+    }
+}


### PR DESCRIPTION

*Description of changes:*


After #689 the Maven publishing does not longer generated the javadocs and sources jars for the `json-codec` module. This change is to add those back that are expected to be part of the release.
