### PR TITLE
JDK HTTP client perf

### DIFF
--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientReplayableByteBufferPublisher.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientReplayableByteBufferPublisher.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http;
+
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Fast path {@link HttpRequest.BodyPublisher} for replayable in-memory {@link ByteBuffer} bodies.
+ *
+ * <p>Publishes the body in a single {@code onNext} without forcing a {@code byte[]} copy or an
+ * extra publisher wrapper.
+ */
+final class JavaHttpClientReplayableByteBufferPublisher implements HttpRequest.BodyPublisher {
+    private final ByteBuffer body;
+
+    JavaHttpClientReplayableByteBufferPublisher(ByteBuffer body) {
+        this.body = body.asReadOnlyBuffer();
+    }
+
+    @Override
+    public long contentLength() {
+        return body.remaining();
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
+        subscriber.onSubscribe(new Flow.Subscription() {
+            private final AtomicBoolean completed = new AtomicBoolean();
+
+            @Override
+            public void request(long n) {
+                if (n <= 0 || !completed.compareAndSet(false, true)) {
+                    return;
+                } else {
+                    subscriber.onNext(body.duplicate());
+                    subscriber.onComplete();
+                }
+            }
+
+            @Override
+            public void cancel() {
+                completed.set(true);
+            }
+        });
+    }
+}

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientSmallBodySubscriber.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientSmallBodySubscriber.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http;
+
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
+import software.amazon.smithy.java.io.datastream.DataStream;
+
+/**
+ * Small-body subscriber for known-length responses that fit in memory cheaply.
+ *
+ * <p>Allocates one array up front and completes with a replayable {@link DataStream}.
+ */
+final class JavaHttpClientSmallBodySubscriber implements HttpResponse.BodySubscriber<DataStream> {
+    private final String contentType;
+    private final byte[] bytes;
+    private int position;
+    private final CompletableFuture<DataStream> body = new CompletableFuture<>();
+
+    JavaHttpClientSmallBodySubscriber(HttpHeaders headers, int contentLength) {
+        this.contentType = headers.firstValue("content-type").orElse(null);
+        this.bytes = new byte[Math.max(contentLength, 0)];
+    }
+
+    @Override
+    public CompletionStage<DataStream> getBody() {
+        return body;
+    }
+
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+        // This path is only used for known small bodies, so the full response is already
+        // bounded by the fast-path threshold and can be aggregated safely in memory.
+        subscription.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(List<ByteBuffer> item) {
+        for (ByteBuffer buffer : item) {
+            int remaining = buffer.remaining();
+            buffer.get(bytes, position, remaining);
+            position += remaining;
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        body.completeExceptionally(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        byte[] result = position == bytes.length ? bytes : Arrays.copyOf(bytes, position);
+        body.complete(DataStream.ofBytes(result, contentType));
+    }
+}

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientTransport.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpClientTransport.java
@@ -5,15 +5,22 @@
 
 package software.amazon.smithy.java.client.http;
 
+import static java.net.http.HttpRequest.BodyPublisher;
 import static java.net.http.HttpRequest.BodyPublishers;
-import static java.net.http.HttpResponse.BodyHandlers;
+import static java.net.http.HttpResponse.BodyHandler;
+import static java.net.http.HttpResponse.BodySubscriber;
+import static java.net.http.HttpResponse.BodySubscribers;
+import static java.net.http.HttpResponse.ResponseInfo;
+import static software.amazon.smithy.java.http.api.HttpHeaders.HeaderWithValueConsumer;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpConnectTimeoutException;
+import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import software.amazon.smithy.java.client.core.ClientTransport;
 import software.amazon.smithy.java.client.core.ClientTransportFactory;
 import software.amazon.smithy.java.client.core.MessageExchange;
@@ -21,33 +28,43 @@ import software.amazon.smithy.java.client.core.error.ConnectTimeoutException;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.http.api.HeaderName;
-import software.amazon.smithy.java.http.api.HttpHeaders;
 import software.amazon.smithy.java.http.api.HttpRequest;
 import software.amazon.smithy.java.http.api.HttpResponse;
 import software.amazon.smithy.java.http.api.HttpVersion;
-import software.amazon.smithy.java.io.ByteBufferUtils;
 import software.amazon.smithy.java.io.datastream.DataStream;
 import software.amazon.smithy.java.logging.InternalLogger;
 
 /**
- * A client transport that uses Java's built-in {@link HttpClient} to send {@link HttpRequest} and return
- * {@link HttpResponse}.
+ * Smithy HTTP transport backed by Java's built-in {@link HttpClient}.
+ *
+ * <p>Uses a direct {@link ByteBuffer} request-body fast path for replayable in-memory bodies,
+ * a small-body response subscriber for known small responses, and a streaming bridge for larger
+ * response bodies. When this transport builds its own {@link HttpClient}, it also owns and
+ * closes the attached virtual-thread executor.
  */
 public final class JavaHttpClientTransport implements ClientTransport<HttpRequest, HttpResponse> {
 
     private static final URI DUMMY_URI = URI.create("http://localhost");
 
+    private static final int SMALL_RESPONSE_BODY_FAST_PATH_THRESHOLD = 64 * 1024;
+
+    private static final HeaderWithValueConsumer<java.net.http.HttpRequest.Builder> VALUE_CONSUMER = (b, n, v) -> {
+        if (n != HeaderName.CONTENT_LENGTH.name()) {
+            b.setHeader(n, v);
+        }
+    };
+
     private static final InternalLogger LOGGER = InternalLogger.getLogger(JavaHttpClientTransport.class);
     private final HttpClient client;
     private final Duration defaultRequestTimeout;
+    private final ExecutorService ownedExecutor;
 
     static {
-        // For some reason, this can't just be done in the constructor to always take effect.
         setHostProperties();
+        setDefaultTuningProperties();
     }
 
     private static void setHostProperties() {
-        // Allow clients to set Host header. This has to be done using a system property and can't be done per/client.
         var currentValues = System.getProperty("jdk.httpclient.allowRestrictedHeaders");
         if (currentValues == null || currentValues.isEmpty()) {
             System.setProperty("jdk.httpclient.allowRestrictedHeaders", "host");
@@ -60,31 +77,51 @@ public final class JavaHttpClientTransport implements ClientTransport<HttpReques
                     .setHeader("host", "localhost")
                     .build();
         } catch (IllegalArgumentException e) {
-            throw new RuntimeException("Unable to add host header. " +
-                    "This means that the HttpClient was initialized before we could allowlist it. " +
-                    "You need to explicitly set allow `host` via the system property `jdk.httpclient.allowRestrictedHeaders`",
+            throw new RuntimeException("Unable to add host header. "
+                    + "This means that the HttpClient was initialized before we could allowlist it. "
+                    + "You need to explicitly set allow `host` via the system property "
+                    + "`jdk.httpclient.allowRestrictedHeaders`",
                     e);
         }
     }
 
-    public JavaHttpClientTransport() {
-        this(HttpClient.newHttpClient(), null);
+    /**
+     * Set JVM-global JDK HttpClient tuning defaults when the application has not already set
+     * them.
+     */
+    private static void setDefaultTuningProperties() {
+        setIfUnset("jdk.httpclient.maxframesize", "65536");
+        setIfUnset("jdk.httpclient.maxstreams", "1024");
+        setIfUnset("jdk.httpclient.bufsize", "65536");
     }
 
-    /**
-     * @param client Java client to use.
-     */
+    private static void setIfUnset(String name, String value) {
+        if (System.getProperty(name) == null) {
+            System.setProperty(name, value);
+        }
+    }
+
+    public JavaHttpClientTransport() {
+        this.ownedExecutor = Executors.newVirtualThreadPerTaskExecutor();
+        this.client = HttpClient.newBuilder().executor(ownedExecutor).build();
+        this.defaultRequestTimeout = null;
+        setHostProperties();
+    }
+
     public JavaHttpClientTransport(HttpClient client) {
         this(client, null);
     }
 
-    /**
-     * @param client Java client to use.
-     * @param defaultRequestTimeout Default per-request timeout. Used when {@link HttpContext#HTTP_REQUEST_TIMEOUT}
-     *                              is not set in the request context. Null means no default.
-     */
     public JavaHttpClientTransport(HttpClient client, Duration defaultRequestTimeout) {
         this.client = client;
+        this.ownedExecutor = null;
+        this.defaultRequestTimeout = defaultRequestTimeout;
+        setHostProperties();
+    }
+
+    private JavaHttpClientTransport(HttpClient client, ExecutorService ownedExecutor, Duration defaultRequestTimeout) {
+        this.client = client;
+        this.ownedExecutor = ownedExecutor;
         this.defaultRequestTimeout = defaultRequestTimeout;
         setHostProperties();
     }
@@ -93,17 +130,14 @@ public final class JavaHttpClientTransport implements ClientTransport<HttpReques
         int length = currentValues.length();
         for (int i = 0; i < length; i++) {
             char c = currentValues.charAt(i);
-            // Check if "host" starts at the current position.
             if ((c == 'h' || c == 'H') && i + 3 < length
                     && (currentValues.charAt(i + 1) == 'o')
                     && (currentValues.charAt(i + 2) == 's')
                     && (currentValues.charAt(i + 3) == 't')) {
-                // Ensure "t" is at the end or followed by a comma.
                 if (i + 4 == length || currentValues.charAt(i + 4) == ',') {
                     return true;
                 }
             }
-            // Skip to the next comma or end of string.
             while (i < length && currentValues.charAt(i) != ',') {
                 i++;
             }
@@ -121,16 +155,31 @@ public final class JavaHttpClientTransport implements ClientTransport<HttpReques
         return sendRequest(createJavaRequest(context, request));
     }
 
+    /**
+     * Convert a Smithy {@link HttpRequest} into a JDK {@link java.net.http.HttpRequest}.
+     *
+     * <p>Known-empty bodies use {@link BodyPublishers#noBody()}, replayable in-memory
+     * {@link ByteBuffer} bodies use {@link JavaHttpClientReplayableByteBufferPublisher}, and
+     * everything else falls back to {@link DataStream#bodyPublisher()}.
+     *
+     * <p>Request timeout precedence: context value takes priority over the transport-level
+     * {@link #defaultRequestTimeout}; if neither is set the JDK applies no timeout.
+     */
     private java.net.http.HttpRequest createJavaRequest(Context context, HttpRequest request) {
-        java.net.http.HttpRequest.BodyPublisher bodyPublisher;
-        if (request.body().hasKnownLength()) {
-            if (request.body().contentLength() == 0) {
-                bodyPublisher = BodyPublishers.noBody();
-            } else {
-                bodyPublisher = BodyPublishers.ofByteArray(ByteBufferUtils.getBytes(request.body().asByteBuffer()));
-            }
+        DataStream requestBody = request.body();
+        BodyPublisher bodyPublisher;
+        ByteBuffer replayableRequestBody = toReplayableBodyBuffer(requestBody);
+
+        if (replayableRequestBody != null) {
+            bodyPublisher = !replayableRequestBody.hasRemaining()
+                    ? BodyPublishers.noBody()
+                    : new JavaHttpClientReplayableByteBufferPublisher(replayableRequestBody);
+        } else if (requestBody.hasKnownLength()) {
+            bodyPublisher = requestBody.contentLength() == 0
+                    ? BodyPublishers.noBody()
+                    : BodyPublishers.fromPublisher(requestBody, requestBody.contentLength());
         } else {
-            bodyPublisher = BodyPublishers.ofInputStream(() -> request.body().asInputStream());
+            bodyPublisher = BodyPublishers.fromPublisher(requestBody);
         }
 
         var httpRequestBuilder = java.net.http.HttpRequest.newBuilder()
@@ -146,28 +195,36 @@ public final class JavaHttpClientTransport implements ClientTransport<HttpReques
             httpRequestBuilder.timeout(requestTimeout);
         }
 
-        // Any explicitly set headers overwrite existing headers, they do not merge.
-        request.headers().forEachEntry(httpRequestBuilder, (b, name, value) -> {
-            // Skip restricted headers; Header names in HttpHeaders are always canonicalized, so check by reference.
-            if (name != HeaderName.CONTENT_LENGTH.name()) {
-                b.setHeader(name, value);
-            }
-        });
-
+        request.headers().forEachEntry(httpRequestBuilder, VALUE_CONSUMER);
         return httpRequestBuilder.build();
     }
 
-    private HttpResponse sendRequest(java.net.http.HttpRequest request) {
-        java.net.http.HttpResponse<InputStream> res = null;
+    /**
+     * Return the body as a {@link ByteBuffer} when it can be published directly; otherwise
+     * return {@code null}.
+     */
+    private static ByteBuffer toReplayableBodyBuffer(DataStream requestBody) {
+        if (!requestBody.isReplayable() || !requestBody.hasKnownLength() || !requestBody.hasByteBuffer()) {
+            return null;
+        }
+
         try {
-            res = client.send(request, BodyHandlers.ofInputStream());
+            return requestBody.asByteBuffer().asReadOnlyBuffer();
+        } catch (UnsupportedOperationException | IllegalStateException e) {
+            return null;
+        }
+    }
+
+    private HttpResponse sendRequest(java.net.http.HttpRequest request) {
+        java.net.http.HttpResponse<DataStream> res = null;
+        try {
+            res = client.send(request, new ResponseBodyHandler());
             return createSmithyResponse(res);
         } catch (IOException | InterruptedException | RuntimeException e) {
-            // Close the response body stream if we got a response but failed to process it
             if (res != null) {
                 try {
                     res.body().close();
-                } catch (IOException closeException) {
+                } catch (RuntimeException closeException) {
                     LOGGER.trace("Failed to close response body after error", closeException);
                 }
             }
@@ -183,28 +240,16 @@ public final class JavaHttpClientTransport implements ClientTransport<HttpReques
     }
 
     // package-private for testing
-    HttpResponse createSmithyResponse(java.net.http.HttpResponse<InputStream> response) {
-        var headers = HttpHeaders.ofModifiable();
-        for (var e : response.headers().map().entrySet()) {
-            var name = e.getKey();
-            if (!name.equals(":status")) {
-                headers.addHeader(name, e.getValue());
-            }
-        }
-
+    HttpResponse createSmithyResponse(java.net.http.HttpResponse<? extends DataStream> response) {
+        var headers = new JavaHttpHeaders(response.headers());
         LOGGER.trace("Got response: {}; headers: {}", response, response.headers().map());
 
         var length = headers.contentLength();
         var adaptedLength = length == null ? -1 : length;
         var contentType = headers.contentType();
-        var body = DataStream.ofInputStream(response.body(), contentType, adaptedLength);
+        var body = DataStream.withMetadata(response.body(), contentType, adaptedLength, response.body().isReplayable());
 
-        return HttpResponse.create()
-                .setHttpVersion(javaToSmithyVersion(response.version()))
-                .setStatusCode(response.statusCode())
-                .setHeaders(headers)
-                .setBody(body)
-                .toUnmodifiable();
+        return new JavaHttpResponse(javaToSmithyVersion(response.version()), response.statusCode(), headers, body);
     }
 
     private static HttpClient.Version smithyToHttpVersion(HttpVersion version) {
@@ -225,7 +270,13 @@ public final class JavaHttpClientTransport implements ClientTransport<HttpReques
 
     @Override
     public void close() {
-        client.close();
+        try {
+            client.close();
+        } finally {
+            if (ownedExecutor != null) {
+                ownedExecutor.shutdown();
+            }
+        }
     }
 
     public static final class Factory implements ClientTransportFactory<HttpRequest, HttpResponse> {
@@ -238,22 +289,53 @@ public final class JavaHttpClientTransport implements ClientTransport<HttpReques
         public JavaHttpClientTransport createTransport(Document node, Document pluginSettings) {
             setHostProperties();
             // Start with httpConfig from plugin settings as baseline, then apply transport-specific settings on top.
-            var config = new HttpTransportConfig().fromDocument(pluginSettings.asStringMap()
-                    .getOrDefault("httpConfig", Document.EMPTY_MAP));
+            var config = new HttpTransportConfig()
+                    .fromDocument(pluginSettings.asStringMap().getOrDefault("httpConfig", Document.EMPTY_MAP));
             config.fromDocument(node);
-            var builder = HttpClient.newBuilder();
+
+            var executor = Executors.newVirtualThreadPerTaskExecutor();
+            var builder = HttpClient.newBuilder().executor(executor);
             if (config.httpVersion() != null) {
                 builder.version(smithyToHttpVersion(config.httpVersion()));
             }
             if (config.connectTimeout() != null) {
                 builder.connectTimeout(config.connectTimeout());
             }
-            return new JavaHttpClientTransport(builder.build(), config.requestTimeout());
+            return new JavaHttpClientTransport(builder.build(), executor, config.requestTimeout());
         }
 
         @Override
         public MessageExchange<HttpRequest, HttpResponse> messageExchange() {
             return HttpMessageExchange.INSTANCE;
+        }
+    }
+
+    /**
+     * Picks a {@link BodySubscriber} implementation based on the advertised response size.
+     *
+     * <p>Small-body fast path ({@link JavaHttpClientSmallBodySubscriber}): when
+     * {@code Content-Length} is present and within {@link #SMALL_RESPONSE_BODY_FAST_PATH_THRESHOLD}
+     * bytes, we pre-size a {@code byte[]} and accumulate the response fully before handing it
+     * back. The result is a replayable {@link DataStream} with known length, avoiding the producer/consumer hand-off
+     * of the streaming path.
+     *
+     * <p>If the fast path is not taken, the transport falls back to the JDK's built-in
+     * {@code ofInputStream()} body subscriber and wraps the returned stream as a Smithy
+     * {@link DataStream}.
+     */
+    private static final class ResponseBodyHandler implements BodyHandler<DataStream> {
+        @Override
+        public BodySubscriber<DataStream> apply(ResponseInfo responseInfo) {
+            long contentLength = responseInfo.headers().firstValueAsLong("content-length").orElse(-1L);
+
+            if (contentLength >= 0 && contentLength <= SMALL_RESPONSE_BODY_FAST_PATH_THRESHOLD) {
+                return new JavaHttpClientSmallBodySubscriber(responseInfo.headers(), (int) contentLength);
+            }
+
+            String contentType = responseInfo.headers().firstValue("content-type").orElse(null);
+            return BodySubscribers.mapping(
+                    BodySubscribers.ofInputStream(),
+                    inputStream -> DataStream.ofInputStream(inputStream, contentType, contentLength));
         }
     }
 }

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpHeaders.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpHeaders.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.java.http.api.HeaderName;
+import software.amazon.smithy.java.http.api.HttpHeaders;
+
+final class JavaHttpHeaders implements HttpHeaders {
+    private final java.net.http.HttpHeaders headers;
+    private volatile Map<String, List<String>> materialized;
+    private volatile int size = -1;
+
+    JavaHttpHeaders(java.net.http.HttpHeaders headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public List<String> allValues(String name) {
+        return allValuesCanonical(HeaderName.canonicalize(name));
+    }
+
+    @Override
+    public List<String> allValues(HeaderName name) {
+        return allValuesCanonical(name.name());
+    }
+
+    @Override
+    public int size() {
+        int result = size;
+        if (result >= 0) {
+            return result;
+        }
+
+        result = 0;
+        for (List<String> values : headers.map().values()) {
+            result += values.size();
+        }
+        size = result;
+        return result;
+    }
+
+    @Override
+    public Map<String, List<String>> map() {
+        Map<String, List<String>> result = materialized;
+        if (result != null) {
+            return result;
+        }
+
+        Map<String, List<String>> grouped = new LinkedHashMap<>();
+        for (var entry : headers.map().entrySet()) {
+            String canonical = HeaderName.canonicalize(entry.getKey());
+            if (canonical.equals(":status")) {
+                continue;
+            }
+            List<String> values = grouped.get(canonical);
+            if (values == null) {
+                values = new ArrayList<>(entry.getValue().size());
+                grouped.put(canonical, values);
+            }
+            values.addAll(entry.getValue());
+        }
+        materialized = grouped;
+        return grouped;
+    }
+
+    private List<String> allValuesCanonical(String canonical) {
+        Map<String, List<String>> cached = materialized;
+        if (cached != null) {
+            return cached.getOrDefault(canonical, Collections.emptyList());
+        }
+
+        if (canonical.equals(":status")) {
+            return Collections.emptyList();
+        }
+
+        List<String> values = null;
+        for (var entry : headers.map().entrySet()) {
+            if (HeaderName.canonicalize(entry.getKey()).equals(canonical)) {
+                if (values == null) {
+                    values = new ArrayList<>(entry.getValue().size());
+                }
+                values.addAll(entry.getValue());
+            }
+        }
+        return values == null ? Collections.emptyList() : values;
+    }
+}

--- a/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpResponse.java
+++ b/client/client-http/src/main/java/software/amazon/smithy/java/client/http/JavaHttpResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.http;
+
+import software.amazon.smithy.java.http.api.HttpHeaders;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.http.api.HttpVersion;
+import software.amazon.smithy.java.http.api.ModifiableHttpResponse;
+import software.amazon.smithy.java.io.datastream.DataStream;
+
+record JavaHttpResponse(
+        HttpVersion httpVersion,
+        int statusCode,
+        HttpHeaders headers,
+        DataStream body) implements HttpResponse {
+
+    @Override
+    public HttpResponse toUnmodifiable() {
+        return this;
+    }
+
+    @Override
+    public ModifiableHttpResponse toModifiable() {
+        return toModifiableCopy();
+    }
+
+    @Override
+    public ModifiableHttpResponse toModifiableCopy() {
+        return HttpResponse.create()
+                .setHttpVersion(httpVersion)
+                .setStatusCode(statusCode)
+                .setHeaders(headers.toModifiable())
+                .setBody(body);
+    }
+}

--- a/client/client-http/src/test/java/software/amazon/smithy/java/client/http/JavaHttpClientTest.java
+++ b/client/client-http/src/test/java/software/amazon/smithy/java/client/http/JavaHttpClientTest.java
@@ -11,26 +11,41 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.aws.client.awsjson.AwsJson1Protocol;
 import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.endpoints.EndpointResolver;
+import software.amazon.smithy.java.io.datastream.DataStream;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class JavaHttpClientTest {
@@ -106,7 +121,7 @@ public class JavaHttpClientTest {
     @Test
     public void filtersStatusPseudoHeaderFromResponse() throws Exception {
         // Create a fake Java HttpResponse with :status pseudo-header
-        var fakeResponse = new HttpResponse<InputStream>() {
+        var fakeResponse = new HttpResponse<DataStream>() {
             @Override
             public int statusCode() {
                 return 200;
@@ -120,8 +135,8 @@ public class JavaHttpClientTest {
             }
 
             @Override
-            public InputStream body() {
-                return new ByteArrayInputStream(new byte[0]);
+            public DataStream body() {
+                return DataStream.ofEmpty();
             }
 
             @Override
@@ -135,7 +150,7 @@ public class JavaHttpClientTest {
             }
 
             @Override
-            public Optional<HttpResponse<InputStream>> previousResponse() {
+            public Optional<HttpResponse<DataStream>> previousResponse() {
                 return Optional.empty();
             }
 
@@ -153,8 +168,499 @@ public class JavaHttpClientTest {
         var transport = new JavaHttpClientTransport();
         var response = transport.createSmithyResponse(fakeResponse);
 
+        assertInstanceOf(JavaHttpResponse.class, response);
+        assertInstanceOf(JavaHttpHeaders.class, response.headers());
         assertFalse(response.headers().map().containsKey(":status"),
                 "Response headers should not contain :status pseudo-header");
         assertThat(response.headers().firstValue("content-type"), equalTo("application/json"));
+    }
+
+    @Test
+    public void usesPublisherFastPathForKnownLengthBodies() {
+        byte[] payload = new byte[128 * 1024];
+        Arrays.fill(payload, (byte) 'a');
+        var client = new CapturingHttpClient();
+        var transport = new JavaHttpClientTransport(client);
+        var request = software.amazon.smithy.java.http.api.HttpRequest.create()
+                .setUri(URI.create("http://localhost/test"))
+                .setMethod("POST")
+                .setBody(new DataStream() {
+                    @Override
+                    public long contentLength() {
+                        return payload.length;
+                    }
+
+                    @Override
+                    public String contentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public boolean isReplayable() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isAvailable() {
+                        return true;
+                    }
+
+                    @Override
+                    public InputStream asInputStream() {
+                        throw new AssertionError("asInputStream should not be called");
+                    }
+
+                    @Override
+                    public ByteBuffer asByteBuffer() {
+                        return ByteBuffer.wrap(payload);
+                    }
+
+                    @Override
+                    public boolean hasByteBuffer() {
+                        return true;
+                    }
+
+                    @Override
+                    public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
+                        throw new AssertionError("subscribe should not be called");
+                    }
+                })
+                .toUnmodifiable();
+
+        try (var response = transport.send(Context.create(), request)) {
+            assertThat(response.statusCode(), equalTo(200));
+        }
+
+        assertThat(client.capturedBytes, equalTo(payload));
+    }
+
+    @Test
+    public void streamsResponseBodyThroughCustomBodySubscriber() throws Exception {
+        byte[] payload = "streamed response body".getBytes();
+        var client = new StreamingResponseHttpClient(payload);
+        var transport = new JavaHttpClientTransport(client);
+        var request = software.amazon.smithy.java.http.api.HttpRequest.create()
+                .setUri(URI.create("http://localhost/test"))
+                .setMethod("GET")
+                .toUnmodifiable();
+
+        try (var response = transport.send(Context.create(), request);
+                var body = response.body().asInputStream()) {
+            assertThat(response.statusCode(), equalTo(200));
+            assertThat(body.readAllBytes(), equalTo(payload));
+        }
+    }
+
+    @Test
+    public void preservesExplicitHttp11RequestVersionOnHttp2Client() {
+        var client = new CapturingHttpClient() {
+            @Override
+            public Version version() {
+                return Version.HTTP_2;
+            }
+        };
+        var transport = new JavaHttpClientTransport(client);
+        var request = software.amazon.smithy.java.http.api.HttpRequest.create()
+                .setUri(URI.create("http://localhost/test"))
+                .setMethod("GET")
+                .setHttpVersion(software.amazon.smithy.java.http.api.HttpVersion.HTTP_1_1)
+                .toUnmodifiable();
+
+        try (var response = transport.send(Context.create(), request)) {
+            assertThat(response.statusCode(), equalTo(200));
+        }
+
+        assertThat(client.capturedVersion().orElseThrow(), equalTo(HttpClient.Version.HTTP_1_1));
+    }
+
+    @Test
+    public void preservesReplayabilityForSmallResponseBodies() throws Exception {
+        var fakeResponse = new HttpResponse<DataStream>() {
+            @Override
+            public int statusCode() {
+                return 200;
+            }
+
+            @Override
+            public HttpHeaders headers() {
+                return HttpHeaders.of(
+                        Map.of(
+                                "content-type",
+                                List.of("text/plain"),
+                                "content-length",
+                                List.of("5")),
+                        (k, v) -> true);
+            }
+
+            @Override
+            public DataStream body() {
+                return DataStream.ofBytes("hello".getBytes());
+            }
+
+            @Override
+            public HttpClient.Version version() {
+                return HttpClient.Version.HTTP_2;
+            }
+
+            @Override
+            public HttpRequest request() {
+                return null;
+            }
+
+            @Override
+            public Optional<HttpResponse<DataStream>> previousResponse() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<SSLSession> sslSession() {
+                return Optional.empty();
+            }
+
+            @Override
+            public URI uri() {
+                return URI.create("http://localhost/test");
+            }
+        };
+
+        var transport = new JavaHttpClientTransport();
+        var response = transport.createSmithyResponse(fakeResponse);
+
+        assertTrue(response.body().isReplayable());
+        assertThat(response.body().asInputStream().readAllBytes(), equalTo("hello".getBytes()));
+        assertThat(response.body().asInputStream().readAllBytes(), equalTo("hello".getBytes()));
+    }
+
+    private static class CapturingHttpClient extends HttpClient {
+        private byte[] capturedBytes = new byte[0];
+        private Optional<HttpClient.Version> capturedVersion = Optional.empty();
+
+        Optional<HttpClient.Version> capturedVersion() {
+            return capturedVersion;
+        }
+
+        @Override
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+            capturedBytes = collect(request.bodyPublisher().orElseThrow());
+            capturedVersion = request.version();
+            var responseInfo = new HttpResponse.ResponseInfo() {
+                @Override
+                public int statusCode() {
+                    return 200;
+                }
+
+                @Override
+                public HttpHeaders headers() {
+                    return HttpHeaders.of(Map.of(), (k, v) -> true);
+                }
+
+                @Override
+                public HttpClient.Version version() {
+                    return HttpClient.Version.HTTP_1_1;
+                }
+            };
+            var subscriber = responseBodyHandler.apply(responseInfo);
+            subscriber.onSubscribe(new Flow.Subscription() {
+                @Override
+                public void request(long n) {
+                    subscriber.onComplete();
+                }
+
+                @Override
+                public void cancel() {}
+            });
+            T body = subscriber.getBody().toCompletableFuture().join();
+            return new HttpResponse<>() {
+                @Override
+                public int statusCode() {
+                    return 200;
+                }
+
+                @Override
+                public HttpHeaders headers() {
+                    return responseInfo.headers();
+                }
+
+                @Override
+                public T body() {
+                    return body;
+                }
+
+                @Override
+                public HttpClient.Version version() {
+                    return responseInfo.version();
+                }
+
+                @Override
+                public HttpRequest request() {
+                    return request;
+                }
+
+                @Override
+                public Optional<HttpResponse<T>> previousResponse() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<SSLSession> sslSession() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public URI uri() {
+                    return request.uri();
+                }
+            };
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler
+        ) {
+            return CompletableFuture.completedFuture(send(request, responseBodyHandler));
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler,
+                HttpResponse.PushPromiseHandler<T> pushPromiseHandler
+        ) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Duration> connectTimeout() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+
+        @Override
+        public Optional<ProxySelector> proxy() {
+            return Optional.empty();
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            return null;
+        }
+
+        @Override
+        public SSLParameters sslParameters() {
+            return new SSLParameters();
+        }
+
+        @Override
+        public Optional<Authenticator> authenticator() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_1_1;
+        }
+
+        @Override
+        public Optional<Executor> executor() {
+            return Optional.empty();
+        }
+
+        private static byte[] collect(HttpRequest.BodyPublisher publisher) {
+            var out = new java.io.ByteArrayOutputStream();
+            publisher.subscribe(new Flow.Subscriber<>() {
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    subscription.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(ByteBuffer item) {
+                    ByteBuffer copy = item.duplicate();
+                    byte[] bytes = new byte[copy.remaining()];
+                    copy.get(bytes);
+                    out.write(bytes, 0, bytes.length);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    throw new AssertionError("BodyPublisher failed", throwable);
+                }
+
+                @Override
+                public void onComplete() {}
+            });
+            return out.toByteArray();
+        }
+    }
+
+    private static final class StreamingResponseHttpClient extends HttpClient {
+        private final byte[] responseBytes;
+
+        private StreamingResponseHttpClient(byte[] responseBytes) {
+            this.responseBytes = responseBytes;
+        }
+
+        @Override
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+            var responseInfo = new HttpResponse.ResponseInfo() {
+                @Override
+                public int statusCode() {
+                    return 200;
+                }
+
+                @Override
+                public HttpHeaders headers() {
+                    return HttpHeaders.of(
+                            Map.of(
+                                    "content-length",
+                                    List.of(Integer.toString(responseBytes.length)),
+                                    "content-type",
+                                    List.of("text/plain")),
+                            (k, v) -> true);
+                }
+
+                @Override
+                public HttpClient.Version version() {
+                    return HttpClient.Version.HTTP_2;
+                }
+            };
+
+            var subscriber = responseBodyHandler.apply(responseInfo);
+            subscriber.onSubscribe(new Flow.Subscription() {
+                private boolean cancelled;
+
+                @Override
+                public void request(long n) {
+                    if (cancelled) {
+                        return;
+                    }
+                    var buffers = new ArrayList<ByteBuffer>(2);
+                    buffers.add(ByteBuffer.wrap(responseBytes, 0, 8));
+                    buffers.add(ByteBuffer.wrap(responseBytes, 8, responseBytes.length - 8));
+                    subscriber.onNext((List) buffers);
+                    subscriber.onComplete();
+                }
+
+                @Override
+                public void cancel() {
+                    cancelled = true;
+                }
+            });
+
+            T body = subscriber.getBody().toCompletableFuture().join();
+            return new HttpResponse<>() {
+                @Override
+                public int statusCode() {
+                    return 200;
+                }
+
+                @Override
+                public HttpRequest request() {
+                    return request;
+                }
+
+                @Override
+                public Optional<HttpResponse<T>> previousResponse() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public HttpHeaders headers() {
+                    return responseInfo.headers();
+                }
+
+                @Override
+                public T body() {
+                    return body;
+                }
+
+                @Override
+                public Optional<SSLSession> sslSession() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public URI uri() {
+                    return request.uri();
+                }
+
+                @Override
+                public HttpClient.Version version() {
+                    return responseInfo.version();
+                }
+            };
+        }
+
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Duration> connectTimeout() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+
+        @Override
+        public Optional<ProxySelector> proxy() {
+            return Optional.empty();
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            return null;
+        }
+
+        @Override
+        public SSLParameters sslParameters() {
+            return null;
+        }
+
+        @Override
+        public Optional<Authenticator> authenticator() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_2;
+        }
+
+        @Override
+        public Optional<Executor> executor() {
+            return Optional.empty();
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler
+        ) {
+            return CompletableFuture.completedFuture(send(request, responseBodyHandler));
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler,
+                HttpResponse.PushPromiseHandler<T> pushPromiseHandler
+        ) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/http/http-client/build.gradle.kts
+++ b/http/http-client/build.gradle.kts
@@ -1,0 +1,123 @@
+import java.net.Socket
+
+plugins {
+    id("smithy-java.module-conventions")
+    id("me.champeau.jmh") version "0.7.3"
+}
+
+description = "JDK transport benchmarks and benchmark server"
+
+extra["displayName"] = "Smithy :: Java :: HTTP :: Client Benchmarks"
+extra["moduleName"] = "software.amazon.smithy.java.http.client"
+
+sourceSets {
+    create("jmhServer") {
+        java.srcDir("src/jmhServer/java")
+    }
+}
+
+val jmhServerImplementation by configurations.getting
+
+dependencies {
+    jmh(project(":client:client-http"))
+
+    jmhServerImplementation("io.netty:netty-all:4.2.7.Final")
+    jmhServerImplementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
+}
+
+val benchmarkH2cPort = 18081
+val benchmarkPidFile = layout.buildDirectory.file("benchmark-server.pid")
+val jmhServerClasspath = sourceSets["jmhServer"].runtimeClasspath
+
+val startBenchmarkServer by tasks.registering {
+    dependsOn("jmhServerClasses")
+    notCompatibleWithConfigurationCache("Starts external process")
+
+    doLast {
+        val pidFile = benchmarkPidFile.get().asFile
+        pidFile.parentFile.mkdirs()
+
+        val process =
+            ProcessBuilder(
+                "java",
+                "-cp",
+                jmhServerClasspath.asPath,
+                "software.amazon.smithy.java.http.client.BenchmarkServer",
+            ).inheritIO().start()
+
+        pidFile.writeText(process.pid().toString())
+
+        var attempts = 0
+        var ready = false
+        while (!ready && attempts < 50) {
+            Thread.sleep(100)
+            attempts++
+            if (!process.isAlive) {
+                pidFile.delete()
+                throw GradleException("Benchmark server process exited before becoming ready")
+            }
+            try {
+                Socket("localhost", benchmarkH2cPort).close()
+                ready = true
+            } catch (_: Exception) {
+                // Server not ready yet.
+            }
+        }
+
+        if (!ready) {
+            process.destroyForcibly()
+            throw GradleException("Benchmark server failed to start (not ready after 5s)")
+        }
+    }
+}
+
+val stopBenchmarkServer by tasks.registering {
+    notCompatibleWithConfigurationCache("Stops external process")
+
+    doLast {
+        val pidFile = benchmarkPidFile.get().asFile
+        if (pidFile.exists()) {
+            val pid = pidFile.readText().trim().toLong()
+            try {
+                ProcessHandle.of(pid).ifPresent { handle -> handle.destroy() }
+            } catch (_: Exception) {
+                // Best effort cleanup.
+            }
+            pidFile.delete()
+        }
+    }
+}
+
+jmh {
+    val includesProp = project.findProperty("jmh.includes")?.toString()
+    val jvmArgsProp = project.findProperty("jmh.jvmArgsAppend")?.toString()
+    val profilersProp = project.findProperty("jmh.profilers")?.toString()
+    val defaultJvmArgs = listOf("-Djdk.httpclient.allowRestrictedHeaders=host")
+
+    includes = if (includesProp != null) listOf(includesProp) else listOf(".*")
+    warmupIterations = 3
+    iterations = 3
+    fork = 1
+    resultFormat = "CSV"
+    resultsFile = project.file("build/reports/jmh/results.csv")
+
+    if (jvmArgsProp != null) {
+        jvmArgsAppend = defaultJvmArgs + jvmArgsProp.split(Regex("\\s*;\\s*")).filter { it.isNotEmpty() }
+    } else {
+        jvmArgsAppend = defaultJvmArgs
+    }
+    if (profilersProp != null) {
+        val profilerSpecs =
+            if (profilersProp.contains(";;")) {
+                profilersProp.split(Regex("\\s*;;\\s*")).filter { it.isNotEmpty() }
+            } else {
+                listOf(profilersProp)
+            }
+        profilers.addAll(profilerSpecs)
+    }
+}
+
+tasks.named("jmh") {
+    dependsOn(startBenchmarkServer)
+    finalizedBy(stopBenchmarkServer)
+}

--- a/http/http-client/build.gradle.kts
+++ b/http/http-client/build.gradle.kts
@@ -1,14 +1,14 @@
 import java.net.Socket
 
 plugins {
-    id("smithy-java.module-conventions")
+    java
     id("me.champeau.jmh") version "0.7.3"
 }
 
-description = "JDK transport benchmarks and benchmark server"
-
-extra["displayName"] = "Smithy :: Java :: HTTP :: Client Benchmarks"
-extra["moduleName"] = "software.amazon.smithy.java.http.client"
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
 
 sourceSets {
     create("jmhServer") {

--- a/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/BenchmarkSupport.java
+++ b/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/BenchmarkSupport.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.client;
+
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * Shared utilities for JDK transport benchmarks.
+ */
+public final class BenchmarkSupport {
+
+    static {
+        System.setProperty("jdk.httpclient.allowRestrictedHeaders", "host");
+    }
+
+    public static final String H1_URL = "http://localhost:18080";
+    public static final String H2C_URL = "http://localhost:18081";
+    public static final String H2_URL = "https://localhost:18443";
+
+    public static final byte[] POST_PAYLOAD = "{\"id\":12345,\"name\":\"benchmark\"}".getBytes(StandardCharsets.UTF_8);
+    public static final byte[] MB_PAYLOAD = new byte[1024 * 1024];
+
+    private BenchmarkSupport() {}
+
+    public record IoStats(long getMbRequests, long getMbBytesSent, long putMbRequests, long putMbBytesReceived) {}
+
+    public static SSLContext trustAllSsl() throws Exception {
+        TrustManager[] trustAllCerts = new TrustManager[] {
+                new X509TrustManager() {
+                    @Override
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return new X509Certificate[0];
+                    }
+
+                    @Override
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) {}
+
+                    @Override
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) {}
+                }
+        };
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustAllCerts, new SecureRandom());
+        return sslContext;
+    }
+
+    public static void resetServer(HttpClient client, String baseUrl) throws Exception {
+        sendAndDrain(client, baseUrl + "/reset", "POST");
+        sendAndDrain(client, baseUrl + "/reset-io-stats", "POST");
+        Thread.sleep(100);
+    }
+
+    public static String getServerStats(HttpClient client, String baseUrl) throws Exception {
+        return getServerStats(client, baseUrl, null);
+    }
+
+    public static String getServerStats(HttpClient client, String baseUrl, String runId)
+            throws Exception {
+        String url = runId == null ? baseUrl + "/stats" : baseUrl + "/stats?runId=" + runId;
+        var request = HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
+        var response = client.send(request, BodyHandlers.ofInputStream());
+        try (var body = response.body()) {
+            return new String(body.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    public static String createRunId(String prefix) {
+        return prefix + "-" + UUID.randomUUID();
+    }
+
+    public static IoStats parseIoStats(String json) {
+        return new IoStats(
+                parseLongField(json, "getMbRequests"),
+                parseLongField(json, "getMbBytesSent"),
+                parseLongField(json, "putMbRequests"),
+                parseLongField(json, "putMbBytesReceived"));
+    }
+
+    public static void assertIoStats(String label, IoStats actual, IoStats expected) {
+        if (!actual.equals(expected)) {
+            throw new IllegalStateException(label + " mismatch. expected=" + expected + ", actual=" + actual);
+        }
+    }
+
+    public static <T> void runBenchmark(
+            int concurrency,
+            int totalRequests,
+            BenchmarkTask<T> task,
+            T context,
+            RequestCounter counter
+    ) throws InterruptedException {
+        var completed = new AtomicInteger(0);
+        var errors = new AtomicLong();
+        var firstError = new AtomicReference<Throwable>();
+        var latch = new CountDownLatch(concurrency);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int i = 0; i < concurrency; i++) {
+                final int threadId = i;
+                executor.submit(() -> {
+                    try {
+                        while (completed.getAndIncrement() < totalRequests) {
+                            task.run(context);
+                        }
+                    } catch (Exception e) {
+                        errors.incrementAndGet();
+                        firstError.compareAndSet(null, e);
+                    } catch (Throwable t) {
+                        errors.incrementAndGet();
+                        firstError.compareAndSet(null, new RuntimeException("Thread " + threadId + " error", t));
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                Throwable err = firstError.get();
+                System.err.println("BENCHMARK TIMEOUT: " + (concurrency - (int) latch.getCount())
+                        + "/" + concurrency + " threads completed, errors=" + errors.get()
+                        + (err != null ? ", firstError=" + err : ""));
+                if (err != null) {
+                    err.printStackTrace(System.err);
+                }
+            }
+        }
+
+        counter.requests = completed.get();
+        counter.errors = errors.get();
+        counter.firstError = firstError.get();
+    }
+
+    @FunctionalInterface
+    public interface BenchmarkTask<T> {
+        void run(T context) throws Exception;
+    }
+
+    public static class RequestCounter {
+        public long requests;
+        public long errors;
+        public Throwable firstError;
+
+        public long requests() {
+            return requests;
+        }
+
+        public long errors() {
+            return errors;
+        }
+
+        public void reset() {
+            requests = 0;
+            errors = 0;
+            firstError = null;
+        }
+
+        public void logErrors(String label) {
+            if (firstError != null) {
+                System.err.println(label + " errors: " + errors + ", first:");
+                firstError.printStackTrace(System.err);
+            }
+        }
+
+        public void throwIfErrored(String label) {
+            if (firstError == null) {
+                return;
+            }
+            if (firstError instanceof RuntimeException runtimeException) {
+                throw new IllegalStateException(label + " failed with " + errors + " error(s)", runtimeException);
+            }
+            throw new IllegalStateException(label + " failed with " + errors + " error(s)", firstError);
+        }
+    }
+
+    public static String getH2ConnectionStats(HttpClient client) {
+        return "(stats unavailable for java.net.http.HttpClient)";
+    }
+
+    private static void sendAndDrain(HttpClient client, String url, String method) throws Exception {
+        var builder = HttpRequest.newBuilder().uri(URI.create(url));
+        if ("POST".equals(method)) {
+            builder.POST(HttpRequest.BodyPublishers.noBody());
+        } else {
+            builder.GET();
+        }
+        var response = client.send(builder.build(), BodyHandlers.ofInputStream());
+        try (var body = response.body()) {
+            body.transferTo(OutputStream.nullOutputStream());
+        }
+    }
+
+    private static long parseLongField(String json, String fieldName) {
+        String needle = "\"" + fieldName + "\":";
+        int start = json.indexOf(needle);
+        if (start < 0) {
+            throw new IllegalArgumentException("Missing field `" + fieldName + "` in stats: " + json);
+        }
+        start += needle.length();
+        int end = start;
+        while (end < json.length()) {
+            char c = json.charAt(end);
+            if ((c < '0' || c > '9') && c != '-') {
+                break;
+            }
+            end++;
+        }
+        return Long.parseLong(json.substring(start, end));
+    }
+}

--- a/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/BenchmarkSupport.java
+++ b/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/BenchmarkSupport.java
@@ -186,9 +186,6 @@ public final class BenchmarkSupport {
             if (firstError == null) {
                 return;
             }
-            if (firstError instanceof RuntimeException runtimeException) {
-                throw new IllegalStateException(label + " failed with " + errors + " error(s)", runtimeException);
-            }
             throw new IllegalStateException(label + " failed with " + errors + " error(s)", firstError);
         }
     }

--- a/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/H2MixedGetPutBenchmark.java
+++ b/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/H2MixedGetPutBenchmark.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.client;
+
+import java.io.OutputStream;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import software.amazon.smithy.java.client.http.JavaHttpClientTransport;
+import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.http.api.HttpRequest;
+import software.amazon.smithy.java.http.api.HttpVersion;
+import software.amazon.smithy.java.io.datastream.DataStream;
+import software.amazon.smithy.java.io.uri.SmithyUri;
+
+/**
+ * Mixed H2 benchmark that interleaves 1 MB GETs and 1 MB PUTs on the JDK transport.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 3)
+@Measurement(iterations = 3, time = 5)
+@Fork(value = 1, jvmArgs = {"-Xms2g", "-Xmx2g"})
+@State(Scope.Benchmark)
+public class H2MixedGetPutBenchmark {
+
+    @Param({
+            "1",
+            "10"
+    })
+    private int concurrency;
+
+    @Param({"1", "3"})
+    private int connections;
+
+    @Param({"4096"})
+    private int streamsPerConnection;
+
+    private HttpClient benchmarkClient;
+    private HttpClient javaClient;
+    private ExecutorService javaExecutor;
+    private JavaHttpClientTransport javaTransport;
+    private Context transportContext;
+    private MixedRequests mixedRequests;
+    private String runId;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        var sslContext = BenchmarkSupport.trustAllSsl();
+
+        benchmarkClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .sslContext(sslContext)
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+
+        javaExecutor = Executors.newVirtualThreadPerTaskExecutor();
+        javaClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .sslContext(sslContext)
+                .executor(javaExecutor)
+                .build();
+        javaTransport = new JavaHttpClientTransport(javaClient);
+        transportContext = Context.create();
+
+        BenchmarkSupport.resetServer(benchmarkClient, BenchmarkSupport.H2_URL);
+        runId = BenchmarkSupport.createRunId("h2-mixed");
+
+        mixedRequests = new MixedRequests(
+                new RequestPlan(
+                        HttpRequest.create()
+                                .setUri(SmithyUri.of(BenchmarkSupport.H2_URL + "/getmb?runId=" + runId))
+                                .setHttpVersion(HttpVersion.HTTP_2)
+                                .setMethod("GET"),
+                        true,
+                        0,
+                        BenchmarkSupport.MB_PAYLOAD.length),
+                new RequestPlan(
+                        HttpRequest.create()
+                                .setUri(SmithyUri.of(BenchmarkSupport.H2_URL + "/putmb?runId=" + runId))
+                                .setHttpVersion(HttpVersion.HTTP_2)
+                                .setMethod("PUT")
+                                .setBody(DataStream.ofBytes(BenchmarkSupport.MB_PAYLOAD)),
+                        false,
+                        BenchmarkSupport.MB_PAYLOAD.length,
+                        0));
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception {
+        try {
+            if (benchmarkClient != null) {
+                String stats = BenchmarkSupport.getServerStats(benchmarkClient, BenchmarkSupport.H2_URL, runId);
+                var actualStats = BenchmarkSupport.parseIoStats(stats);
+                var expectedStats = mixedRequests.expectedIoStats();
+                BenchmarkSupport.assertIoStats("H2 mixed server IO stats", actualStats, expectedStats);
+                mixedRequests.assertClientIoMatches(expectedStats);
+                System.out.println("H2 mixed GET+PUT stats [c=" + concurrency + ", conn=" + connections
+                        + ", streams=" + streamsPerConnection + "]: " + stats);
+                System.out.println("H2 client stats: " + BenchmarkSupport.getH2ConnectionStats(benchmarkClient));
+                System.out.println("JDK mixed config: executor=vt"
+                        + ", transferScratchSize="
+                        + Integer.getInteger("smithy.java.client.http.jdk.transferScratchSize", 16 * 1024)
+                        + ", jdk.httpclient.maxframesize=" + System.getProperty("jdk.httpclient.maxframesize")
+                        + ", jdk.httpclient.bufsize=" + System.getProperty("jdk.httpclient.bufsize")
+                        + ", jdk.httpclient.maxstreams=" + System.getProperty("jdk.httpclient.maxstreams"));
+            }
+        } finally {
+            if (benchmarkClient != null) {
+                benchmarkClient.close();
+                benchmarkClient = null;
+            }
+            if (javaClient != null) {
+                javaClient.close();
+                javaClient = null;
+            }
+            if (javaExecutor != null) {
+                javaExecutor.close();
+                javaExecutor = null;
+            }
+            javaTransport = null;
+        }
+    }
+
+    @AuxCounters(AuxCounters.Type.EVENTS)
+    @State(Scope.Thread)
+    public static class Counter extends BenchmarkSupport.RequestCounter {
+        public long getRequests;
+        public long putRequests;
+
+        @Setup(Level.Trial)
+        public void reset() {
+            super.reset();
+            getRequests = 0;
+            putRequests = 0;
+        }
+    }
+
+    private static final class MixedRequests {
+        private final RequestPlan getRequest;
+        private final RequestPlan putRequest;
+        private final AtomicInteger sequence = new AtomicInteger();
+        private final AtomicLong totalGetRequests = new AtomicLong();
+        private final AtomicLong totalPutRequests = new AtomicLong();
+        private final AtomicLong clientRequestBytes = new AtomicLong();
+        private final AtomicLong clientResponseBytes = new AtomicLong();
+
+        private MixedRequests(RequestPlan getRequest, RequestPlan putRequest) {
+            this.getRequest = getRequest;
+            this.putRequest = putRequest;
+        }
+
+        private RequestPlan next() {
+            if ((sequence.getAndIncrement() & 1) == 0) {
+                totalGetRequests.incrementAndGet();
+                return getRequest;
+            }
+            totalPutRequests.incrementAndGet();
+            return putRequest;
+        }
+
+        private void recordCompletion(RequestPlan request, long responseBytes) {
+            clientRequestBytes.addAndGet(request.requestBytes());
+            clientResponseBytes.addAndGet(responseBytes);
+            if (responseBytes != request.responseBytes()) {
+                throw new IllegalStateException("Unexpected response byte count for "
+                        + (request.isGet() ? "GET" : "PUT") + ": expected=" + request.responseBytes()
+                        + ", actual=" + responseBytes);
+            }
+        }
+
+        private BenchmarkSupport.IoStats expectedIoStats() {
+            return new BenchmarkSupport.IoStats(
+                    totalGetRequests.get(),
+                    totalGetRequests.get() * BenchmarkSupport.MB_PAYLOAD.length,
+                    totalPutRequests.get(),
+                    totalPutRequests.get() * BenchmarkSupport.MB_PAYLOAD.length);
+        }
+
+        private void assertClientIoMatches(BenchmarkSupport.IoStats expectedStats) {
+            long expectedRequestBytes = expectedStats.putMbBytesReceived();
+            long expectedResponseBytes = expectedStats.getMbBytesSent();
+            if (clientRequestBytes.get() != expectedRequestBytes
+                    || clientResponseBytes.get() != expectedResponseBytes) {
+                throw new IllegalStateException("H2 mixed client IO mismatch. expectedRequestBytes="
+                        + expectedRequestBytes + ", actualRequestBytes=" + clientRequestBytes.get()
+                        + ", expectedResponseBytes=" + expectedResponseBytes + ", actualResponseBytes="
+                        + clientResponseBytes.get());
+            }
+        }
+    }
+
+    private record RequestPlan(HttpRequest request, boolean isGet, long requestBytes, long responseBytes) {}
+
+    @Benchmark
+    @Threads(1)
+    public void h2JavaWrapperMixedGetPutMb(Counter counter) throws InterruptedException {
+        long startGet = mixedRequests.totalGetRequests.get();
+        long startPut = mixedRequests.totalPutRequests.get();
+        BenchmarkSupport.runBenchmark(concurrency, concurrency * 2, (MixedRequests requests) -> {
+            var request = requests.next();
+            try (var response = javaTransport.send(transportContext, request.request())) {
+                long responseBytes = response.body().asInputStream().transferTo(OutputStream.nullOutputStream());
+                requests.recordCompletion(request, responseBytes);
+            }
+        }, mixedRequests, counter);
+        counter.getRequests = mixedRequests.totalGetRequests.get() - startGet;
+        counter.putRequests = mixedRequests.totalPutRequests.get() - startPut;
+
+        counter.logErrors("Java-wrapper H2 mixed GET+PUT");
+        counter.throwIfErrored("Java-wrapper H2 mixed GET+PUT");
+    }
+}

--- a/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/H2ScalingBenchmark.java
+++ b/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/H2ScalingBenchmark.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.client;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import software.amazon.smithy.java.client.http.JavaHttpClientTransport;
+import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.http.api.HttpRequest;
+import software.amazon.smithy.java.http.api.HttpVersion;
+import software.amazon.smithy.java.io.datastream.DataStream;
+import software.amazon.smithy.java.io.uri.SmithyUri;
+
+/**
+ * HTTP/2 over TLS (h2) benchmark focused on the JDK transport.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 3)
+@Measurement(iterations = 3, time = 5)
+@Fork(value = 1, jvmArgs = {"-Xms2g", "-Xmx2g"})
+@State(Scope.Benchmark)
+public class H2ScalingBenchmark {
+
+    @Param({
+            "1",
+            "10"
+    })
+    private int concurrency;
+
+    @Param({"3"})
+    private int connections;
+
+    @Param({"4096"})
+    private int streamsPerConnection;
+
+    private HttpClient benchmarkClient;
+    private HttpClient javaClient;
+    private ExecutorService javaExecutor;
+    private JavaHttpClientTransport javaTransport;
+    private Context transportContext;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        closeClients();
+
+        System.out.println("H2 setup: concurrency=" + concurrency
+                + ", connections=" + connections
+                + ", streams=" + streamsPerConnection);
+
+        var sslContext = BenchmarkSupport.trustAllSsl();
+
+        benchmarkClient = HttpClient.newBuilder()
+                .version(Version.HTTP_2)
+                .sslContext(sslContext)
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+
+        javaExecutor = Executors.newVirtualThreadPerTaskExecutor();
+        javaClient = HttpClient.newBuilder()
+                .version(Version.HTTP_2)
+                .sslContext(sslContext)
+                .executor(javaExecutor)
+                .build();
+        javaTransport = new JavaHttpClientTransport(javaClient);
+        transportContext = Context.create();
+
+        BenchmarkSupport.resetServer(benchmarkClient, BenchmarkSupport.H2_URL);
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception {
+        String stats = BenchmarkSupport.getServerStats(benchmarkClient, BenchmarkSupport.H2_URL);
+        System.out.println("H2 stats [c=" + concurrency + ", conn=" + connections
+                + ", streams=" + streamsPerConnection + "]: " + stats);
+        System.out.println("H2 client stats: " + BenchmarkSupport.getH2ConnectionStats(benchmarkClient));
+        closeClients();
+    }
+
+    private void closeClients() throws Exception {
+        if (benchmarkClient != null) {
+            benchmarkClient.close();
+            benchmarkClient = null;
+        }
+        if (javaClient != null) {
+            javaClient.close();
+            javaClient = null;
+        }
+        if (javaExecutor != null) {
+            javaExecutor.close();
+            javaExecutor = null;
+        }
+        javaTransport = null;
+    }
+
+    @AuxCounters(AuxCounters.Type.EVENTS)
+    @State(Scope.Thread)
+    public static class Counter extends BenchmarkSupport.RequestCounter {
+        @Setup(Level.Trial)
+        public void reset() {
+            super.reset();
+        }
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void h2JdkGet(Counter counter) throws InterruptedException {
+        var request = java.net.http.HttpRequest.newBuilder()
+                .uri(URI.create(BenchmarkSupport.H2_URL + "/get"))
+                .GET()
+                .build();
+
+        BenchmarkSupport.runBenchmark(concurrency, concurrency, (java.net.http.HttpRequest req) -> {
+            var response = javaClient.send(req, BodyHandlers.ofInputStream());
+            try (InputStream body = response.body()) {
+                body.transferTo(OutputStream.nullOutputStream());
+            }
+        }, request, counter);
+
+        counter.logErrors("Java HttpClient H2");
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void h2JdkPost(Counter counter) throws InterruptedException {
+        var request = java.net.http.HttpRequest.newBuilder()
+                .uri(URI.create(BenchmarkSupport.H2_URL + "/post"))
+                .POST(BodyPublishers.ofByteArray(BenchmarkSupport.POST_PAYLOAD))
+                .build();
+
+        BenchmarkSupport.runBenchmark(concurrency, concurrency, (java.net.http.HttpRequest req) -> {
+            var response = javaClient.send(req, BodyHandlers.ofInputStream());
+            try (InputStream body = response.body()) {
+                body.transferTo(OutputStream.nullOutputStream());
+            }
+        }, request, counter);
+
+        counter.logErrors("Java HttpClient H2 POST");
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void h2JdkPutMb(Counter counter) throws InterruptedException {
+        var request = java.net.http.HttpRequest.newBuilder()
+                .uri(URI.create(BenchmarkSupport.H2_URL + "/putmb"))
+                .PUT(BodyPublishers.ofByteArray(BenchmarkSupport.MB_PAYLOAD))
+                .build();
+
+        BenchmarkSupport.runBenchmark(concurrency, concurrency, (java.net.http.HttpRequest req) -> {
+            var response = javaClient.send(req, BodyHandlers.ofInputStream());
+            try (InputStream body = response.body()) {
+                body.transferTo(OutputStream.nullOutputStream());
+            }
+        }, request, counter);
+
+        counter.logErrors("Java HttpClient H2 PUT 1MB");
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void h2JavaWrapperPutMb(Counter counter) throws InterruptedException {
+        var uri = SmithyUri.of(BenchmarkSupport.H2_URL + "/putmb");
+        var request = HttpRequest.create()
+                .setUri(uri)
+                .setHttpVersion(HttpVersion.HTTP_2)
+                .setMethod("PUT")
+                .setBody(DataStream.ofBytes(BenchmarkSupport.MB_PAYLOAD));
+
+        BenchmarkSupport.runBenchmark(concurrency, concurrency, (HttpRequest req) -> {
+            try (var response = javaTransport.send(transportContext, req)) {
+                response.body().asInputStream().transferTo(OutputStream.nullOutputStream());
+            }
+        }, request, counter);
+
+        counter.logErrors("Java wrapper H2 PUT 1MB");
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void h2JavaWrapperGetMb(Counter counter) throws InterruptedException {
+        var uri = SmithyUri.of(BenchmarkSupport.H2_URL + "/getmb");
+        var request = HttpRequest.create().setUri(uri).setHttpVersion(HttpVersion.HTTP_2).setMethod("GET");
+
+        BenchmarkSupport.runBenchmark(concurrency, concurrency, (HttpRequest req) -> {
+            try (var response = javaTransport.send(transportContext, req)) {
+                response.body().asInputStream().transferTo(OutputStream.nullOutputStream());
+            }
+        }, request, counter);
+
+        counter.logErrors("Java Wrapper H2 GET 1MB");
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void h2JdkGetMb(Counter counter) throws InterruptedException {
+        var request = java.net.http.HttpRequest.newBuilder()
+                .uri(URI.create(BenchmarkSupport.H2_URL + "/getmb"))
+                .GET()
+                .build();
+
+        BenchmarkSupport.runBenchmark(concurrency, concurrency, (java.net.http.HttpRequest req) -> {
+            var response = javaClient.send(req, BodyHandlers.ofInputStream());
+            try (InputStream body = response.body()) {
+                body.transferTo(OutputStream.nullOutputStream());
+            }
+        }, request, counter);
+
+        counter.logErrors("Java HttpClient H2 GET 1MB");
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void h2JavaWrapperGet10Mb(Counter counter) throws InterruptedException {
+        var uri = SmithyUri.of(BenchmarkSupport.H2_URL + "/get10mb");
+        var request = HttpRequest.create().setUri(uri).setHttpVersion(HttpVersion.HTTP_2).setMethod("GET");
+
+        BenchmarkSupport.runBenchmark(concurrency, concurrency, (HttpRequest req) -> {
+            try (var response = javaTransport.send(transportContext, req)) {
+                response.body().asInputStream().transferTo(OutputStream.nullOutputStream());
+            }
+        }, request, counter);
+
+        counter.logErrors("Java Wrapper H2 GET 10MB");
+    }
+}

--- a/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/H2TinyRpcBenchmark.java
+++ b/http/http-client/src/jmh/java/software/amazon/smithy/java/http/client/H2TinyRpcBenchmark.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.client;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import software.amazon.smithy.java.client.http.JavaHttpClientTransport;
+import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.http.api.HttpRequest;
+import software.amazon.smithy.java.http.api.HttpVersion;
+import software.amazon.smithy.java.io.datastream.DataStream;
+import software.amazon.smithy.java.io.uri.SmithyUri;
+
+/**
+ * Tiny request/response RPC latency benchmark over H2 for the JDK transport.
+ *
+ * <p>This uses JMH threads directly rather than the internal virtual-thread fanout so SampleTime
+ * percentile output reflects per-request latency under real concurrent pressure.
+ */
+@BenchmarkMode(org.openjdk.jmh.annotations.Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 3)
+@Measurement(iterations = 3, time = 5)
+@Fork(value = 1, jvmArgs = {"-Xms2g", "-Xmx2g"})
+@State(Scope.Benchmark)
+public class H2TinyRpcBenchmark {
+
+    @Param({"3"})
+    private int connections;
+
+    @Param({"4096"})
+    private int streamsPerConnection;
+
+    private HttpClient benchmarkClient;
+    private HttpClient javaClient;
+    private ExecutorService javaExecutor;
+    private JavaHttpClientTransport javaTransport;
+    private Context transportContext;
+    private HttpRequest smithyRequest;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        var sslContext = BenchmarkSupport.trustAllSsl();
+
+        benchmarkClient = HttpClient.newBuilder()
+                .version(Version.HTTP_2)
+                .sslContext(sslContext)
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+
+        javaExecutor = Executors.newVirtualThreadPerTaskExecutor();
+        javaClient = HttpClient.newBuilder()
+                .version(Version.HTTP_2)
+                .sslContext(sslContext)
+                .executor(javaExecutor)
+                .build();
+        javaTransport = new JavaHttpClientTransport(javaClient);
+        transportContext = Context.create();
+
+        BenchmarkSupport.resetServer(benchmarkClient, BenchmarkSupport.H2_URL);
+
+        smithyRequest = HttpRequest.create()
+                .setUri(SmithyUri.of(BenchmarkSupport.H2_URL + "/rpc"))
+                .setHttpVersion(HttpVersion.HTTP_2)
+                .setMethod("POST")
+                .setBody(DataStream.ofBytes(BenchmarkSupport.POST_PAYLOAD));
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception {
+        try {
+            if (benchmarkClient != null) {
+                String stats = BenchmarkSupport.getServerStats(benchmarkClient, BenchmarkSupport.H2_URL);
+                System.out.println("H2 tiny RPC stats [conn=" + connections
+                        + ", streams=" + streamsPerConnection + "]: " + stats);
+                System.out.println("H2 client stats: " + BenchmarkSupport.getH2ConnectionStats(benchmarkClient));
+            }
+        } finally {
+            if (benchmarkClient != null) {
+                benchmarkClient.close();
+                benchmarkClient = null;
+            }
+            if (javaClient != null) {
+                javaClient.close();
+                javaClient = null;
+            }
+            if (javaExecutor != null) {
+                javaExecutor.close();
+                javaExecutor = null;
+            }
+            javaTransport = null;
+        }
+    }
+
+    @Benchmark
+    @Threads(64)
+    public void h2JavaWrapperTinyRpc() throws Exception {
+        try (var response = javaTransport.send(transportContext, smithyRequest)) {
+            try (InputStream body = response.body().asInputStream()) {
+                body.transferTo(OutputStream.nullOutputStream());
+            }
+        }
+    }
+}

--- a/http/http-client/src/jmhServer/java/software/amazon/smithy/java/http/client/BenchmarkServer.java
+++ b/http/http-client/src/jmhServer/java/software/amazon/smithy/java/http/client/BenchmarkServer.java
@@ -1,0 +1,744 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.client;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.KEEP_ALIVE;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
+import io.netty.handler.codec.http2.Http2DataFrame;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.handler.codec.http2.Http2MultiplexHandler;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.codec.http2.Http2StreamFrame;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Standalone Netty-based benchmark server.
+ *
+ * <p>Runs in a separate process from JMH benchmarks to get clean flame graphs
+ * without Netty code polluting the profile.
+ *
+ * <p>Writes port information to a file for the benchmark to read:
+ * <pre>
+ * h1Port=12345
+ * h2Port=12346
+ * h2cPort=12347
+ * </pre>
+ *
+ * <p>Usage:
+ * <pre>
+ * java -cp ... software.amazon.smithy.java.http.client.BenchmarkServer [port-file]
+ * </pre>
+ */
+public final class BenchmarkServer {
+
+    private static final byte[] CONTENT = "{\"status\":\"ok\"}".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] MB_CONTENT = new byte[1024 * 1024]; // 1MB for large transfer tests
+    private static final byte[] MB10_CONTENT = new byte[10 * 1024 * 1024]; // 10MB for bulk transfer tests
+
+    // Fixed ports for benchmark server (avoids dynamic port discovery complexity)
+    public static final int DEFAULT_H1_PORT = 18080;
+    public static final int DEFAULT_H2_PORT = 18443;
+    public static final int DEFAULT_H2C_PORT = 18081;
+
+    // HTTP/2 settings - tunable for benchmarking
+    private static final int H2_MAX_CONCURRENT_STREAMS = 20000;
+    private static final int H2_INITIAL_WINDOW_SIZE = 1024 * 1024 * 2;
+    private static final int H2_MAX_FRAME_SIZE = 1024 * 64;
+    // Additional connection-level receive window credit for h2c.
+    // Without this, concurrent uploads can bottleneck on the RFC default 64KB connection window.
+    private static final int H2_CONNECTION_WINDOW_INCREMENT = 64 * 1024 * 1024;
+
+    // HTTP/2 TLS settings (slightly more conservative)
+    private static final int H2_TLS_MAX_CONCURRENT_STREAMS = 10000;
+    private static final int H2_TLS_INITIAL_WINDOW_SIZE = 1024 * 1024;
+    // Additional connection-level receive window credit beyond the RFC default 64KB.
+    // With default 64KB, 10 concurrent 1MB uploads must serialize WINDOW_UPDATE roundtrips.
+    // Bumping by 64MB leaves only per-stream flow control as a throttling factor.
+    private static final int H2_TLS_CONNECTION_WINDOW_INCREMENT = 64 * 1024 * 1024;
+    private static final AtomicLong GET_MB_BYTES_SENT = new AtomicLong();
+    private static final AtomicLong PUT_MB_BYTES_RECEIVED = new AtomicLong();
+    private static final AtomicLong GET_MB_REQUESTS = new AtomicLong();
+    private static final AtomicLong PUT_MB_REQUESTS = new AtomicLong();
+    private static final ConcurrentHashMap<String, IoStatsAccumulator> RUN_IO_STATS = new ConcurrentHashMap<>();
+
+    private final EventLoopGroup bossGroup;
+    private final EventLoopGroup workerGroup;
+    private final Channel h1ServerChannel;
+    private final Channel h2ServerChannel;
+    private final Channel h2cServerChannel;
+    private final int h1Port;
+    private final int h2Port;
+    private final int h2cPort;
+
+    public BenchmarkServer() throws Exception {
+        this(DEFAULT_H1_PORT, DEFAULT_H2_PORT, DEFAULT_H2C_PORT);
+    }
+
+    public BenchmarkServer(int h1Port, int h2Port, int h2cPort) throws Exception {
+        this.h1Port = h1Port;
+        this.h2Port = h2Port;
+        this.h2cPort = h2cPort;
+
+        int cores = Runtime.getRuntime().availableProcessors();
+        bossGroup = new NioEventLoopGroup(1);
+        workerGroup = new NioEventLoopGroup(cores * 4);
+
+        // Start HTTP/1.1 server
+        h1ServerChannel = startH1Server(h1Port);
+
+        // Start HTTP/2 server with TLS (h2)
+        h2ServerChannel = startH2Server(h2Port);
+
+        // Start HTTP/2 cleartext server (h2c) - prior knowledge only
+        h2cServerChannel = startH2cServer(h2cPort);
+    }
+
+    public int getH1Port() {
+        return h1Port;
+    }
+
+    public int getH2Port() {
+        return h2Port;
+    }
+
+    public int getH2cPort() {
+        return h2cPort;
+    }
+
+    private static void resetIoStats() {
+        GET_MB_BYTES_SENT.set(0);
+        PUT_MB_BYTES_RECEIVED.set(0);
+        GET_MB_REQUESTS.set(0);
+        PUT_MB_REQUESTS.set(0);
+        RUN_IO_STATS.clear();
+    }
+
+    private static String extractPath(String uri) {
+        try {
+            URI parsed = URI.create(uri);
+            String path = parsed.getPath();
+            if (path != null && !path.isEmpty()) {
+                return path;
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Fall back to raw request-target handling below.
+        }
+        int query = uri.indexOf('?');
+        if (query >= 0) {
+            uri = uri.substring(0, query);
+        }
+        return uri;
+    }
+
+    private static boolean pathMatches(String uri, String path) {
+        return path.contentEquals(extractPath(uri));
+    }
+
+    private static boolean pathMatches(CharSequence uri, String path) {
+        return uri != null && path.contentEquals(extractPath(uri.toString()));
+    }
+
+    private static String extractQueryParam(String uri, String name) {
+        int queryStart = uri.indexOf('?');
+        if (queryStart < 0 || queryStart == uri.length() - 1) {
+            return null;
+        }
+        int index = queryStart + 1;
+        while (index < uri.length()) {
+            int nextAmp = uri.indexOf('&', index);
+            if (nextAmp < 0) {
+                nextAmp = uri.length();
+            }
+            int equals = uri.indexOf('=', index);
+            if (equals > index && equals < nextAmp && uri.regionMatches(index, name, 0, name.length())) {
+                return uri.substring(equals + 1, nextAmp);
+            }
+            index = nextAmp + 1;
+        }
+        return null;
+    }
+
+    private static IoStatsAccumulator ioStatsFor(String uri) {
+        String runId = extractQueryParam(uri, "runId");
+        if (runId == null || runId.isEmpty()) {
+            return null;
+        }
+        return RUN_IO_STATS.computeIfAbsent(runId, ignored -> new IoStatsAccumulator());
+    }
+
+    private static byte[] statsJson(String uri) {
+        IoStatsAccumulator runStats = ioStatsFor(uri);
+        if (runStats == null) {
+            return statsJson();
+        }
+        return statsJson(runStats.getMbRequests.get(),
+                runStats.getMbBytesSent.get(),
+                runStats.putMbRequests.get(),
+                runStats.putMbBytesReceived.get());
+    }
+
+    private static byte[] ioStatsJson() {
+        return ioStatsJson(GET_MB_REQUESTS.get(),
+                GET_MB_BYTES_SENT.get(),
+                PUT_MB_REQUESTS.get(),
+                PUT_MB_BYTES_RECEIVED.get());
+    }
+
+    private static byte[] statsJson() {
+        return statsJson(GET_MB_REQUESTS.get(),
+                GET_MB_BYTES_SENT.get(),
+                PUT_MB_REQUESTS.get(),
+                PUT_MB_BYTES_RECEIVED.get());
+    }
+
+    private static byte[] ioStatsJson(long getRequests, long getBytesSent, long putRequests, long putBytesReceived) {
+        String json = "{"
+                + "\"getMbRequests\":" + getRequests + ","
+                + "\"getMbBytesSent\":" + getBytesSent + ","
+                + "\"putMbRequests\":" + putRequests + ","
+                + "\"putMbBytesReceived\":" + putBytesReceived
+                + "}";
+        return json.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] statsJson(long getRequests, long getBytesSent, long putRequests, long putBytesReceived) {
+        String json = "{"
+                + "\"settings\":{"
+                + "\"maxConcurrentStreams\":" + H2_MAX_CONCURRENT_STREAMS + ","
+                + "\"initialWindowSize\":" + H2_INITIAL_WINDOW_SIZE + ","
+                + "\"maxFrameSize\":" + H2_MAX_FRAME_SIZE
+                + "},"
+                + "\"io\":{"
+                + "\"getMbRequests\":" + getRequests + ","
+                + "\"getMbBytesSent\":" + getBytesSent + ","
+                + "\"putMbRequests\":" + putRequests + ","
+                + "\"putMbBytesReceived\":" + putBytesReceived
+                + "}"
+                + "}";
+        return json.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private Channel startH1Server(int port) throws InterruptedException {
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .option(ChannelOption.SO_BACKLOG, 16384)
+                .option(ChannelOption.SO_REUSEADDR, true)
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childOption(ChannelOption.TCP_NODELAY, true)
+                .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    public void initChannel(SocketChannel ch) {
+                        ch.pipeline()
+                                .addLast(new HttpServerCodec())
+                                .addLast(new HttpObjectAggregator(8192))
+                                .addLast(new Http1RequestHandler());
+                    }
+                });
+
+        return b.bind(port).sync().channel();
+    }
+
+    private Channel startH2Server(int port) throws Exception {
+        // Create self-signed certificate (uses BouncyCastle)
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+
+        // Build SSL context with ALPN for HTTP/2
+        SslContext sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                .applicationProtocolConfig(new ApplicationProtocolConfig(
+                        ApplicationProtocolConfig.Protocol.ALPN,
+                        ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                        ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                        ApplicationProtocolNames.HTTP_2,
+                        ApplicationProtocolNames.HTTP_1_1))
+                .build();
+
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .option(ChannelOption.SO_BACKLOG, 16384)
+                .option(ChannelOption.SO_REUSEADDR, true)
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childOption(ChannelOption.TCP_NODELAY, true)
+                .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    public void initChannel(SocketChannel ch) {
+                        ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()));
+                        ch.pipeline().addLast(new Http2OrHttpHandler());
+                    }
+                });
+
+        return b.bind(port).sync().channel();
+    }
+
+    /**
+     * Start HTTP/2 cleartext server (h2c) with prior knowledge.
+     * No TLS, no upgrade - client must speak HTTP/2 directly.
+     */
+    private Channel startH2cServer(int port) throws InterruptedException {
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .option(ChannelOption.SO_BACKLOG, 65536)
+                .option(ChannelOption.SO_REUSEADDR, true)
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childOption(ChannelOption.TCP_NODELAY, true)
+                .childOption(ChannelOption.SO_RCVBUF, 2097152)
+                .childOption(ChannelOption.SO_SNDBUF, 2097152)
+                .childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(32768, 65536))
+                .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    public void initChannel(SocketChannel ch) {
+                        var settings = io.netty.handler.codec.http2.Http2Settings.defaultSettings()
+                                .maxConcurrentStreams(H2_MAX_CONCURRENT_STREAMS)
+                                .initialWindowSize(H2_INITIAL_WINDOW_SIZE)
+                                .maxFrameSize(H2_MAX_FRAME_SIZE);
+                        var frameCodec = Http2FrameCodecBuilder.forServer()
+                                .initialSettings(settings)
+                                .autoAckSettingsFrame(true)
+                                .autoAckPingFrame(true)
+                                .build();
+                        ch.pipeline()
+                                .addLast(
+                                        frameCodec,
+                                        new Http2MultiplexHandler(new ChannelInitializer<Channel>() {
+                                            @Override
+                                            protected void initChannel(Channel ch) {
+                                                ch.pipeline().addLast(new Http2StreamHandler());
+                                            }
+                                        }));
+                        ch.eventLoop().execute(() -> {
+                            try {
+                                var connection = frameCodec.connection();
+                                connection.local()
+                                        .flowController()
+                                        .incrementWindowSize(
+                                                connection.connectionStream(),
+                                                H2_CONNECTION_WINDOW_INCREMENT);
+                            } catch (Http2Exception e) {
+                                ch.pipeline().fireExceptionCaught(e);
+                            }
+                        });
+                    }
+                });
+
+        return b.bind(port).sync().channel();
+    }
+
+    public void shutdown() throws InterruptedException {
+        if (h1ServerChannel != null) {
+            h1ServerChannel.close().sync();
+        }
+        if (h2ServerChannel != null) {
+            h2ServerChannel.close().sync();
+        }
+        if (h2cServerChannel != null) {
+            h2cServerChannel.close().sync();
+        }
+        if (bossGroup != null) {
+            bossGroup.shutdownGracefully().sync();
+        }
+        if (workerGroup != null) {
+            workerGroup.shutdownGracefully().sync();
+        }
+    }
+
+    /**
+     * Handler for HTTP/1.1 requests.
+     */
+    private static class Http1RequestHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) {
+            String uri = msg.uri();
+            FullHttpResponse response;
+
+            if (pathMatches(uri, "/rpc")) {
+                response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.wrappedBuffer(CONTENT));
+                response.headers()
+                        .set(CONTENT_TYPE, "application/json")
+                        .set(CONNECTION, KEEP_ALIVE)
+                        .setInt(CONTENT_LENGTH, CONTENT.length);
+            } else if (pathMatches(uri, "/reset-io-stats")) {
+                resetIoStats();
+                response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.EMPTY_BUFFER);
+                response.headers()
+                        .set(CONNECTION, KEEP_ALIVE)
+                        .setInt(CONTENT_LENGTH, 0);
+            } else if (pathMatches(uri, "/io-stats")) {
+                byte[] body = ioStatsJson();
+                response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.wrappedBuffer(body));
+                response.headers()
+                        .set(CONTENT_TYPE, "application/json")
+                        .set(CONNECTION, KEEP_ALIVE)
+                        .setInt(CONTENT_LENGTH, body.length);
+            } else if (pathMatches(uri, "/stats")) {
+                byte[] body = statsJson(uri);
+                System.out.println("[H1 stats] " + new String(body, StandardCharsets.UTF_8));
+                response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.wrappedBuffer(body));
+                response.headers()
+                        .set(CONTENT_TYPE, "application/json")
+                        .set(CONNECTION, KEEP_ALIVE)
+                        .setInt(CONTENT_LENGTH, body.length);
+            } else if (pathMatches(uri, "/post") || pathMatches(uri, "/putmb")) {
+                if (pathMatches(uri, "/putmb")) {
+                    IoStatsAccumulator runStats = ioStatsFor(uri);
+                    PUT_MB_REQUESTS.incrementAndGet();
+                    PUT_MB_BYTES_RECEIVED.addAndGet(msg.content().readableBytes());
+                    if (runStats != null) {
+                        runStats.putMbRequests.incrementAndGet();
+                        runStats.putMbBytesReceived.addAndGet(msg.content().readableBytes());
+                    }
+                }
+                // POST/PUT returns empty 200 OK
+                response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.EMPTY_BUFFER);
+                response.headers()
+                        .set(CONNECTION, KEEP_ALIVE)
+                        .setInt(CONTENT_LENGTH, 0);
+            } else if (pathMatches(uri, "/get10mb")) {
+                // Return 10MB response
+                response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.wrappedBuffer(MB10_CONTENT));
+                response.headers()
+                        .set(CONTENT_TYPE, "application/octet-stream")
+                        .set(CONNECTION, KEEP_ALIVE)
+                        .setInt(CONTENT_LENGTH, MB10_CONTENT.length);
+            } else if (pathMatches(uri, "/getmb")) {
+                IoStatsAccumulator runStats = ioStatsFor(uri);
+                GET_MB_REQUESTS.incrementAndGet();
+                GET_MB_BYTES_SENT.addAndGet(MB_CONTENT.length);
+                if (runStats != null) {
+                    runStats.getMbRequests.incrementAndGet();
+                    runStats.getMbBytesSent.addAndGet(MB_CONTENT.length);
+                }
+                // Return 1MB response
+                response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.wrappedBuffer(MB_CONTENT));
+                response.headers()
+                        .set(CONTENT_TYPE, "application/octet-stream")
+                        .set(CONNECTION, KEEP_ALIVE)
+                        .setInt(CONTENT_LENGTH, MB_CONTENT.length);
+            } else {
+                // GET returns JSON body
+                response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.wrappedBuffer(CONTENT));
+                response.headers()
+                        .set(CONTENT_TYPE, "application/json")
+                        .set(CONNECTION, KEEP_ALIVE)
+                        .setInt(CONTENT_LENGTH, CONTENT.length);
+            }
+            ctx.writeAndFlush(response);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            ctx.close();
+        }
+    }
+
+    /**
+     * ALPN handler that configures the pipeline for HTTP/2 or HTTP/1.1.
+     */
+    private static class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
+        Http2OrHttpHandler() {
+            super(ApplicationProtocolNames.HTTP_1_1);
+        }
+
+        @Override
+        protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
+            if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
+                var settings = io.netty.handler.codec.http2.Http2Settings.defaultSettings()
+                        .maxConcurrentStreams(H2_TLS_MAX_CONCURRENT_STREAMS)
+                        .initialWindowSize(H2_TLS_INITIAL_WINDOW_SIZE)
+                        .maxFrameSize(H2_MAX_FRAME_SIZE);
+                var frameCodec = Http2FrameCodecBuilder.forServer()
+                        .initialSettings(settings)
+                        .build();
+                ctx.pipeline()
+                        .addLast(
+                                frameCodec,
+                                new Http2MultiplexHandler(new ChannelInitializer<Channel>() {
+                                    @Override
+                                    protected void initChannel(Channel ch) {
+                                        ch.pipeline().addLast(new Http2StreamHandler());
+                                    }
+                                }));
+                // Grow the connection-level receive window so it isn't the bottleneck under
+                // concurrent uploads. RFC default is 64KB, which forces frequent WINDOW_UPDATE
+                // roundtrips when many streams share one connection. We run in the event loop
+                // because flow-controller methods require it.
+                ctx.channel().eventLoop().execute(() -> {
+                    try {
+                        var connection = frameCodec.connection();
+                        connection.local()
+                                .flowController()
+                                .incrementWindowSize(
+                                        connection.connectionStream(),
+                                        H2_TLS_CONNECTION_WINDOW_INCREMENT);
+                    } catch (Http2Exception e) {
+                        ctx.fireExceptionCaught(e);
+                    }
+                });
+            } else {
+                ctx.pipeline()
+                        .addLast(
+                                new HttpServerCodec(),
+                                new HttpObjectAggregator(8192),
+                                new Http1RequestHandler());
+            }
+        }
+    }
+
+    /**
+     * Per-stream handler for HTTP/2 requests.
+     *
+     * <p>Each stream gets its own instance via Http2MultiplexHandler.
+     * Flow control is handled automatically by Netty when using stream channels.
+     */
+    private static class Http2StreamHandler extends SimpleChannelInboundHandler<Http2StreamFrame> {
+        private static final Http2Headers RESPONSE_HEADERS = new DefaultHttp2Headers(true, 3)
+                .status("200")
+                .set("content-type", "application/json")
+                .setInt("content-length", CONTENT.length);
+        private static final Http2Headers EMPTY_RESPONSE_HEADERS = new DefaultHttp2Headers(true, 2)
+                .status("200")
+                .setInt("content-length", 0);
+        private static final Http2Headers MB_RESPONSE_HEADERS = new DefaultHttp2Headers(true, 3)
+                .status("200")
+                .set("content-type", "application/octet-stream")
+                .setInt("content-length", MB_CONTENT.length);
+
+        private static final Http2Headers MB10_RESPONSE_HEADERS = new DefaultHttp2Headers(true, 3)
+                .status("200")
+                .set("content-type", "application/octet-stream")
+                .setInt("content-length", MB10_CONTENT.length);
+        private RequestKind requestKind = RequestKind.OTHER;
+        private String requestUri;
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, Http2StreamFrame frame) {
+            if (frame instanceof Http2HeadersFrame headersFrame) {
+                CharSequence path = headersFrame.headers().path();
+                requestUri = path == null ? null : path.toString();
+                if (pathMatches(path, "/reset")) {
+                    System.gc();
+                    Http2Headers resetHeaders = new DefaultHttp2Headers(true, 1).status("200");
+                    ctx.writeAndFlush(new DefaultHttp2HeadersFrame(resetHeaders, true));
+                } else if (pathMatches(path, "/reset-io-stats")) {
+                    resetIoStats();
+                    Http2Headers resetHeaders = new DefaultHttp2Headers(true, 2)
+                            .status("200")
+                            .setInt("content-length", 0);
+                    ctx.writeAndFlush(new DefaultHttp2HeadersFrame(resetHeaders, true));
+                } else if (pathMatches(path, "/io-stats")) {
+                    byte[] body = ioStatsJson();
+                    Http2Headers ioHeaders = new DefaultHttp2Headers(true, 3)
+                            .status("200")
+                            .set("content-type", "application/json")
+                            .setInt("content-length", body.length);
+                    ctx.write(new DefaultHttp2HeadersFrame(ioHeaders, false));
+                    ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.wrappedBuffer(body), true));
+                } else if (pathMatches(path, "/stats")) {
+                    byte[] body = statsJson(path.toString());
+                    System.out.println("[H2 stats] " + new String(body, StandardCharsets.UTF_8));
+                    Http2Headers statsHeaders = new DefaultHttp2Headers(true, 2)
+                            .set("content-type", "application/json")
+                            .status("200")
+                            .setInt("content-length", body.length);
+                    ctx.write(new DefaultHttp2HeadersFrame(statsHeaders, false));
+                    ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.wrappedBuffer(body), true));
+                } else if (pathMatches(path, "/rpc")) {
+                    requestKind = RequestKind.RPC;
+                    if (headersFrame.isEndStream()) {
+                        writeResponse(ctx, requestKind);
+                    }
+                } else if (pathMatches(path, "/post") || pathMatches(path, "/putmb")) {
+                    requestKind = RequestKind.EMPTY;
+                    if (pathMatches(path, "/putmb")) {
+                        PUT_MB_REQUESTS.incrementAndGet();
+                        IoStatsAccumulator runStats = ioStatsFor(requestUri);
+                        if (runStats != null) {
+                            runStats.putMbRequests.incrementAndGet();
+                        }
+                    }
+                    // POST/PUT with body - wait for data frames
+                    if (headersFrame.isEndStream()) {
+                        // No body, respond immediately
+                        writeResponse(ctx, requestKind);
+                    }
+                    // else: wait for DATA frames with endStream
+                } else if (pathMatches(path, "/get10mb")) {
+                    requestKind = RequestKind.GET_10MB;
+                    if (headersFrame.isEndStream()) {
+                        writeResponse(ctx, requestKind);
+                    }
+                } else if (pathMatches(path, "/getmb")) {
+                    requestKind = RequestKind.GET_MB;
+                    if (headersFrame.isEndStream()) {
+                        writeResponse(ctx, requestKind);
+                    }
+                } else if (headersFrame.isEndStream()) {
+                    requestKind = RequestKind.OTHER;
+                    // Simple GET - respond with JSON body
+                    writeResponse(ctx, requestKind);
+                }
+            } else if (frame instanceof Http2DataFrame dataFrame) {
+                // Data consumed - flow control handled automatically by Http2MultiplexHandler
+                if (requestKind == RequestKind.EMPTY) {
+                    PUT_MB_BYTES_RECEIVED.addAndGet(dataFrame.content().readableBytes());
+                    IoStatsAccumulator runStats = ioStatsFor(requestUri);
+                    if (runStats != null) {
+                        runStats.putMbBytesReceived.addAndGet(dataFrame.content().readableBytes());
+                    }
+                }
+                if (dataFrame.isEndStream()) {
+                    writeResponse(ctx, requestKind);
+                }
+            }
+        }
+
+        private void writeResponse(ChannelHandlerContext ctx, RequestKind kind) {
+            switch (kind) {
+                case RPC -> {
+                    ctx.write(new DefaultHttp2HeadersFrame(RESPONSE_HEADERS, false));
+                    ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.wrappedBuffer(CONTENT), true));
+                }
+                case EMPTY -> ctx.writeAndFlush(new DefaultHttp2HeadersFrame(EMPTY_RESPONSE_HEADERS, true));
+                case GET_MB -> {
+                    IoStatsAccumulator runStats = ioStatsFor(requestUri);
+                    GET_MB_REQUESTS.incrementAndGet();
+                    GET_MB_BYTES_SENT.addAndGet(MB_CONTENT.length);
+                    if (runStats != null) {
+                        runStats.getMbRequests.incrementAndGet();
+                        runStats.getMbBytesSent.addAndGet(MB_CONTENT.length);
+                    }
+                    ctx.write(new DefaultHttp2HeadersFrame(MB_RESPONSE_HEADERS, false));
+                    ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.wrappedBuffer(MB_CONTENT), true));
+                }
+                case GET_10MB -> {
+                    ctx.write(new DefaultHttp2HeadersFrame(MB10_RESPONSE_HEADERS, false));
+                    ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.wrappedBuffer(MB10_CONTENT), true));
+                }
+                case OTHER -> {
+                    ctx.write(new DefaultHttp2HeadersFrame(RESPONSE_HEADERS, false));
+                    ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.wrappedBuffer(CONTENT), true));
+                }
+            }
+            requestKind = RequestKind.OTHER;
+        }
+
+        private enum RequestKind {
+            RPC,
+            EMPTY,
+            GET_MB,
+            GET_10MB,
+            OTHER
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            ctx.close();
+        }
+    }
+
+    private static final class IoStatsAccumulator {
+        private final AtomicLong getMbRequests = new AtomicLong();
+        private final AtomicLong getMbBytesSent = new AtomicLong();
+        private final AtomicLong putMbRequests = new AtomicLong();
+        private final AtomicLong putMbBytesReceived = new AtomicLong();
+    }
+
+    /**
+     * Write port configuration to a file for the benchmark to read.
+     */
+    public void writePortFile(File portFile) throws IOException {
+        try (FileWriter writer = new FileWriter(portFile, StandardCharsets.UTF_8)) {
+            writer.write("h1Port=" + h1Port + "\n");
+            writer.write("h2Port=" + h2Port + "\n");
+            writer.write("h2cPort=" + h2cPort + "\n");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Default port file location
+        String portFilePath = args.length > 0 ? args[0] : "build/benchmark-server-ports.properties";
+
+        System.out.println("Starting benchmark server...");
+        BenchmarkServer server = new BenchmarkServer();
+
+        System.out.println("HTTP/1.1 server: http://localhost:" + server.getH1Port());
+        System.out.println("HTTP/2 (TLS) server: https://localhost:" + server.getH2Port());
+        System.out.println("HTTP/2 (h2c) server: http://localhost:" + server.getH2cPort());
+
+        // Write port file
+        File portFile = new File(portFilePath);
+        File parentDir = portFile.getParentFile();
+        if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
+            throw new IOException("Failed to create directory: " + parentDir);
+        }
+        server.writePortFile(portFile);
+        System.out.println("Port file written to: " + portFile.getAbsolutePath());
+
+        // Wait for shutdown signal
+        System.out.println("Press Ctrl+C to stop...");
+        CountDownLatch shutdownLatch = new CountDownLatch(1);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("\nShutting down...");
+            try {
+                server.shutdown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            shutdownLatch.countDown();
+        }));
+
+        shutdownLatch.await();
+        System.out.println("Server stopped.");
+    }
+}

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/ByteBufferDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/ByteBufferDataStream.java
@@ -44,6 +44,11 @@ final class ByteBufferDataStream implements DataStream {
     }
 
     @Override
