### PR TITLE
Mark prompts trait @unstable

### DIFF
--- a/smithy-ai-traits/model/prompts.smithy
+++ b/smithy-ai-traits/model/prompts.smithy
@@ -2,6 +2,7 @@ $version: "2"
 
 namespace smithy.ai
 
+@unstable
 @trait(selector: ":is(service, operation)")
 map prompts {
     /// Name of the prompt template


### PR DESCRIPTION
*Description of changes:*
- This is for marking the trait as @unstable indicating this trait shape may change in future after customer feedback or if the MCP Spec changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
