### PR TITLE
Mark ProcessIoProxy done when the underlying process has terminated

### DIFF
--- a/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/ProcessIoProxy.java
+++ b/mcp/mcp-cli/src/main/java/software/amazon/smithy/java/mcp/cli/ProcessIoProxy.java
@@ -222,6 +222,21 @@ public final class ProcessIoProxy {
                         running);
             }
 
+            // Thread to monitor process exit and signal completion
+            Thread.ofVirtual()
+                    .name("process-exit-monitor")
+                    .start(() -> {
+                        try {
+                            process.waitFor();
+                        } catch (InterruptedException e) {
+                            LOG.error("Process exit monitor interrupted", e);
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            running.set(false);
+                            done.countDown();
+                        }
+                    });
+
         } catch (IOException e) {
             running.set(false);
             throw new RuntimeException("Failed to start process: " + e.getMessage(), e);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Without this the CLI just keeps hanging when an EOF is sent, because the underlying process terminates.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
