### PR TITLE
Add model bundle version and based on that decide whether to wrap input or not

### DIFF
--- a/model-bundle/model-bundle-api/src/main/resources/META-INF/smithy/bundle.smithy
+++ b/model-bundle/model-bundle-api/src/main/resources/META-INF/smithy/bundle.smithy
@@ -26,6 +26,10 @@ structure SmithyBundle {
     /// model describing the generic arguments that must be present in every request. If this
     /// bundle does not require generic arguments, this field may be omitted.
     additionalInput: AdditionalInput
+
+    /// Version of the model bundle format. Determines how additionalInput is handled.
+    /// If not specified, defaults to V1 (legacy) behavior.
+    modelBundleVersion: ModelBundleVersion
 }
 
 string SmithyModel
@@ -36,4 +40,13 @@ structure AdditionalInput {
 
     @required
     model: SmithyModel
+}
+
+/// Version of the model bundle format. Used to determine input handling behavior.
+enum ModelBundleVersion {
+    /// Mix additionalInput into existing input shape (legacy behavior)
+    V1
+
+    /// Wrap input in new structure containing both original input and additionalInput
+    V2
 }

--- a/model-bundle/model-bundle-api/src/test/java/software/amazon/smithy/modelbundle/api/ModelBundlesTest.java
+++ b/model-bundle/model-bundle-api/src/test/java/software/amazon/smithy/modelbundle/api/ModelBundlesTest.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.modelbundle.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -15,12 +16,13 @@ import software.amazon.smithy.java.server.ProxyOperationTrait;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.modelbundle.api.model.AdditionalInput;
+import software.amazon.smithy.modelbundle.api.model.ModelBundleVersion;
 import software.amazon.smithy.modelbundle.api.model.SmithyBundle;
 
 class ModelBundlesTest {
 
     @Test
-    void testOperationWithNoInputGetsSyntheticAdditionalInputShape() {
+    void testV2OperationWithNoInputGetsSyntheticAdditionalInputShape() {
         String smithyModel = """
                 $version: "2.0"
 
@@ -61,6 +63,7 @@ class ModelBundlesTest {
                 .additionalInput(additionalInput)
                 .configType("configType")
                 .config(Document.ofObject(null))
+                .modelBundleVersion(ModelBundleVersion.V2)
                 .build();
 
         var model = ModelBundles.prepareModelForBundling(bundle);
@@ -89,10 +92,11 @@ class ModelBundlesTest {
         assertEquals(ShapeId.from("com.example#TestOperation"), trait.getDelegateOperation());
         assertNull(trait.getInputMemberName());
         assertEquals("additionalInput", trait.getAdditionalInputMemberName());
+        assertTrue(trait.shouldUnwrapInput());
     }
 
     @Test
-    void testOperationWithInputGetsWrapperWithOriginalInputMember() {
+    void testV2OperationWithInputGetsWrapperWithOriginalInputMember() {
         String smithyModel = """
                 $version: "2.0"
 
@@ -138,6 +142,7 @@ class ModelBundlesTest {
                 .additionalInput(additionalInput)
                 .configType("configType")
                 .config(Document.ofObject(null))
+                .modelBundleVersion(ModelBundleVersion.V2)
                 .build();
 
         var model = ModelBundles.prepareModelForBundling(bundle);
@@ -173,5 +178,231 @@ class ModelBundlesTest {
         assertEquals(ShapeId.from("com.example#GetUser"), trait.getDelegateOperation());
         assertEquals("getUserInput", trait.getInputMemberName());
         assertEquals("additionalInput", trait.getAdditionalInputMemberName());
+        assertTrue(trait.shouldUnwrapInput());
+    }
+
+    @Test
+    void testV1OperationWithNoInputUsesLegacyBehavior() {
+        String smithyModel = """
+                $version: "2.0"
+
+                namespace com.example
+
+                service TestService {
+                    version: "1.0"
+                    operations: [TestOperation]
+                }
+
+                operation TestOperation {
+                    output: TestOutput
+                }
+
+                structure TestOutput {
+                    result: String
+                }
+                """;
+
+        String additionalInputModel = """
+                $version: "2.0"
+
+                namespace com.example.additional
+
+                structure AdditionalInputData {
+                    context: String
+                }
+                """;
+
+        AdditionalInput additionalInput = AdditionalInput.builder()
+                .identifier("com.example.additional#AdditionalInputData")
+                .model(additionalInputModel)
+                .build();
+
+        SmithyBundle bundle = SmithyBundle.builder()
+                .model(smithyModel)
+                .serviceName("com.example#TestService")
+                .additionalInput(additionalInput)
+                .configType("configType")
+                .config(Document.ofObject(null))
+                .modelBundleVersion(ModelBundleVersion.V1)
+                .build();
+
+        var model = ModelBundles.prepareModelForBundling(bundle);
+
+        // Verify proxy operation exists
+        ShapeId proxyOperationId = ShapeId.from("com.example#TestOperationProxy");
+        assertTrue(model.getShape(proxyOperationId).isPresent());
+
+        var proxyOperation = model.expectShape(proxyOperationId).asOperationShape().get();
+        assertTrue(proxyOperation.getInput().isPresent());
+
+        // Verify V1 uses synthetic container named after additionalInput shape
+        ShapeId syntheticInputId = ShapeId.from("smithy.mcp#AdditionalInputForAdditionalInputData");
+        assertEquals(syntheticInputId, proxyOperation.getInputShape());
+
+        var syntheticInputShape = model.expectShape(syntheticInputId, StructureShape.class);
+        // Only additionalInput member since original operation had no input
+        assertEquals(1, syntheticInputShape.members().size());
+        assertTrue(syntheticInputShape.getMember("additionalInput").isPresent());
+
+        // Verify ProxyOperationTrait has correct metadata for V1
+        var trait = proxyOperation.expectTrait(ProxyOperationTrait.class);
+        assertEquals(ShapeId.from("com.example#TestOperation"), trait.getDelegateOperation());
+        assertNull(trait.getInputMemberName());
+        assertEquals("additionalInput", trait.getAdditionalInputMemberName());
+        assertFalse(trait.shouldUnwrapInput());
+    }
+
+    @Test
+    void testV1OperationWithInputMixesAdditionalInputIntoExistingShape() {
+        String smithyModel = """
+                $version: "2.0"
+
+                namespace com.example
+
+                service TestService {
+                    version: "1.0"
+                    operations: [GetUser]
+                }
+
+                operation GetUser {
+                    input: GetUserInput
+                    output: GetUserOutput
+                }
+
+                structure GetUserInput {
+                    userId: String
+                }
+
+                structure GetUserOutput {
+                    name: String
+                }
+                """;
+
+        String additionalInputModel = """
+                $version: "2.0"
+
+                namespace com.example.additional
+
+                structure AuthContext {
+                    token: String
+                }
+                """;
+
+        AdditionalInput additionalInput = AdditionalInput.builder()
+                .identifier("com.example.additional#AuthContext")
+                .model(additionalInputModel)
+                .build();
+
+        SmithyBundle bundle = SmithyBundle.builder()
+                .model(smithyModel)
+                .serviceName("com.example#TestService")
+                .additionalInput(additionalInput)
+                .configType("configType")
+                .config(Document.ofObject(null))
+                .modelBundleVersion(ModelBundleVersion.V1)
+                .build();
+
+        var model = ModelBundles.prepareModelForBundling(bundle);
+
+        // Verify proxy operation exists
+        ShapeId proxyOperationId = ShapeId.from("com.example#GetUserProxy");
+        assertTrue(model.getShape(proxyOperationId).isPresent());
+        var proxyOperation = model.expectShape(proxyOperationId).asOperationShape().get();
+
+        // Verify proxy has input - V1 uses modified input shape (with Proxy suffix)
+        assertTrue(proxyOperation.getInput().isPresent());
+        var inputShapeId = proxyOperation.getInputShape();
+        assertEquals(ShapeId.from("com.example#GetUserInputProxy"), inputShapeId);
+
+        var inputShape = model.expectShape(inputShapeId, StructureShape.class);
+
+        // Should have 2 members: original userId and mixed-in additionalInput
+        assertEquals(2, inputShape.members().size());
+
+        // Should have original input member
+        assertTrue(inputShape.getMember("userId").isPresent());
+
+        // Should have member named "additionalInput" mixed in
+        assertTrue(inputShape.getMember("additionalInput").isPresent());
+        var additionalInputMember = inputShape.getMember("additionalInput").get();
+        assertEquals(ShapeId.from("com.example.additional#AuthContext"), additionalInputMember.getTarget());
+
+        // Verify ProxyOperationTrait has correct metadata for V1
+        var trait = proxyOperation.expectTrait(ProxyOperationTrait.class);
+        assertEquals(ShapeId.from("com.example#GetUser"), trait.getDelegateOperation());
+        assertNull(trait.getInputMemberName());
+        assertEquals("additionalInput", trait.getAdditionalInputMemberName());
+        assertFalse(trait.shouldUnwrapInput());
+    }
+
+    @Test
+    void testMissingVersionDefaultsToV1Behavior() {
+        String smithyModel = """
+                $version: "2.0"
+
+                namespace com.example
+
+                service TestService {
+                    version: "1.0"
+                    operations: [GetUser]
+                }
+
+                operation GetUser {
+                    input: GetUserInput
+                    output: GetUserOutput
+                }
+
+                structure GetUserInput {
+                    userId: String
+                }
+
+                structure GetUserOutput {
+                    name: String
+                }
+                """;
+
+        String additionalInputModel = """
+                $version: "2.0"
+
+                namespace com.example.additional
+
+                structure AuthContext {
+                    token: String
+                }
+                """;
+
+        AdditionalInput additionalInput = AdditionalInput.builder()
+                .identifier("com.example.additional#AuthContext")
+                .model(additionalInputModel)
+                .build();
+
+        // Bundle without modelBundleVersion set - should default to V1
+        SmithyBundle bundle = SmithyBundle.builder()
+                .model(smithyModel)
+                .serviceName("com.example#TestService")
+                .additionalInput(additionalInput)
+                .configType("configType")
+                .config(Document.ofObject(null))
+                .build();
+
+        var model = ModelBundles.prepareModelForBundling(bundle);
+
+        // Verify it uses V1 behavior (mixed-in input shape)
+        ShapeId proxyOperationId = ShapeId.from("com.example#GetUserProxy");
+        var proxyOperation = model.expectShape(proxyOperationId).asOperationShape().get();
+
+        // V1 uses modified input shape (with Proxy suffix)
+        var inputShapeId = proxyOperation.getInputShape();
+        assertEquals(ShapeId.from("com.example#GetUserInputProxy"), inputShapeId);
+
+        var inputShape = model.expectShape(inputShapeId, StructureShape.class);
+        // Should have 2 members: original userId and mixed-in additionalInput
+        assertEquals(2, inputShape.members().size());
+        assertTrue(inputShape.getMember("userId").isPresent());
+        assertTrue(inputShape.getMember("additionalInput").isPresent());
+
+        // Verify ProxyOperationTrait has unwrapInput=false for V1
+        var trait = proxyOperation.expectTrait(ProxyOperationTrait.class);
+        assertFalse(trait.shouldUnwrapInput());
     }
 }

--- a/server/server-proxy/src/main/java/software/amazon/smithy/java/server/ProxyOperationTrait.java
+++ b/server/server-proxy/src/main/java/software/amazon/smithy/java/server/ProxyOperationTrait.java
@@ -43,11 +43,18 @@ public final class ProxyOperationTrait implements Trait {
     private final ShapeId delegateOperation;
     private final String inputMemberName;
     private final String additionalInputMemberName;
+    private final boolean unwrapInput;
 
-    public ProxyOperationTrait(ShapeId delegateOperation, String inputMemberName, String additionalInputMemberName) {
+    public ProxyOperationTrait(
+            ShapeId delegateOperation,
+            String inputMemberName,
+            String additionalInputMemberName,
+            boolean unwrapInput
+    ) {
         this.delegateOperation = delegateOperation;
         this.inputMemberName = inputMemberName;
         this.additionalInputMemberName = additionalInputMemberName;
+        this.unwrapInput = unwrapInput;
     }
 
     @Override
@@ -80,5 +87,21 @@ public final class ProxyOperationTrait implements Trait {
      */
     public String getAdditionalInputMemberName() {
         return additionalInputMemberName;
+    }
+
+    /**
+     * Returns whether the proxy service should unwrap the input from a wrapper structure.
+     *
+     * <p>When true (V2 behavior), the proxy input is a wrapper structure containing both
+     * the original input member and the additional input member. The proxy service should
+     * extract the original input before forwarding to the delegate operation.</p>
+     *
+     * <p>When false (V1 legacy behavior), the additional input was mixed into the existing
+     * input shape, so no unwrapping is needed - the full input can be passed directly.</p>
+     *
+     * @return true if the proxy service should unwrap the input, false otherwise
+     */
+    public boolean shouldUnwrapInput() {
+        return unwrapInput;
     }
 }

--- a/server/server-proxy/src/main/java/software/amazon/smithy/java/server/ProxyService.java
+++ b/server/server-proxy/src/main/java/software/amazon/smithy/java/server/ProxyService.java
@@ -318,13 +318,16 @@ public final class ProxyService implements Service {
                         .putConfig(PROXY_INPUT, input.getMember(proxyTrait.getAdditionalInputMemberName()))
                         .build();
 
-                // Unwrap original input from wrapper
                 Document unwrappedInput;
-                var inputMemberName = proxyTrait.getInputMemberName();
-                if (inputMemberName != null) {
-                    unwrappedInput = input.getMember(inputMemberName);
+                if (proxyTrait.shouldUnwrapInput()) {
+                    var inputMemberName = proxyTrait.getInputMemberName();
+                    if (inputMemberName != null) {
+                        unwrappedInput = input.getMember(inputMemberName);
+                    } else {
+                        unwrappedInput = Document.of(Unit.getInstance());
+                    }
                 } else {
-                    unwrappedInput = Document.of(Unit.getInstance());
+                    unwrappedInput = input;
                 }
 
                 output = dynamicClient.call(operation, unwrappedInput, requestOverride);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We need a compatibility mode to ensure existing callers don't break.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
