### PR TITLE
feat(mcp): infer ToolAnnotations from @readonly and @idempotent traits

### DIFF
--- a/mcp/mcp-schemas/model/main.smithy
+++ b/mcp/mcp-schemas/model/main.smithy
@@ -96,6 +96,13 @@ structure ToolInfo {
     inputSchema: JsonObjectSchema
 
     outputSchema: JsonObjectSchema
+
+    annotations: ToolAnnotations
+}
+
+structure ToolAnnotations {
+    readOnlyHint: Boolean
+    idempotentHint: Boolean
 }
 
 list ToolInfoList {

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpService.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpService.java
@@ -56,6 +56,7 @@ import software.amazon.smithy.java.mcp.model.PromptInfo;
 import software.amazon.smithy.java.mcp.model.Prompts;
 import software.amazon.smithy.java.mcp.model.ServerInfo;
 import software.amazon.smithy.java.mcp.model.TextContent;
+import software.amazon.smithy.java.mcp.model.ToolAnnotations;
 import software.amazon.smithy.java.mcp.model.ToolInfo;
 import software.amazon.smithy.java.mcp.model.Tools;
 import software.amazon.smithy.java.server.Operation;
@@ -250,12 +251,11 @@ public final class McpService {
     }
 
     private JsonRpcResponse handleToolsList(JsonRpcRequest req, ProtocolVersion protocolVersion) {
-        var supportsOutputSchema = supportsOutputSchema(protocolVersion);
         var result = ListToolsResult.builder()
                 .tools(tools.values()
                         .stream()
                         .filter(t -> toolFilter.allowTool(t.serverId(), t.toolInfo().getName()))
-                        .map(tool -> extractToolInfo(tool, supportsOutputSchema))
+                        .map(tool -> extractToolInfo(tool, protocolVersion))
                         .toList())
                 .build();
         return createSuccessResponse(req.getId(), result);
@@ -467,6 +467,10 @@ public final class McpService {
         return protocolVersion != null && protocolVersion.compareTo(ProtocolVersion.v2025_06_18.INSTANCE) >= 0;
     }
 
+    private boolean supportsAnnotations(ProtocolVersion protocolVersion) {
+        return protocolVersion != null && protocolVersion.compareTo(ProtocolVersion.v2025_03_26.INSTANCE) >= 0;
+    }
+
     private CallToolResult formatStructuredContent(
             Tool tool,
             SerializableShape output,
@@ -485,14 +489,21 @@ public final class McpService {
         return result.build();
     }
 
-    private ToolInfo extractToolInfo(Tool tool, boolean supportsOutput) {
+    private ToolInfo extractToolInfo(Tool tool, ProtocolVersion protocolVersion) {
         var toolInfo = tool.toolInfo();
-        if (supportsOutput || toolInfo.getOutputSchema() == null) {
+        boolean stripOutput = !supportsOutputSchema(protocolVersion) && toolInfo.getOutputSchema() != null;
+        boolean stripAnnotations = !supportsAnnotations(protocolVersion) && toolInfo.getAnnotations() != null;
+        if (!stripOutput && !stripAnnotations) {
             return toolInfo;
         }
-        return toolInfo.toBuilder()
-                .outputSchema(null)
-                .build();
+        var builder = toolInfo.toBuilder();
+        if (stripOutput) {
+            builder.outputSchema(null);
+        }
+        if (stripAnnotations) {
+            builder.annotations(null);
+        }
+        return builder.build();
     }
 
     private void validate(JsonRpcRequest req) {
@@ -588,11 +599,28 @@ public final class McpService {
                                 operation.getApiOperation().outputSchema(),
                                 new HashSet<>(),
                                 cache))
+                        .annotations(createAnnotations(schema))
                         .build();
                 tools.put(operationName, new Tool(toolInfo, id, operation));
             }
         }
         return tools;
+    }
+
+    private ToolAnnotations createAnnotations(Schema operationSchema) {
+        boolean isReadOnly = operationSchema.hasTrait(TraitKey.READ_ONLY_TRAIT);
+        boolean isIdempotent = operationSchema.hasTrait(TraitKey.IDEMPOTENT_TRAIT);
+        if (!isReadOnly && !isIdempotent) {
+            return null;
+        }
+        var builder = ToolAnnotations.builder();
+        if (isReadOnly) {
+            builder.readOnlyHint(true);
+        }
+        if (isIdempotent) {
+            builder.idempotentHint(true);
+        }
+        return builder.build();
     }
 
     private JsonObjectSchema createJsonObjectSchema(

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
@@ -165,7 +165,7 @@ public class McpServerTest {
         var result = response.getResult().asStringMap();
         var tools = result.get("tools").asList();
 
-        assertEquals(4, tools.size());
+        assertEquals(6, tools.size());
 
         var toolNames = tools.stream()
                 .map(tool -> tool.asStringMap().get("name").asString())
@@ -175,6 +175,8 @@ public class McpServerTest {
         assertTrue(toolNames.contains("NoOutputOperation"));
         assertTrue(toolNames.contains("TestOperation"));
         assertTrue(toolNames.contains("NoInputOperation"));
+        assertTrue(toolNames.contains("ReadOnlyOperation"));
+        assertTrue(toolNames.contains("IdempotentOperation"));
     }
 
     @Test
@@ -329,6 +331,130 @@ public class McpServerTest {
 
         validateTestInputSchema(tool.get("inputSchema").asStringMap());
         validateTestInputSchema(tool.get("outputSchema").asStringMap());
+    }
+
+    @Test
+    void readOnlyOperationHasReadOnlyHintAnnotation() {
+        server = McpServer.builder()
+                .name("smithy-mcp-server")
+                .input(input)
+                .output(output)
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
+                .build();
+
+        server.start();
+
+        initializeWithProtocolVersion(null);
+        write("tools/list", Document.of(Map.of()));
+        var response = read();
+        var tools = response.getResult().asStringMap().get("tools").asList();
+
+        var tool = tools.stream()
+                .filter(t -> t.asStringMap().get("name").asString().equals("ReadOnlyOperation"))
+                .findFirst()
+                .orElseThrow()
+                .asStringMap();
+
+        var annotations = tool.get("annotations").asStringMap();
+        assertTrue(annotations.get("readOnlyHint").asBoolean());
+        assertNull(annotations.get("idempotentHint"));
+    }
+
+    @Test
+    void idempotentOperationHasIdempotentHintAnnotation() {
+        server = McpServer.builder()
+                .name("smithy-mcp-server")
+                .input(input)
+                .output(output)
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
+                .build();
+
+        server.start();
+
+        initializeWithProtocolVersion(null);
+        write("tools/list", Document.of(Map.of()));
+        var response = read();
+        var tools = response.getResult().asStringMap().get("tools").asList();
+
+        var tool = tools.stream()
+                .filter(t -> t.asStringMap().get("name").asString().equals("IdempotentOperation"))
+                .findFirst()
+                .orElseThrow()
+                .asStringMap();
+
+        var annotations = tool.get("annotations").asStringMap();
+        assertTrue(annotations.get("idempotentHint").asBoolean());
+        assertNull(annotations.get("readOnlyHint"));
+    }
+
+    @Test
+    void plainOperationHasNoAnnotations() {
+        server = McpServer.builder()
+                .name("smithy-mcp-server")
+                .input(input)
+                .output(output)
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
+                .build();
+
+        server.start();
+
+        initializeWithProtocolVersion(null);
+        write("tools/list", Document.of(Map.of()));
+        var response = read();
+        var tools = response.getResult().asStringMap().get("tools").asList();
+
+        var tool = tools.stream()
+                .filter(t -> t.asStringMap().get("name").asString().equals("TestOperation"))
+                .findFirst()
+                .orElseThrow()
+                .asStringMap();
+
+        assertNull(tool.get("annotations"));
+    }
+
+    @Test
+    void annotationsStrippedForOldProtocolVersion() {
+        server = McpServer.builder()
+                .name("smithy-mcp-server")
+                .input(input)
+                .output(output)
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
+                .build();
+
+        server.start();
+
+        initializeWithProtocolVersion(ProtocolVersion.v2024_11_05.INSTANCE);
+        write("tools/list", Document.of(Map.of()));
+        var response = read();
+        var tools = response.getResult().asStringMap().get("tools").asList();
+
+        var tool = tools.stream()
+                .filter(t -> t.asStringMap().get("name").asString().equals("ReadOnlyOperation"))
+                .findFirst()
+                .orElseThrow()
+                .asStringMap();
+
+        assertNull(tool.get("annotations"));
     }
 
     @Test
@@ -1086,7 +1212,7 @@ public class McpServerTest {
                         search_users: { description: "Test Template", template: "Search for if many results expected." }
                     })
                     service TestService {
-                        operations: [TestOperation, NoInputOperation, NoOutputOperation, NoIOOperation]
+                        operations: [TestOperation, NoInputOperation, NoOutputOperation, NoIOOperation, ReadOnlyOperation, IdempotentOperation]
                     }
 
                     operation NoOutputOperation {
@@ -1102,6 +1228,26 @@ public class McpServerTest {
                     }
 
                     operation NoIOOperation {}
+
+                    @readonly
+                    operation ReadOnlyOperation {
+                        input := {
+                            query: String
+                        }
+                        output := {
+                            result: String
+                        }
+                    }
+
+                    @idempotent
+                    operation IdempotentOperation {
+                        input := {
+                            key: String
+                        }
+                        output := {
+                            value: String
+                        }
+                    }
 
                     /// A TestOperation
                     @prompts({


### PR DESCRIPTION
   Background

   - Adds ToolAnnotations support to the MCP server module, automatically inferring readOnlyHint from @readonly and idempotentHint
    from @idempotent Smithy traits on operations.
   - The MCP spec includes these hints to help LLM clients understand tool behavior. Without them, clients must assume worst-case
   defaults (mutable, non-idempotent).

   Testing

   - Added three test cases to McpServerTest: verifies @readonly emits readOnlyHint: true, @idempotent emits idempotentHint: true,
   and plain operations omit annotations entirely.
   - All existing tests pass with updated tool count.

   Links

   - MCP spec ToolAnnotations: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-03-26/schema.json
    (https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-03-26/schema.json)

   ───────────────────────────────────────

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
