### PR TITLE
Revert disabling jar task in json-codecs

### DIFF
--- a/codecs/json-codec/build.gradle.kts
+++ b/codecs/json-codec/build.gradle.kts
@@ -33,7 +33,7 @@ tasks {
         }
     }
     jar {
-        enabled = false
+        finalizedBy(shadowJar)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This was done as a part of #980 to remove build cache misses but this causes issues in publication. Reverting for now to unblock publishing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
