### PR TITLE
Orient DataStream around InputStream

### DIFF
--- a/aws/aws-sigv4/src/main/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4Signer.java
+++ b/aws/aws-sigv4/src/main/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4Signer.java
@@ -130,7 +130,7 @@ final class SigV4Signer implements Signer<HttpRequest, AwsCredentialsIdentity> {
     }
 
     private String getPayloadHash(DataStream dataStream) {
-        return hexHash(dataStream.waitForByteBuffer());
+        return hexHash(dataStream.asByteBuffer());
     }
 
     private String hexHash(ByteBuffer bytes) {

--- a/aws/client/aws-client-awsjson/src/it/java/software/amazon/smithy/java/client/aws/jsonprotocols/AwsJson1ProtocolTests.java
+++ b/aws/client/aws-client-awsjson/src/it/java/software/amazon/smithy/java/client/aws/jsonprotocols/AwsJson1ProtocolTests.java
@@ -39,7 +39,7 @@ public class AwsJson1ProtocolTests {
         if (expected.contentLength() != 0) {
             // Use the node parser to strip out white space.
             expectedJson = Node.printJson(
-                    Node.parse(new String(ByteBufferUtils.getBytes(expected.waitForByteBuffer()),
+                    Node.parse(new String(ByteBufferUtils.getBytes(expected.asByteBuffer()),
                             StandardCharsets.UTF_8)));
         }
         assertEquals(expectedJson, new StringBuildingSubscriber(actual).getResult());

--- a/aws/client/aws-client-awsjson/src/main/java/software/amazon/smithy/java/aws/client/awsjson/AwsJsonProtocol.java
+++ b/aws/client/aws-client-awsjson/src/main/java/software/amazon/smithy/java/aws/client/awsjson/AwsJsonProtocol.java
@@ -101,7 +101,7 @@ abstract sealed class AwsJsonProtocol extends HttpClientProtocol permits AwsJson
             return codec.deserializeShape(EMPTY_PAYLOAD, builder);
         }
 
-        var bytes = content.waitForByteBuffer();
+        var bytes = content.asByteBuffer();
         return codec.deserializeShape(bytes, builder);
     }
 }

--- a/aws/client/aws-client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
+++ b/aws/client/aws-client-restjson/src/it/java/software/amazon/smithy/java/client/aws/restjson/RestJson1ProtocolTests.java
@@ -41,7 +41,7 @@ public class RestJson1ProtocolTests {
         var actualStr = new StringBuildingSubscriber(actual).getResult();
         if (expected.contentLength() != 0) {
             var expectedStr = new String(
-                    ByteBufferUtils.getBytes(expected.waitForByteBuffer()),
+                    ByteBufferUtils.getBytes(expected.asByteBuffer()),
                     StandardCharsets.UTF_8);
             if ("application/json".equals(expected.contentType())) {
                 var expectedNode = Node.parse(expectedStr);

--- a/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
+++ b/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
@@ -41,8 +41,8 @@ public class RestXmlProtocolTests {
             })
     public void requestTest(DataStream expected, DataStream actual) {
         if (expected.contentLength() != 0) {
-            var a = new String(ByteBufferUtils.getBytes(actual.waitForByteBuffer()), StandardCharsets.UTF_8);
-            var b = new String(ByteBufferUtils.getBytes(expected.waitForByteBuffer()), StandardCharsets.UTF_8);
+            var a = new String(ByteBufferUtils.getBytes(actual.asByteBuffer()), StandardCharsets.UTF_8);
+            var b = new String(ByteBufferUtils.getBytes(expected.asByteBuffer()), StandardCharsets.UTF_8);
             if ("application/xml".equals(expected.contentType())) {
                 if (!XMLComparator.compareXMLStrings(a, b)) {
                     // Do this comparison to see what is different.

--- a/aws/integrations/aws-lambda-endpoint/src/main/java/software/amazon/smithy/java/aws/integrations/lambda/LambdaEndpoint.java
+++ b/aws/integrations/aws-lambda-endpoint/src/main/java/software/amazon/smithy/java/aws/integrations/lambda/LambdaEndpoint.java
@@ -157,7 +157,7 @@ public final class LambdaEndpoint implements RequestHandler<ProxyRequest, ProxyR
 
         DataStream val = httpResponse.getSerializedValue();
         if (val != null) {
-            ByteBuffer buf = val.waitForByteBuffer();
+            ByteBuffer buf = val.asByteBuffer();
             String body;
             // TODO: handle base64 encoding better
             if (shouldBase64Encode) {

--- a/aws/server/aws-server-restjson/src/it/java/software/amazon/smithy/java/aws/server/restjson/AwsRestJson1ProtocolTests.java
+++ b/aws/server/aws-server-restjson/src/it/java/software/amazon/smithy/java/aws/server/restjson/AwsRestJson1ProtocolTests.java
@@ -85,9 +85,9 @@ public class AwsRestJson1ProtocolTests {
                 .isTrue()
                 .isSameAs(actual.hasKnownLength());
 
-        String actualJson = new String(ByteBufferUtils.getBytes(actual.waitForByteBuffer()), StandardCharsets.UTF_8);
+        String actualJson = new String(ByteBufferUtils.getBytes(actual.asByteBuffer()), StandardCharsets.UTF_8);
         String expectedJson = new String(
-                ByteBufferUtils.getBytes(expected.waitForByteBuffer()),
+                ByteBufferUtils.getBytes(expected.asByteBuffer()),
                 StandardCharsets.UTF_8);
         if (expected.contentLength() == 0) {
             assertThat(actualJson).isIn("", "{}");

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/HttpErrorDeserializer.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/HttpErrorDeserializer.java
@@ -138,7 +138,7 @@ public final class HttpErrorDeserializer {
                 ShapeBuilder<ModeledException> builder
         ) {
             try {
-                ByteBuffer bytes = createDataStream(response).waitForByteBuffer();
+                ByteBuffer bytes = createDataStream(response).asByteBuffer();
                 return codec.deserializeShape(bytes, builder);
             } catch (Exception e) {
                 throw new RuntimeException("Failed to deserialize error", e);
@@ -248,7 +248,7 @@ public final class HttpErrorDeserializer {
         try {
             // Read the payload into a JSON document so we can efficiently find __type and then directly
             // deserialize the document into the identified builder.
-            ByteBuffer buffer = content.waitForByteBuffer();
+            ByteBuffer buffer = content.asByteBuffer();
 
             if (buffer.remaining() > 0) {
                 var document = codec.createDeserializer(buffer).readDocument();

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/plugins/HttpChecksumPlugin.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/plugins/HttpChecksumPlugin.java
@@ -50,7 +50,7 @@ public final class HttpChecksumPlugin implements ClientPlugin {
         static HttpRequest addContentMd5Header(HttpRequest request) {
             var body = request.body();
             if (body != null) {
-                var buffer = body.waitForByteBuffer();
+                var buffer = body.asByteBuffer();
                 var bytes = ByteBufferUtils.getBytes(buffer);
                 try {
                     byte[] hash = MessageDigest.getInstance("MD5").digest(bytes);

--- a/client/client-rpcv2-cbor/src/it/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocolTests.java
+++ b/client/client-rpcv2-cbor/src/it/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocolTests.java
@@ -29,7 +29,7 @@ public class RpcV2CborProtocolTests {
                     "RpcV2CborClientUsesExplicitlyProvidedMemberValuesOverDefaults",
             })
     public void requestTest(DataStream expected, DataStream actual) {
-        CborComparator.assertEquals(expected.waitForByteBuffer(), actual.waitForByteBuffer());
+        CborComparator.assertEquals(expected.asByteBuffer(), actual.asByteBuffer());
     }
 
     @HttpClientResponseTests

--- a/client/client-rpcv2-cbor/src/main/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocol.java
+++ b/client/client-rpcv2-cbor/src/main/java/software/amazon/smithy/java/client/rpcv2/RpcV2CborProtocol.java
@@ -111,7 +111,7 @@ public final class RpcV2CborProtocol extends HttpClientProtocol {
             return builder.build();
         }
 
-        var bytes = content.waitForByteBuffer();
+        var bytes = content.asByteBuffer();
         return CBOR_CODEC.deserializeShape(bytes, builder);
     }
 

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/ClientErrorCorrectionTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/ClientErrorCorrectionTest.java
@@ -39,7 +39,7 @@ public class ClientErrorCorrectionTest {
         assertEquals(corrected.getShort(), (short) 0);
         assertEquals(corrected.getBlob(), ByteBuffer.allocate(0));
         assertEquals(corrected.getStreamingBlob().contentLength(), 0);
-        assertEquals(0, corrected.getStreamingBlob().waitForByteBuffer().remaining());
+        assertEquals(0, corrected.getStreamingBlob().asByteBuffer().remaining());
         assertNull(corrected.getDocument());
         assertEquals(corrected.getList(), List.of());
         assertEquals(corrected.getMap(), Map.of());

--- a/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
+++ b/codegen/codegen-core/src/it/java/software/amazon/smithy/java/codegen/test/DefaultsTest.java
@@ -37,7 +37,7 @@ public class DefaultsTest {
         assertEquals(defaults.getLong(), 1);
         assertEquals(defaults.getShort(), (short) 1);
         assertEquals(defaults.getBlob(), ByteBuffer.wrap(Base64.getDecoder().decode("YmxvYg==")));
-        assertEquals(defaults.getStreamingBlob().waitForByteBuffer(),
+        assertEquals(defaults.getStreamingBlob().asByteBuffer(),
                 ByteBuffer.wrap(Base64.getDecoder().decode("c3RyZWFtaW5n")));
         assertEquals(defaults.getBoolDoc(), Document.of(true));
         assertEquals(defaults.getStringDoc(), Document.of("string"));

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializer.java
@@ -162,7 +162,7 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
 
     // TODO: Should there be a configurable limit on the client/server for how much can be read in memory?
     private ByteBuffer bodyAsByteBuffer() {
-        return body.waitForByteBuffer();
+        return body.asByteBuffer();
     }
 
     private void validateMediaType() {

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PayloadDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PayloadDeserializer.java
@@ -26,7 +26,7 @@ final class PayloadDeserializer implements ShapeDeserializer {
     }
 
     private ByteBuffer resolveBodyBytes() {
-        return body.waitForByteBuffer();
+        return body.asByteBuffer();
     }
 
     private ShapeDeserializer createDeserializer() {
@@ -119,7 +119,7 @@ final class PayloadDeserializer implements ShapeDeserializer {
             return null;
         }
 
-        var buffer = body.waitForByteBuffer();
+        var buffer = body.asByteBuffer();
         int pos = buffer.arrayOffset() + buffer.position();
         int len = buffer.remaining();
         return new String(buffer.array(), pos, len, StandardCharsets.UTF_8);

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/EmptyDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/EmptyDataStream.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.io.datastream;
 import java.io.InputStream;
 import java.net.http.HttpRequest;
 import java.nio.ByteBuffer;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 
 final class EmptyDataStream implements DataStream {
@@ -18,23 +17,13 @@ final class EmptyDataStream implements DataStream {
     private static final Flow.Publisher<ByteBuffer> PUBLISHER = HttpRequest.BodyPublishers.noBody();
 
     @Override
-    public CompletableFuture<ByteBuffer> asByteBuffer() {
-        return CompletableFuture.completedFuture(ByteBuffer.wrap(EMPTY_BYTES));
-    }
-
-    @Override
-    public CompletableFuture<InputStream> asInputStream() {
-        return CompletableFuture.completedFuture(InputStream.nullInputStream());
-    }
-
-    @Override
-    public boolean hasByteBuffer() {
-        return true;
-    }
-
-    @Override
-    public ByteBuffer waitForByteBuffer() {
+    public ByteBuffer asByteBuffer() {
         return ByteBuffer.wrap(EMPTY_BYTES);
+    }
+
+    @Override
+    public InputStream asInputStream() {
+        return InputStream.nullInputStream();
     }
 
     @Override

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/FileDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/FileDataStream.java
@@ -12,7 +12,6 @@ import java.net.http.HttpRequest;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 
 final class FileDataStream implements DataStream {
@@ -34,7 +33,7 @@ final class FileDataStream implements DataStream {
     }
 
     @Override
-    public ByteBuffer waitForByteBuffer() {
+    public ByteBuffer asByteBuffer() {
         try {
             return ByteBuffer.wrap(Files.readAllBytes(file));
         } catch (IOException e) {
@@ -48,12 +47,11 @@ final class FileDataStream implements DataStream {
     }
 
     @Override
-    public CompletableFuture<InputStream> asInputStream() {
+    public InputStream asInputStream() {
         try {
-            return CompletableFuture.completedFuture(Files.newInputStream(file));
+            return Files.newInputStream(file);
         } catch (IOException e) {
-            // To match what happens in the publisher.
-            return CompletableFuture.failedFuture(new UncheckedIOException(e));
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/InputStreamDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/InputStreamDataStream.java
@@ -5,20 +5,14 @@
 
 package software.amazon.smithy.java.io.datastream;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.net.http.HttpRequest;
-import java.nio.ByteBuffer;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Flow;
 
 final class InputStreamDataStream implements DataStream {
 
     private final InputStream inputStream;
     private final String contentType;
     private final long contentLength;
-    private Flow.Publisher<ByteBuffer> publisher;
+    private boolean consumed;
 
     InputStreamDataStream(InputStream inputStream, String contentType, long contentLength) {
         this.inputStream = inputStream;
@@ -27,17 +21,12 @@ final class InputStreamDataStream implements DataStream {
     }
 
     @Override
-    public ByteBuffer waitForByteBuffer() {
-        try {
-            return ByteBuffer.wrap(inputStream.readAllBytes());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+    public InputStream asInputStream() {
+        if (consumed) {
+            throw new IllegalStateException("DataStream is not replayable and has already been consumed");
         }
-    }
-
-    @Override
-    public CompletableFuture<InputStream> asInputStream() {
-        return CompletableFuture.completedFuture(inputStream);
+        consumed = true;
+        return inputStream;
     }
 
     @Override
@@ -53,14 +42,5 @@ final class InputStreamDataStream implements DataStream {
     @Override
     public String contentType() {
         return contentType;
-    }
-
-    @Override
-    public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
-        var p = publisher;
-        if (p == null) {
-            p = publisher = HttpRequest.BodyPublishers.ofInputStream(() -> inputStream);
-        }
-        p.subscribe(subscriber);
     }
 }

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/PublisherDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/PublisherDataStream.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.java.io.datastream;
 
+import java.io.InputStream;
+import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Flow;
 
@@ -14,17 +16,13 @@ final class PublisherDataStream implements DataStream {
     private final long contentLength;
     private final String contentType;
     private final boolean isReplayable;
+    private boolean consumed;
 
     PublisherDataStream(Flow.Publisher<ByteBuffer> publisher, long contentLength, String contentType, boolean replay) {
         this.publisher = publisher;
         this.contentLength = contentLength;
         this.contentType = contentType;
         this.isReplayable = replay;
-    }
-
-    @Override
-    public boolean isReplayable() {
-        return isReplayable;
     }
 
     @Override
@@ -38,7 +36,44 @@ final class PublisherDataStream implements DataStream {
     }
 
     @Override
+    public boolean isReplayable() {
+        return isReplayable;
+    }
+
+    // Override to skip needing an intermediate InputStream for this.
+    @Override
+    public ByteBuffer asByteBuffer() {
+        if (!isReplayable && consumed) {
+            throw new IllegalStateException("DataStream is not replayable and has already been consumed");
+        }
+        consumed = true;
+
+        var subscriber = HttpResponse.BodySubscribers.ofByteArray();
+        var delegate = new HttpBodySubscriberAdapter<>(subscriber);
+        subscribe(delegate);
+        return ByteBuffer.wrap(subscriber.getBody().toCompletableFuture().join());
+    }
+
+    @Override
+    public InputStream asInputStream() {
+        if (!isReplayable && consumed) {
+            throw new IllegalStateException("DataStream is not replayable and has already been consumed");
+        }
+
+        consumed = true;
+        var subscriber = HttpResponse.BodySubscribers.ofInputStream();
+        var delegate = new HttpBodySubscriberAdapter<>(subscriber);
+        subscribe(delegate);
+        return subscriber.getBody().toCompletableFuture().join();
+    }
+
+    @Override
     public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
+        if (!isReplayable && consumed) {
+            throw new IllegalStateException("DataStream is not replayable and has already been consumed");
+        }
+
+        consumed = true;
         publisher.subscribe(subscriber);
     }
 }

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/WrappedDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/WrappedDataStream.java
@@ -7,7 +7,6 @@ package software.amazon.smithy.java.io.datastream;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 
 final class WrappedDataStream implements DataStream {
@@ -25,12 +24,12 @@ final class WrappedDataStream implements DataStream {
     }
 
     @Override
-    public CompletableFuture<ByteBuffer> asByteBuffer() {
+    public ByteBuffer asByteBuffer() {
         return delegate.asByteBuffer();
     }
 
     @Override
-    public CompletableFuture<InputStream> asInputStream() {
+    public InputStream asInputStream() {
         return delegate.asInputStream();
     }
 
@@ -42,16 +41,6 @@ final class WrappedDataStream implements DataStream {
     @Override
     public String contentType() {
         return contentType;
-    }
-
-    @Override
-    public ByteBuffer waitForByteBuffer() {
-        return delegate.waitForByteBuffer();
-    }
-
-    @Override
-    public boolean hasByteBuffer() {
-        return delegate.hasByteBuffer();
     }
 
     @Override

--- a/io/src/test/java/software/amazon/smithy/java/io/datastream/ByteBufferDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/datastream/ByteBufferDataStreamTest.java
@@ -19,8 +19,7 @@ public class ByteBufferDataStreamTest {
         var bytes = "foo".getBytes(StandardCharsets.UTF_8);
         var ds = DataStream.ofBytes(bytes);
 
-        assertThat(ds.hasByteBuffer(), is(true));
-        assertThat(ds.waitForByteBuffer(), equalTo(ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.asByteBuffer(), equalTo(ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8))));
         assertThat(ds.isReplayable(), is(true));
     }
 }

--- a/io/src/test/java/software/amazon/smithy/java/io/datastream/FileDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/datastream/FileDataStreamTest.java
@@ -21,7 +21,7 @@ public class FileDataStreamTest {
 
         assertThat(ds.contentLength(), equalTo(6L));
         assertThat(ds.contentType(), equalTo("text/plain"));
-        assertThat(ds.waitForByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.asByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
         assertThat(ds.isReplayable(), is(true));
     }
 
@@ -31,20 +31,20 @@ public class FileDataStreamTest {
 
         assertThat(ds.contentLength(), equalTo(6L));
         assertThat(ds.contentType(), equalTo("text/foo"));
-        assertThat(ds.waitForByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.asByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
     }
 
     @Test
     public void convertsFileStreamToInputStream() throws Exception {
         var ds = DataStream.ofFile(Paths.get(getClass().getResource("test.txt").toURI()), "text/foo");
 
-        assertThat(ds.asInputStream().get().readAllBytes(), equalTo("Hello!".getBytes(StandardCharsets.UTF_8)));
+        assertThat(ds.asInputStream().readAllBytes(), equalTo("Hello!".getBytes(StandardCharsets.UTF_8)));
     }
 
     @Test
     public void readsDataToByteBuffer() throws Exception {
         var ds = DataStream.ofFile(Paths.get(getClass().getResource("test.txt").toURI()));
 
-        assertThat(ds.waitForByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.asByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
     }
 }

--- a/io/src/test/java/software/amazon/smithy/java/io/datastream/InputStreamDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/datastream/InputStreamDataStreamTest.java
@@ -14,6 +14,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class InputStreamDataStreamTest {
@@ -23,7 +24,7 @@ public class InputStreamDataStreamTest {
 
         assertThat(ds.contentLength(), equalTo(-1L));
         assertThat(ds.contentType(), nullValue());
-        assertThat(ds.waitForByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.asByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
         assertThat(ds.isReplayable(), is(false));
     }
 
@@ -36,7 +37,7 @@ public class InputStreamDataStreamTest {
 
         assertThat(ds.contentLength(), equalTo(6L));
         assertThat(ds.contentType(), equalTo("text/plain"));
-        assertThat(ds.waitForByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.asByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
     }
 
     @Test
@@ -46,7 +47,7 @@ public class InputStreamDataStreamTest {
                 "text/plain",
                 6);
 
-        assertThat(ds.asInputStream().get().readAllBytes(), equalTo("Hello!".getBytes(StandardCharsets.UTF_8)));
+        assertThat(ds.asInputStream().readAllBytes(), equalTo("Hello!".getBytes(StandardCharsets.UTF_8)));
     }
 
     @Test
@@ -56,6 +57,17 @@ public class InputStreamDataStreamTest {
                 "text/plain",
                 6);
 
-        assertThat(ds.waitForByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
+        assertThat(ds.asByteBuffer(), equalTo(ByteBuffer.wrap("Hello!".getBytes(StandardCharsets.UTF_8))));
+    }
+
+    @Test
+    public void cannotReadDataStreamTwice() throws Exception {
+        var ds = DataStream.ofInputStream(
+                Files.newInputStream(Paths.get(getClass().getResource("test.txt").toURI())),
+                "text/plain",
+                6);
+
+        Assertions.assertDoesNotThrow(ds::asInputStream);
+        Assertions.assertThrows(IllegalStateException.class, ds::asInputStream);
     }
 }

--- a/io/src/test/java/software/amazon/smithy/java/io/datastream/WrappedDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/datastream/WrappedDataStreamTest.java
@@ -7,7 +7,6 @@ package software.amazon.smithy.java.io.datastream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -20,7 +19,6 @@ public class WrappedDataStreamTest {
         var ds = DataStream.ofBytes(bytes);
         var wrapped = DataStream.ofPublisher(ds, "text/plain", 3);
 
-        assertThat(wrapped.hasByteBuffer(), is(true));
-        assertThat(wrapped.waitForByteBuffer(), equalTo(ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8))));
+        assertThat(wrapped.asByteBuffer(), equalTo(ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8))));
     }
 }

--- a/server/server-netty/src/main/java/software/amazon/smithy/java/server/netty/HttpRequestHandler.java
+++ b/server/server-netty/src/main/java/software/amazon/smithy/java/server/netty/HttpRequestHandler.java
@@ -98,7 +98,7 @@ final class HttpRequestHandler extends ChannelDuplexHandler {
             response = new DefaultFullHttpResponse(
                     HttpVersion.HTTP_1_1,
                     HttpResponseStatus.valueOf(job.response().getStatusCode()),
-                    Unpooled.wrappedBuffer(serializedValue.waitForByteBuffer()));
+                    Unpooled.wrappedBuffer(serializedValue.asByteBuffer()));
             CorsHeaders.addCorsHeaders(job);
             response.headers().set(((NettyHttpHeaders) job.response().headers()).getNettyHeaders());
             response.headers().set("content-length", serializedValue.contentLength());

--- a/server/server-rpcv2-cbor/src/it/java/software/amazon/smithy/java/server/rpcv2/RpcV2CborProtocolTests.java
+++ b/server/server-rpcv2-cbor/src/it/java/software/amazon/smithy/java/server/rpcv2/RpcV2CborProtocolTests.java
@@ -51,7 +51,7 @@ public class RpcV2CborProtocolTests {
         assertThat(expected.hasKnownLength())
                 .isTrue()
                 .isSameAs(actual.hasKnownLength());
-        CborComparator.assertEquals(expected.waitForByteBuffer(), actual.waitForByteBuffer());
+        CborComparator.assertEquals(expected.asByteBuffer(), actual.asByteBuffer());
     }
 
 }

--- a/server/server-rpcv2-cbor/src/main/java/software/amazon/smithy/java/server/rpcv2/RpcV2CborProtocol.java
+++ b/server/server-rpcv2-cbor/src/main/java/software/amazon/smithy/java/server/rpcv2/RpcV2CborProtocol.java
@@ -76,13 +76,10 @@ final class RpcV2CborProtocol extends ServerProtocol {
         if (dataStream.contentLength() > 0 && !"application/cbor".equals(dataStream.contentType())) {
             throw MalformedRequestException.builder().message("Invalid content type").build();
         }
-        return dataStream.asByteBuffer().thenApply(b -> {
-            var input = codec.deserializeShape(
-                    dataStream.waitForByteBuffer(),
-                    job.operation().getApiOperation().inputBuilder());
-            job.request().setDeserializedValue(input);
-            return null;
-        });
+
+        var input = codec.deserializeShape(dataStream.asByteBuffer(), job.operation().getApiOperation().inputBuilder());
+        job.request().setDeserializedValue(input);
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override


### PR DESCRIPTION
DataStream now is written around the idea of using an underyling InputStream more often than a Publisher, so default implementations were updated (now default provided for asPublisher, and asInputStream no longer has a default).

Also closes InputStreams in a couple places that we could have leaked.

Addresses #913

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
