### PR TITLE
Fix permissions of update-gradle-wrapper and add workflow_dispatch

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,5 +1,6 @@
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 name: Update Gradle Wrapper
 # Needed because dependabot doesn't support updating the gradle wrapper
 # see: https://github.com/dependabot/dependabot-core/issues/2223
@@ -7,6 +8,7 @@ name: Update Gradle Wrapper
 on:
   schedule:
     - cron: "0 14 * * 1" # 2PM UTC (7AM PST) every Monday.
+  workflow_dispatch:
 
 jobs:
   update-gradle-wrapper:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

After taking in GH's automated security fix in #860 , the update gradle wrapper action has been failing because of lack of permissions to create a branch and PRs (https://github.com/smithy-lang/smithy-java/actions/runs/17917802797). This fixes that. 

Also add `workflow_dispatch` trigger so this can be run on demand from the Actions page.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
