### PR TITLE
Convert Jackson exceptions to SerializationException

### DIFF
--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerdeProvider.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonSerdeProvider.java
@@ -7,11 +7,13 @@ package software.amazon.smithy.java.json.jackson;
 
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.json.JsonSerdeProvider;
 import software.amazon.smithy.java.json.JsonSettings;
 import software.amazon.smithy.utils.SmithyInternalApi;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.ObjectReadContext;
 import tools.jackson.core.ObjectWriteContext;
 import tools.jackson.core.PrettyPrinter;
@@ -56,7 +58,11 @@ public class JacksonJsonSerdeProvider implements JsonSerdeProvider {
             byte[] source,
             JsonSettings settings
     ) {
-        return new JacksonJsonDeserializer(FACTORY.createParser(readCtx(settings), source), settings);
+        try {
+            return new JacksonJsonDeserializer(FACTORY.createParser(readCtx(settings), source), settings);
+        } catch (JacksonException e) {
+            throw new SerializationException(e);
+        }
     }
 
     @Override
@@ -64,7 +70,11 @@ public class JacksonJsonSerdeProvider implements JsonSerdeProvider {
         int offset = source.arrayOffset() + source.position();
         int length = source.remaining();
         var ctx = readCtx(settings);
-        return new JacksonJsonDeserializer(FACTORY.createParser(ctx, source.array(), offset, length), settings);
+        try {
+            return new JacksonJsonDeserializer(FACTORY.createParser(ctx, source.array(), offset, length), settings);
+        } catch (JacksonException e) {
+            throw new SerializationException(e);
+        }
     }
 
     @Override


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Jackson 3.0 throws an exception if the encoding is incorrect while creating the parser itself. This fixes the failing Fuzz tests https://github.com/smithy-lang/smithy-java/actions/runs/20449720141


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
