### PR TITLE
For query protocols ignore the body if the output schema has the unit type trait

### DIFF
--- a/aws/client/aws-client-awsquery/src/main/java/software/amazon/smithy/java/aws/client/awsquery/AwsQueryClientProtocol.java
+++ b/aws/client/aws-client-awsquery/src/main/java/software/amazon/smithy/java/aws/client/awsquery/AwsQueryClientProtocol.java
@@ -102,7 +102,7 @@ public final class AwsQueryClientProtocol extends HttpClientProtocol {
         var builder = operation.outputBuilder();
         var content = response.body();
 
-        if (content.contentLength() == 0) {
+        if (content.contentLength() == 0 || operation.outputSchema().hasTrait(TraitKey.UNIT_TYPE_TRAIT)) {
             return builder.build();
         }
 


### PR DESCRIPTION
*Description of changes:*

Some services such as Neptune's AddTagsToResourceResponse operation that targets `smithy.api#Unit` for its output still returns the `ResponseMetadata` in the payload. This change ignores the response when the operation output targes Unit. See example of output below.

```
  <AddTagsToResourceResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
    <ResponseMetadata>
      <RequestId>abc-123</RequestId>
    </ResponseMetadata>
  </AddTagsToResourceResponse
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
