### PR TITLE
Delay publishing the initial event until fully wired

### DIFF
--- a/aws/aws-event-streams/build.gradle.kts
+++ b/aws/aws-event-streams/build.gradle.kts
@@ -9,5 +9,6 @@ extra["moduleName"] = "software.amazon.smithy.java.aws.events"
 
 dependencies {
     api(project(":core"))
+    implementation(project(":logging"))
     api("software.amazon.eventstream:eventstream:1.0.1")
 }

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/RpcEventStreamsUtil.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/RpcEventStreamsUtil.java
@@ -31,7 +31,7 @@ public final class RpcEventStreamsUtil {
         Flow.Publisher<SerializableStruct> eventStream = input.getMemberValue(streamingMember(input.schema()));
         var publisher = EventStreamFrameEncodingProcessor.create(eventStream, eventStreamEncodingFactory);
         // Queue the input as the initial-request.
-        publisher.onNext(input);
+        publisher.enqueueItem(input);
         return publisher;
     }
 
@@ -62,7 +62,7 @@ public final class RpcEventStreamsUtil {
 
             @Override
             public void onComplete() {
-                result.completeExceptionally(new RuntimeException("Unexpected vent stream completion"));
+                result.completeExceptionally(new RuntimeException("Unexpected event stream completion"));
             }
         });
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     api(project(":io"))
     api(project(":retries-api"))
     api(libs.smithy.model)
