### PR TITLE
Add DataStream.writeTo() and DataStream fixes

### DIFF
--- a/io/src/main/java/software/amazon/smithy/java/io/ByteBufferOutputStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/ByteBufferOutputStream.java
@@ -69,6 +69,35 @@ public final class ByteBufferOutputStream extends OutputStream {
     }
 
     /**
+     * Returns the internal buffer array.
+     *
+     * <p>This provides direct access to avoid copying. The valid data is from index 0 to {@link #size()} - 1.
+     * The buffer may be larger than the valid data. Do not hold onto a reference to this data.
+     *
+     * @return the internal buffer
+     */
+    public byte[] array() {
+        return buf;
+    }
+
+    /**
+     * Writes an ASCII string directly to the buffer.
+     * Each character is cast to a byte (assumes ASCII/Latin-1 input).
+     *
+     * @param s the string to write
+     */
+    @SuppressWarnings("deprecation")
+    public void writeAscii(String s) {
+        int len = s.length();
+        if (len == 0) {
+            return;
+        }
+        ensureCapacity(count + len);
+        s.getBytes(0, len, buf, count);
+        count += len;
+    }
+
+    /**
      * Resets the stream to empty, allowing buffer reuse.
      * The internal buffer is retained, avoiding reallocation.
      */

--- a/io/src/main/java/software/amazon/smithy/java/io/ByteBufferUtils.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/ByteBufferUtils.java
@@ -5,7 +5,9 @@
 
 package software.amazon.smithy.java.io;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -74,6 +76,17 @@ public final class ByteBufferUtils {
             len = Math.min(len, b.remaining());
             b.get(bytes, off, len);
             return len;
+        }
+
+        @Override
+        public long transferTo(OutputStream out) throws IOException {
+            // Skip buffering used in the default implementation.
+            int remaining = b.remaining();
+            if (remaining > 0 && b.hasArray()) {
+                out.write(b.array(), b.arrayOffset() + b.position(), remaining);
+                b.position(b.limit());
+            }
+            return remaining;
         }
     }
 }

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/ByteBufferDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/ByteBufferDataStream.java
@@ -5,7 +5,9 @@
 
 package software.amazon.smithy.java.io.datastream;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.http.HttpRequest;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Flow;