+    public boolean hasByteBuffer() {
+        return true;
+    }
+
+    @Override
     public InputStream asInputStream() {
         // Use duplicate() to avoid mutating the original buffer's position,
         // allowing the DataStream to be replayed (isReplayable() returns true)

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/DataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/DataStream.java
@@ -117,6 +117,19 @@ public interface DataStream extends Flow.Publisher<ByteBuffer>, AutoCloseable {
         }
     }
 
+    /**
+     * Indicates whether this stream already has a stable in-memory {@link ByteBuffer} representation.
+     *
+     * <p>When this returns {@code true}, calling {@link #asByteBuffer()} must not require materializing or reading
+     * the underlying stream contents. This is stronger than merely supporting {@code asByteBuffer()}, since the
+     * default implementation always materializes the stream into memory.
+     *
+     * @return true if {@link #asByteBuffer()} is backed by an already-available in-memory buffer.
+     */
+    default boolean hasByteBuffer() {
+        return false;
+    }
+
     @Override
     default void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
         HttpRequest.BodyPublishers.ofInputStream(this::asInputStream).subscribe(subscriber);

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/EmptyDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/EmptyDataStream.java
@@ -23,6 +23,11 @@ final class EmptyDataStream implements DataStream {
     }
 
     @Override
+    public boolean hasByteBuffer() {
+        return true;
+    }
+
+    @Override
     public InputStream asInputStream() {
         return InputStream.nullInputStream();
     }

--- a/io/src/main/java/software/amazon/smithy/java/io/datastream/WrappedDataStream.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/datastream/WrappedDataStream.java
@@ -31,6 +31,11 @@ final class WrappedDataStream implements DataStream {
     }
 
     @Override
+    public boolean hasByteBuffer() {
+        return delegate.hasByteBuffer();
+    }
+
+    @Override
     public InputStream asInputStream() {
         return delegate.asInputStream();
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ include(":endpoints")
 include(":framework-errors")
 include(":http:http-api")
 include(":http:http-binding")
+include(":http:http-client")
 include(":retries-api")
 include(":retries")
 


### PR DESCRIPTION
Improve JDK HTTP client transport performance

On my M1 Mac mini:

- Mixed H2/TLS GET 1 MiB + PUT 1 MiB, c=10
  - original: 32.767 ops/s at conn=1, 30.575 at conn=3
  - current: 49.357 ops/s at conn=1, 43.678 at conn=3
  - change: about +51% at conn=1, about +43% at conn=3
- Tiny RPC, lower is better
  - original: 1460.365 us/op
  - current: 1069.535 us/op
  - change: about 27% lower mean latency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
