### PR TITLE
Add a dollar sign prefix to the inner types for enums to avoid conflicts

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
@@ -114,7 +114,7 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
                 types.add(fieldName);
                 writer.putContext("fieldName", fieldName);
                 writer.putContext("className", className);
-                writer.write("${shape:T} ${fieldName:L} = new ${className:L}();");
+                writer.write("${shape:T} ${fieldName:L} = new $$${className:L}();");
                 writer.popState();
             }
             writer.putContext("types", types);
@@ -186,8 +186,8 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
                 var memberValue = enumValues.get(member.getMemberName());
 
                 var template = """
-                        final class ${className:L} implements ${shape:T} {
-                            private ${className:L}() {}
+                        final class $$${className:L} implements ${shape:T} {
+                            private $$${className:L}() {}
 
                             @Override
                             public ${value:N} getValue() {

--- a/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/NamingTest.java
+++ b/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/NamingTest.java
@@ -148,7 +148,7 @@ public class NamingTest extends AbstractCodegenFileTest {
         // Enum field stays as UPPER_SNAKE_CASE (like CAMEL_CASE), but inner class uses PascalCase + Type suffix (like CamelCaseType)
         // Sealed interface pattern: EnumCasing CAMEL_CASE = new CamelCaseType(); with getValue() returning "camelCase"
         var className = CaseUtils.toPascalCase(updated) + "Type";
-        assertTrue(fileStr.contains(String.format("EnumCasing %s = new %s();", updated, className)));
+        assertTrue(fileStr.contains(String.format("EnumCasing %s = new $%s();", updated, className)));
         assertTrue(fileStr.contains(String.format("return \"%s\";", original)));
     }
 }

--- a/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/codegen-core/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -201,12 +201,12 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                                      * @deprecated As of the past.
                                      */
                                     @Deprecated(since = "the past")
-                                    EnumWithDocs DOCUMENTED = new DocumentedType();
+                                    EnumWithDocs DOCUMENTED = new $DocumentedType();
                                     /**
                                      * General Docs
                                      */
                                     @SmithyUnstableApi
-                                    EnumWithDocs ALSO_DOCUMENTED = new AlsoDocumentedType();
+                                    EnumWithDocs ALSO_DOCUMENTED = new $AlsoDocumentedType();
                                 """));
     }
 

--- a/codegen/plugins/types-codegen/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/enums/expected/EnumType.java
+++ b/codegen/plugins/types-codegen/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/enums/expected/EnumType.java
@@ -15,8 +15,8 @@ import software.amazon.smithy.utils.SmithyGenerated;
 
 @SmithyGenerated
 public sealed interface EnumType extends SerializableShape {
-    EnumType OPTION_ONE = new OptionOneType();
-    EnumType OPTION_TWO = new OptionTwoType();
+    EnumType OPTION_ONE = new $OptionOneType();
+    EnumType OPTION_TWO = new $OptionTwoType();
     List<EnumType> $TYPES = List.of(OPTION_ONE, OPTION_TWO);
 
     Schema $SCHEMA = Schema.createEnum(ShapeId.from("smithy.java.codegen.types.naming#EnumType"),
@@ -62,8 +62,8 @@ public sealed interface EnumType extends SerializableShape {
         };
     }
 
-    final class OptionOneType implements EnumType {
-        private OptionOneType() {}
+    final class $OptionOneType implements EnumType {
+        private $OptionOneType() {}
 
         @Override
         public String getValue() {
@@ -77,8 +77,8 @@ public sealed interface EnumType extends SerializableShape {
 
     }
 
-    final class OptionTwoType implements EnumType {
-        private OptionTwoType() {}
+    final class $OptionTwoType implements EnumType {
+        private $OptionTwoType() {}
 
         @Override
         public String getValue() {

--- a/codegen/plugins/types-codegen/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/enums/expected/IntEnumType.java
+++ b/codegen/plugins/types-codegen/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/enums/expected/IntEnumType.java
@@ -14,9 +14,9 @@ import software.amazon.smithy.utils.SmithyGenerated;
 
 @SmithyGenerated
 public sealed interface IntEnumType extends SerializableShape {
-    IntEnumType FIRST = new FirstType();
-    IntEnumType SECOND = new SecondType();
-    IntEnumType FIFTH = new FifthType();
+    IntEnumType FIRST = new $FirstType();
+    IntEnumType SECOND = new $SecondType();
+    IntEnumType FIFTH = new $FifthType();
     List<IntEnumType> $TYPES = List.of(FIRST, SECOND, FIFTH);
 
     Schema $SCHEMA = Schema.createIntEnum(ShapeId.from("smithy.java.codegen.types.naming#IntEnumType"),
@@ -63,8 +63,8 @@ public sealed interface IntEnumType extends SerializableShape {
         };
     }
 
-    final class FirstType implements IntEnumType {
-        private FirstType() {}
+    final class $FirstType implements IntEnumType {
+        private $FirstType() {}
 
         @Override
         public int getValue() {
@@ -78,8 +78,8 @@ public sealed interface IntEnumType extends SerializableShape {
 
     }
 
-    final class SecondType implements IntEnumType {
-        private SecondType() {}
+    final class $SecondType implements IntEnumType {
+        private $SecondType() {}
 
         @Override
         public int getValue() {
@@ -93,8 +93,8 @@ public sealed interface IntEnumType extends SerializableShape {
 
     }
 
-    final class FifthType implements IntEnumType {
-        private FifthType() {}
+    final class $FifthType implements IntEnumType {
+        private $FifthType() {}
 
         @Override
         public int getValue() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds a `$` prefix to the names of the inner types for enums. This avoids naming conflicts with enums for which is outer name matches the generated name of the value class.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
