### PR TITLE
Fix incorrect codegen for HttpApiKeyAuthTrait

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/HttpApiKeyAuthTraitInitializer.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/HttpApiKeyAuthTraitInitializer.java
@@ -19,12 +19,13 @@ final class HttpApiKeyAuthTraitInitializer implements TraitInitializer<HttpApiKe
     public void accept(JavaWriter writer, HttpApiKeyAuthTrait httpApiKeyAuthTrait) {
         writer.putContext("auth", HttpApiKeyAuthTrait.class);
         writer.putContext("name", httpApiKeyAuthTrait.getName());
-        writer.putContext("in", httpApiKeyAuthTrait.getIn());
+        var location = httpApiKeyAuthTrait.getIn().toString().equals("header") ? "HEADER" : "QUERY";
+        writer.putContext("location", location);
         writer.putContext("scheme", httpApiKeyAuthTrait.getScheme());
         writer.writeInline("""
                 ${auth:T}.builder()
                     .name(${name:S})
-                    .in(${auth:T}.Location.from(${in:S})${?scheme}
+                    .in(${auth:T}.Location.${location:L})${?scheme}
                     .scheme(${scheme:S})${/scheme}
                     .build()""");
     }

--- a/codegen/plugins/client-codegen/src/it/resources/META-INF/smithy/main.smithy
+++ b/codegen/plugins/client-codegen/src/it/resources/META-INF/smithy/main.smithy
@@ -11,6 +11,7 @@ use smithy.test.auth#testAuthScheme
 )
 @restJson1
 @testAuthScheme
+@httpApiKeyAuth(name: "X-Api-Key", in: "header")
 service TestService {
     version: "today"
     operations: [


### PR DESCRIPTION
The current codegen for `@httpApiKeyAuthTrait` in client side missed a `)` at the end of the assignment of `in` field and the enum `Location` in [HttpApiKeyAuthTrait.java](https://github.com/smithy-lang/smithy/blob/be1715b2ce8fd7c21823a174caf3359ec3e4211e/smithy-model/src/main/java/software/amazon/smithy/model/traits/HttpApiKeyAuthTrait.java#L68) does not have a public `from()` method, which makes the generated `HttpApiKeyAuthTrait` invalid.
For the following trait:
```smithy
@httpApiKeyAuth(name: "X-API-Key", in: "header")
```
The original generated code would be:
```java
private static final HttpApiKeyAuthTrait httpApiKeyAuthScheme = HttpApiKeyAuthTrait.builder()
            .name("X-API-Key")
            .in(HttpApiKeyAuthTrait.Location.from("header")
            .build();
```
Generated code after fix:
```java
private static final HttpApiKeyAuthTrait httpApiKeyAuthScheme = HttpApiKeyAuthTrait.builder()
            .name("X-Api-Key")
            .in(HttpApiKeyAuthTrait.Location.HEADER)
            .build();
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
