### PR TITLE
Represent unions as oneOf and add a OneOf trait to create faux Unions from Documents which can be flattened

### DIFF
--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/StructDocument.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/StructDocument.java
@@ -144,7 +144,7 @@ public final class StructDocument implements Document, SerializableStruct {
             if (value != null) {
                 var member = schema.member(name);
                 if (member != null) {
-                    value.serializeContents(serializer);
+                    value.serialize(serializer);
                 }
             }
         }

--- a/mcp/mcp-schemas/model/main.smithy
+++ b/mcp/mcp-schemas/model/main.smithy
@@ -34,15 +34,6 @@ structure JsonRpcErrorResponse {
     data: Document
 }
 
-@trait(selector: "service")
-structure jsonRpc2 {}
-
-@trait(selector: "operation")
-structure jsonRpc2Method {
-    @required
-    method: NonEmptyString
-}
-
 @private
 @length(min: 1)
 string NonEmptyString
@@ -147,6 +138,9 @@ structure JsonPrimitiveSchema {
     type: JsonPrimitiveType
 
     description: String
+
+    @jsonName("const")
+    constValue: String
 }
 
 structure JsonDocumentSchema {
@@ -154,6 +148,22 @@ structure JsonDocumentSchema {
     type: StringList
 
     description: String
+}
+
+structure JsonOneOfSchema {
+    /// List of inline schema variants
+    @required
+    oneOf: JsonSchemaList
+
+    description: String
+
+    @required
+    type: String = "object"
+}
+
+list JsonSchemaList {
+    /// Each element is a full inline JSON Schema (JsonObjectSchema, etc.)
+    member: Document
 }
 
 enum JsonPrimitiveType {
@@ -260,3 +270,34 @@ structure GetPromptResult {
     description: String
     messages: PromptMessageList
 }
+
+@unstable
+@trait(selector: "document")
+structure oneOf {
+    /// Discriminator field name to add during runtime input adaptation
+    @required
+    discriminator: String
+
+    /// List of possible variant types
+    @required
+    members: OneOfMemberList
+}
+
+list OneOfMemberList {
+    member: OneOfMember
+}
+
+structure OneOfMember {
+    /// The member name (e.g., "circle", "square")
+    @required
+    name: String
+
+    /// Target shape ID - uses @idRef for Smithy validation
+    @required
+    target: OneOfTargetShape
+}
+
+/// Shape ID reference for oneOf target - validates it points to a structure
+@private
+@idRef(failWhenMissing: true, selector: "structure")
+string OneOfTargetShape

--- a/mcp/mcp-schemas/smithy-build.json
+++ b/mcp/mcp-schemas/smithy-build.json
@@ -1,16 +1,22 @@
 {
   "version": "1.0",
+  "sources": ["model"],
   "plugins": {
     "java-type-codegen": {
       "namespace": "software.amazon.smithy.java.mcp",
       "headerFile": "license.txt",
-      "runtimeTraits": ["smithy.api#documentation", "smithy.api#examples" ]
+      "runtimeTraits": ["smithy.api#documentation", "smithy.api#examples", "smithy.mcp#oneOf" ]
     },
     "java-server-codegen": {
       "service": "smithy.mcp.toolassistant#ToolAssistant",
       "namespace": "software.amazon.smithy.java.mcp.toolassistant",
       "headerFile": "license.txt",
-      "runtimeTraits": ["smithy.api#documentation", "smithy.api#examples", "smithy.ai#prompts" ]
+      "runtimeTraits": ["smithy.api#documentation", "smithy.api#examples", "smithy.ai#prompts", "smithy.mcp#oneOf" ]
+    },
+    "trait-codegen": {
+      "package": "software.amazon.smithy.java.mcp",
+      "namespace": "smithy.mcp",
+      "header": ["license.txt"]
     }
   }
 }

--- a/mcp/mcp-server/src/it/resources/META-INF/smithy/main.smithy
+++ b/mcp/mcp-server/src/it/resources/META-INF/smithy/main.smithy
@@ -2,9 +2,12 @@ $version: "2"
 
 namespace smithy.java.mcp.test
 
+use smithy.mcp#oneOf
+
 service TestService {
     operations: [
-        McpEcho
+        McpEcho,
+    CalculateArea
     ]
 }
 
@@ -15,6 +18,56 @@ operation McpEcho {
     output:= {
         echo: Echo
     }
+}
+
+operation CalculateArea {
+    input : CalculateAreaInput
+
+    output := {
+        @required
+        area: Double
+
+        @required
+        originalShape: Shape
+    }
+}
+
+structure CalculateAreaInput {
+    oneOfInput : Shape
+}
+
+
+/// Union without @oneOf trait - uses wrapper format natively
+union Shape {
+    circle : Circle
+    square: Square
+    rectangle: Rectangle
+}
+
+/// Document with @oneOf trait - for testing Document-based polymorphic types
+/// Used when services need discriminator-based polymorphism
+@oneOf(discriminator: "__type", members: [
+    {name: "circle", target: Circle},
+    {name: "square", target: Square},
+    {name: "rectangle", target: Rectangle}
+])
+document ShapeWithOneOf
+
+structure Circle {
+    @required
+    radius : Integer
+}
+
+structure Square {
+    @required
+    side: Integer
+}
+
+structure Rectangle {
+    @required
+    length: Integer
+    @required
+    breadth: Integer
 }
 
 /// A comprehensive structure containing all supported Smithy types for testing MCP serde

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/utils/TestJavaCodegenRunner.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/utils/TestJavaCodegenRunner.java
@@ -9,6 +9,8 @@ package software.amazon.smithy.java.mcp.server.utils;
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static software.amazon.smithy.model.node.Node.fromStrings;
+
 import java.nio.file.Paths;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.build.PluginContext;
@@ -37,6 +39,11 @@ public final class TestJavaCodegenRunner {
                         ObjectNode.builder()
                                 .withMember("service", "smithy.java.mcp.test#TestService")
                                 .withMember("namespace", "software.amazon.smithy.java.mcp.test")
+                                .withMember("runtimeTraits",
+                                        fromStrings("smithy.api#documentation",
+                                                "smithy.api#examples",
+                                                "smithy.ai#prompts",
+                                                "smithy.mcp#oneOf"))
                                 .build())
                 .model(model)
                 .build();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Represent unions has oneOf and add a OneOf trait to create faux Unions from Documents which can be flattened


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
