### PR TITLE
Handle null protocol version in the request

### DIFF
--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServer.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServer.java
@@ -136,11 +136,13 @@ public final class McpServer implements Server {
                             pv = protocolVersion.identifier();
                         }
                     }
-
                     proxies.values().forEach(this::initialize);
+                    var builder = InitializeResult.builder();
+                    if (pv != null) {
+                        builder.protocolVersion(pv);
+                    }
                     writeResponse(req.getId(),
-                            InitializeResult.builder()
-                                    .protocolVersion(pv)
+                            builder
                                     .capabilities(Capabilities.builder()
                                             .tools(Tools.builder().listChanged(true).build())
                                             .prompts(Prompts.builder().listChanged(true).build())

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
@@ -63,9 +63,18 @@ public class McpServerTest {
     }
 
     private void initializeWithProtocolVersion(ProtocolVersion protocolVersion) {
-        write("initialize", Document.of(Map.of("protocolVersion", Document.of(protocolVersion.identifier()))));
+        final Document pvDoc;
+        final String expectedPv;
+        if (protocolVersion == null) {
+            pvDoc = Document.of(Map.of());
+            expectedPv = ProtocolVersion.v2024_11_05.INSTANCE.identifier();
+        } else {
+            pvDoc = Document.of(Map.of("protocolVersion", Document.of(protocolVersion.identifier())));
+            expectedPv = protocolVersion.identifier();
+        }
+        write("initialize", pvDoc);
         var pv = read().getResult().getMember("protocolVersion").asString();
-        assertEquals(protocolVersion.identifier(), pv);
+        assertEquals(expectedPv, pv);
     }
 
     @Test
@@ -116,7 +125,7 @@ public class McpServerTest {
 
         server.start();
 
-        initializeWithProtocolVersion(ProtocolVersion.v2025_06_18.INSTANCE);
+        initializeWithProtocolVersion(null);
         write("tools/list", Document.of(Map.of()));
         var response = read();
         var result = response.getResult().asStringMap();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Without this we get the following error in older versions of Q CLI.

```
JsonRpcResponse {
    jsonrpc: JsonRpcVersion(
        "2.0",
    ),
    id: 0,
    result: None,
    error: Some(
        JsonRpcError {
            code: 500,
            message: "java.lang.NullPointerException: protocolVersion cannot be null| \tat java.base@25/java.util.Objects.requireNonNull(Objects.java:246)| \tat software.amazon.smithy.java.mcp.model.InitializeResult$Builder.protocolVersion(InitializeResult.java:159)| \tat software.amazon.smithy.java.mcp.server.McpServer.handleRequest(McpServer.java:143)| \tat software.amazon.smithy.java.mcp.server.McpServer.listen(McpServer.java:118)| \tat software.amazon.smithy.java.mcp.server.McpServer.lambda$new$0(McpServer.java:101)| \tat java.base@25/java.lang.Thread.runWith(Thread.java:1487)| \tat java.base@25/java.lang.Thread.run(Thread.java:1474)| \tat org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)| \tat org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)| ",
            data: None,
        },
    ),
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
