### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Update Gradle Wrapper
 # Needed because dependabot doesn't support updating the gradle wrapper
 # see: https://github.com/dependabot/dependabot-core/issues/2223


### PR DESCRIPTION
Potential fix for [https://github.com/smithy-lang/smithy-java/security/code-scanning/1](https://github.com/smithy-lang/smithy-java/security/code-scanning/1)

To resolve the issue, add a `permissions` block with the minimum required privileges for the workflow. The best way to fix this is to add `permissions: { contents: read }` at the top level of the workflow (just after the `name:` line), which will apply to all jobs in the workflow except those with an override. This change preserves existing functionality while explicitly limiting the GITHUB_TOKEN's access. If the action needs to open pull requests, the minimal required write permission for that purpose (e.g., `pull-requests: write` or `contents: write`) should also be added, but with the information provided, start with `contents: read` as suggested by CodeQL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
