### PR TITLE
Fix httpHeader and httpPrefixHeaders protocol tests

### DIFF
--- a/aws/client/aws-client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
+++ b/aws/client/aws-client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
@@ -33,10 +33,6 @@ public class RestJson1ProtocolTests {
     private static final String EMPTY_BODY = "";
 
     @HttpClientRequestTests
-    @ProtocolTestFilter(
-            skipTests = {
-                    "RestJsonHttpEmptyPrefixHeadersRequestClient" //FIXME https://github.com/smithy-lang/smithy-java/issues/647
-            })
     public void requestTest(DataStream expected, DataStream actual) {
         assertThat(expected.hasKnownLength())
                 .isTrue()

--- a/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
+++ b/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
@@ -38,7 +38,6 @@ public class RestXmlProtocolTests {
             skipTests = {
                     "SDKAppliedContentEncoding_restXml",
                     "SDKAppendedGzipAfterProvidedEncoding_restXml",
-                    "HttpEmptyPrefixHeadersRequestClient" //FIXME https://github.com/smithy-lang/smithy-java/issues/647
             })
     public void requestTest(DataStream expected, DataStream actual) {
         if (expected.contentLength() != 0) {

--- a/aws/server/aws-server-restjson/src/it/java/software/amazon/smithy/java/aws/server/restjson/AwsRestJson1ProtocolTests.java
+++ b/aws/server/aws-server-restjson/src/it/java/software/amazon/smithy/java/aws/server/restjson/AwsRestJson1ProtocolTests.java
@@ -45,7 +45,6 @@ public class AwsRestJson1ProtocolTests {
 
                     // Header splitting needs work.
                     "RestJsonInputAndOutputWithQuotedStringHeaders",
-                    "RestJsonHttpEmptyPrefixHeadersRequestServer" //FIXME https://github.com/smithy-lang/smithy-java/issues/647
             },
             skipOperations = {
                     "aws.protocoltests.restjson#DocumentType",
@@ -80,8 +79,6 @@ public class AwsRestJson1ProtocolTests {
                     "RestJsonEmptyComplexErrorWithNoMessage",
                     //TODO this breaks because of Validation and errorCorrection doesn't handle that.
                     "RestJsonServerPopulatesNestedDefaultValuesWhenMissingInInResponseParams",
-                    "RestJsonHttpEmptyPrefixHeadersResponseServer" //FIXME https://github.com/smithy-lang/smithy-java/issues/647
-
             })
     public void responseTest(DataStream expected, DataStream actual) {
         assertThat(expected.hasKnownLength())

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpPrefixHeadersDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpPrefixHeadersDeserializer.java
@@ -32,7 +32,9 @@ final class HttpPrefixHeadersDeserializer extends SpecificShapeDeserializer {
         var prefix = trait.getValue().toLowerCase(Locale.ENGLISH);
         for (var entry : headers) {
             var name = entry.getKey();
-            if (PrefixConstants.OMITTED_HEADER_NAMES.contains(name) || !name.startsWith(prefix)) {
+            var lowerCaseName = name.toLowerCase(Locale.ENGLISH);
+            if (PrefixConstants.OMITTED_HEADER_NAMES.contains(lowerCaseName)
+                    || !lowerCaseName.startsWith(prefix)) {
                 continue;
             }
             consumer.accept(state, name.substring(prefix.length()), new HeaderValueDeserializer(name));


### PR DESCRIPTION
This PR fixe the protocol failing protocol tests listed in #647 .
* Serialization tests were failing because there is no handling for precedence of the usage of `@httpHeader` if `@httpPrefixHeader`'s value is an empty string.
* Deserialization tests were failing because the filter failed to exclude unnormalized system generated headers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
