### PR TITLE
Add support for @eventHeader and @eventPayload for RPC protocols

### DIFF
--- a/aws/aws-event-streams/build.gradle.kts
+++ b/aws/aws-event-streams/build.gradle.kts
@@ -7,7 +7,12 @@ description = "This module provides AWS event streaming support"
 extra["displayName"] = "Smithy :: Java :: AWS :: Event Streams"
 extra["moduleName"] = "software.amazon.smithy.java.aws.events"
 
+tasks.test {
+    dependsOn(":codecs:json-codec:shadowJar")
+}
+
 dependencies {
     api(project(":core"))
     api("software.amazon.eventstream:eventstream:1.0.1")
+    testImplementation(project(":codecs:json-codec"))
 }

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeDecoder.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeDecoder.java
@@ -5,9 +5,13 @@
 
 package software.amazon.smithy.java.aws.events;
 
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Flow;
 import java.util.function.Supplier;
+import software.amazon.eventstream.HeaderValue;
 import software.amazon.eventstream.Message;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
@@ -52,7 +56,7 @@ public final class AwsEventShapeDecoder<E extends SerializableStruct, IR extends
     public SerializableStruct decode(AwsEventFrame frame) {
         var message = frame.unwrap();
         var eventType = getEventType(message);
-        if (initialEventType.getName().equals(eventType)) {
+        if (initialEventType.value().equals(eventType)) {
             return decodeInitialResponse(frame);
         }
         return decodeEvent(frame);
@@ -71,9 +75,14 @@ public final class AwsEventShapeDecoder<E extends SerializableStruct, IR extends
             throw new IllegalArgumentException("Unsupported event type: " + eventType);
         }
         var codecDeserializer = codec.createDeserializer(message.getPayload());
-        var eventDeserializer = new AwsEventDeserializer(memberSchema, codecDeserializer);
+        var headers = message.getHeaders();
+        var deserializer = new EventStreamDeserializer(codecDeserializer, new HeadersDeserializer(headers));
+        var memberTarget = memberSchema.memberTarget();
+        var shapeBuilder = memberTarget.shapeBuilder().get();
+        shapeBuilder.deserialize(deserializer);
         var builder = eventBuilder.get();
-        return builder.deserialize(eventDeserializer).build();
+        builder.setMemberValue(memberSchema, shapeBuilder.build());
+        return builder.build();
     }
 
     private IR decodeInitialResponse(AwsEventFrame frame) {
@@ -82,8 +91,13 @@ public final class AwsEventShapeDecoder<E extends SerializableStruct, IR extends
         var builder = initialEventBuilder.get();
         builder.deserialize(codecDeserializer);
         var publisherMember = getPublisherMember(builder.schema());
-        var responseDeserializer = new EventStreamDeserializer(publisherMember, publisher);
+        // Set the publisher member
+        var responseDeserializer = new InitialResponseDeserializer(publisherMember, publisher);
         builder.deserialize(responseDeserializer);
+        // Deserialize the rest of the members if any
+        var headers = message.getHeaders();
+        var deserializer = new EventStreamDeserializer(codecDeserializer, new HeadersDeserializer(headers));
+        builder.deserialize(deserializer);
         return builder.build();
     }
 
@@ -100,11 +114,11 @@ public final class AwsEventShapeDecoder<E extends SerializableStruct, IR extends
         return message.getHeaders().get(":event-type").getString();
     }
 
-    static class EventStreamDeserializer extends SpecificShapeDeserializer {
+    static class InitialResponseDeserializer extends SpecificShapeDeserializer {
         private final Schema publisherMember;
         private final Flow.Publisher<? extends SerializableStruct> publisher;
 
-        EventStreamDeserializer(Schema publisherMember, Flow.Publisher<? extends SerializableStruct> publisher) {
+        InitialResponseDeserializer(Schema publisherMember, Flow.Publisher<? extends SerializableStruct> publisher) {
             this.publisherMember = publisherMember;
             this.publisher = publisher;
         }
@@ -117,6 +131,101 @@ public final class AwsEventShapeDecoder<E extends SerializableStruct, IR extends
         @Override
         public <T> void readStruct(Schema schema, T state, ShapeDeserializer.StructMemberConsumer<T> consumer) {
             consumer.accept(state, publisherMember, this);
+        }
+    }
+
+    static class EventStreamDeserializer extends SpecificShapeDeserializer {
+        private final ShapeDeserializer codecDeserializer;
+        private final HeadersDeserializer headersDeserializer;
+
+        EventStreamDeserializer(ShapeDeserializer codecDeserializer, HeadersDeserializer headersDeserializer) {
+            this.codecDeserializer = codecDeserializer;
+            this.headersDeserializer = headersDeserializer;
+        }
+
+        @Override
+        public <T> void readStruct(Schema schema, T builder, ShapeDeserializer.StructMemberConsumer<T> consumer) {
+            var payloadWritten = false;
+            for (Schema member : schema.members()) {
+                if (member.hasTrait(TraitKey.EVENT_HEADER_TRAIT)) {
+                    consumer.accept(builder, member, headersDeserializer);
+                } else if (member.hasTrait(TraitKey.EVENT_PAYLOAD_TRAIT)) {
+                    consumer.accept(builder, member, codecDeserializer);
+                    payloadWritten = true;
+                }
+            }
+            // Deserialize from the payload if still needed.
+            if (!payloadWritten) {
+                codecDeserializer.readStruct(schema, builder, consumer);
+            }
+        }
+    }
+
+    static class HeadersDeserializer extends SpecificShapeDeserializer {
+        private final Map<String, HeaderValue> headers;
+
+        HeadersDeserializer(Map<String, HeaderValue> headers) {
+            this.headers = headers;
+        }
+
+        @Override
+        public ByteBuffer readBlob(Schema schema) {
+            return getValueForShapeType(schema);
+        }
+
+        @Override
+
+        public byte readByte(Schema schema) {
+            return getValueForShapeType(schema);
+        }
+
+        @Override
+        public short readShort(Schema schema) {
+            return getValueForShapeType(schema);
+        }
+
+        @Override
+        public int readInteger(Schema schema) {
+            return getValueForShapeType(schema);
+        }
+
+        @Override
+        public long readLong(Schema schema) {
+            return getValueForShapeType(schema);
+        }
+
+        @Override
+        public String readString(Schema schema) {
+            return getValueForShapeType(schema);
+        }
+
+        @Override
+        public boolean readBoolean(Schema schema) {
+            return getValueForShapeType(schema);
+        }
+
+        @Override
+        public Instant readTimestamp(Schema schema) {
+            return getValueForShapeType(schema);
+        }
+
+        @SuppressWarnings("unchecked")
+        private <T> T getValueForShapeType(Schema member) {
+            HeaderValue value = headers.get(member.memberName());
+            if (value == null) {
+                return null;
+            }
+            return (T) switch (member.type()) {
+                case BLOB -> value.getByteBuffer();
+                case BOOLEAN -> value.getBoolean();
+                case BYTE -> value.getByte();
+                case SHORT -> value.getShort();
+                case INTEGER, INT_ENUM -> value.getInteger();
+                case LONG -> value.getLong();
+                case TIMESTAMP -> value.getTimestamp();
+                case STRING -> value.getString();
+                default -> throw new IllegalArgumentException("Unsupported shape type: " + member.type());
+            };
         }
     }
 }

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoder.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoder.java
@@ -6,13 +6,13 @@
 package software.amazon.smithy.java.aws.events;
 
 import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import software.amazon.eventstream.HeaderValue;
 import software.amazon.eventstream.Message;
@@ -22,6 +22,7 @@ import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.java.core.serde.event.EventEncoder;
 import software.amazon.smithy.java.core.serde.event.EventStreamingException;
@@ -32,7 +33,7 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
     private final InitialEventType initialEventType;
     private final Codec codec;
     private final String payloadMediaType;
-    private final Set<String> possibleTypes;
+    private final Map<String, BiFunction<OutputStream, Map<String, HeaderValue>, ShapeSerializer>> possibleTypes;
     private final Map<ShapeId, Schema> possibleExceptions;
     private final Function<Throwable, EventStreamingException> exceptionHandler;
 
@@ -46,7 +47,9 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
         this.initialEventType = Objects.requireNonNull(initialEventType, "initialEventType");
         this.codec = Objects.requireNonNull(codec, "codec");
         this.payloadMediaType = Objects.requireNonNull(payloadMediaType, "payloadMediaType");
-        this.possibleTypes = possibleTypes(Objects.requireNonNull(eventSchema, "eventSchema"));
+        this.possibleTypes = possibleTypes(Objects.requireNonNull(eventSchema, "eventSchema"),
+                codec,
+                initialEventType.value());
         this.possibleExceptions = possibleExceptions(Objects.requireNonNull(eventSchema, "eventSchema"));
         this.exceptionHandler = Objects.requireNonNull(exceptionHandler, "exceptionHandler");
     }
@@ -54,41 +57,43 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
     @Override
     public AwsEventFrame encode(SerializableStruct item) {
         var typeHolder = new AtomicReference<String>();
-        var payload = encodeInput(item, typeHolder);
-        var headers = Map.of(
-                ":message-type",
-                HeaderValue.fromString("event"),
-                ":event-type",
-                HeaderValue.fromString(typeHolder.get()),
-                ":content-type",
-                HeaderValue.fromString(payloadMediaType));
+        var headers = new HashMap<String, HeaderValue>();
+        var payload = encodeInput(item, typeHolder, headers);
+        headers.put(":message-type", HeaderValue.fromString("event"));
+        headers.put(":event-type", HeaderValue.fromString(typeHolder.get()));
+        headers.put(":content-type", HeaderValue.fromString(payloadMediaType));
         return new AwsEventFrame(new Message(headers, payload));
     }
 
