### PR TITLE
 add metrics observer support to McpServerBuilder

### DIFF
--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServerBuilder.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpServerBuilder.java
@@ -27,6 +27,7 @@ public final class McpServerBuilder {
     String name;
     String version;
     ToolFilter toolFilter = (server, tool) -> true;
+    McpMetricsObserver metricsObserver;
     McpService mcpService;
 
     McpServerBuilder() {}
@@ -64,7 +65,8 @@ public final class McpServerBuilder {
                 .services(services)
                 .proxyList(proxyList)
                 .name(name != null ? name : "mcp-server")
-                .toolFilter(toolFilter);
+                .toolFilter(toolFilter)
+                .metricsObserver(metricsObserver);
 
         if (version != null) {
             builder.version(version);
@@ -91,6 +93,11 @@ public final class McpServerBuilder {
 
     public McpServerBuilder toolFilter(ToolFilter filter) {
         this.toolFilter = filter;
+        return this;
+    }
+
+    public McpServerBuilder metricsObserver(McpMetricsObserver observer) {
+        this.metricsObserver = observer;
         return this;
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds metrics observer support to `McpServerBuilder` to enable metrics collection for MCP server operations.

Changes:
- Added `metricsObserver` field to `McpServerBuilder`
- Added `metricsObserver(McpMetricsObserver)` builder method
- Updated `build()` method to pass metrics observer to underlying `McpService`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
