### PR TITLE
Make additionalProperties a Document

### DIFF
--- a/mcp/mcp-schemas/model/main.smithy
+++ b/mcp/mcp-schemas/model/main.smithy
@@ -110,7 +110,7 @@ structure JsonObjectSchema {
 
     required: StringList
 
-    additionalProperties: Boolean
+    additionalProperties: Document
 
     description: String
 

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpService.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpService.java
@@ -604,13 +604,7 @@ public final class McpService {
             var targetSchema = schemaIndex.getSchema(targetShapeId);
             var memberSchema = createJsonObjectSchema(targetSchema, visited);
 
-            var wrapperSchema = JsonObjectSchema.builder()
-                    .properties(Map.of(memberName, Document.of(memberSchema)))
-                    .required(List.of(memberName))
-                    .additionalProperties(false)
-                    .build();
-
-            oneOfVariants.add(Document.of(wrapperSchema));
+            oneOfVariants.add(createUnionVariant(memberName, memberSchema));
         }
 
         return JsonOneOfSchema.builder()
@@ -631,14 +625,7 @@ public final class McpService {
             var memberName = member.memberName();
             var memberSchema = createMemberSchema(member, visited);
 
-            // Wrap in object with member name as key
-            var wrapperSchema = JsonObjectSchema.builder()
-                    .properties(Map.of(memberName, Document.of(memberSchema)))
-                    .required(List.of(memberName))
-                    .additionalProperties(false)
-                    .build();
-
-            variants.add(Document.of(wrapperSchema));
+            variants.add(createUnionVariant(memberName, memberSchema));
         }
 
         visited.remove(targetId);
@@ -646,6 +633,15 @@ public final class McpService {
                 .oneOf(variants)
                 .description(memberDescription(schema))
                 .build();
+    }
+
+    private static Document createUnionVariant(String memberName, SerializableShape memberSchema) {
+        var wrapperSchema = JsonObjectSchema.builder()
+                .properties(Map.of(memberName, Document.of(memberSchema)))
+                .required(List.of(memberName))
+                .additionalProperties(Document.of(false))
+                .build();
+        return Document.of(wrapperSchema);
     }
 
     private SerializableShape createMemberSchema(Schema member, Set<ShapeId> visited) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ref https://json-schema.org/understanding-json-schema/reference/object#additionalproperties

> You can use non-boolean schemas to put more complex constraints on the additional properties of an instance. For example, one can allow additional properties, but only if their values are each a string:
> ```json
> {
>   "type": "object",
>   "properties": {
>     "number": { "type": "number" },
>     "street_name": { "type": "string" },
>     "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
>   },
>   "additionalProperties": { "type": "string" }
> }
> ```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
