### PR TITLE
Remove default from JsonArraySchema

### DIFF
--- a/mcp/mcp-schemas/model/main.smithy
+++ b/mcp/mcp-schemas/model/main.smithy
@@ -129,8 +129,6 @@ structure JsonArraySchema {
     uniqueItems: PrimitiveBoolean = false
 
     description: String
-
-    default: Document
 }
 
 structure JsonPrimitiveSchema {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I am not sure why this was added in https://github.com/smithy-lang/smithy-java/pull/733, JSON Schema doesn't specify any such field for arrays, https://json-schema.org/understanding-json-schema/reference/array


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
