### PR TITLE
Improve HttpHeaders

### DIFF
--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpRequestImpl.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpRequestImpl.java
@@ -98,6 +98,7 @@ record HttpRequestImpl(
             Objects.requireNonNull(method, "Method cannot be null");
             Objects.requireNonNull(uri, "URI cannot be null");
             body = Objects.requireNonNullElse(body, DataStream.ofEmpty());
+            mutatedHeaders = null; // decouple from built request
         }
 
         @Override

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpResponseImpl.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpResponseImpl.java
@@ -87,6 +87,7 @@ record HttpResponseImpl(
             }
             Objects.requireNonNull(httpVersion);
             body = Objects.requireNonNullElse(body, DataStream.ofEmpty());
+            mutatedHeaders = null; // decouple from built response
         }
 
         @Override

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpHeaders.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpHeaders.java
@@ -10,6 +10,10 @@ import java.util.Map;
 
 /**
  * A modifiable version of {@link HttpHeaders}.
+ *
+ * <p><b>Thread Safety:</b> Implementations are <b>not</b> guaranteed to be thread-safe.
+ * If multiple threads access an instance concurrently, and at least one thread modifies
+ * the headers, external synchronization is required.
  */
 public interface ModifiableHttpHeaders extends HttpHeaders {
     /**
@@ -96,6 +100,11 @@ public interface ModifiableHttpHeaders extends HttpHeaders {
      * @param name Case-insensitive name of the header to remove.
      */
     void removeHeader(String name);
+
+    /**
+     * Removes all headers.
+     */
+    void clear();
 
     @Override
     default ModifiableHttpHeaders toModifiable() {

--- a/server/server-core/src/test/java/software/amazon/smithy/java/server/core/TestStructs.java
+++ b/server/server-core/src/test/java/software/amazon/smithy/java/server/core/TestStructs.java
@@ -155,6 +155,11 @@ public class TestStructs {
         }
 
         @Override
+        public void clear() {
+            headers.clear();
+        }
+
+        @Override
         public List<String> allValues(String name) {
             return headers.getOrDefault(name, List.of());
         }

--- a/server/server-netty/src/main/java/software/amazon/smithy/java/server/netty/NettyHttpHeaders.java
+++ b/server/server-netty/src/main/java/software/amazon/smithy/java/server/netty/NettyHttpHeaders.java
@@ -63,6 +63,11 @@ final class NettyHttpHeaders implements ModifiableHttpHeaders {
     }
 
     @Override
+    public void clear() {
+        nettyHeaders.clear();
+    }
+
+    @Override
     public boolean isEmpty() {
         return nettyHeaders.isEmpty();
     }


### PR DESCRIPTION
Better immutability

No need to make mutable headers thread-safe. These are typically created in a single thread and then used after that. Use external synchronization if needed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
