### PR TITLE
Allow lists being marked as httpPayload

### DIFF
--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializer.java
@@ -126,7 +126,8 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
                                 return body;
                             }
                         });
-                    } else if (member.type() == ShapeType.STRUCTURE || member.type() == ShapeType.UNION) {
+                    } else if (member.type() == ShapeType.STRUCTURE || member.type() == ShapeType.UNION
+                            || member.type() == ShapeType.LIST) {
                         // Read the payload into a byte buffer to deserialize a shape in the body.
                         ByteBuffer bb = bodyAsByteBuffer();
                         if (bb.remaining() > 0) {


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*

When developing a custom protocol based on JSON it is not possible to have a list marked as `@httpPayload`, e.g. for the model:

```smithy
operation Op {
  output := {
    @httpPayload
    content: StringList
  }
}

list StringList {
  member: String
}
```

Whilst it is possible to define such model in a custom protocol (with `aws.protocols#restJson1` it still validates the model and fails with an error that AWS Protocols don't support it).

I understand why built-in/AWS protocols might not want to support it (e.g. enforcing best practices), but it feels like it should be possible to define this in a custom protocol (especially for backward compatibility when onboarding smithy to an existing services).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
