### PR TITLE
Add service schema to ProtocolSettings for service-level traits

### DIFF
--- a/aws/client/aws-client-restxml/build.gradle.kts
+++ b/aws/client/aws-client-restxml/build.gradle.kts
@@ -21,3 +21,4 @@ dependencies {
 
 val generator = "software.amazon.smithy.java.protocoltests.generators.ProtocolTestGenerator"
 addGenerateSrcsTask(generator, "restXml", "aws.protocoltests.restxml#RestXml")
+addGenerateSrcsTask(generator, "restXmlWithNamespace", "aws.protocoltests.restxml.xmlns#RestXmlWithNamespace")

--- a/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
+++ b/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlProtocolTests.java
@@ -129,17 +129,25 @@ public class RestXmlProtocolTests {
                 return false;
             }
 
-            // Compare child nodes
+            // Compare child nodes (order-independent)
             NodeList children1 = node1.getChildNodes();
             NodeList children2 = node2.getChildNodes();
             if (children1.getLength() != children2.getLength()) {
                 return false;
             }
 
+            boolean[] matched = new boolean[children2.getLength()];
             for (int i = 0; i < children1.getLength(); i++) {
                 Node child1 = children1.item(i);
-                Node child2 = children2.item(i);
-                if (!compareNodes(child1, child2)) {
+                boolean found = false;
+                for (int j = 0; j < children2.getLength(); j++) {
+                    if (!matched[j] && compareNodes(child1, children2.item(j))) {
+                        matched[j] = true;
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
                     return false;
                 }
             }

--- a/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlWithNamespaceProtocolTests.java
+++ b/aws/client/aws-client-restxml/src/it/java/software/amazon/smithy/java/aws/client/restxml/RestXmlWithNamespaceProtocolTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.aws.client.restxml;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import software.amazon.smithy.java.io.ByteBufferUtils;
+import software.amazon.smithy.java.io.datastream.DataStream;
+import software.amazon.smithy.java.protocoltests.harness.HttpClientRequestTests;
+import software.amazon.smithy.java.protocoltests.harness.HttpClientResponseTests;
+import software.amazon.smithy.java.protocoltests.harness.ProtocolTest;
+import software.amazon.smithy.java.protocoltests.harness.StringBuildingSubscriber;
+import software.amazon.smithy.java.protocoltests.harness.TestType;
+
+@ProtocolTest(
+        service = "aws.protocoltests.restxml.xmlns#RestXmlWithNamespace",
+        testType = TestType.CLIENT)
+public class RestXmlWithNamespaceProtocolTests {
+    @HttpClientRequestTests
+    public void requestTest(DataStream expected, DataStream actual) {
+        if (expected.contentLength() != 0) {
+            var a = new String(ByteBufferUtils.getBytes(actual.asByteBuffer()), StandardCharsets.UTF_8);
+            var b = new String(ByteBufferUtils.getBytes(expected.asByteBuffer()), StandardCharsets.UTF_8);
+            if ("application/xml".equals(expected.contentType())) {
+                if (!RestXmlProtocolTests.XMLComparator.compareXMLStrings(a, b)) {
+                    assertThat(a, equalTo(b));
+                }
+            } else {
+                assertEquals(a, b);
+            }
+        } else if (expected.contentType() != null) {
+            assertEquals("", new StringBuildingSubscriber(actual).getResult());
+        }
+    }
+
+    @HttpClientResponseTests
+    public void responseTest(Runnable test) {
+        test.run();
+    }
+}

--- a/aws/client/aws-client-restxml/src/main/java/software/amazon/smithy/java/aws/client/restxml/RestXmlClientProtocol.java
+++ b/aws/client/aws-client-restxml/src/main/java/software/amazon/smithy/java/aws/client/restxml/RestXmlClientProtocol.java
@@ -21,6 +21,8 @@ import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.error.CallException;
 import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.TypeRegistry;
 import software.amazon.smithy.java.core.serde.document.Document;
@@ -45,9 +47,18 @@ public final class RestXmlClientProtocol extends HttpBindingClientProtocol<AwsEv
      *                relative shape IDs.
      */
     public RestXmlClientProtocol(ShapeId service) {
+        this(service, null);
+    }
+
+    /**
+     * @param service The service being called.
+     * @param serviceSchema The service schema, used to extract service-level traits like xmlNamespace.
+     */
+    public RestXmlClientProtocol(ShapeId service, Schema serviceSchema) {
         super(RestXmlTrait.ID);
 
-        this.codec = XmlCodec.builder().build();
+        var xmlNamespace = serviceSchema != null ? serviceSchema.getTrait(TraitKey.XML_NAMESPACE_TRAIT) : null;
+        this.codec = XmlCodec.builder().defaultNamespace(xmlNamespace).build();
         this.errorDeserializer = HttpErrorDeserializer.builder()
                 .codec(codec)
                 .serviceId(service)
@@ -129,7 +140,7 @@ public final class RestXmlClientProtocol extends HttpBindingClientProtocol<AwsEv
 
         @Override
         public ClientProtocol<?, ?> createProtocol(ProtocolSettings settings, RestXmlTrait trait) {
-            return new RestXmlClientProtocol(settings.service());
+            return new RestXmlClientProtocol(settings.service(), settings.serviceSchema());
         }
     }
 }

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ProtocolSettings.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ProtocolSettings.java
@@ -84,6 +84,9 @@ public final class ProtocolSettings {
          * @return the builder
          */
         public Builder serviceSchema(Schema serviceSchema) {
+            if (service == null && serviceSchema != null) {
+                service = serviceSchema.id();
+            }
             this.serviceSchema = serviceSchema;
             return this;
         }

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ProtocolSettings.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ProtocolSettings.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.client.core;
 
+import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -13,10 +14,12 @@ import software.amazon.smithy.model.shapes.ShapeId;
 public final class ProtocolSettings {
     private final ShapeId service;
     private final String serviceVersion;
+    private final Schema serviceSchema;
 
     private ProtocolSettings(Builder builder) {
         this.service = builder.service;
         this.serviceVersion = builder.serviceVersion;
+        this.serviceSchema = builder.serviceSchema;
     }
 
     public ShapeId service() {
@@ -35,6 +38,18 @@ public final class ProtocolSettings {
         return serviceVersion;
     }
 
+    /**
+     * Gets the service schema.
+     *
+     * <p>The service schema carries service-level traits that protocols may
+     * need at runtime (e.g., {@code xmlNamespace}).
+     *
+     * @return the service schema, or null if not set
+     */
+    public Schema serviceSchema() {
+        return serviceSchema;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -42,6 +57,7 @@ public final class ProtocolSettings {
     public static final class Builder {
         private ShapeId service;
         private String serviceVersion;
+        private Schema serviceSchema;
 
         private Builder() {}
 
@@ -58,6 +74,17 @@ public final class ProtocolSettings {
          */
         public Builder serviceVersion(String serviceVersion) {
             this.serviceVersion = serviceVersion;
+            return this;
+        }
+
+        /**
+         * Sets the service schema.
+         *
+         * @param serviceSchema the service schema
+         * @return the builder
+         */
+        public Builder serviceSchema(Schema serviceSchema) {
+            this.serviceSchema = serviceSchema;
             return this;
         }
 

--- a/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/plugins/DetectProtocolPlugin.java
+++ b/client/dynamic-client/src/main/java/software/amazon/smithy/java/dynamicclient/plugins/DetectProtocolPlugin.java
@@ -17,6 +17,8 @@ import software.amazon.smithy.java.client.core.ClientTransport;
 import software.amazon.smithy.java.client.core.ProtocolSettings;
 import software.amazon.smithy.java.dynamicclient.settings.ModelSetting;
 import software.amazon.smithy.java.dynamicclient.settings.ServiceIdSetting;
+import software.amazon.smithy.java.dynamicschemas.SchemaConverter;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.Trait;
@@ -74,8 +76,8 @@ public final class DetectProtocolPlugin implements ClientPlugin {
 
         var transport = config.transport();
         ClientProtocol<?, ?> protocol = transport != null
-                ? findProtocolMatchingTransport(service, protocols, transport)
-                : findProtocol(service, protocols);
+                ? findProtocolMatchingTransport(model, service, protocols, transport)
+                : findProtocol(model, service, protocols);
 
         if (protocol != null) {
             config.protocol(protocol);
@@ -89,32 +91,39 @@ public final class DetectProtocolPlugin implements ClientPlugin {
                         + " (transport set?=" + (transport == null ? "no" : transport.getClass().getName()) + ")");
     }
 
-    private static ClientProtocol<?, ?> findProtocol(ShapeId service, Map<ShapeId, Trait> protocols) {
+    private static ClientProtocol<?, ?> findProtocol(Model model, ShapeId service, Map<ShapeId, Trait> protocols) {
         for (var protocolImpl : PROTOCOL_FACTORIES) {
             if (protocols.containsKey(protocolImpl.id())) {
-                return createProtocol(service, protocols, protocolImpl);
+                return createProtocol(model, service, protocols, protocolImpl);
             }
         }
         return null;
     }
 
     private static ClientProtocol<?, ?> createProtocol(
+            Model model,
             ShapeId service,
             Map<ShapeId, Trait> protocols,
             ClientProtocolFactory<Trait> protocolImpl
     ) {
-        var settings = ProtocolSettings.builder().service(service).build();
+        var converter = new SchemaConverter(model);
+        var serviceSchema = converter.getSchema(model.expectShape(service));
+        var settings = ProtocolSettings.builder()
+                .service(service)
+                .serviceSchema(serviceSchema)
+                .build();
         return protocolImpl.createProtocol(settings, protocols.get(protocolImpl.id()));
     }
 
     private static ClientProtocol<?, ?> findProtocolMatchingTransport(
+            Model model,
             ShapeId service,
             Map<ShapeId, Trait> protocols,
             ClientTransport<?, ?> transport
     ) {
         for (var protocolImpl : PROTOCOL_FACTORIES) {
             if (protocols.containsKey(protocolImpl.id())) {
-                var protocol = createProtocol(service, protocols, protocolImpl);
+                var protocol = createProtocol(model, service, protocols, protocolImpl);
                 // Only return the protocol if it has the same message exchange as the transport.
                 if (protocol.messageExchange().equals(transport.messageExchange())) {
                     return protocol;

--- a/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlCodec.java
+++ b/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlCodec.java
@@ -16,6 +16,7 @@ import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.io.ByteBufferUtils;
+import software.amazon.smithy.model.traits.XmlNamespaceTrait;
 
 /**
  * Serialize and deserialize XML documents.
@@ -29,6 +30,7 @@ public final class XmlCodec implements Codec {
     private final XmlInfo xmlInfo = new XmlInfo();
     private final XMLEventFactory eventFactory = XMLEventFactory.newInstance();
     private final List<String> wrapperElements;
+    private final XmlNamespaceTrait defaultNamespace;
 
     private XmlCodec(Builder builder) {
         xmlInputFactory = XMLInputFactory.newInstance();
@@ -38,6 +40,7 @@ public final class XmlCodec implements Codec {
         xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, false);
         xmlOutputFactory = XMLOutputFactory.newInstance();
         this.wrapperElements = builder.wrapperElements;
+        this.defaultNamespace = builder.defaultNamespace;
     }
 
     /**
@@ -52,7 +55,7 @@ public final class XmlCodec implements Codec {
     @Override
     public ShapeSerializer createSerializer(OutputStream sink) {
         try {
-            return new XmlSerializer(xmlOutputFactory.createXMLStreamWriter(sink), xmlInfo);
+            return new XmlSerializer(xmlOutputFactory.createXMLStreamWriter(sink), xmlInfo, defaultNamespace);
         } catch (XMLStreamException e) {
             throw new RuntimeException(e);
         }
@@ -77,6 +80,7 @@ public final class XmlCodec implements Codec {
      */
     public static final class Builder {
         private List<String> wrapperElements = List.of();
+        private XmlNamespaceTrait defaultNamespace;
 
         private Builder() {}
 
@@ -96,6 +100,17 @@ public final class XmlCodec implements Codec {
          */
         public Builder wrapperElements(List<String> wrapperElements) {
             this.wrapperElements = wrapperElements;
+            return this;
+        }
+
+        /**
+         * Sets a default XML namespace to apply to top-level elements during serialization.
+         *
+         * @param defaultNamespace the default namespace trait
+         * @return the builder
+         */
+        public Builder defaultNamespace(XmlNamespaceTrait defaultNamespace) {
+            this.defaultNamespace = defaultNamespace;
             return this;
         }
 

--- a/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlDeserializer.java
+++ b/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlDeserializer.java
@@ -614,7 +614,14 @@ final class XmlDeserializer implements ShapeDeserializer {
             for (var entry : decoder.attributes.entrySet()) {
                 String attributeName = entry.getKey();
                 Schema attributeSchema = entry.getValue();
-                String attributeValue = reader.getAttributeValue(null, attributeName);
+                // For namespace-prefixed attributes (e.g., "xsi:someName"), use the local part
+                // for lookup since namespace-aware XML parsers store them by local name.
+                String lookupName = attributeName;
+                int colonIdx = attributeName.indexOf(':');
+                if (colonIdx >= 0) {
+                    lookupName = attributeName.substring(colonIdx + 1);
+                }
+                String attributeValue = reader.getAttributeValue(null, lookupName);
                 if (attributeValue != null) {
                     try {
                         consumer.accept(state, attributeSchema, new AttributeDeserializer(reader, attributeValue));

--- a/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlSerializer.java
+++ b/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlSerializer.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.java.core.serde.TimestampFormatter;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.io.ByteBufferUtils;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
+import software.amazon.smithy.model.traits.XmlNamespaceTrait;
 
 final class XmlSerializer extends InterceptingSerializer {
 
@@ -31,15 +32,17 @@ final class XmlSerializer extends InterceptingSerializer {
 
     private final XmlInfo xmlInfo;
     private final XMLStreamWriter writer;
+    private final XmlNamespaceTrait defaultNamespace;
     private final NonFlattenedMemberSerializer nonFlattenedMemberSerializer = new NonFlattenedMemberSerializer();
     private final ValueSerializer valueSerializer = new ValueSerializer();
     private final StructMemberSerializer structMemberSerializer = new StructMemberSerializer();
     private final StructAttributeSerializer structAttributeSerializer = new StructAttributeSerializer();
     private final AttributeSerializer attributeSerializer = new AttributeSerializer();
 
-    XmlSerializer(XMLStreamWriter writer, XmlInfo xmlInfo) {
+    XmlSerializer(XMLStreamWriter writer, XmlInfo xmlInfo, XmlNamespaceTrait defaultNamespace) {
         this.writer = writer;
         this.xmlInfo = xmlInfo;
+        this.defaultNamespace = defaultNamespace;
     }
 
     // Handles writing top-level shapes that are not members. The element uses xmlName or the shape name.
@@ -61,6 +64,9 @@ final class XmlSerializer extends InterceptingSerializer {
 
             // Add a namespace if present, and peek-through to the target shape for a namespace when it's a member.
             var ns = schema.getTrait(TraitKey.XML_NAMESPACE_TRAIT);
+            if (ns == null) {
+                ns = defaultNamespace;
+            }
             if (ns != null) {
                 writer.writeNamespace(ns.getPrefix().orElse(null), ns.getUri());
             }

--- a/codegen/codegen-plugin/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
+++ b/codegen/codegen-plugin/src/main/java/software/amazon/smithy/java/codegen/client/generators/ClientInterfaceGenerator.java
@@ -447,6 +447,7 @@ public final class ClientInterfaceGenerator
                     private static final ${protocolSettings:T} protocolSettings = ${protocolSettings:T}.builder()
                             .service(${shapeId:T}.from(${service:S}))
                             .serviceVersion(${serviceVersion:S})
+                            .serviceSchema(${serviceApi:T}.instance().schema())
                             .build();
                     private static final ${trait:T} protocolTrait = ${initializer:C};
                     """;

--- a/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
+++ b/protocol-test-harness/src/main/java/software/amazon/smithy/java/protocoltests/harness/ProtocolTestExtension.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.java.codegen.JavaSymbolProvider;
 import software.amazon.smithy.java.codegen.ServerSymbolProperties;
 import software.amazon.smithy.java.core.error.ModeledException;
 import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.logging.InternalLogger;
@@ -37,6 +38,7 @@ import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.protocoltests.traits.HttpMalformedRequestTestCase;
 import software.amazon.smithy.protocoltests.traits.HttpMalformedRequestTestsTrait;
@@ -243,9 +245,13 @@ public final class ProtocolTestExtension implements BeforeAllCallback, AfterAllC
             if (protocolFactory == null) {
                 continue;
             }
+            var serviceSchema = Schema.createService(
+                    service.getId(),
+                    service.getAllTraits().values().toArray(new Trait[0]));
             var protocolSettings = ProtocolSettings.builder()
                     .service(service.getId())
                     .serviceVersion(service.getVersion())
+                    .serviceSchema(serviceSchema)
                     .build();
             var instance = protocolFactory.createProtocol(protocolSettings, protocolTraitEntry.getValue());
             protocols.put(protocolTraitEntry.getKey(), instance);


### PR DESCRIPTION
### Summary

When a service has the `@xmlNamespace` trait, the namespace must be applied to the top-level XML element during serialization and deserialization.
The restXml protocol was not handling this because the `XmlCodec` only read `@xmlNamespace` from individual shapes, not from the service.

### Approach

Add `serviceSchema(Schema)` to `ProtocolSettings`. Since `Schema` already carries traits throughout the codebase, protocols can extract whatever service-level traits they need without adding protocol-specific fields to the shared settings class. The `RestXmlClientProtocol` factory reads the `xmlNamespace~ trait from the service schema and passes it to the `XmlCodec` as a default namespace for top-level elements.

### Additional fixes

- `XmlDeserializer`: Namespace-prefixed attributes (e.g., xsi:someName) were not being deserialized because the namespace-aware XML parser stores them by local name (someName), not the prefixed form.
- XML test comparator: Changed child node comparison to be order-independent, since XML element order.

### Testing

Used AmazonSSM to test codegen, the client builder adds the service schema as expected

```java
    /**
     * Builder for {@link AmazonSSMClient}.
     */
    final class Builder extends Client.Builder<AmazonSSMClient, Builder> {
        private static final ProtocolSettings protocolSettings = ProtocolSettings.builder()
                .service(ShapeId.from("com.amazonaws.ssm#AmazonSSM"))
                .serviceVersion("2014-11-06")
                .serviceSchema(AmazonSSMApiService.instance().schema())
                .build();
        private static final AwsJson1_1Trait protocolTrait = new AwsJson1_1Trait.Provider().createTrait(
            ShapeId.from("aws.protocols#awsJson1_1"),
            Node.objectNode()
        );
```

--
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
