### PR TITLE
Fixing shadow build to include transitive dependencies

### DIFF
--- a/codecs/json-codec/build.gradle.kts
+++ b/codecs/json-codec/build.gradle.kts
@@ -37,7 +37,8 @@ tasks {
     }
 }
 
-(components["shadow"] as AdhocComponentWithVariants).addVariantsFromConfiguration(configurations.apiElements.get()) {
+configurations {
+    shadow.get().extendsFrom(api.get())
 }
 
 configurePublishing {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Not sure if it is intended, but currently it is not possible to consume json-codec library in order to implement custom protocol based on json and by utilizing smithy-java's codecs (by not re-implementing the wheel). This change fixes this and makes it available for others to consume.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
