### PR TITLE
Simplify header and message creation, add closeable

### DIFF
--- a/aws/aws-sigv4/src/main/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4Signer.java
+++ b/aws/aws-sigv4/src/main/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4Signer.java
@@ -41,6 +41,7 @@ final class SigV4Signer implements Signer<HttpRequest, AwsCredentialsIdentity> {
     private static final InternalLogger LOGGER = InternalLogger.getLogger(SigV4Signer.class);
     private static final List<String> HEADERS_TO_IGNORE_IN_LOWER_CASE = List.of(
             "connection",
+            "content-length",
             "x-amzn-trace-id",
             "user-agent",
             "expect");

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientTransport.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientTransport.java
@@ -134,8 +134,11 @@ public class JavaHttpClientTransport implements ClientTransport<HttpRequest, Htt
 
         // Any explicitly set headers overwrite existing headers, they do not merge.
         for (var entry : request.headers().map().entrySet()) {
-            for (var value : entry.getValue()) {
-                httpRequestBuilder.setHeader(entry.getKey(), value);
+            // Skip restricted headers
+            if (!entry.getKey().equals("content-length")) {
+                for (var value : entry.getValue()) {
+                    httpRequestBuilder.setHeader(entry.getKey(), value);
+                }
             }
         }
 

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpHeaders.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpHeaders.java
@@ -110,7 +110,18 @@ public interface HttpHeaders extends Iterable<Map.Entry<String, List<String>>> {
      *
      * @return the created modifiable headers.
      */
-    ModifiableHttpHeaders toModifiable();
+    default ModifiableHttpHeaders toModifiable() {
+        return SimpleModifiableHttpHeaders.of(this);
+    }
+
+    /**
+     * Get an unmodifiable version of the headers.
+     *
+     * @return the unmodifiable headers.
+     */
+    default HttpHeaders toUnmodifiable() {
+        return SimpleUnmodifiableHttpHeaders.of(this);
+    }
 
     /**
      * Normalizes an HTTP header name by trimming whitespace and converting ASCII uppercase to lowercase.

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpMessage.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpMessage.java
@@ -13,8 +13,10 @@ import software.amazon.smithy.java.io.datastream.DataStream;
 
 /**
  * HTTP message.
+ *
+ * <p>When closed, the body of the message is also closed.
  */
-public interface HttpMessage {
+public interface HttpMessage extends AutoCloseable {
     /**
      * Get the HTTP version.
      *
@@ -70,11 +72,19 @@ public interface HttpMessage {
     HttpHeaders headers();
 
     /**
-     * Get the body of the message, or null.
+     * Get the body of the message.
      *
-     * @return the message body or null.
+     * @return the message body (never null, may be zero length).
      */
     DataStream body();
+
+    @Override
+    default void close() {
+        var body = body();
+        if (body != null) {
+            body.close();
+        }
+    }
 
     /**
      * Builder for HTTP messages.

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpRequest.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpRequest.java
@@ -33,6 +33,13 @@ public interface HttpRequest extends HttpMessage {
     ModifiableHttpRequest toModifiable();
 
     /**
+     * Creates an unmodifiable copy of the request, or returns it as is if it is already unmodifiable.
+     *
+     * @return the unmodifiable version of this request.
+     */
+    HttpRequest toUnmodifiable();
+
+    /**
      * Create a builder configured with the values of the request.
      *
      * @return the created builder.

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpResponse.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpResponse.java
@@ -24,6 +24,13 @@ public interface HttpResponse extends HttpMessage {
     ModifiableHttpResponse toModifiable();
 
     /**
+     * Creates an unmodifiable copy of the request, or returns it as is if it is already unmodifiable.
+     *
+     * @return the unmodifiable version of this request.
+     */
+    HttpResponse toUnmodifiable();
+
+    /**
      * Create a builder configured with the values of the response.
      *
      * @return the created builder.

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpVersion.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpVersion.java
@@ -9,6 +9,7 @@ package software.amazon.smithy.java.http.api;
  * Enumeration of the HTTP protocol versions.
  */
 public enum HttpVersion {
+    HTTP_1_0,
     HTTP_1_1,
     HTTP_2;
 
@@ -20,8 +21,9 @@ public enum HttpVersion {
      */
     public static HttpVersion from(String version) {
         return switch (version) {
-            case "HTTP/1.1" -> HTTP_1_1;
-            case "HTTP/2.0" -> HTTP_2;
+            case "HTTP/1.0", "http/1.0" -> HTTP_1_0;
+            case "HTTP/1.1", "http/1.1" -> HTTP_1_1;
+            case "HTTP/2.0", "h2" -> HTTP_2;
             default -> throw new UnsupportedOperationException("Unsupported HTTP version: " + version);
         };
     }
@@ -29,6 +31,7 @@ public enum HttpVersion {
     @Override
     public String toString() {
         return switch (this) {
+            case HTTP_1_0 -> "HTTP/1.0";
             case HTTP_1_1 -> "HTTP/1.1";
             case HTTP_2 -> "HTTP/2.0";
         };

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpMessage.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpMessage.java
@@ -11,6 +11,9 @@ import software.amazon.smithy.java.io.datastream.DataStream;
  * A modifiable HTTP message.
  */
 public interface ModifiableHttpMessage extends HttpMessage {
+    @Override
+    ModifiableHttpHeaders headers();
+
     /**
      * Set the HTTP version.
      *
@@ -27,6 +30,10 @@ public interface ModifiableHttpMessage extends HttpMessage {
 
     /**
      * Set the HTTP body.
+     *
+     * <p>If the body has a known content-type and no content-type is set, the content-type header is added to the
+     * message. If the body has a known content-length and no content-length header is set, the content-length header
+     * is added to the message.
      *
      * @param body Body to set.
      */

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpRequest.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpRequest.java
@@ -29,4 +29,11 @@ public interface ModifiableHttpRequest extends ModifiableHttpMessage, HttpReques
     default ModifiableHttpRequest toModifiable() {
         return this;
     }
+
+    /**
+     * Create a copy of the modifiable request.
+     *
+     * @return the standalone copy.
+     */
+    ModifiableHttpRequest copy();
 }

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpRequestImpl.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpRequestImpl.java
@@ -14,8 +14,18 @@ final class ModifiableHttpRequestImpl implements ModifiableHttpRequest {
     private URI uri;
     private String method;
     private HttpVersion httpVersion = HttpVersion.HTTP_1_1;
-    private HttpHeaders headers = new SimpleModifiableHttpHeaders();
+    private ModifiableHttpHeaders headers = new SimpleModifiableHttpHeaders();
     private DataStream body = DataStream.ofEmpty();
+
+    ModifiableHttpRequestImpl() {}
+
+    ModifiableHttpRequestImpl(ModifiableHttpRequestImpl copy) {
+        this.httpVersion = copy.httpVersion;
+        this.method = copy.method;
+        this.uri = copy.uri;
+        this.headers = copy.headers.copy();
+        this.body = copy.body;
+    }
 
     @Override
     public String method() {
@@ -48,7 +58,7 @@ final class ModifiableHttpRequestImpl implements ModifiableHttpRequest {
     }
 
     @Override
-    public HttpHeaders headers() {
+    public ModifiableHttpHeaders headers() {
         return headers;
     }
 
@@ -64,7 +74,22 @@ final class ModifiableHttpRequestImpl implements ModifiableHttpRequest {
 
     @Override
     public void setBody(DataStream body) {
-        this.body = Objects.requireNonNull(body);
+        if (body == null) {
+            this.body = DataStream.ofEmpty();
+        } else {
+            this.body = body;
+            ModifiableHttpResponseImpl.addBodyHeaders(body, headers);
+        }
+    }
+
+    @Override
+    public HttpRequest toUnmodifiable() {
+        return new HttpRequestImpl(this);
+    }
+
+    @Override
+    public ModifiableHttpRequest copy() {
+        return new ModifiableHttpRequestImpl(this);
     }
 
     @Override

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpResponse.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpResponse.java
@@ -20,4 +20,11 @@ public interface ModifiableHttpResponse extends ModifiableHttpMessage, HttpRespo
     default ModifiableHttpResponse toModifiable() {
         return this;
     }
+
+    /**
+     * Create a copy of the modifiable response.
+     *
+     * @return the standalone copy.
+     */
+    ModifiableHttpResponse copy();
 }

--- a/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/ServerTestClient.java
+++ b/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/ServerTestClient.java
@@ -38,6 +38,7 @@ final class ServerTestClient {
                 .version(switch (request.httpVersion()) {
                     case HTTP_1_1 -> HttpClient.Version.HTTP_1_1;
                     case HTTP_2 -> HttpClient.Version.HTTP_2;
+                    default -> throw new UnsupportedOperationException(request.httpVersion() + " is not supported");
                 })
                 .method(request.method(), bodyPublisher)
                 .uri(request.uri());


### PR DESCRIPTION
Centralize header and message creation around building up modifiable headers/messages and then copying them to make them unmodifiable. This centralizes all formatting and grouping and trimming logic for headers, and we have some "fast-paths" for making copies since we know headers were already formatted and grouped.

This also updates HttpMessage to be closeable so it cleans up any contained DataStream.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
