### PR TITLE
Set CHECKED when there are no modules to avoid repeating the work

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/core/VersionCheck.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/VersionCheck.java
@@ -62,6 +62,7 @@ public final class VersionCheck {
         }
 
         if (modules.isEmpty()) {
+            CHECKED.set(true);
             return;
         }
 


### PR DESCRIPTION
*Issue #, if available:*

Follow up to #1167, set `CHECKED` if we exit early due no modules discovered by SPI to avoid repeating the work the next time we call this code.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
