### PR TITLE
Prevent allocating large arrays based on BigInteger lengths

### DIFF
--- a/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborReadUtil.java
+++ b/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborReadUtil.java
@@ -106,6 +106,7 @@ public final class CborReadUtil {
         }
         final byte[] buff;
         if (len >= 0) {
+            checkInvalidLength(buffer, off, len);
             final int desOff;
             if (buffer[off] >= 0) {
                 buff = new byte[len];
@@ -313,6 +314,12 @@ public final class CborReadUtil {
 
     private static byte getMinor(byte b) {
         return (byte) (b & MINOR_TYPE_MASK);
+    }
+
+    private static void checkInvalidLength(byte[] buf, int off, int len) {
+        if (len > buf.length - off) {
+            throw new BadCborException("Invalid length");
+        }
     }
 
     private CborReadUtil() {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added a validation check to prevent potential out-of-memory errors by ensuring buffer lengths are valid before allocating byte arrays. This security improvement prevents possible denial-of-service attacks through malformed CBOR data containing invalid length specifications.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