-    private byte[] encodeInput(SerializableStruct item, AtomicReference<String> typeHolder) {
+    private byte[] encodeInput(
+            SerializableStruct item,
+            AtomicReference<String> typeHolder,
+            Map<String, HeaderValue> headers
+    ) {
         if (isInitialRequest(item.schema())) {
             // The initial event is serialized fully instead of just a single member as for events.
-            typeHolder.compareAndSet(null, initialEventType.getName());
+            typeHolder.set(initialEventType.value());
             var os = new ByteArrayOutputStream();
-            try (var baseSerializer = codec.createSerializer(os)) {
-                SchemaUtils.withFilteredMembers(item.schema(), item, this::excludeEventStreamMember)
+            try (var baseSerializer = possibleTypes.get(initialEventType.value()).apply(os, headers)) {
+                SchemaUtils.withFilteredMembers(item.schema(), item, AwsEventShapeEncoder::excludeEventStreamMember)
                         .serialize(baseSerializer);
             }
             return os.toByteArray();
         }
         var os = new ByteArrayOutputStream();
-        try (var baseSerializer = codec.createSerializer(os)) {
-            var serializer = new SpecificShapeSerializer() {
-                @Override
-                public void writeStruct(Schema schema, SerializableStruct struct) {
-                    if (possibleTypes.contains(schema.memberName())) {
-                        typeHolder.compareAndSet(null, schema.memberName());
+        var serializer = new SpecificShapeSerializer() {
+            @Override
+            public void writeStruct(Schema schema, SerializableStruct struct) {
+                var memberName = schema.memberName();
+                if (possibleTypes.containsKey(memberName) &&
+                        typeHolder.compareAndSet(null, schema.memberName())) {
+                    try (var baseSerializer = possibleTypes.get(memberName).apply(os, headers)) {
+                        baseSerializer.writeStruct(schema, struct);
                     }
-                    baseSerializer.writeStruct(schema, struct);
                 }
-            };
-            item.serializeMembers(serializer);
-        }
+            }
+        };
+        item.serializeMembers(serializer);
         return os.toByteArray();
     }
 
@@ -101,11 +106,11 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
         return false;
     }
 
-    private boolean excludeEventStreamMember(Schema schema) {
+    private static boolean excludeEventStreamMember(Schema schema) {
         return !isEventStreamMember(schema);
     }
 
-    private boolean isEventStreamMember(Schema schema) {
+    private static boolean isEventStreamMember(Schema schema) {
         if (schema.isMember() && schema.memberTarget().hasTrait(TraitKey.STREAMING_TRAIT)) {
             return true;
         }
@@ -144,13 +149,19 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
 
     }
 
-    static Set<String> possibleTypes(Schema eventSchema) {
-        var result = new HashSet<String>();
+    static Map<String, BiFunction<OutputStream, Map<String, HeaderValue>, ShapeSerializer>> possibleTypes(
+            Schema eventSchema,
+            Codec codec,
+            String initialEventType
+    ) {
+        var result = new HashMap<String, BiFunction<OutputStream, Map<String, HeaderValue>, ShapeSerializer>>();
+        var factory = new EventShapeSerializerFactory(codec);
         for (var memberSchema : eventSchema.members()) {
             String memberName = memberSchema.memberName();
-            result.add(memberName);
+            result.put(memberName, factory::createSerializer);
         }
-        return Collections.unmodifiableSet(result);
+        result.put(initialEventType, factory::createSerializer);
+        return Collections.unmodifiableMap(result);
     }
 
     static Map<ShapeId, Schema> possibleExceptions(Schema eventSchema) {
@@ -163,5 +174,78 @@ public final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
             }
         }
         return Collections.unmodifiableMap(result);
+    }
+
+    static class EventShapeSerializerFactory {
+        private final Codec codec;
+
+        EventShapeSerializerFactory(Codec codec) {
+            this.codec = codec;
+        }
+
+        public ShapeSerializer createSerializer(OutputStream out, Map<String, HeaderValue> headers) {
+            var eventSerializer = new EventHeaderSerializer(headers);
+            var baseSerializer = codec.createSerializer(out);
+            return new EventSerializer(eventSerializer, baseSerializer);
+        }
+    }
+
+    static class EventSerializer extends SpecificShapeSerializer {
+        private final EventHeaderSerializer headerSerializer;
+        private final ShapeSerializer baseSerializer;
+
+        public EventSerializer(EventHeaderSerializer headerSerializer, ShapeSerializer baseSerializer) {
+            this.headerSerializer = headerSerializer;
+            this.baseSerializer = baseSerializer;
+        }
+
+        @Override
+        public void writeStruct(Schema schema, SerializableStruct struct) {
+            if (hasEventPayloadMember(schema)) {
+                SchemaUtils.withFilteredMembers(schema, struct, this::isEventPayload)
+                        .serializeMembers(baseSerializer);
+
+            } else {
+                SchemaUtils.withFilteredMembers(schema, struct, this::isPayloadMember)
+                        .serialize(baseSerializer);
+            }
+            SchemaUtils.withFilteredMembers(schema, struct, this::isHeadersMember)
+                    .serialize(headerSerializer);
+        }
+
+        private boolean isPayloadMember(Schema schema) {
+            if (schema.hasTrait(TraitKey.EVENT_HEADER_TRAIT)) {
+                return false;
+            }
+            if (isEventStreamMember(schema)) {
+                return false;
+            }
+            return true;
+        }
+
+        private boolean isEventPayload(Schema schema) {
+            if (schema.hasTrait(TraitKey.EVENT_PAYLOAD_TRAIT)) {
+                return true;
+            }
+            return false;
+        }
+
+        private boolean hasEventPayloadMember(Schema schema) {
+            for (var member : schema.members()) {
+                if (member.hasTrait(TraitKey.EVENT_PAYLOAD_TRAIT)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean isHeadersMember(Schema schema) {
+            return schema.hasTrait(TraitKey.EVENT_HEADER_TRAIT);
+        }
+
+        @Override
+        public void flush() {
+            baseSerializer.flush();
+        }
     }
 }

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/EventHeaderSerializer.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/EventHeaderSerializer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events;
+
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.Map;
+import software.amazon.eventstream.HeaderValue;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.SpecificShapeSerializer;
+
+public class EventHeaderSerializer extends SpecificShapeSerializer {
+    private final Map<String, HeaderValue> headers;
+
+    public EventHeaderSerializer(Map<String, HeaderValue> headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public void writeBoolean(Schema schema, boolean value) {
+        headers.put(schema.memberName(), HeaderValue.fromBoolean(value));
+    }
+
+    @Override
+    public void writeShort(Schema schema, short value) {
+        headers.put(schema.memberName(), HeaderValue.fromShort(value));
+    }
+
+    @Override
+    public void writeByte(Schema schema, byte value) {
+        headers.put(schema.memberName(), HeaderValue.fromByte(value));
+    }
+
+    @Override
+    public void writeInteger(Schema schema, int value) {
+        headers.put(schema.memberName(), HeaderValue.fromInteger(value));
+    }
+
+    @Override
+    public void writeLong(Schema schema, long value) {
+        headers.put(schema.memberName(), HeaderValue.fromLong(value));
+    }
+
+    @Override
+    public void writeString(Schema schema, String value) {
+        headers.put(schema.memberName(), HeaderValue.fromString(value));
+    }
+
+    @Override
+    public void writeBlob(Schema schema, ByteBuffer value) {
+        headers.put(schema.memberName(), HeaderValue.fromByteBuffer(value));
+    }
+
+    @Override
+    public void writeTimestamp(Schema schema, Instant value) {
+        headers.put(schema.memberName(), HeaderValue.fromTimestamp(value));
+    }
+
+    @Override
+    public void writeStruct(Schema schema, SerializableStruct struct) {
+        struct.serializeMembers(this);
+    }
+}

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/InitialEventType.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/InitialEventType.java
@@ -12,13 +12,13 @@ public enum InitialEventType {
     INITIAL_REQUEST("initial-request"),
     INITIAL_RESPONSE("initial-response");
 
-    private final String name;
+    private final String value;
 
-    InitialEventType(String name) {
-        this.name = name;
+    InitialEventType(String value) {
+        this.value = value;
     }
 
-    public String getName() {
-        return name;
+    public String value() {
+        return value;
     }
 }

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/AwsEventShapeDecoderTest.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/AwsEventShapeDecoderTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import software.amazon.eventstream.Message;
+import software.amazon.smithy.java.aws.events.model.BodyAndHeaderEvent;
+import software.amazon.smithy.java.aws.events.model.HeadersOnlyEvent;
+import software.amazon.smithy.java.aws.events.model.StringEvent;
+import software.amazon.smithy.java.aws.events.model.StructureEvent;
+import software.amazon.smithy.java.aws.events.model.TestEventStream;
+import software.amazon.smithy.java.aws.events.model.TestOperation;
+import software.amazon.smithy.java.aws.events.model.TestOperationOutput;
+import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.json.JsonCodec;
+
+class AwsEventShapeDecoderTest {
+
+    @Test
+    public void testDecodeInitialResponse() {
+        // Arrange
+        var headers = new AwsEventShapeEncoderTest.HeadersBuilder()
+                .eventType("initial-response")
+                .contentType("text/json")
+                .put("intMemberHeader", 123)
+                .build();
+        var message = new Message(headers, "{\"stringMember\":\"Hello World!\"}".getBytes(StandardCharsets.UTF_8));
+        var frame = new AwsEventFrame(message);
+
+        // Act
+        var struct = createDecoder().decode(frame);
+
+        // Assert
+        assertInstanceOf(TestOperationOutput.class, struct);
+        TestOperationOutput expected = TestOperationOutput.builder()
+                .intMemberHeader(123)
+                .stringMember("Hello World!")
+                .build();
+        assertEquals(expected, struct);
+    }
+
+    @Test
+    public void testDecodeHeadersOnlyMember() {
+        // Arrange
+        var headers = new AwsEventShapeEncoderTest.HeadersBuilder()
+                .contentType("text/json")
+                .eventType("headersOnlyMember")
+                .put("sequenceNum", 123)
+                .build();
+        var message = new Message(headers, "{}".getBytes(StandardCharsets.UTF_8));
+        var frame = new AwsEventFrame(message);
+
+        // Act
+        var struct = createDecoder().decode(frame);
+
+        // Assert
+        assertInstanceOf(TestEventStream.class, struct);
+        var actual = (TestEventStream) struct;
+        assertEquals(TestEventStream.Type.headersOnlyMember, actual.type());
+        var expected = TestEventStream.builder()
+                .headersOnlyMember(HeadersOnlyEvent.builder().sequenceNum(123).build())
+                .build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testDecodeStructureMember() {
+        // Arrange
+        var headers = new AwsEventShapeEncoderTest.HeadersBuilder()
+                .contentType("text/json")
+                .eventType("structureMember")
+                .build();
+        var message = new Message(headers, "{\"foo\":\"memberFooValue\"}".getBytes(StandardCharsets.UTF_8));
+        var frame = new AwsEventFrame(message);
+
+        // Act
+        var struct = createDecoder().decode(frame);
+
+        // Assert
+        assertInstanceOf(TestEventStream.class, struct);
+        var actual = (TestEventStream) struct;
+        assertEquals(TestEventStream.Type.structureMember, actual.type());
+        var expected = TestEventStream.builder()
+                .structureMember(StructureEvent.builder().foo("memberFooValue").build())
+                .build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testDecodeBodyAndHeaderMember() {
+        // Arrange
+        var headers = new AwsEventShapeEncoderTest.HeadersBuilder()
+                .contentType("text/json")
+                .eventType("bodyAndHeaderMember")
+                .put("intMember", 123)
+                .build();
+        var message = new Message(headers, "{\"stringMember\":\"Hello world!\"}".getBytes(StandardCharsets.UTF_8));
+        var frame = new AwsEventFrame(message);
+
+        // Act
+        var struct = createDecoder().decode(frame);
+
+        // Assert
+        assertInstanceOf(TestEventStream.class, struct);
+        var actual = (TestEventStream) struct;
+        assertEquals(TestEventStream.Type.bodyAndHeaderMember, actual.type());
+        var expected = TestEventStream.builder()
+                .bodyAndHeaderMember(BodyAndHeaderEvent.builder()
+                        .intMember(123)
+                        .stringMember("Hello world!")
+                        .build())
+                .build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testDecodeStringMember() {
+        // Arrange
+        var headers = new AwsEventShapeEncoderTest.HeadersBuilder()
+                .contentType("text/json")
+                .eventType("stringMember")
+                .build();;
+        var message = new Message(headers, "\"hello world!\"".getBytes(StandardCharsets.UTF_8));
+        var frame = new AwsEventFrame(message);
+
+        // Act
+        var struct = createDecoder().decode(frame);
+
+        // Assert
+        assertInstanceOf(TestEventStream.class, struct);
+        var actual = (TestEventStream) struct;
+        assertEquals(TestEventStream.Type.stringMember, actual.type());
+        var expected = TestEventStream.builder()
+                .stringMember(StringEvent.builder().payload("hello world!").build())
+                .build();
+        assertEquals(expected, actual);
+    }
+
+    static AwsEventShapeDecoder<?, ?> createDecoder() {
+        return new AwsEventShapeDecoder<>(InitialEventType.INITIAL_RESPONSE,
+                () -> TestOperation.instance().outputBuilder(), // output builder
+                TestOperation.instance().outputEventBuilderSupplier(),
+                TestOperation.instance().outputStreamMember(),
+                createJsonCodec());
+    }
+
+    static Codec createJsonCodec() {
+        return JsonCodec.builder().build();
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoderTest.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoderTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.eventstream.HeaderValue;
+import software.amazon.smithy.java.aws.events.model.BodyAndHeaderEvent;
+import software.amazon.smithy.java.aws.events.model.HeadersOnlyEvent;
+import software.amazon.smithy.java.aws.events.model.StringEvent;
+import software.amazon.smithy.java.aws.events.model.StructureEvent;
+import software.amazon.smithy.java.aws.events.model.TestEventStream;
+import software.amazon.smithy.java.aws.events.model.TestOperation;
+import software.amazon.smithy.java.aws.events.model.TestOperationInput;
+import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.event.EventStreamingException;
+import software.amazon.smithy.java.json.JsonCodec;
+
+class AwsEventShapeEncoderTest {
+
+    @Test
+    public void testEncodeInitialRequest() {
+        // Arrange
+        var encoder = createEncoder();
+        var event = TestOperationInput.builder()
+                .headerString("headerValue")
+                .inputStringMember("inputStringValue")
+                .build();
+        // Act
+        var result = encoder.encode(event);
+
+        // Assert
+        var expectedHeaders = new HeadersBuilder()
+                .contentType("text/json")
+                .eventType("initial-request")
+                .put("headerString", "headerValue")
+                .build();
+        assertEquals(expectedHeaders, result.unwrap().getHeaders());
+        assertEquals("{\"inputStringMember\":\"inputStringValue\"}", new String(result.unwrap().getPayload()));
+    }
+
+    @Test
+    public void testEncodeHeadersOnlyMember() {
+        // Arrange
+        var encoder = createEncoder();
+        var event = TestEventStream.builder()
+                .headersOnlyMember(HeadersOnlyEvent.builder().sequenceNum(123).build())
+                .build();
+
+        // Act
+        var result = encoder.encode(event);
+
+        // Assert
+        var expectedHeaders = new HeadersBuilder()
+                .contentType("text/json")
+                .eventType("headersOnlyMember")
+                .put("sequenceNum", 123)
+                .build();
+        assertEquals(expectedHeaders, result.unwrap().getHeaders());
+        assertEquals("{}", new String(result.unwrap().getPayload()));
+    }
+
+    @Test
+    public void testEncodeStructureMember() {
+        // Arrange
+        var encoder = createEncoder();
+        var event = TestEventStream.builder()
+                .structureMember(StructureEvent.builder().foo("memberFooValue").build())
+                .build();
+
+        // Act
+        var result = encoder.encode(event);
+
+        // Assert
+        var expectedHeaders = new HeadersBuilder()
+                .contentType("text/json")
+                .eventType("structureMember")
+                .build();
+        assertEquals(expectedHeaders, result.unwrap().getHeaders());
+        assertEquals("{\"foo\":\"memberFooValue\"}", new String(result.unwrap().getPayload()));
+    }
+
+    @Test
+    public void testEncodeBodyAndHeaderMember() {
+        // Arrange
+        var encoder = createEncoder();
+        var event = TestEventStream.builder()
+                .bodyAndHeaderMember(BodyAndHeaderEvent.builder()
+                        .intMember(123)
+                        .stringMember("Hello world!")
+                        .build())
+                .build();
+
+        // Act
+        var result = encoder.encode(event);
+
+        // Assert
+        var expectedHeaders = new HeadersBuilder()
+                .contentType("text/json")
+                .eventType("bodyAndHeaderMember")
+                .put("intMember", 123)
+                .build();
+        assertEquals(expectedHeaders, result.unwrap().getHeaders());
+        assertEquals("{\"stringMember\":\"Hello world!\"}", new String(result.unwrap().getPayload()));
+    }
+
+    @Test
+    public void testEncodeStringMember() {
+        // Arrange
+        var encoder = createEncoder();
+        var event = TestEventStream.builder()
+                .stringMember(StringEvent.builder().payload("hello world!").build())
+                .build();
+
+        // Act
+        var result = encoder.encode(event);
+
+        // Assert
+        var expectedHeaders = new HeadersBuilder()
+                .contentType("text/json")
+                .eventType("stringMember")
+                .build();
+        assertEquals(expectedHeaders, result.unwrap().getHeaders());
+        assertEquals("\"hello world!\"", new String(result.unwrap().getPayload()));
+    }
+
+    static AwsEventShapeEncoder createEncoder() {
+        return new AwsEventShapeEncoder(InitialEventType.INITIAL_REQUEST,
+                TestOperation.instance().inputStreamMember(), // event schema
+                createJsonCodec(), // codec
+                "text/json",
+                (e) -> new EventStreamingException("InternalServerException", "Internal Server Error"));
+    }
+
+    static Codec createJsonCodec() {
+        return JsonCodec.builder().build();
+    }
+
+    static class HeadersBuilder {
+        private final Map<String, HeaderValue> headers = new HashMap<>();
+
+        HeadersBuilder() {
+            headers.put(":message-type", HeaderValue.fromString("event"));
+        }
+
+        public HeadersBuilder messageType(String messageType) {
+            headers.put(":message-type", HeaderValue.fromString(messageType));
+            return this;
+        }
+
+        public HeadersBuilder contentType(String contentType) {
+            headers.put(":content-type", HeaderValue.fromString(contentType));
+            return this;
+        }
+
+        public HeadersBuilder eventType(String eventType) {
+            headers.put(":event-type", HeaderValue.fromString(eventType));
+            return this;
+        }
+
+        public HeadersBuilder put(String name, String value) {
+            headers.put(name, HeaderValue.fromString(value));
+            return this;
+        }
+
+        public HeadersBuilder put(String name, int value) {
+            headers.put(name, HeaderValue.fromInteger(value));
+            return this;
+        }
+
+        public Map<String, HeaderValue> build() {
+            return headers;
+        }
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/BlobEvent.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/BlobEvent.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.ToStringSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public final class BlobEvent implements SerializableStruct {
+
+    public static final Schema $SCHEMA = Schemas.BLOB_EVENT;
+    private static final Schema $SCHEMA_PAYLOAD = $SCHEMA.member("payload");
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private final transient ByteBuffer payload;
+
+    private BlobEvent(Builder builder) {
+        this.payload = builder.payload == null ? null : builder.payload.duplicate();
+    }
+
+    public ByteBuffer getPayload() {
+        return payload;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringSerializer.serialize(this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        BlobEvent that = (BlobEvent) other;
+        return Objects.equals(this.payload, that.payload);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(payload);
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        if (payload != null) {
+            serializer.writeBlob($SCHEMA_PAYLOAD, payload);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return switch (member.memberIndex()) {
+            case 0 -> (T) SchemaUtils.validateSameMember($SCHEMA_PAYLOAD, member, payload);
+            default -> throw new IllegalArgumentException("Attempted to get non-existent member: " + member.id());
+        };
+    }
+
+    /**
+     * Create a new builder containing all the current property values of this object.
+     *
+     * <p><strong>Note:</strong> This method performs only a shallow copy of the original properties.
+     *
+     * @return a builder for {@link BlobEvent}.
+     */
+    public Builder toBuilder() {
+        var builder = new Builder();
+        builder.payload(this.payload);
+        return builder;
+    }
+
+    /**
+     * @return returns a new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link BlobEvent}.
+     */
+    public static final class Builder implements ShapeBuilder<BlobEvent> {
+        private ByteBuffer payload;
+
+        private Builder() {}
+
+        @Override
+        public Schema schema() {
+            return $SCHEMA;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder payload(ByteBuffer payload) {
+            this.payload = payload;
+            return this;
+        }
+
+        @Override
+        public BlobEvent build() {
+            return new BlobEvent(this);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void setMemberValue(Schema member, Object value) {
+            switch (member.memberIndex()) {
+                case 0 -> payload((ByteBuffer) SchemaUtils.validateSameMember($SCHEMA_PAYLOAD, member, value));
+                default -> ShapeBuilder.super.setMemberValue(member, value);
+            }
+        }
+
+        @Override
+        public Builder deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct($SCHEMA, this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        @Override
+        public Builder deserializeMember(ShapeDeserializer decoder, Schema schema) {
+            decoder.readStruct(schema.assertMemberTargetIs($SCHEMA), this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        private static final class $InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
+            private static final $InnerDeserializer INSTANCE = new $InnerDeserializer();
+
+            @Override
+            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.payload(de.readBlob(member));
+                    default -> throw new IllegalArgumentException("Unexpected member: " + member.memberName());
+                }
+            }
+        }
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/BodyAndHeaderEvent.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/BodyAndHeaderEvent.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.util.Objects;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.ToStringSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public final class BodyAndHeaderEvent implements SerializableStruct {
+
+    public static final Schema $SCHEMA = Schemas.BODY_AND_HEADER_EVENT;
+    private static final Schema $SCHEMA_INT_MEMBER = $SCHEMA.member("intMember");
+    private static final Schema $SCHEMA_STRING_MEMBER = $SCHEMA.member("stringMember");
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private final transient Integer intMember;
+    private final transient String stringMember;
+
+    private BodyAndHeaderEvent(Builder builder) {
+        this.intMember = builder.intMember;
+        this.stringMember = builder.stringMember;
+    }
+
+    public Integer getIntMember() {
+        return intMember;
+    }
+
+    public String getStringMember() {
+        return stringMember;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringSerializer.serialize(this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        BodyAndHeaderEvent that = (BodyAndHeaderEvent) other;
+        return Objects.equals(this.intMember, that.intMember)
+                && Objects.equals(this.stringMember, that.stringMember);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(intMember, stringMember);
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        if (intMember != null) {
+            serializer.writeInteger($SCHEMA_INT_MEMBER, intMember);
+        }
+        if (stringMember != null) {
+            serializer.writeString($SCHEMA_STRING_MEMBER, stringMember);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return switch (member.memberIndex()) {
+            case 0 -> (T) SchemaUtils.validateSameMember($SCHEMA_INT_MEMBER, member, intMember);
+            case 1 -> (T) SchemaUtils.validateSameMember($SCHEMA_STRING_MEMBER, member, stringMember);
+            default -> throw new IllegalArgumentException("Attempted to get non-existent member: " + member.id());
+        };
+    }
+
+    /**
+     * Create a new builder containing all the current property values of this object.
+     *
+     * <p><strong>Note:</strong> This method performs only a shallow copy of the original properties.
+     *
+     * @return a builder for {@link BodyAndHeaderEvent}.
+     */
+    public Builder toBuilder() {
+        var builder = new Builder();
+        builder.intMember(this.intMember);
+        builder.stringMember(this.stringMember);
+        return builder;
+    }
+
+    /**
+     * @return returns a new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link BodyAndHeaderEvent}.
+     */
+    public static final class Builder implements ShapeBuilder<BodyAndHeaderEvent> {
+        private Integer intMember;
+        private String stringMember;
+
+        private Builder() {}
+
+        @Override
+        public Schema schema() {
+            return $SCHEMA;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder intMember(Integer intMember) {
+            this.intMember = intMember;
+            return this;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder stringMember(String stringMember) {
+            this.stringMember = stringMember;
+            return this;
+        }
+
+        @Override
+        public BodyAndHeaderEvent build() {
+            return new BodyAndHeaderEvent(this);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void setMemberValue(Schema member, Object value) {
+            switch (member.memberIndex()) {
+                case 0 -> intMember((Integer) SchemaUtils.validateSameMember($SCHEMA_INT_MEMBER, member, value));
+                case 1 -> stringMember((String) SchemaUtils.validateSameMember($SCHEMA_STRING_MEMBER, member, value));
+                default -> ShapeBuilder.super.setMemberValue(member, value);
+            }
+        }
+
+        @Override
+        public Builder deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct($SCHEMA, this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        @Override
+        public Builder deserializeMember(ShapeDeserializer decoder, Schema schema) {
+            decoder.readStruct(schema.assertMemberTargetIs($SCHEMA), this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        private static final class $InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
+            private static final $InnerDeserializer INSTANCE = new $InnerDeserializer();
+
+            @Override
+            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.intMember(de.readInteger(member));
+                    case 1 -> builder.stringMember(de.readString(member));
+                    default -> throw new IllegalArgumentException("Unexpected member: " + member.memberName());
+                }
+            }
+        }
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/EventStreamingTestServiceApiService.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/EventStreamingTestServiceApiService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import software.amazon.smithy.java.core.schema.ApiService;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+/**
+ * Service API schema
+ */
+@SmithyGenerated
+public final class EventStreamingTestServiceApiService implements ApiService {
+    private static final EventStreamingTestServiceApiService $INSTANCE = new EventStreamingTestServiceApiService();
+    private static final Schema $SCHEMA =
+            Schema.createService(ShapeId.from("smithy.test.eventstreaming#EventStreamingTestService"));
+
+    /**
+     * Get an instance of this {@code ApiService}.
+     *
+     * @return An instance of this class.
+     */
+    public static EventStreamingTestServiceApiService instance() {
+        return $INSTANCE;
+    }
+
+    private EventStreamingTestServiceApiService() {}
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/EventStreamingTestServiceException.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/EventStreamingTestServiceException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import software.amazon.smithy.java.core.error.ErrorFault;
+import software.amazon.smithy.java.core.error.ModeledException;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+/**
+ * Base-level exception for the service.
+ *
+ * <p>Some exceptions do not extend from this class, including synthetic, implicit, and shared
+ * exception types.
+ */
+@SmithyGenerated
+public abstract class EventStreamingTestServiceException extends ModeledException {
+    protected EventStreamingTestServiceException(
+            Schema schema,
+            String message,
+            Throwable cause,
+            ErrorFault errorType,
+            Boolean captureStackTrace,
+            boolean deserialized
+    ) {
+        super(schema, message, cause, errorType, captureStackTrace, deserialized);
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/GeneratedSchemaIndex.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/GeneratedSchemaIndex.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaIndex;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Generated SchemaIndex implementation that provides access to all schemas in the model.
+ */
+public final class GeneratedSchemaIndex extends SchemaIndex {
+
+    private static final Map<ShapeId, Schema> SCHEMA_MAP = new HashMap<>();
+
+    static {
+        SCHEMA_MAP.put(Schemas.BLOB_EVENT.id(), Schemas.BLOB_EVENT);
+        SCHEMA_MAP.put(Schemas.BODY_AND_HEADER_EVENT.id(), Schemas.BODY_AND_HEADER_EVENT);
+        SCHEMA_MAP.put(Schemas.HEADERS_ONLY_EVENT.id(), Schemas.HEADERS_ONLY_EVENT);
+        SCHEMA_MAP.put(Schemas.STRING_EVENT.id(), Schemas.STRING_EVENT);
+        SCHEMA_MAP.put(Schemas.STRUCTURE_EVENT.id(), Schemas.STRUCTURE_EVENT);
+        SCHEMA_MAP.put(Schemas.TEST_EVENT_STREAM.id(), Schemas.TEST_EVENT_STREAM);
+        SCHEMA_MAP.put(Schemas.TEST_OPERATION_INPUT.id(), Schemas.TEST_OPERATION_INPUT);
+        SCHEMA_MAP.put(Schemas.TEST_OPERATION_OUTPUT.id(), Schemas.TEST_OPERATION_OUTPUT);
+    }
+
+    @Override
+    public Schema getSchema(ShapeId id) {
+        return SCHEMA_MAP.get(id);
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/HeadersOnlyEvent.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/HeadersOnlyEvent.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.util.Objects;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.ToStringSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public final class HeadersOnlyEvent implements SerializableStruct {
+
+    public static final Schema $SCHEMA = Schemas.HEADERS_ONLY_EVENT;
+    private static final Schema $SCHEMA_SEQUENCE_NUM = $SCHEMA.member("sequenceNum");
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private final transient Integer sequenceNum;
+
+    private HeadersOnlyEvent(Builder builder) {
+        this.sequenceNum = builder.sequenceNum;
+    }
+
+    public Integer getSequenceNum() {
+        return sequenceNum;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringSerializer.serialize(this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        HeadersOnlyEvent that = (HeadersOnlyEvent) other;
+        return Objects.equals(this.sequenceNum, that.sequenceNum);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sequenceNum);
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        if (sequenceNum != null) {
+            serializer.writeInteger($SCHEMA_SEQUENCE_NUM, sequenceNum);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return switch (member.memberIndex()) {
+            case 0 -> (T) SchemaUtils.validateSameMember($SCHEMA_SEQUENCE_NUM, member, sequenceNum);
+            default -> throw new IllegalArgumentException("Attempted to get non-existent member: " + member.id());
+        };
+    }
+
+    /**
+     * Create a new builder containing all the current property values of this object.
+     *
+     * <p><strong>Note:</strong> This method performs only a shallow copy of the original properties.
+     *
+     * @return a builder for {@link HeadersOnlyEvent}.
+     */
+    public Builder toBuilder() {
+        var builder = new Builder();
+        builder.sequenceNum(this.sequenceNum);
+        return builder;
+    }
+
+    /**
+     * @return returns a new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link HeadersOnlyEvent}.
+     */
+    public static final class Builder implements ShapeBuilder<HeadersOnlyEvent> {
+        private Integer sequenceNum;
+
+        private Builder() {}
+
+        @Override
+        public Schema schema() {
+            return $SCHEMA;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder sequenceNum(Integer sequenceNum) {
+            this.sequenceNum = sequenceNum;
+            return this;
+        }
+
+        @Override
+        public HeadersOnlyEvent build() {
+            return new HeadersOnlyEvent(this);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void setMemberValue(Schema member, Object value) {
+            switch (member.memberIndex()) {
+                case 0 -> sequenceNum((Integer) SchemaUtils.validateSameMember($SCHEMA_SEQUENCE_NUM, member, value));
+                default -> ShapeBuilder.super.setMemberValue(member, value);
+            }
+        }
+
+        @Override
+        public Builder deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct($SCHEMA, this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        @Override
+        public Builder deserializeMember(ShapeDeserializer decoder, Schema schema) {
+            decoder.readStruct(schema.assertMemberTargetIs($SCHEMA), this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        private static final class $InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
+            private static final $InnerDeserializer INSTANCE = new $InnerDeserializer();
+
+            @Override
+            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.sequenceNum(de.readInteger(member));
+                    default -> throw new IllegalArgumentException("Unexpected member: " + member.memberName());
+                }
+            }
+        }
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/Schemas.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/Schemas.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.EventHeaderTrait;
+import software.amazon.smithy.model.traits.EventPayloadTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
+
+/**
+ * Defines schemas for shapes in the model package.
+ */
+final class Schemas {
+    static final Schema BLOB_EVENT = Schema.structureBuilder(ShapeId.from("smithy.test.eventstreaming#BlobEvent"))
+            .putMember("payload",
+                    PreludeSchemas.BLOB,
+                    new EventPayloadTrait())
+            .builderSupplier(BlobEvent::builder)
+            .build();
+
+    static final Schema BODY_AND_HEADER_EVENT =
+            Schema.structureBuilder(ShapeId.from("smithy.test.eventstreaming#BodyAndHeaderEvent"))
+                    .putMember("intMember",
+                            PreludeSchemas.INTEGER,
+                            new EventHeaderTrait())
+                    .putMember("stringMember", PreludeSchemas.STRING)
+                    .builderSupplier(BodyAndHeaderEvent::builder)
+                    .build();
+
+    static final Schema HEADERS_ONLY_EVENT =
+            Schema.structureBuilder(ShapeId.from("smithy.test.eventstreaming#HeadersOnlyEvent"))
+                    .putMember("sequenceNum",
+                            PreludeSchemas.INTEGER,
+                            new EventHeaderTrait())
+                    .builderSupplier(HeadersOnlyEvent::builder)
+                    .build();
+
+    static final Schema STRING_EVENT = Schema.structureBuilder(ShapeId.from("smithy.test.eventstreaming#StringEvent"))
+            .putMember("payload",
+                    PreludeSchemas.STRING,
+                    new EventPayloadTrait())
+            .builderSupplier(StringEvent::builder)
+            .build();
+
+    static final Schema STRUCTURE_EVENT =
+            Schema.structureBuilder(ShapeId.from("smithy.test.eventstreaming#StructureEvent"))
+                    .putMember("foo", PreludeSchemas.STRING)
+                    .builderSupplier(StructureEvent::builder)
+                    .build();
+
+    static final Schema TEST_EVENT_STREAM = Schema
+            .unionBuilder(ShapeId.from("smithy.test.eventstreaming#TestEventStream"),
+                    new StreamingTrait())
+            .putMember("structureMember", Schemas.STRUCTURE_EVENT)
+            .putMember("stringMember", Schemas.STRING_EVENT)
+            .putMember("blobMember", Schemas.BLOB_EVENT)
+            .putMember("headersOnlyMember", Schemas.HEADERS_ONLY_EVENT)
+            .putMember("bodyAndHeaderMember", Schemas.BODY_AND_HEADER_EVENT)
+            .builderSupplier(TestEventStream::builder)
+            .build();
+
+    static final Schema TEST_OPERATION_INPUT =
+            Schema.structureBuilder(ShapeId.from("smithy.test.eventstreaming#TestInput"))
+                    .putMember("headerString",
+                            PreludeSchemas.STRING,
+                            new EventHeaderTrait())
+                    .putMember("inputStringMember", PreludeSchemas.STRING)
+                    .putMember("stream", Schemas.TEST_EVENT_STREAM)
+                    .builderSupplier(TestOperationInput::builder)
+                    .build();
+
+    static final Schema TEST_OPERATION_OUTPUT =
+            Schema.structureBuilder(ShapeId.from("smithy.test.eventstreaming#TestOutput"))
+                    .putMember("intMemberHeader",
+                            PreludeSchemas.INTEGER,
+                            new EventHeaderTrait())
+                    .putMember("stringMember", PreludeSchemas.STRING)
+                    .putMember("outputStream", Schemas.TEST_EVENT_STREAM)
+                    .builderSupplier(TestOperationOutput::builder)
+                    .build();
+
+    private Schemas() {}
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/SharedSerde.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/SharedSerde.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+/**
+ * Defines shared serialization and deserialization methods for map and list shapes.
+ */
+final class SharedSerde {
+
+    private SharedSerde() {}
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/StringEvent.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/StringEvent.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.util.Objects;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.ToStringSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public final class StringEvent implements SerializableStruct {
+
+    public static final Schema $SCHEMA = Schemas.STRING_EVENT;
+    private static final Schema $SCHEMA_PAYLOAD = $SCHEMA.member("payload");
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private final transient String payload;
+
+    private StringEvent(Builder builder) {
+        this.payload = builder.payload;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringSerializer.serialize(this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        StringEvent that = (StringEvent) other;
+        return Objects.equals(this.payload, that.payload);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(payload);
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        if (payload != null) {
+            serializer.writeString($SCHEMA_PAYLOAD, payload);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return switch (member.memberIndex()) {
+            case 0 -> (T) SchemaUtils.validateSameMember($SCHEMA_PAYLOAD, member, payload);
+            default -> throw new IllegalArgumentException("Attempted to get non-existent member: " + member.id());
+        };
+    }
+
+    /**
+     * Create a new builder containing all the current property values of this object.
+     *
+     * <p><strong>Note:</strong> This method performs only a shallow copy of the original properties.
+     *
+     * @return a builder for {@link StringEvent}.
+     */
+    public Builder toBuilder() {
+        var builder = new Builder();
+        builder.payload(this.payload);
+        return builder;
+    }
+
+    /**
+     * @return returns a new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link StringEvent}.
+     */
+    public static final class Builder implements ShapeBuilder<StringEvent> {
+        private String payload;
+
+        private Builder() {}
+
+        @Override
+        public Schema schema() {
+            return $SCHEMA;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder payload(String payload) {
+            this.payload = payload;
+            return this;
+        }
+
+        @Override
+        public StringEvent build() {
+            return new StringEvent(this);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void setMemberValue(Schema member, Object value) {
+            switch (member.memberIndex()) {
+                case 0 -> payload((String) SchemaUtils.validateSameMember($SCHEMA_PAYLOAD, member, value));
+                default -> ShapeBuilder.super.setMemberValue(member, value);
+            }
+        }
+
+        @Override
+        public Builder deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct($SCHEMA, this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        @Override
+        public Builder deserializeMember(ShapeDeserializer decoder, Schema schema) {
+            decoder.readStruct(schema.assertMemberTargetIs($SCHEMA), this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        private static final class $InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
+            private static final $InnerDeserializer INSTANCE = new $InnerDeserializer();
+
+            @Override
+            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.payload(de.readString(member));
+                    default -> throw new IllegalArgumentException("Unexpected member: " + member.memberName());
+                }
+            }
+        }
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/StructureEvent.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/StructureEvent.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.util.Objects;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.ToStringSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public final class StructureEvent implements SerializableStruct {
+
+    public static final Schema $SCHEMA = Schemas.STRUCTURE_EVENT;
+    private static final Schema $SCHEMA_FOO = $SCHEMA.member("foo");
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private final transient String foo;
+
+    private StructureEvent(Builder builder) {
+        this.foo = builder.foo;
+    }
+
+    public String getFoo() {
+        return foo;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringSerializer.serialize(this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        StructureEvent that = (StructureEvent) other;
+        return Objects.equals(this.foo, that.foo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(foo);
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        if (foo != null) {
+            serializer.writeString($SCHEMA_FOO, foo);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return switch (member.memberIndex()) {
+            case 0 -> (T) SchemaUtils.validateSameMember($SCHEMA_FOO, member, foo);
+            default -> throw new IllegalArgumentException("Attempted to get non-existent member: " + member.id());
+        };
+    }
+
+    /**
+     * Create a new builder containing all the current property values of this object.
+     *
+     * <p><strong>Note:</strong> This method performs only a shallow copy of the original properties.
+     *
+     * @return a builder for {@link StructureEvent}.
+     */
+    public Builder toBuilder() {
+        var builder = new Builder();
+        builder.foo(this.foo);
+        return builder;
+    }
+
+    /**
+     * @return returns a new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link StructureEvent}.
+     */
+    public static final class Builder implements ShapeBuilder<StructureEvent> {
+        private String foo;
+
+        private Builder() {}
+
+        @Override
+        public Schema schema() {
+            return $SCHEMA;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder foo(String foo) {
+            this.foo = foo;
+            return this;
+        }
+
+        @Override
+        public StructureEvent build() {
+            return new StructureEvent(this);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void setMemberValue(Schema member, Object value) {
+            switch (member.memberIndex()) {
+                case 0 -> foo((String) SchemaUtils.validateSameMember($SCHEMA_FOO, member, value));
+                default -> ShapeBuilder.super.setMemberValue(member, value);
+            }
+        }
+
+        @Override
+        public Builder deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct($SCHEMA, this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        @Override
+        public Builder deserializeMember(ShapeDeserializer decoder, Schema schema) {
+            decoder.readStruct(schema.assertMemberTargetIs($SCHEMA), this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        private static final class $InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
+            private static final $InnerDeserializer INSTANCE = new $InnerDeserializer();
+
+            @Override
+            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.foo(de.readString(member));
+                    default -> throw new IllegalArgumentException("Unexpected member: " + member.memberName());
+                }
+            }
+        }
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/TestEventStream.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/TestEventStream.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.util.Objects;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.ToStringSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public abstract class TestEventStream implements SerializableStruct {
+    public static final Schema $SCHEMA = Schemas.TEST_EVENT_STREAM;
+    private static final Schema $SCHEMA_STRUCTURE_MEMBER = $SCHEMA.member("structureMember");
+    private static final Schema $SCHEMA_STRING_MEMBER = $SCHEMA.member("stringMember");
+    private static final Schema $SCHEMA_BLOB_MEMBER = $SCHEMA.member("blobMember");
+    private static final Schema $SCHEMA_HEADERS_ONLY_MEMBER = $SCHEMA.member("headersOnlyMember");
+    private static final Schema $SCHEMA_BODY_AND_HEADER_MEMBER = $SCHEMA.member("bodyAndHeaderMember");
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private final Type type;
+
+    private TestEventStream(Type type) {
+        this.type = type;
+    }
+
+    public Type type() {
+        return type;
+    }
+
+    /**
+     * Enum representing the possible variants of {@link TestEventStream}.
+     */
+    public enum Type {
+        $UNKNOWN,
+        structureMember,
+        stringMember,
+        blobMember,
+        headersOnlyMember,
+        bodyAndHeaderMember
+    }
+
+    @Override
+    public String toString() {
+        return ToStringSerializer.serialize(this);
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public <T> T getMemberValue(Schema member) {
+        return SchemaUtils.validateMemberInSchema($SCHEMA, member, getValue());
+    }
+
+    public abstract <T> T getValue();
+
+    @SmithyGenerated
+    public static final class StructureMemberMember extends TestEventStream {
+        private final transient StructureEvent value;
+
+        public StructureMemberMember(StructureEvent value) {
+            super(Type.structureMember);
+            this.value = Objects.requireNonNull(value, "Union value cannot be null");
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeStruct($SCHEMA_STRUCTURE_MEMBER, value);
+        }
+
+        public StructureEvent getStructureMember() {
+            return value;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getValue() {
+            return (T) value;
+        }
+    }
+
+    @SmithyGenerated
+    public static final class StringMemberMember extends TestEventStream {
+        private final transient StringEvent value;
+
+        public StringMemberMember(StringEvent value) {
+            super(Type.stringMember);
+            this.value = Objects.requireNonNull(value, "Union value cannot be null");
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeStruct($SCHEMA_STRING_MEMBER, value);
+        }
+
+        public StringEvent getStringMember() {
+            return value;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getValue() {
+            return (T) value;
+        }
+    }
+
+    @SmithyGenerated
+    public static final class BlobMemberMember extends TestEventStream {
+        private final transient BlobEvent value;
+
+        public BlobMemberMember(BlobEvent value) {
+            super(Type.blobMember);
+            this.value = Objects.requireNonNull(value, "Union value cannot be null");
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeStruct($SCHEMA_BLOB_MEMBER, value);
+        }
+
+        public BlobEvent getBlobMember() {
+            return value;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getValue() {
+            return (T) value;
+        }
+    }
+
+    @SmithyGenerated
+    public static final class HeadersOnlyMemberMember extends TestEventStream {
+        private final transient HeadersOnlyEvent value;
+
+        public HeadersOnlyMemberMember(HeadersOnlyEvent value) {
+            super(Type.headersOnlyMember);
+            this.value = Objects.requireNonNull(value, "Union value cannot be null");
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeStruct($SCHEMA_HEADERS_ONLY_MEMBER, value);
+        }
+
+        public HeadersOnlyEvent getHeadersOnlyMember() {
+            return value;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getValue() {
+            return (T) value;
+        }
+    }
+
+    @SmithyGenerated
+    public static final class BodyAndHeaderMemberMember extends TestEventStream {
+        private final transient BodyAndHeaderEvent value;
+
+        public BodyAndHeaderMemberMember(BodyAndHeaderEvent value) {
+            super(Type.bodyAndHeaderMember);
+            this.value = Objects.requireNonNull(value, "Union value cannot be null");
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeStruct($SCHEMA_BODY_AND_HEADER_MEMBER, value);
+        }
+
+        public BodyAndHeaderEvent getBodyAndHeaderMember() {
+            return value;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getValue() {
+            return (T) value;
+        }
+    }
+
+    public static final class $UnknownMember extends TestEventStream {
+        private final String memberName;
+
+        public $UnknownMember(String memberName) {
+            super(Type.$UNKNOWN);
+            this.memberName = memberName;
+        }
+
+        public String memberName() {
+            return memberName;
+        }
+
+        @Override
+        public void serialize(ShapeSerializer serializer) {
+            throw new UnsupportedOperationException("Cannot serialize union with unknown member " + this.memberName);
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getValue() {
+            return (T) memberName;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, getValue());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        return Objects.equals(getValue(), ((TestEventStream) other).getValue());
+    }
+
+    public interface BuildStage {
+        TestEventStream build();
+    }
+
+    /**
+     * @return returns a new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link TestEventStream}.
+     */
+    public static final class Builder implements ShapeBuilder<TestEventStream>, BuildStage {
+        private TestEventStream value;
+
+        private Builder() {}
+
+        @Override
+        public Schema schema() {
+            return $SCHEMA;
+        }
+
+        public BuildStage structureMember(StructureEvent value) {
+            return setValue(new StructureMemberMember(value));
+        }
+
+        public BuildStage stringMember(StringEvent value) {
+            return setValue(new StringMemberMember(value));
+        }
+
+        public BuildStage blobMember(BlobEvent value) {
+            return setValue(new BlobMemberMember(value));
+        }
+
+        public BuildStage headersOnlyMember(HeadersOnlyEvent value) {
+            return setValue(new HeadersOnlyMemberMember(value));
+        }
+
+        public BuildStage bodyAndHeaderMember(BodyAndHeaderEvent value) {
+            return setValue(new BodyAndHeaderMemberMember(value));
+        }
+
+        public BuildStage $unknownMember(String memberName) {
+            return setValue(new $UnknownMember(memberName));
+        }
+
+        private BuildStage setValue(TestEventStream value) {
+            if (this.value != null) {
+                if (this.value.type() == Type.$UNKNOWN) {
+                    throw new IllegalArgumentException("Cannot change union from unknown to known variant");
+                }
+                throw new IllegalArgumentException("Only one value may be set for unions");
+            }
+            this.value = value;
+            return this;
+        }
+
+        @Override
+        public TestEventStream build() {
+            return Objects.requireNonNull(value, "no union value set");
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void setMemberValue(Schema member, Object value) {
+            switch (member.memberIndex()) {
+                case 0 -> structureMember(
+                        (StructureEvent) SchemaUtils.validateSameMember($SCHEMA_STRUCTURE_MEMBER, member, value));
+                case 1 ->
+                    stringMember((StringEvent) SchemaUtils.validateSameMember($SCHEMA_STRING_MEMBER, member, value));
+                case 2 -> blobMember((BlobEvent) SchemaUtils.validateSameMember($SCHEMA_BLOB_MEMBER, member, value));
+                case 3 -> headersOnlyMember(
+                        (HeadersOnlyEvent) SchemaUtils.validateSameMember($SCHEMA_HEADERS_ONLY_MEMBER, member, value));
+                case 4 -> bodyAndHeaderMember((BodyAndHeaderEvent) SchemaUtils
+                        .validateSameMember($SCHEMA_BODY_AND_HEADER_MEMBER, member, value));
+                default -> ShapeBuilder.super.setMemberValue(member, value);
+            }
+        }
+
+        @Override
+        public Builder deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct($SCHEMA, this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        @Override
+        public Builder deserializeMember(ShapeDeserializer decoder, Schema schema) {
+            decoder.readStruct(schema.assertMemberTargetIs($SCHEMA), this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        private static final class $InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
+            private static final $InnerDeserializer INSTANCE = new $InnerDeserializer();
+
+            @Override
+            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.structureMember(StructureEvent.builder().deserializeMember(de, member).build());
+                    case 1 -> builder.stringMember(StringEvent.builder().deserializeMember(de, member).build());
+                    case 2 -> builder.blobMember(BlobEvent.builder().deserializeMember(de, member).build());
+                    case 3 ->
+                        builder.headersOnlyMember(HeadersOnlyEvent.builder().deserializeMember(de, member).build());
+                    case 4 ->
+                        builder.bodyAndHeaderMember(BodyAndHeaderEvent.builder().deserializeMember(de, member).build());
+                    default -> throw new IllegalArgumentException("Unexpected member: " + member.memberName());
+                }
+            }
+
+            @Override
+            public void unknownMember(Builder builder, String memberName) {
+                builder.$unknownMember(memberName);
+            }
+        }
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/TestOperation.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/TestOperation.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.util.List;
+import java.util.function.Supplier;
+import software.amazon.smithy.java.core.schema.ApiService;
+import software.amazon.smithy.java.core.schema.InputEventStreamingApiOperation;
+import software.amazon.smithy.java.core.schema.OutputEventStreamingApiOperation;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public final class TestOperation
+        implements InputEventStreamingApiOperation<TestOperationInput, TestOperationOutput, TestEventStream>,
+        OutputEventStreamingApiOperation<TestOperationInput, TestOperationOutput, TestEventStream> {
+
+    private static final TestOperation $INSTANCE = new TestOperation();
+
+    static final Schema $SCHEMA = Schema.createOperation(ShapeId.from("smithy.test.eventstreaming#TestOperation"));
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private static final TypeRegistry TYPE_REGISTRY = TypeRegistry.empty();
+
+    private static final List<ShapeId> SCHEMES = List.of(ShapeId.from("smithy.api#noAuth"));
+
+    private static final Schema INPUT_STREAM_MEMBER = TestOperationInput.$SCHEMA.member("stream");
+    private static final Schema OUTPUT_STREAM_MEMBER = TestOperationOutput.$SCHEMA.member("outputStream");
+
+    /**
+     * Get an instance of this {@code ApiOperation}.
+     *
+     * @return An instance of this class.
+     */
+    public static TestOperation instance() {
+        return $INSTANCE;
+    }
+
+    private TestOperation() {}
+
+    @Override
+    public ShapeBuilder<TestOperationInput> inputBuilder() {
+        return TestOperationInput.builder();
+    }
+
+    @Override
+    public Supplier<ShapeBuilder<TestEventStream>> inputEventBuilderSupplier() {
+        return () -> TestEventStream.builder();
+    }
+
+    @Override
+    public ShapeBuilder<TestOperationOutput> outputBuilder() {
+        return TestOperationOutput.builder();
+    }
+
+    @Override
+    public Supplier<ShapeBuilder<TestEventStream>> outputEventBuilderSupplier() {
+        return () -> TestEventStream.builder();
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public Schema inputSchema() {
+        return TestOperationInput.$SCHEMA;
+    }
+
+    @Override
+    public Schema outputSchema() {
+        return TestOperationOutput.$SCHEMA;
+    }
+
+    @Override
+    public TypeRegistry errorRegistry() {
+        return TYPE_REGISTRY;
+    }
+
+    @Override
+    public List<ShapeId> effectiveAuthSchemes() {
+        return SCHEMES;
+    }
+
+    @Override
+    public Schema inputStreamMember() {
+        return INPUT_STREAM_MEMBER;
+    }
+
+    @Override
+    public Schema outputStreamMember() {
+        return OUTPUT_STREAM_MEMBER;
+    }
+
+    @Override
+    public Schema idempotencyTokenMember() {
+        return null;
+    }
+
+    @Override
+    public ApiService service() {
+        return EventStreamingTestServiceApiService.instance();
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/TestOperationInput.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/TestOperationInput.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.util.Objects;
+import java.util.concurrent.Flow.Publisher;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.ToStringSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public final class TestOperationInput implements SerializableStruct {
+
+    public static final Schema $SCHEMA = Schemas.TEST_OPERATION_INPUT;
+    private static final Schema $SCHEMA_HEADER_STRING = $SCHEMA.member("headerString");
+    private static final Schema $SCHEMA_INPUT_STRING_MEMBER = $SCHEMA.member("inputStringMember");
+    private static final Schema $SCHEMA_STREAM = $SCHEMA.member("stream");
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private final transient String headerString;
+    private final transient String inputStringMember;
+    private final transient Publisher<TestEventStream> stream;
+
+    private TestOperationInput(Builder builder) {
+        this.headerString = builder.headerString;
+        this.inputStringMember = builder.inputStringMember;
+        this.stream = builder.stream;
+    }
+
+    public String getHeaderString() {
+        return headerString;
+    }
+
+    public String getInputStringMember() {
+        return inputStringMember;
+    }
+
+    public Publisher<TestEventStream> getStream() {
+        return stream;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringSerializer.serialize(this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        TestOperationInput that = (TestOperationInput) other;
+        return Objects.equals(this.headerString, that.headerString)
+                && Objects.equals(this.inputStringMember, that.inputStringMember)
+                && Objects.equals(this.stream, that.stream);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(headerString, inputStringMember, stream);
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        if (headerString != null) {
+            serializer.writeString($SCHEMA_HEADER_STRING, headerString);
+        }
+        if (inputStringMember != null) {
+            serializer.writeString($SCHEMA_INPUT_STRING_MEMBER, inputStringMember);
+        }
+        if (stream != null) {
+            serializer.writeEventStream($SCHEMA_STREAM, stream);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return switch (member.memberIndex()) {
+            case 0 -> (T) SchemaUtils.validateSameMember($SCHEMA_HEADER_STRING, member, headerString);
+            case 1 -> (T) SchemaUtils.validateSameMember($SCHEMA_INPUT_STRING_MEMBER, member, inputStringMember);
+            case 2 -> (T) SchemaUtils.validateSameMember($SCHEMA_STREAM, member, stream);
+            default -> throw new IllegalArgumentException("Attempted to get non-existent member: " + member.id());
+        };
+    }
+
+    /**
+     * Create a new builder containing all the current property values of this object.
+     *
+     * <p><strong>Note:</strong> This method performs only a shallow copy of the original properties.
+     *
+     * @return a builder for {@link TestOperationInput}.
+     */
+    public Builder toBuilder() {
+        var builder = new Builder();
+        builder.headerString(this.headerString);
+        builder.inputStringMember(this.inputStringMember);
+        builder.stream(this.stream);
+        return builder;
+    }
+
+    /**
+     * @return returns a new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link TestOperationInput}.
+     */
+    public static final class Builder implements ShapeBuilder<TestOperationInput> {
+        private String headerString;
+        private String inputStringMember;
+        private Publisher<TestEventStream> stream;
+
+        private Builder() {}
+
+        @Override
+        public Schema schema() {
+            return $SCHEMA;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder headerString(String headerString) {
+            this.headerString = headerString;
+            return this;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder inputStringMember(String inputStringMember) {
+            this.inputStringMember = inputStringMember;
+            return this;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder stream(Publisher<TestEventStream> stream) {
+            this.stream = stream;
+            return this;
+        }
+
+        @Override
+        public TestOperationInput build() {
+            return new TestOperationInput(this);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void setMemberValue(Schema member, Object value) {
+            switch (member.memberIndex()) {
+                case 0 -> headerString((String) SchemaUtils.validateSameMember($SCHEMA_HEADER_STRING, member, value));
+                case 1 -> inputStringMember(
+                        (String) SchemaUtils.validateSameMember($SCHEMA_INPUT_STRING_MEMBER, member, value));
+                case 2 ->
+                    stream((Publisher<TestEventStream>) SchemaUtils.validateSameMember($SCHEMA_STREAM, member, value));
+                default -> ShapeBuilder.super.setMemberValue(member, value);
+            }
+        }
+
+        @Override
+        public Builder deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct($SCHEMA, this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        @Override
+        public Builder deserializeMember(ShapeDeserializer decoder, Schema schema) {
+            decoder.readStruct(schema.assertMemberTargetIs($SCHEMA), this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        private static final class $InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
+            private static final $InnerDeserializer INSTANCE = new $InnerDeserializer();
+
+            @Override
+            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.headerString(de.readString(member));
+                    case 1 -> builder.inputStringMember(de.readString(member));
+                    case 2 -> builder.stream((Publisher<TestEventStream>) de.readEventStream(member));
+                    default -> throw new IllegalArgumentException("Unexpected member: " + member.memberName());
+                }
+            }
+        }
+    }
+}

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/TestOperationOutput.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/model/TestOperationOutput.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.events.model;
+
+import java.util.Objects;
+import java.util.concurrent.Flow.Publisher;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.ToStringSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public final class TestOperationOutput implements SerializableStruct {
+
+    public static final Schema $SCHEMA = Schemas.TEST_OPERATION_OUTPUT;
+    private static final Schema $SCHEMA_INT_MEMBER_HEADER = $SCHEMA.member("intMemberHeader");
+    private static final Schema $SCHEMA_STRING_MEMBER = $SCHEMA.member("stringMember");
+    private static final Schema $SCHEMA_OUTPUT_STREAM = $SCHEMA.member("outputStream");
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private final transient Integer intMemberHeader;
+    private final transient String stringMember;
+    private final transient Publisher<TestEventStream> outputStream;
+
+    private TestOperationOutput(Builder builder) {
+        this.intMemberHeader = builder.intMemberHeader;
+        this.stringMember = builder.stringMember;
+        this.outputStream = builder.outputStream;
+    }
+
+    public Integer getIntMemberHeader() {
+        return intMemberHeader;
+    }
+
+    public String getStringMember() {
+        return stringMember;
+    }
+
+    public Publisher<TestEventStream> getOutputStream() {
+        return outputStream;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringSerializer.serialize(this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        TestOperationOutput that = (TestOperationOutput) other;
+        return Objects.equals(this.intMemberHeader, that.intMemberHeader)
+                && Objects.equals(this.stringMember, that.stringMember)
+                && Objects.equals(this.outputStream, that.outputStream);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(intMemberHeader, stringMember, outputStream);
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        if (intMemberHeader != null) {
+            serializer.writeInteger($SCHEMA_INT_MEMBER_HEADER, intMemberHeader);
+        }
+        if (stringMember != null) {
+            serializer.writeString($SCHEMA_STRING_MEMBER, stringMember);
+        }
+        if (outputStream != null) {
+            serializer.writeEventStream($SCHEMA_OUTPUT_STREAM, outputStream);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return switch (member.memberIndex()) {
+            case 0 -> (T) SchemaUtils.validateSameMember($SCHEMA_INT_MEMBER_HEADER, member, intMemberHeader);
+            case 1 -> (T) SchemaUtils.validateSameMember($SCHEMA_STRING_MEMBER, member, stringMember);
+            case 2 -> (T) SchemaUtils.validateSameMember($SCHEMA_OUTPUT_STREAM, member, outputStream);
+            default -> throw new IllegalArgumentException("Attempted to get non-existent member: " + member.id());
+        };
+    }
+
+    /**
+     * Create a new builder containing all the current property values of this object.
+     *
+     * <p><strong>Note:</strong> This method performs only a shallow copy of the original properties.
+     *
+     * @return a builder for {@link TestOperationOutput}.
+     */
+    public Builder toBuilder() {
+        var builder = new Builder();
+        builder.intMemberHeader(this.intMemberHeader);
+        builder.stringMember(this.stringMember);
+        builder.outputStream(this.outputStream);
+        return builder;
+    }
+
+    /**
+     * @return returns a new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link TestOperationOutput}.
+     */
+    public static final class Builder implements ShapeBuilder<TestOperationOutput> {
+        private Integer intMemberHeader;
+        private String stringMember;
+        private Publisher<TestEventStream> outputStream;
+
+        private Builder() {}
+
+        @Override
+        public Schema schema() {
+            return $SCHEMA;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder intMemberHeader(Integer intMemberHeader) {
+            this.intMemberHeader = intMemberHeader;
+            return this;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder stringMember(String stringMember) {
+            this.stringMember = stringMember;
+            return this;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder outputStream(Publisher<TestEventStream> outputStream) {
+            this.outputStream = outputStream;
+            return this;
+        }
+
+        @Override
+        public TestOperationOutput build() {
+            return new TestOperationOutput(this);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void setMemberValue(Schema member, Object value) {
+            switch (member.memberIndex()) {
+                case 0 ->
+                    intMemberHeader((Integer) SchemaUtils.validateSameMember($SCHEMA_INT_MEMBER_HEADER, member, value));
+                case 1 -> stringMember((String) SchemaUtils.validateSameMember($SCHEMA_STRING_MEMBER, member, value));
+                case 2 -> outputStream((Publisher<TestEventStream>) SchemaUtils
+                        .validateSameMember($SCHEMA_OUTPUT_STREAM, member, value));
+                default -> ShapeBuilder.super.setMemberValue(member, value);
+            }
+        }
+
+        @Override
+        public Builder deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct($SCHEMA, this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        @Override
+        public Builder deserializeMember(ShapeDeserializer decoder, Schema schema) {
+            decoder.readStruct(schema.assertMemberTargetIs($SCHEMA), this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        private static final class $InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
+            private static final $InnerDeserializer INSTANCE = new $InnerDeserializer();
+
+            @Override
+            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.intMemberHeader(de.readInteger(member));
+                    case 1 -> builder.stringMember(de.readString(member));
+                    case 2 -> builder.outputStream((Publisher<TestEventStream>) de.readEventStream(member));
+                    default -> throw new IllegalArgumentException("Unexpected member: " + member.memberName());
+                }
+            }
+        }
+    }
+}

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemasGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemasGenerator.java
@@ -315,19 +315,22 @@ public final class SchemasGenerator
                     template = """
                                 ${name:L}_BUILDER${?hasMembers}
                                     ${C|}
-                                    ${/hasMembers}.build();
+                                    ${/hasMembers}.builderSupplier(${schemaTypeClass:T}::builder)
+                                    .build();
                             """;
                 } else {
                     template =
                             """
                                     static final ${schemaClass:T} ${name:L} = ${schemaClass:T}.${builderMethod:L}(${shapeId:T}.from(${id:S})${traits:C})${?hasMembers}
                                              ${C|}
-                                             ${/hasMembers}.build();
+                                             ${/hasMembers}.builderSupplier(${schemaTypeClass:T}::builder)
+                                             .build();
                                     """;
                 }
                 writer.pushState();
                 writer.putContext("hasMembers", !shape.members().isEmpty());
                 writer.putContext("builderMethod", builderMethod);
+                writer.putContext("schemaTypeClass", context.symbolProvider().toSymbol(shape));
 
                 writer.write(
                         template,

--- a/codegen/plugins/types-codegen/src/it/java/software/amazon/smithy/java/codegen/types/GenericSerdeTest.java
+++ b/codegen/plugins/types-codegen/src/it/java/software/amazon/smithy/java/codegen/types/GenericSerdeTest.java
@@ -11,8 +11,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import smithy.java.codegen.server.test.model.A;
-import smithy.java.codegen.server.test.model.B;
+import smithy.java.codegen.server.test.model.Astruct;
+import smithy.java.codegen.server.test.model.Bstruct;
 import smithy.java.codegen.server.test.model.MyNestedStruct;
 import smithy.java.codegen.server.test.model.MyStruct;
 import smithy.java.codegen.server.test.model.MyUnion;
@@ -43,7 +43,7 @@ public class GenericSerdeTest {
                                 .build(),
                         UsesOtherStructs.builder()),
                 Arguments.of(new MyUnion.OptionAMember("Value"), MyUnion.builder()),
-                Arguments.of(A.builder().b(B.builder().build()).value("top").build(), A.builder()));
+                Arguments.of(Astruct.builder().b(Bstruct.builder().build()).value("top").build(), Astruct.builder()));
     }
 
     @ParameterizedTest

--- a/codegen/plugins/types-codegen/src/it/resources/META-INF/smithy/a.smithy
+++ b/codegen/plugins/types-codegen/src/it/resources/META-INF/smithy/a.smithy
@@ -14,12 +14,11 @@ union MyUnion {
     optionB: Integer
 }
 
-structure A {
+structure Astruct {
     value: String
-    b: B
+    b: Bstruct
 }
 
-structure B {
-    a: A
+structure Bstruct {
+    a: Astruct
 }
-

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/DeferredRootSchema.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/DeferredRootSchema.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 
@@ -31,9 +32,10 @@ final class DeferredRootSchema extends Schema {
             List<MemberSchemaBuilder> memberBuilders,
             Set<String> stringEnumValues,
             Set<Integer> intEnumValues,
+            Supplier<ShapeBuilder<?>> builderSupplier,
             SchemaBuilder schemaBuilder
     ) {
-        super(type, id, traits, memberBuilders, stringEnumValues);
+        super(type, id, traits, memberBuilders, stringEnumValues, builderSupplier);
         this.stringEnumValues = Collections.unmodifiableSet(stringEnumValues);
         this.intEnumValues = Collections.unmodifiableSet(intEnumValues);
         this.memberBuilders = memberBuilders;

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/ResolvedRootSchema.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/ResolvedRootSchema.java
@@ -25,7 +25,8 @@ final class ResolvedRootSchema extends Schema {
                 deferredRootSchema.id(),
                 deferredRootSchema.traits,
                 deferredRootSchema.memberBuilders,
-                deferredRootSchema.stringEnumValues);
+                deferredRootSchema.stringEnumValues,
+                deferredRootSchema.shapeBuilder);
         var resolvedMembers = deferredRootSchema.resolvedMembers();
         this.memberList = resolvedMembers.memberList();
         this.requiredMemberCount = resolvedMembers.requiredMemberCount();

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/RootSchema.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/RootSchema.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 
@@ -47,9 +48,10 @@ final class RootSchema extends Schema {
             TraitMap traits,
             List<MemberSchemaBuilder> memberBuilders,
             Set<String> stringEnumValues,
-            Set<Integer> intEnumValues
+            Set<Integer> intEnumValues,
+            Supplier<ShapeBuilder<?>> builderSupplier
     ) {
-        super(type, id, traits, memberBuilders, stringEnumValues);
+        super(type, id, traits, memberBuilders, stringEnumValues, builderSupplier);
         this.stringEnumValues = Collections.unmodifiableSet(stringEnumValues);
         this.intEnumValues = Collections.unmodifiableSet(intEnumValues);
 
@@ -70,6 +72,17 @@ final class RootSchema extends Schema {
                     memberList,
                     Schema::requiredByValidationBitmask);
         }
+    }
+
+    RootSchema(
+            ShapeType type,
+            ShapeId id,
+            TraitMap traits,
+            List<MemberSchemaBuilder> memberBuilders,
+            Set<String> stringEnumValues,
+            Set<Integer> intEnumValues
+    ) {
+        this(type, id, traits, memberBuilders, stringEnumValues, intEnumValues, null);
     }
 
     @Override

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/Schema.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/Schema.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.function.Supplier;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.Trait;
@@ -61,6 +62,8 @@ public abstract sealed class Schema implements MemberLookup
     private Schema mapKeyMember;
     private Schema mapValueMember;
 
+    final Supplier<ShapeBuilder<?>> shapeBuilder;
+
     private final int hash;
 
     Schema(
@@ -68,12 +71,14 @@ public abstract sealed class Schema implements MemberLookup
             ShapeId id,
             TraitMap traits,
             List<MemberSchemaBuilder> members,
-            Set<String> stringEnumValues
+            Set<String> stringEnumValues,
+            Supplier<ShapeBuilder<?>> shapeBuilder
     ) {
         this.type = type;
         this.id = id;
         this.traits = traits;
         this.memberName = null;
+        this.shapeBuilder = shapeBuilder;
 
         // Structure shapes need to sort members so that required members come before optional members.
         if (type == ShapeType.STRUCTURE) {
@@ -106,6 +111,16 @@ public abstract sealed class Schema implements MemberLookup
         this.hash = computeHash(this);
     }
 
+    Schema(
+            ShapeType type,
+            ShapeId id,
+            TraitMap traits,
+            List<MemberSchemaBuilder> members,
+            Set<String> stringEnumValues
+    ) {
+        this(type, id, traits, members, stringEnumValues, null);
+    }
+
     Schema(MemberSchemaBuilder builder) {
         this.type = builder.type;
         this.id = builder.id;
@@ -113,6 +128,7 @@ public abstract sealed class Schema implements MemberLookup
         this.memberName = builder.id.getMember().orElseThrow();
         this.memberIndex = builder.memberIndex;
         this.isRequiredByValidation = builder.isRequiredByValidation;
+        this.shapeBuilder = null;
 
         this.minLengthConstraint = builder.validationState.minLengthConstraint();
         this.maxLengthConstraint = builder.validationState.maxLengthConstraint();
@@ -343,8 +359,8 @@ public abstract sealed class Schema implements MemberLookup
      * Get a trait if present.
      *
      * @param trait Trait to get.
+     * @param <T>   Trait type to get.
      * @return Returns the trait, or null if not found.
-     * @param <T> Trait type to get.
      */
     public final <T extends Trait> T getTrait(TraitKey<T> trait) {
         return traits.get(trait);
@@ -364,8 +380,8 @@ public abstract sealed class Schema implements MemberLookup
      * Requires that the given trait type is found and returns it.
      *
      * @param trait Trait type to get.
+     * @param <T>   Trait to get.
      * @return Returns the found value.
-     * @param <T> Trait to get.
      * @throws NoSuchElementException if the value does not exist.
      */
     public final <T extends Trait> T expectTrait(TraitKey<T> trait) {
@@ -385,8 +401,8 @@ public abstract sealed class Schema implements MemberLookup
      * {@link #getTrait} for non-member shapes.
      *
      * @param trait Trait to get.
+     * @param <T>   Trait to get.
      * @return the trait if found, or null.
-     * @param <T> Trait to get.
      */
     public <T extends Trait> T getDirectTrait(TraitKey<T> trait) {
         return getTrait(trait);
@@ -461,6 +477,18 @@ public abstract sealed class Schema implements MemberLookup
     }
 
     /**
+     * Returns the supplier to create builders for this schema.
+     *
+     * @return The supplier to create builders for this schema
+     */
+    public final Supplier<ShapeBuilder<?>> shapeBuilder() {
+        if (shapeBuilder == null) {
+            throw new IllegalStateException("Schema does not have a shape builder");
+        }
+        return shapeBuilder;
+    }
+
+    /**
      * Get the allowed values of the string.
      *
      * @return allowed string values (only relevant if not empty).
@@ -479,13 +507,11 @@ public abstract sealed class Schema implements MemberLookup
     }
 
     /**
-     *
      * @return The structure member count that are required by validation.
      */
     abstract int requiredMemberCount();
 
     /**
-     *
      * @return The bitmask to use for this member to compute a required member bitfield. This value will match the
      * memberIndex if the member is required and has no default value. It will be zero if
      * isRequiredByValidation == false.
@@ -493,7 +519,6 @@ public abstract sealed class Schema implements MemberLookup
     abstract long requiredByValidationBitmask();
 
     /**
-     *
      * @return The result of creating a bitfield of the memberIndex of every required member with no default value.
      * This allows for an inexpensive comparison for required structure member validation.
      */

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/TraitKey.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/TraitKey.java
@@ -12,6 +12,8 @@ import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.EndpointTrait;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.EventHeaderTrait;
+import software.amazon.smithy.model.traits.EventPayloadTrait;
 import software.amazon.smithy.model.traits.HostLabelTrait;
 import software.amazon.smithy.model.traits.HttpErrorTrait;
 import software.amazon.smithy.model.traits.HttpHeaderTrait;
@@ -104,6 +106,8 @@ public final class TraitKey<T extends Trait> {
     public static final TraitKey<XmlFlattenedTrait> XML_FLATTENED_TRAIT = TraitKey.get(XmlFlattenedTrait.class);
     public static final TraitKey<XmlNamespaceTrait> XML_NAMESPACE_TRAIT = TraitKey.get(XmlNamespaceTrait.class);
     public static final TraitKey<CorsTrait> CORS_TRAIT = TraitKey.get(CorsTrait.class);
+    public static final TraitKey<EventHeaderTrait> EVENT_HEADER_TRAIT = TraitKey.get(EventHeaderTrait.class);
+    public static final TraitKey<EventPayloadTrait> EVENT_PAYLOAD_TRAIT = TraitKey.get(EventPayloadTrait.class);
 
     private final Class<T> traitClass;
     final int id;


### PR DESCRIPTION
Adds support to encode and decode members with the @eventHeader and @eventPayload traits. For the decoding part, it's necessary to decode the union member independently of the union itself for which we need its builder, but we currently have no means to get one. For this, the schema was enhanced wiht a method that to return a supplier to generate new instances of builder for that schema which is only set for structures and unions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