+    implementation(project(":logging"))
 }
 
 jmh {}

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/BufferingFlatMapProcessor.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/BufferingFlatMapProcessor.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import software.amazon.smithy.java.logging.InternalLogger;
 
 /**
  * A processor abstraction that maps inputs of type I from an upstream publisher to 0-n items of type O
@@ -27,12 +28,12 @@ import java.util.stream.Stream;
 public abstract class BufferingFlatMapProcessor<I, O> implements
         Flow.Processor<I, O>,
         Flow.Subscription {
+    private static final InternalLogger LOG = InternalLogger.getLogger(BufferingFlatMapProcessor.class);
     private static final Throwable COMPLETE_SENTINEL = new RuntimeException();
 
-    private final AtomicReference<Throwable> terminalEvent = new AtomicReference<>();
+    private final AtomicReference<Throwable> terminalEventHolder = new AtomicReference<>();
     private final AtomicLong pendingRequests = new AtomicLong();
     private final AtomicInteger pendingFlushes = new AtomicInteger();
-    private final Flow.Publisher<I> publisher;
     private final BlockingQueue<O> queue = new LinkedBlockingQueue<>();
 
     private volatile Flow.Subscription upstreamSubscription;
@@ -42,7 +43,6 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
     public BufferingFlatMapProcessor(
             Flow.Publisher<I> publisher
     ) {
-        this.publisher = publisher;
         publisher.subscribe(this);
     }
 
@@ -64,13 +64,23 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
 
     @Override
     public final void onNext(I item) {
+        enqueueItem(item);
+        flush();
+    }
+
+    /**
+     * Adds the item to the queue for later delivery. The queue will get flushed upon calls to {@link #request} or
+     * {@link #onNext(Object)}.
+     *
+     * @param item The item to add to the queue
+     */
+    public final void enqueueItem(I item) {
         try {
             map(item).forEach(this::addToQueue);
         } catch (Exception e) {
+            LOG.warn("Malformed input", e);
             onError(new SerializationException("Malformed input", e));
-            return;
         }
-        flush();
     }
 
     private void addToQueue(O item) {
@@ -80,7 +90,7 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
     @Override
     public final void onError(Throwable t) {
         upstreamSubscription.cancel();
-        terminalEvent.compareAndSet(null, t);
+        terminalEventHolder.compareAndSet(null, t);
         if (upstreamSubscription != null && downstream != null) {
             flush();
         }
@@ -88,7 +98,7 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
 
     @Override
     public final void onComplete() {
-        terminalEvent.compareAndSet(null, COMPLETE_SENTINEL);
+        terminalEventHolder.compareAndSet(null, COMPLETE_SENTINEL);
         if (upstreamSubscription != null && downstream != null) {
             flush();
         }
@@ -107,6 +117,10 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
 
     private void flush() {
         if (upstreamSubscription == null || downstream == null) {
+            LOG.warn("flush() requested before upstream and downstream fully wired, " +
+                    "upstreamSubscription is null: {}, downstream is null: {}",
+                    upstreamSubscription == null,
+                    downstream == null);
             onError(new IllegalStateException("flush() requested before upstream and downstream fully wired."));
             return;
         }
@@ -126,8 +140,8 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
             Flow.Subscriber<? super O> subscriber = downstream;
             long delivered = sendMessages(subscriber, pending);
             boolean empty = queue.isEmpty();
-            Throwable term = terminalEvent.get();
-            if (term != null && attemptTermination(subscriber, term, empty)) {
+            Throwable terminalEvent = terminalEventHolder.get();
+            if (terminalEvent != null && attemptTermination(subscriber, terminalEvent, empty)) {
                 terminated = true;
                 return;
             }
@@ -184,12 +198,12 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
     /**
      * @return true if this decoder is in a terminal state
      */
-    private boolean attemptTermination(Flow.Subscriber<? super O> subscriber, Throwable term, boolean done) {
+    private boolean attemptTermination(Flow.Subscriber<? super O> subscriber, Throwable terminalEvent, boolean done) {
         if (done && subscriber != null) {
-            if (term == COMPLETE_SENTINEL) {
+            if (terminalEvent == COMPLETE_SENTINEL) {
                 subscriber.onComplete();
             } else {
-                handleError(term, subscriber);
+                handleError(terminalEvent, subscriber);
             }
             return true;
         }
@@ -238,7 +252,7 @@ public abstract class BufferingFlatMapProcessor<I, O> implements
         }
     }
 
-    private static long accumulate(AtomicLong l, long n) {
-        return l.accumulateAndGet(n, BufferingFlatMapProcessor::accumulate);
+    private static void accumulate(AtomicLong l, long n) {
+        l.accumulateAndGet(n, BufferingFlatMapProcessor::accumulate);
     }
 }

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/event/EventStreamFrameEncodingProcessor.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/event/EventStreamFrameEncodingProcessor.java
@@ -8,11 +8,14 @@ package software.amazon.smithy.java.core.serde.event;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Flow;
 import java.util.stream.Stream;
+
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.BufferingFlatMapProcessor;
+import software.amazon.smithy.java.logging.InternalLogger;
 
 public final class EventStreamFrameEncodingProcessor<F extends Frame<?>, T extends SerializableStruct>
         extends BufferingFlatMapProcessor<T, ByteBuffer> {
+    private static final InternalLogger LOG = InternalLogger.getLogger(EventStreamFrameEncodingProcessor.class);
     private final EventEncoder<F> eventEncoder;
     private final FrameEncoder<F> encoder;
 
@@ -44,6 +47,7 @@ public final class EventStreamFrameEncodingProcessor<F extends Frame<?>, T exten
     @Override
     protected void handleError(Throwable error, Flow.Subscriber<? super ByteBuffer> subscriber) {
         subscriber.onNext(encoder.encode(eventEncoder.encodeFailure(error)));
+        LOG.warn("Unexpected error", error);
         subscriber.onComplete();
     }
 }

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseSerializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseSerializer.java
@@ -121,6 +121,7 @@ public final class ResponseSerializer {
      *
      * @return Returns the created response.
      */
+    @SuppressWarnings("unchecked")
     public HttpResponse serializeResponse() {
         Objects.requireNonNull(shapeValue, "shapeValue is not set");
         Objects.requireNonNull(operation, "operation is not set");
@@ -151,8 +152,7 @@ public final class ResponseSerializer {
 
         var eventStream = (Flow.Publisher<SerializableStruct>) serializer.getEventStream();
         if (eventStream != null && operation instanceof OutputEventStreamingApiOperation<?, ?, ?>) {
-            builder.body(
-                    EventStreamFrameEncodingProcessor.create(eventStream, eventEncoderFactory));
+            builder.body(EventStreamFrameEncodingProcessor.create(eventStream, eventEncoderFactory));
             serializer.setContentType(eventEncoderFactory.contentType());
         } else if (serializer.hasBody()) {
             builder.body(serializer.getBody());


### PR DESCRIPTION
There's a race condition that can happen when we add the initial request using onNext, that call will call flush while the downstream subscriber is not yet set. To avoid this we just enqueue the initial request, and wait till the upstream requests more input.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
