### PR TITLE
add MCPMetricObserver

### DIFF
--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpMetricsObserver.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpMetricsObserver.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.mcp.server;
+
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Observer for collecting metrics on MCP client requests.
+ * Works directly with JSON-RPC structures to remain protocol-agnostic.
+ */
+@SmithyUnstableApi
+public interface McpMetricsObserver {
+
+    /**
+     * Called when a client request is received for any method.
+     */
+    void onClientRequest(
+            String method,
+            String extractedProtocolVersion,
+            boolean rootsListChanged,
+            boolean sampling,
+            boolean elicitation,
+            String clientName,
+            String clientTitle
+    );
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Add metric observer for client requests:

Captures :
• protocolVersion - if present, null otherwise
• rootsListChanged - true if capabilities.roots.listChanged is true, false otherwise
• sampling - true if capabilities.y exists, false otherwise
• elicitation - true if capabilities.elicitation exists, false otherwise
• clientName - extracted if clientInfo.name exists, null otherwise
• clientTitle - extracted if clientInfo.title exists, null otherwise

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.