### PR TITLE
Properly support lists of Document's

### DIFF
--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServer.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServer.java
@@ -388,7 +388,7 @@ public final class McpServer implements Server {
         var listMember = schema.listMember();
         var items = switch (listMember.type()) {
             case LIST, SET -> createJsonArraySchema(listMember.memberTarget(), visited);
-            case MAP, STRUCTURE, UNION -> createJsonObjectSchema(listMember.memberTarget(), visited);
+            case MAP, STRUCTURE, UNION, DOCUMENT -> createJsonObjectSchema(listMember.memberTarget(), visited);
             default -> createJsonPrimitiveSchema(listMember);
         };
         return JsonArraySchema.builder()


### PR DESCRIPTION
*Issue #, if available:*

If the list is of type document the code incorrectly calls `createJsonPrimitiveSchema` which in turns fails with 

```
Schema{id='smithy.example#DocumentList$member', type=document} is not a primitive type
```

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
