### PR TITLE
Avoid double encoding URIs for signing

### DIFF
--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-path/context.json
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-path/context.json
@@ -1,0 +1,11 @@
+{
+  "credentials": {
+    "access_key_id": "AKIDEXAMPLE",
+    "secret_access_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+  },
+  "properties": {
+    "region": "us-east-1",
+    "service": "service",
+    "timestamp": "2015-08-30T12:36:00Z"
+  }
+}

--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-path/request.txt
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-path/request.txt
@@ -1,0 +1,2 @@
+GET /foo%3Abar/?foo=bar HTTP/1.1
+Host:example.amazonaws.com

--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-path/signed.txt
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-path/signed.txt
@@ -1,0 +1,4 @@
+GET /foo%3Abar/?foo=bar HTTP/1.1
+Host:example.amazonaws.com
+X-Amz-Date:20150830T123600Z
+Authorization:AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=bd0ce8146a65497669ff3f650baae183b78931856b0005d4a51bc0612ba7c8a0

--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-query-params/context.json
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-query-params/context.json
@@ -1,0 +1,11 @@
+{
+  "credentials": {
+    "access_key_id": "AKIDEXAMPLE",
+    "secret_access_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+  },
+  "properties": {
+    "region": "us-east-1",
+    "service": "service",
+    "timestamp": "2015-08-30T12:36:00Z"
+  }
+}

--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-query-params/request.txt
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-query-params/request.txt
@@ -1,0 +1,2 @@
+GET /foo/?foo%3Abar=bar HTTP/1.1
+Host:example.amazonaws.com

--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-query-params/signed.txt
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-encoded-query-params/signed.txt
@@ -1,0 +1,4 @@
+GET /foo/?foo%3Abar=bar HTTP/1.1
+Host:example.amazonaws.com
+X-Amz-Date:20150830T123600Z
+Authorization:AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=4e3c84afdc855dfb9df3ec7aa24720a3948e6e843d8beabedba515fb6531d27a

--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-utf8/request.txt
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-utf8/request.txt
@@ -1,2 +1,2 @@
-GET /ሴ HTTP/1.1
+GET /%E1%88%B4 HTTP/1.1
 Host:example.amazonaws.com

--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-utf8/signed.txt
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-utf8/signed.txt
@@ -1,4 +1,4 @@
-GET /ሴ HTTP/1.1
+GET /%E1%88%B4 HTTP/1.1
 Host:example.amazonaws.com
 X-Amz-Date:20150830T123600Z
 Authorization:AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85

--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-vanilla-utf8-query/request.txt
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-vanilla-utf8-query/request.txt
@@ -1,2 +1,2 @@
-GET /?ሴ=bar HTTP/1.1
+GET /?%E1%88%B4=bar HTTP/1.1
 Host:example.amazonaws.com

--- a/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-vanilla-utf8-query/signed.txt
+++ b/aws/aws-sigv4/src/test/resources/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/signing/get-vanilla-utf8-query/signed.txt
@@ -1,4 +1,4 @@
-GET /?ሴ=bar HTTP/1.1
+GET /?%E1%88%B4=bar HTTP/1.1
 Host:example.amazonaws.com
 X-Amz-Date:20150830T123600Z
 Authorization:AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=2cdec8eed098649ff3a119c94853b13c643bcf08f8b0a1d91e12c9027818dd04


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Avoid double URI encoding of path and query params during signing. The path and the query params are already encoded in `HttpBindingSerializer`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
