### PR TITLE
Remove the logic to deserialize using the protocol codec

### DIFF
--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeDecoder.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeDecoder.java
@@ -87,15 +87,14 @@ public final class AwsEventShapeDecoder<E extends SerializableStruct, IR extends
 
     private IR decodeInitialResponse(AwsEventFrame frame) {
         var message = frame.unwrap();
-        var codecDeserializer = codec.createDeserializer(message.getPayload());
         var builder = initialEventBuilder.get();
-        builder.deserialize(codecDeserializer);
         var publisherMember = getPublisherMember(builder.schema());
         // Set the publisher member
         var responseDeserializer = new InitialResponseDeserializer(publisherMember, publisher);
         builder.deserialize(responseDeserializer);
         // Deserialize the rest of the members if any
         var headers = message.getHeaders();
+        var codecDeserializer = codec.createDeserializer(message.getPayload());
         var deserializer = new EventStreamDeserializer(codecDeserializer, new HeadersDeserializer(headers));
         builder.deserialize(deserializer);
         return builder.build();


### PR DESCRIPTION
This is previous logic which was not removed by mistake in the previous PR that introduced the logic to deserialize honoring the `@eventPayload` and `@eventHeader` traits.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
