### PR TITLE
Add better header and value validation

### DIFF
--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HeaderUtils.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HeaderUtils.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.api;
+
+/**
+ * HTTP header utilities.
+ */
+public final class HeaderUtils {
+    // Header name lookup table: 0=invalid, 1=valid lower, 2=valid upper.
+    private static final byte[] HEADER_NAME_TABLE = new byte[128];
+
+    // Header value lookup table: true = allowed character
+    private static final boolean[] VALID_VALUE_CHAR = new boolean[256];
+
+    static {
+        for (char c = 'a'; c <= 'z'; c++) {
+            HEADER_NAME_TABLE[c] = 1;
+        }
+        for (char c = 'A'; c <= 'Z'; c++) {
+            HEADER_NAME_TABLE[c] = 2;
+        }
+        String validChars = "!#$%&'*+-.0123456789^_`|~";
+        for (int i = 0; i < validChars.length(); i++) {
+            HEADER_NAME_TABLE[validChars.charAt(i)] = 1;
+        }
+
+        // Valid value chars per RFC 7230 field-content: SP, HTAB, VCHAR, obs-text
+        VALID_VALUE_CHAR[' '] = true;
+        VALID_VALUE_CHAR['\t'] = true;
+        for (int c = 0x21; c <= 0x7E; c++) {
+            VALID_VALUE_CHAR[c] = true;
+        }
+        for (int c = 0x80; c <= 0xFF; c++) {
+            VALID_VALUE_CHAR[c] = true;
+        }
+    }
+
+    private HeaderUtils() {}
+
+    /**
+     * Normalizes an HTTP header name by trimming OWS (SP/HTAB), converting ASCII uppercase to lowercase, and
+     * validating per RFC 7230 token rules.
+     *
+     * @param name the header name to normalize
+     * @return the normalized header name, or the original instance if already normalized
+     * @throws IllegalArgumentException if the name is empty, whitespace-only, or contains invalid characters
+     */
+    static String normalizeName(String name) {
+        // Simulate String.trim(), but we only want to trim leading and trailing ' ' and '\t'.
+        int len = name.length();
+        int end = len - 1;
+        int start = trimStart(name, end);
+        end = trimEnd(name, start);
+        if (start > end) {
+            throw new IllegalArgumentException("Header name is empty or whitespace-only");
+        }
+
+        // Ensure each character is valid and see if any are uppercase.
+        boolean needsLower = false;
+        for (int i = start; i <= end; i++) {
+            char c = name.charAt(i);
+            if (c >= 128) {
+                throw invalidHeaderNameChar(name);
+            }
+            byte b = HEADER_NAME_TABLE[c];
+            if (b == 0) {
+                throw invalidHeaderNameChar(name);
+            } else if (b == 2) {
+                needsLower = true;
+            }
+        }
+
+        // No lower casing needed means trim or return as-is.
+        if (!needsLower) {
+            return start == 0 && end == len - 1
+                    ? name
+                    : name.substring(start, end + 1);
+        }
+
+        // needs lowercasing and possible trimming.
+        char[] chars = new char[end - start + 1];
+        for (int src = start, dst = 0; src <= end; src++, dst++) {
+            char c = name.charAt(src);
+            chars[dst] = HEADER_NAME_TABLE[c] == 2 ? (char) (c + 32) : c;
+        }
+
+        return new String(chars);
+    }
+
+    /**
+     * Normalizes an HTTP header value by trimming leading/trailing OWS (SP/HTAB) and validating per RFC 7230
+     * field-content rules.
+     *
+     * <p>Interior SP/HTAB are allowed. CR, LF, and other control characters are rejected. Empty values are permitted
+     * per RFC 7230.
+     *
+     * @param value the header value to normalize
+     * @return the normalized header value, or the original instance if already normalized
+     * @throws IllegalArgumentException if the value contains invalid characters
+     */
+    public static String normalizeValue(String value) {
+        // Simulate String.trim(), but we only want to trim leading and trailing ' ' and '\t'.
+        int len = value.length();
+        int end = len - 1;
+        int start = trimStart(value, end);
+        end = trimEnd(value, start);
+        if (start > end) {
+            return "";
+        }
+
+        for (int i = start; i <= end; i++) {
+            char c = value.charAt(i);
+            if (c > 255 || !VALID_VALUE_CHAR[c]) {
+                throw invalidHeaderValueChar(value);
+            }
+        }
+
+        return (start == 0 && end == len - 1)
+                ? value
+                : value.substring(start, end + 1);
+    }
+
+    private static int trimStart(String s, int end) {
+        for (int start = 0; start <= end; start++) {
+            char c = s.charAt(start);
+            if (c != ' ' && c != '\t') {
+                return start;
+            }
+        }
+        return end + 1;
+    }
+
+    private static int trimEnd(String s, int start) {
+        for (int end = s.length() - 1; end >= start; end--) {
+            char c = s.charAt(end);
+            if (c != ' ' && c != '\t') {
+                return end;
+            }
+        }
+        return start - 1;
+    }
+
+    private static IllegalArgumentException invalidHeaderNameChar(String value) {
+        return new IllegalArgumentException("Invalid header name: " + value);
+    }
+
+    private static IllegalArgumentException invalidHeaderValueChar(String value) {
+        return new IllegalArgumentException("Invalid header value: " + value);
+    }
+}

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpHeaders.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HttpHeaders.java
@@ -14,7 +14,6 @@ import java.util.Map;
  * <p>Implementations must always normalize header names to lowercase.
  */
 public interface HttpHeaders extends Iterable<Map.Entry<String, List<String>>> {
-
     /**
      * Create an immutable HttpHeaders.
      *
@@ -121,65 +120,5 @@ public interface HttpHeaders extends Iterable<Map.Entry<String, List<String>>> {
      */
     default HttpHeaders toUnmodifiable() {
         return SimpleUnmodifiableHttpHeaders.of(this);
-    }
-
-    /**
-     * Normalizes an HTTP header name by trimming whitespace and converting ASCII uppercase to lowercase.
-     *
-     * <p>Trimming behavior matches {@link String#trim()}, removing characters {@code <= 'u0020'}.
-     * Only ASCII uppercase letters (A-Z) are lowercased; non-ASCII characters pass through unchanged,
-     * which is correct per RFC 7230 (HTTP/1.1) and RFC 9110 (HTTP semantics) since header field names
-     * are defined as ASCII tokens.
-     *
-     * @param name the header name to normalize
-     * @return the normalized header name, or the original instance if already normalized
-     */
-    static String normalizeHeaderName(String name) {
-        int len = name.length();
-        int start = 0;
-        int end = len - 1;
-        boolean needsWork = false;
-
-        // Detect leading whitespace to trim if needed
-        while (start <= end && name.charAt(start) <= ' ') {
-            needsWork = true;
-            start++;
-        }
-
-        // Detect trailing whitespace to trim if needed
-        while (end >= start && name.charAt(end) <= ' ') {
-            needsWork = true;
-            end--;
-        }
-
-        // All whitespace
-        if (start > end) {
-            return "";
-        }
-
-        // Scan for ASCII uppercase
-        for (int i = start; i <= end; i++) {
-            char c = name.charAt(i);
-            if (c >= 'A' && c <= 'Z') {
-                needsWork = true;
-                break;
-            }
-        }
-
-        if (!needsWork) {
-            return name;
-        }
-
-        int outLen = end - start + 1;
-        char[] chars = new char[outLen];
-        for (int src = start, dst = 0; src <= end; src++, dst++) {
-            char c = name.charAt(src);
-            if (c >= 'A' && c <= 'Z') {
-                c = (char) (c + 32);
-            }
-            chars[dst] = c;
-        }
-
-        return new String(chars);
     }
 }

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpHeaders.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/ModifiableHttpHeaders.java
@@ -55,8 +55,8 @@ public interface ModifiableHttpHeaders extends HttpHeaders {
     /**
      * Sets a header to the given value, overwriting old values if present.
      *
-     * <p>Any previously set values for this header are replaced as if {@link #removeHeader(String) and
-     * {@link #addHeader(String, String)}} were called in sequence. To add a new value to a
+     * <p>Any previously set values for this header are replaced as if {@link #removeHeader(String)} and
+     * {@link #addHeader(String, String)} were called in sequence. To add a new value to a
      * list of values, use {@link #addHeader(String, String)}.
      *
      * @param name Case-insensitive name of the header to set.
@@ -70,8 +70,8 @@ public interface ModifiableHttpHeaders extends HttpHeaders {
     /**
      * Sets a header to the given value, overwriting old values if present.
      *
-     * <p>Any previously set values for this header are replaced as if {@link #removeHeader(String) and
-     * {@link #addHeader(String, String)}} were called in sequence. To add new values to a
+     * <p>Any previously set values for this header are replaced as if {@link #removeHeader(String)} and
+     * {@link #addHeader(String, String)} were called in sequence. To add new values to a
      * list of values, use {@link #addHeader(String, List)}.
      *
      * @param name Case-insensitive name of the header to set.

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/SimpleUnmodifiableHttpHeaders.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/SimpleUnmodifiableHttpHeaders.java
@@ -41,7 +41,7 @@ final class SimpleUnmodifiableHttpHeaders implements HttpHeaders {
             // Single pass to normalize, trim, and make immutable in one go
             Map<String, List<String>> result = HashMap.newHashMap(input.size());
             for (var entry : input.entrySet()) {
-                var key = HttpHeaders.normalizeHeaderName(entry.getKey());
+                var key = HeaderUtils.normalizeName(entry.getKey());
                 var values = entry.getValue();
                 var existing = result.get(key);
                 if (existing == null) {
@@ -64,14 +64,13 @@ final class SimpleUnmodifiableHttpHeaders implements HttpHeaders {
 
     private static void copyAndTrimValuesInto(List<String> source, List<String> dest) {
         for (String s : source) {
-            dest.add(s.trim());
+            dest.add(HeaderUtils.normalizeValue(s));
         }
     }
 
     @Override
     public List<String> allValues(String name) {
-        var values = headers.get(name.toLowerCase(Locale.ENGLISH));
-        return values != null ? values : List.of();
+        return headers.getOrDefault(name.toLowerCase(Locale.ROOT), List.of());
     }
 
     @Override

--- a/http/http-api/src/test/java/software/amazon/smithy/java/http/api/HeaderUtilsTest.java
+++ b/http/http-api/src/test/java/software/amazon/smithy/java/http/api/HeaderUtilsTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class HeaderUtilsTest {
+
+    // Name normalization tests
+
+    @Test
+    void normalizeName_lowercasesUppercase() {
+        assertEquals("content-type", HeaderUtils.normalizeName("Content-Type"));
+        assertEquals("x-amz-date", HeaderUtils.normalizeName("X-AMZ-DATE"));
+    }
+
+    @Test
+    void normalizeName_trimsOws() {
+        assertEquals("foo", HeaderUtils.normalizeName(" foo"));
+        assertEquals("foo", HeaderUtils.normalizeName("foo "));
+        assertEquals("foo", HeaderUtils.normalizeName("\tfoo\t"));
+        assertEquals("foo", HeaderUtils.normalizeName("  foo  "));
+    }
+
+    @Test
+    void normalizeName_returnsSameInstanceWhenNormalized() {
+        String name = "content-type";
+        assertSame(name, HeaderUtils.normalizeName(name));
+    }
+
+    @Test
+    void normalizeName_rejectsEmpty() {
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeName(""));
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeName("   "));
+    }
+
+    @Test
+    void normalizeName_rejectsInvalidChars() {
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeName("foo:bar"));
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeName("foo\nbar"));
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeName("foo\rbar"));
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeName("foo bar"));
+    }
+
+    @Test
+    void normalizeName_rejectsNonAscii() {
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeName("föo"));
+    }
+
+    // Value normalization tests
+
+    @Test
+    void normalizeValue_trimsOws() {
+        assertEquals("bar", HeaderUtils.normalizeValue(" bar"));
+        assertEquals("bar", HeaderUtils.normalizeValue("bar "));
+        assertEquals("bar", HeaderUtils.normalizeValue("\tbar\t"));
+    }
+
+    @Test
+    void normalizeValue_allowsInteriorWhitespace() {
+        assertEquals("foo bar", HeaderUtils.normalizeValue("foo bar"));
+        assertEquals("foo\tbar", HeaderUtils.normalizeValue("foo\tbar"));
+    }
+
+    @Test
+    void normalizeValue_allowsEmpty() {
+        assertEquals("", HeaderUtils.normalizeValue(""));
+        assertEquals("", HeaderUtils.normalizeValue("   "));
+    }
+
+    @Test
+    void normalizeValue_returnsSameInstanceWhenNormalized() {
+        String value = "bar";
+        assertSame(value, HeaderUtils.normalizeValue(value));
+    }
+
+    @Test
+    void normalizeValue_rejectsCrLf() {
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeValue("foo\nbar"));
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeValue("foo\rbar"));
+    }
+
+    @Test
+    void normalizeValue_rejectsControlChars() {
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeValue("foo\u0000bar"));
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeValue("foo\u001Fbar"));
+    }
+
+    @Test
+    void normalizeValue_allowsObsText() {
+        // obs-text (0x80-0xFF) is allowed
+        assertEquals("foo\u0080bar", HeaderUtils.normalizeValue("foo\u0080bar"));
+    }
+}


### PR DESCRIPTION
We now validate that header names and values are valid, and more consistently trim and validate values. This is improved over String.trim as it doesn't trim off \r or \n too, which would be too much lenience.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
