### PR TITLE
feat(mcp): increase default HTTP proxy timeout from 60s to 5 minutes

### DIFF
--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/HttpMcpProxy.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/HttpMcpProxy.java
@@ -47,7 +47,7 @@ public final class HttpMcpProxy extends McpServerProxy {
         this.endpoint = URI.create(builder.endpoint);
         this.name = builder.name != null ? builder.name : sanitizeName(endpoint.getHost());
         this.signer = builder.signer;
-        this.timeout = builder.timeout != null ? builder.timeout : Duration.ofSeconds(60);
+        this.timeout = builder.timeout != null ? builder.timeout : Duration.ofMinutes(5);
     }
 
     private static String sanitizeName(String host) {


### PR DESCRIPTION
## Problem

Remote MCP servers proxied through `HttpMcpProxy` have a hardcoded 60-second HTTP request timeout. MCP tool calls often back long-running operations (e.g., database queries, Lambda invocations) that routinely exceed 60 seconds, causing consistent timeouts for legitimate use cases.

## Solution

Increase the default timeout from `Duration.ofSeconds(60)` to `Duration.ofMinutes(5)`.

The `.timeout(Duration)` builder method remains available for callers who need a specific value. This change only affects the fallback default when no timeout is explicitly configured.

## Impact

- Slow tools that were failing now succeed
- Callers who explicitly set `.timeout()` are unaffected
- Broken/unresponsive servers will take longer to fail (5min vs 60s), but MCP calls are interactive and users can cancel

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*