@@ -43,7 +45,14 @@ final class ByteBufferDataStream implements DataStream {
 
     @Override
     public InputStream asInputStream() {
-        return ByteBufferUtils.byteBufferInputStream(buffer);
+        // Use duplicate() to avoid mutating the original buffer's position,
+        // allowing the DataStream to be replayed (isReplayable() returns true)
+        return ByteBufferUtils.byteBufferInputStream(buffer.duplicate());
+    }
+
+    @Override
+    public void writeTo(OutputStream out) throws IOException {
+        out.write(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
     }
 
     @Override

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/DataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/DataStream.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.io.datastream;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.http.HttpRequest;
 import java.nio.ByteBuffer;
@@ -83,6 +84,22 @@ public interface DataStream extends Flow.Publisher<ByteBuffer>, AutoCloseable {
      * @return Returns the future that contains the blocking {@code InputStream}.
      */
     InputStream asInputStream();
+
+    /**
+     * Write the contents of this stream to the given output stream.
+     *
+     * <p>This is the preferred way to transfer data from a DataStream to an OutputStream.
+     * Implementations may override this to avoid intermediate InputStream allocation
+     * (e.g., writing directly from a byte array or ByteBuffer).
+     *
+     * @param out the output stream to write to
+     * @throws IOException if an I/O error occurs
+     */
+    default void writeTo(OutputStream out) throws IOException {
+        try (var is = asInputStream()) {
+            is.transferTo(out);
+        }
+    }
 
     /**
      * Read the contents of the stream into a ByteBuffer by reading all bytes from {@link #asInputStream()}.

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/EmptyDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/EmptyDataStream.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.io.datastream;
 
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.http.HttpRequest;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Flow;
@@ -24,6 +25,11 @@ final class EmptyDataStream implements DataStream {
     @Override
     public InputStream asInputStream() {
         return InputStream.nullInputStream();
+    }
+
+    @Override
+    public void writeTo(OutputStream out) {
+        // No-op
     }
 
     @Override

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/InputStreamDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/InputStreamDataStream.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.io.datastream;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
 
 final class InputStreamDataStream implements DataStream {
@@ -30,6 +31,11 @@ final class InputStreamDataStream implements DataStream {
         }
         consumed = true;
         return inputStream;
+    }
+
+    @Override
+    public void writeTo(OutputStream out) throws IOException {
+        asInputStream().transferTo(out);
     }
 
     @Override

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/WrappedDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/WrappedDataStream.java
@@ -5,7 +5,9 @@
 
 package software.amazon.smithy.java.io.datastream;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Flow;
 
@@ -31,6 +33,11 @@ final class WrappedDataStream implements DataStream {
     @Override
     public InputStream asInputStream() {
         return delegate.asInputStream();
+    }
+
+    @Override
+    public void writeTo(OutputStream out) throws IOException {
+        delegate.writeTo(out);
     }
 
     @Override

--- a/io/src/test/java/software/amazon/smithy/java/io/datastream/ByteBufferDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/datastream/ByteBufferDataStreamTest.java
@@ -8,7 +8,10 @@ package software.amazon.smithy.java.io.datastream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
@@ -30,5 +33,30 @@ public class ByteBufferDataStreamTest {
         assertThat(ds.isAvailable(), is(true));
         ds.asByteBuffer();
         assertThat(ds.isAvailable(), is(true));
+    }
+
+    @Test
+    public void writeTo() throws IOException {
+        var data = "hello world".getBytes(StandardCharsets.UTF_8);
+        var ds = DataStream.ofBytes(data);
+        var out = new ByteArrayOutputStream();
+
+        ds.writeTo(out);
+
+        assertArrayEquals(data, out.toByteArray());
+    }
+
+    @Test
+    public void writeToIsReplayable() throws IOException {
+        var data = "replay".getBytes(StandardCharsets.UTF_8);
+        var ds = DataStream.ofBytes(data);
+
+        var out1 = new ByteArrayOutputStream();
+        ds.writeTo(out1);
+        var out2 = new ByteArrayOutputStream();
+        ds.writeTo(out2);
+
+        assertArrayEquals(data, out1.toByteArray());
+        assertArrayEquals(data, out2.toByteArray());
     }
 }

--- a/io/src/test/java/software/amazon/smithy/java/io/datastream/InputStreamDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/datastream/InputStreamDataStreamTest.java
@@ -9,7 +9,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -86,5 +91,24 @@ public class InputStreamDataStreamTest {
 
         ds.asInputStream();
         assertThat(ds.isAvailable(), is(false));
+    }
+
+    @Test
+    public void writeTo() throws IOException {
+        var data = "from input stream".getBytes(StandardCharsets.UTF_8);
+        var ds = DataStream.ofInputStream(new ByteArrayInputStream(data));
+        var out = new ByteArrayOutputStream();
+
+        ds.writeTo(out);
+
+        assertArrayEquals(data, out.toByteArray());
+    }
+
+    @Test
+    public void writeToNotReplayable() throws IOException {
+        var ds = DataStream.ofInputStream(new ByteArrayInputStream(new byte[] {1, 2, 3}));
+        ds.writeTo(new ByteArrayOutputStream());
+
+        assertThrows(IllegalStateException.class, () -> ds.writeTo(new ByteArrayOutputStream()));
     }
 }

--- a/io/src/test/java/software/amazon/smithy/java/io/datastream/PublisherDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/datastream/PublisherDataStreamTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.io.datastream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.SubmissionPublisher;
+import org.junit.jupiter.api.Test;
+
+class PublisherDataStreamTest {
+
+    @Test
+    void writeTo() throws IOException {
+        var chunk1 = "hello ".getBytes(StandardCharsets.UTF_8);
+        var chunk2 = "world".getBytes(StandardCharsets.UTF_8);
+
+        var publisher = new SubmissionPublisher<ByteBuffer>();
+        var ds = DataStream.ofPublisher(publisher, null, -1);
+        var out = new ByteArrayOutputStream();
+
+        // Run writeTo on a virtual thread so it subscribes to the publisher
+        // before items are submitted, avoiding a race where close() fires
+        // before the subscription is established.
+        var writeThread = Thread.startVirtualThread(() -> {
+            try {
+                ds.writeTo(out);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Wait for writeTo's subscriber to be registered.
+        while (publisher.getNumberOfSubscribers() < 1) {
+            Thread.onSpinWait();
+        }
+
+        publisher.submit(ByteBuffer.wrap(chunk1));
+        publisher.submit(ByteBuffer.wrap(chunk2));
+        publisher.close();
+
+        try {
+            writeThread.join();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertArrayEquals("hello world".getBytes(StandardCharsets.UTF_8), out.toByteArray());
+    }
+
+    @Test
+    void writeToNotReplayable() throws IOException {
+        var publisher = new SubmissionPublisher<ByteBuffer>();
+        var ds = DataStream.ofPublisher(publisher, null, -1);
+
+        Thread.startVirtualThread(publisher::close);
+        ds.writeTo(new ByteArrayOutputStream());
+
+        assertThrows(IllegalStateException.class, () -> ds.writeTo(new ByteArrayOutputStream()));
+    }
+
+    @Test
+    void writeToEmpty() throws IOException {
+        var publisher = new SubmissionPublisher<ByteBuffer>();
+        var ds = DataStream.ofPublisher(publisher, null, 0);
+        var out = new ByteArrayOutputStream();
+
+        Thread.startVirtualThread(publisher::close);
+        ds.writeTo(out);
+
+        assertEquals(0, out.size());
+    }
+}

--- a/io/src/test/java/software/amazon/smithy/java/io/datastream/WrappedDataStreamTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/datastream/WrappedDataStreamTest.java
@@ -8,8 +8,11 @@ package software.amazon.smithy.java.io.datastream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
@@ -32,5 +35,17 @@ public class WrappedDataStreamTest {
         assertThat(wrapped.isAvailable(), is(true));
         ds.asInputStream();
         assertThat(wrapped.isAvailable(), is(false));
+    }
+
+    @Test
+    public void writeToDelegates() throws IOException {
+        var data = "wrapped".getBytes(StandardCharsets.UTF_8);
+        var inner = DataStream.ofBytes(data);
+        var ds = DataStream.withMetadata(inner, "text/plain", (long) data.length, true);
+        var out = new ByteArrayOutputStream();
+
+        ds.writeTo(out);
+
+        assertArrayEquals(data, out.toByteArray());
     }
 }


### PR DESCRIPTION
Add writeTo(OutputStream) to DataStream interface with optimized overrides in all implementations.

Also:
- Fix ByteBufferDataStream.asInputStream() to use buffer.duplicate() so the stream remains replayable
- Add ByteBufferOutputStream utility class
- Add ByteBufferUtils.wrap(ByteBuffer) helper

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
