### PR TITLE
Make minor timestamp optimizations

### DIFF
--- a/codecs/json-codec/build.gradle.kts
+++ b/codecs/json-codec/build.gradle.kts
@@ -1,8 +1,7 @@
-
-
 plugins {
     id("smithy-java.module-conventions")
     id("smithy-java.fuzz-test")
+    id("me.champeau.jmh") version "0.7.3"
     alias(libs.plugins.shadow)
 }
 
@@ -54,4 +53,12 @@ afterEvaluate {
     shadowComponent.addVariantsFromConfiguration(configurations.javadocElements.get()) {
         mapToMavenScope("runtime")
     }
+}
+
+jmh {
+    warmupIterations = 3
+    iterations = 3
+    fork = 3
+    // profilers.add("async:output=flamegraph")
+    // profilers.add("gc")
 }

--- a/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonBench.java
+++ b/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonBench.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.util.NullOutputStream;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+public class JsonBench {
+    JsonCodec codec;
+    ByteBuffer buff;
+    Schema mainSchema;
+    SerializableStruct struct;
+    ShapeSerializer serializer;
+
+    @Setup
+    public void setup() throws Exception {
+        buff = ByteBuffer.allocate(4096);
+        codec = JsonCodec.builder()
+                .defaultNamespace("foo")
+                .useTimestampFormat(true)
+                .build();
+        var tsId = PreludeSchemas.TIMESTAMP.id();
+        mainSchema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
+                .putMember("a", Schema.createTimestamp(tsId))
+                .putMember("b", Schema.createTimestamp(tsId, new TimestampFormatTrait("epoch-seconds")))
+                .putMember("c", Schema.createTimestamp(tsId))
+                .putMember("d", Schema.createTimestamp(tsId))
+                .putMember("e", Schema.createTimestamp(tsId))
+                .putMember("f", Schema.createTimestamp(tsId))
+                .putMember("g", Schema.createTimestamp(tsId))
+                .putMember("h", Schema.createTimestamp(tsId))
+                .putMember("i", Schema.createTimestamp(tsId))
+                .build();
+        var instant = Instant.now();
+        struct = new TestStruct(mainSchema, instant);
+        serializer = codec.createSerializer(new NullOutputStream());
+    }
+
+    private static final class TestStruct implements SerializableStruct {
+
+        private final Instant instant;
+        private final Schema schema;
+        private final Schema amember;
+        private final Schema bmember;
+        private final Schema cmember;
+        private final Schema dmember;
+        private final Schema emember;
+        private final Schema fmember;
+        private final Schema gmember;
+        private final Schema hmember;
+        private final Schema imember;
+
+        TestStruct(Schema schema, Instant instant) {
+            this.instant = instant;
+            this.schema = schema;
+            amember = schema.member("a");
+            bmember = schema.member("b");
+            cmember = schema.member("c");
+            dmember = schema.member("d");
+            emember = schema.member("e");
+            fmember = schema.member("f");
+            gmember = schema.member("g");
+            hmember = schema.member("h");
+            imember = schema.member("i");
+        }
+
+        @Override
+        public Schema schema() {
+            return schema;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeTimestamp(amember, instant);
+            serializer.writeTimestamp(bmember, instant);
+            serializer.writeTimestamp(cmember, instant);
+            serializer.writeTimestamp(dmember, instant);
+            serializer.writeTimestamp(emember, instant);
+            serializer.writeTimestamp(fmember, instant);
+            serializer.writeTimestamp(gmember, instant);
+            serializer.writeTimestamp(hmember, instant);
+            serializer.writeTimestamp(imember, instant);
+        }
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Benchmark
+    public void serialize(Blackhole bh) {
+        serializer.writeStruct(struct.schema(), struct);
+        bh.consume(buff);
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerdeProvider.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerdeProvider.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.json.jackson;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.StreamWriteFeature;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -27,6 +28,7 @@ public class JacksonJsonSerdeProvider implements JsonSerdeProvider {
     static {
         var serBuilder = new JsonFactoryBuilder();
         serBuilder.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+        serBuilder.enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER);
         serBuilder.enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER);
         serBuilder.enable(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER);
         FACTORY = serBuilder.build();

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerializer.java
@@ -135,18 +135,15 @@ final class JacksonJsonSerializer implements ShapeSerializer {
         try {
             if (Float.isFinite(value)) {
                 int intValue = (int) value;
-                if (value - intValue != 0) {
-                    // Avoid writing 1.0 and instead write 1.
-                    generator.writeNumber(value);
-                } else {
+                if (value == (float) intValue) {
                     generator.writeNumber(intValue);
+                } else {
+                    generator.writeNumber(value);
                 }
             } else if (Float.isNaN(value)) {
                 generator.writeString("NaN");
-            } else if (Float.POSITIVE_INFINITY == value) {
-                generator.writeString("Infinity");
             } else {
-                generator.writeString("-Infinity");
+                generator.writeString(value > 0 ? "Infinity" : "-Infinity");
             }
         } catch (Exception e) {
             throw new SerializationException(e);
@@ -157,19 +154,17 @@ final class JacksonJsonSerializer implements ShapeSerializer {
     public void writeDouble(Schema schema, double value) {
         try {
             if (Double.isFinite(value)) {
+                // Avoid writing 1.0 and instead write 1.
                 long longValue = (long) value;
-                if (value - longValue != 0) {
-                    // Avoid writing 1.0 and instead write 1.
-                    generator.writeNumber(value);
-                } else {
+                if (value == (double) longValue) {
                     generator.writeNumber(longValue);
+                } else {
+                    generator.writeNumber(value);
                 }
             } else if (Double.isNaN(value)) {
                 generator.writeString("NaN");
-            } else if (Double.POSITIVE_INFINITY == value) {
-                generator.writeString("Infinity");
             } else {
-                generator.writeString("-Infinity");
+                generator.writeString(value > 0 ? "Infinity" : "-Infinity");
             }
         } catch (Exception e) {
             throw new SerializationException(e);

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/TimestampFormatter.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/TimestampFormatter.java
@@ -68,11 +68,25 @@ public interface TimestampFormatter {
      * @return the created formatter.
      */
     static TimestampFormatter of(TimestampFormatTrait.Format format) {
+        var result = match(format);
+        if (result == null) {
+            throw new SerializationException("Unknown timestamp format: " + format);
+        }
+        return result;
+    }
+
+    /**
+     * Attempts to create a TimestampFormatter from the given format, or returns null if unknown.
+     *
+     * @param format Format to create.
+     * @return the created formatter.
+     */
+    static TimestampFormatter match(TimestampFormatTrait.Format format) {
         return switch (format) {
             case DATE_TIME -> Prelude.DATE_TIME;
             case EPOCH_SECONDS -> Prelude.EPOCH_SECONDS;
             case HTTP_DATE -> Prelude.HTTP_DATE;
-            default -> throw new SerializationException("Unknown timestamp format: " + format);
+            case null, default -> null;
         };
     }
 
@@ -174,8 +188,7 @@ public interface TimestampFormatter {
 
             @Override
             public void writeToSerializer(Schema schema, Instant instant, ShapeSerializer serializer) {
-                double value = ((double) instant.toEpochMilli()) / 1000;
-                serializer.writeDouble(schema, value);
+                serializer.writeDouble(schema, instant.toEpochMilli() / 1000.0);
             }
         },
 


### PR DESCRIPTION
Now that we cache `getFormat` in the smithy TimestampFormatTrait, we can simplify lookups and remove the cache. This gives a modest improvement but also remove the CHM (~1080ns/iter to ~920ns/iter in the new benchmark).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
