### PR TITLE
Build examples explicitly using JDK21

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -10,4 +10,10 @@ subprojects {
             }
         }
     }
+
+    plugins.withId("java") {
+        the<JavaPluginExtension>().toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes the broken Gradle upgrade wrapper Action, https://github.com/smithy-lang/smithy-java/actions/runs/19636999432


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
