### PR TITLE
Add upper bound on container pre-allocation during deserialization

### DIFF
--- a/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborDeserializer.java
+++ b/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborDeserializer.java
@@ -445,7 +445,7 @@ final class CborDeserializer implements ShapeDeserializer {
 
     @Override
     public int containerSize() {
-        return -1; //parser.collectionSize(); FIXME : Renable once we have some bounds checking, otherwise a small payload can trigger a huge allocation
+        return parser.collectionSize();
     }
 
     @Override

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -60,7 +60,7 @@ public final class ListGenerator
                                             }
 
                                             static ${shape:T} deserialize${name:U}(${schema:T} schema, ${shapeDeserializer:T} deserializer) {
-                                                var size = deserializer.containerSize();
+                                                var size = Math.min(deserializer.containerSize(), deserializer.containerPreAllocationLimit());
                                                 ${shape:T} result = size == -1 ? new ${collectionImpl:T}<>() : new ${collectionImpl:T}<>(size);
                                                 deserializer.readList(schema, result, ${name:U}$$MemberDeserializer.INSTANCE);
                                                 return result;

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
@@ -82,7 +82,7 @@ public final class MapGenerator
                                             }
 
                                             static ${shape:T} deserialize${name:U}(${schema:T} schema, ${shapeDeserializer:T} deserializer) {
-                                                var size = deserializer.containerSize();
+                                                var size = Math.min(deserializer.containerSize(), deserializer.containerPreAllocationLimit());
                                                 ${shape:T} result = size == -1 ? new ${collectionImpl:T}<>() : new ${collectionImpl:T}<>(size);
                                                 deserializer.readStringMap(schema, result, ${name:U}$$ValueDeserializer.INSTANCE);
                                                 return result;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Improve container pre-allocation safety in deserialization


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
