### PR TITLE
Add integ test to compile and check AWS endpoints

### DIFF
--- a/.github/workflows/endpoint-compatibility.yml
+++ b/.github/workflows/endpoint-compatibility.yml
@@ -1,0 +1,58 @@
+name: Endpoint Ruleset Compatibility
+
+on:
+  # Run daily at 3 AM UTC
+  schedule:
+    - cron: '0 3 * * *'
+
+  # Allow manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  endpoint-compatibility:
+    runs-on: ubuntu-latest
+    name: AWS Endpoint Ruleset Compatibility
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Checkout api-models-aws
+        uses: actions/checkout@v6
+        with:
+          repository: aws/api-models-aws
+          path: api-models-aws
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'corretto'
+
+      - name: Cache compiled buildscripts
+        uses: actions/cache@v5
+        with:
+          key: ${{ runner.os }}-gradle-${{ hashFiles('buildSrc/**/*.kts') }}
+          path: |
+            ./buildSrc/build
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle-home-cache-includes: |
+            caches
+
+      - name: Run endpoint ruleset compatibility tests
+        env:
+          API_MODELS_AWS_DIR: ${{ github.workspace }}/api-models-aws
+        run: |
+          ./gradlew :client:client-rulesengine:integ --tests "*.AwsEndpointRulesetTest" --stacktrace
+
+      - uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: endpoint-compatibility-report
+          path: '**/build/reports/tests'

--- a/client/client-rulesengine/src/it/java/software/amazon/smithy/java/client/rulesengine/AwsEndpointRulesetTest.java
+++ b/client/client-rulesengine/src/it/java/software/amazon/smithy/java/client/rulesengine/AwsEndpointRulesetTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.rulesengine;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.ModelAssembler;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
+import software.amazon.smithy.rulesengine.language.evaluation.TestEvaluator;
+import software.amazon.smithy.rulesengine.logic.bdd.NodeReversal;
+import software.amazon.smithy.rulesengine.logic.bdd.SiftingOptimization;
+import software.amazon.smithy.rulesengine.logic.cfg.Cfg;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
+import software.amazon.smithy.rulesengine.traits.EndpointTestCase;
+import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait;
+
+/**
+ * Tests that every AWS service endpoint ruleset can be compiled to BDD bytecode,
+ * evaluated against its endpoint test cases, round-tripped through serialization,
+ * and disassembled without errors.
+ *
+ * <p>Set the {@code API_MODELS_AWS_DIR} environment variable to the root of a local
+ * checkout of api-models-aws to enable this test.
+ */
+class AwsEndpointRulesetTest {
+
+    private static Path getModelsDir() {
+        var dir = System.getenv("API_MODELS_AWS_DIR");
+        return dir != null ? Paths.get(dir, "models") : null;
+    }
+
+    static boolean modelsAvailable() {
+        var dir = getModelsDir();
+        return dir != null && Files.isDirectory(dir);
+    }
+
+    static Stream<Path> awsModels() throws IOException {
+        var modelsDir = getModelsDir();
+        try (var paths = Files.find(modelsDir,
+                4,
+                (p, a) -> p.toString().endsWith(".json")
+                        && p.getParent().getParent().getFileName().toString().equals("service"))) {
+            return paths.sorted().toList().stream();
+        }
+    }
+
+    @EnabledIf("modelsAvailable")
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("awsModels")
+    void compileEvaluateAndRoundTrip(Path modelPath) {
+        // Load the model
+        Model model = Model.assembler()
+                .addImport(modelPath)
+                .putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+
+        // Find the service with endpoint rules
+        ServiceShape service = model.getServiceShapes()
+                .stream()
+                .filter(s -> s.hasTrait(EndpointRuleSetTrait.class))
+                .findFirst()
+                .orElse(null);
+        if (service == null) {
+            // Skip models without endpoint rules
+            return;
+        }
+
+        EndpointRuleSet ruleSet = service.expectTrait(EndpointRuleSetTrait.class).getEndpointRuleSet();
+        List<EndpointTestCase> testCases = service.hasTrait(EndpointTestsTrait.class)
+                ? service.expectTrait(EndpointTestsTrait.class).getTestCases()
+                : List.of();
+
+        // Evaluate test cases against the original rules (if these fail, no point in testing the BDD)
+        for (EndpointTestCase testCase : testCases) {
+            TestEvaluator.evaluate(ruleSet, testCase);
+        }
+
+        // Compile to BDD
+        Cfg cfg = Cfg.from(ruleSet);
+        EndpointBddTrait bddTrait = EndpointBddTrait.from(cfg);
+        EndpointBddTrait optimizedTrait = SiftingOptimization.builder().cfg(cfg).build().apply(bddTrait);
+        EndpointBddTrait finalTrait = new NodeReversal().apply(optimizedTrait);
+
+        // Evaluate test cases against the BDD
+        for (EndpointTestCase testCase : testCases) {
+            TestEvaluator.evaluate(finalTrait, testCase);
+        }
+
+        // Compile BDD to bytecode
+        var builder = new RulesEngineBuilder();
+        Bytecode compiled = builder.compile(finalTrait);
+        assertNotNull(compiled);
+        assertTrue(compiled.getBytecode().length > 0);
+
+        // Round-trip: serialize then load
+        byte[] serialized = compiled.getBytecode();
+        Bytecode loaded = builder.load(serialized);
+        assertArrayEquals(serialized, loaded.getBytecode(), "Round-trip mismatch");
+
+        // Disassemble without error
+        String disassembly = loaded.toString();
+        assertTrue(disassembly.contains("=== Bytecode Program ==="));
+    }
+}


### PR DESCRIPTION
Also adds to CI/CD to test every night. Loads AWS modeled endpoints, makes sure compiling to BDD works, endpoint test cases work, and other things like bytecode round-trip works and disassembler works.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
