### PR TITLE
Remove input from workflow dispatch and set time to 4h

### DIFF
--- a/.github/workflows/fuzz-testing.yml
+++ b/.github/workflows/fuzz-testing.yml
@@ -7,11 +7,6 @@ on:
 
   # Allow manual trigger
   workflow_dispatch:
-    inputs:
-      duration:
-        description: 'Fuzz test duration (e.g., 10m, 1h)'
-        required: false
-        default: '15m'
 
 permissions:
   contents: read
@@ -56,8 +51,7 @@ jobs:
 
       - name: Run all fuzz tests
         run: |
-          DURATION="${{ github.event.inputs.duration || '5h' }}"
-          ./gradlew fuzz -Pfuzz.maxDuration=$DURATION --stacktrace
+          ./gradlew fuzz -Pfuzz.maxDuration=4h --stacktrace
 
       - name: Save fuzz corpus cache
         uses: actions/cache/save@v4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removed ability to pass inputs via manual trigger, also reduce fuzz test time to 4h to reduce job workflow timeouts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
