### PR TITLE
Make McpService take a protocol version in every request. Default to 2025-03-26 protocol version

### DIFF
--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/ProtocolVersion.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/ProtocolVersion.java
@@ -62,10 +62,15 @@ public abstract sealed class ProtocolVersion implements Comparable<ProtocolVersi
 
     public static ProtocolVersion version(String identifier) {
         return switch (identifier) {
+            case null -> v2025_03_26.INSTANCE;
             case "2024-11-05" -> v2024_11_05.INSTANCE;
             case "2025-03-26" -> v2025_03_26.INSTANCE;
             case "2025-06-18" -> v2025_06_18.INSTANCE;
             default -> new UnknownVersion(identifier);
         };
+    }
+
+    public static ProtocolVersion defaultVersion() {
+        return v2025_03_26.INSTANCE;
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

According to spec, 

> For backwards compatibility, if the server does not receive an MCP-Protocol-Version header, and has no other way to identify the version - for example, by relying on the protocol version negotiated during initialization - the server SHOULD assume protocol version 2025-03-26.

This makes it easier to use this with Http Transport and we don't need to maintain state about protocol version sent during initializeRequest.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
