### PR TITLE
Cache if has struct payload for HTTP bindings

### DIFF
--- a/aws/client/aws-client-restjson/src/main/java/software/amazon/smithy/java/aws/client/restjson/RestJsonClientProtocol.java
+++ b/aws/client/aws-client-restjson/src/main/java/software/amazon/smithy/java/aws/client/restjson/RestJsonClientProtocol.java
@@ -19,7 +19,6 @@ import software.amazon.smithy.java.client.http.binding.HttpBindingErrorFactory;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
-import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.event.EventDecoderFactory;
 import software.amazon.smithy.java.core.serde.event.EventEncoderFactory;
@@ -29,7 +28,6 @@ import software.amazon.smithy.java.http.binding.RequestSerializer;
 import software.amazon.smithy.java.io.uri.SmithyUri;
 import software.amazon.smithy.java.json.JsonCodec;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.ShapeType;
 
 /**
  * Implements aws.protocols#restJson1.
@@ -74,7 +72,7 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
                 .shapeValue(input)
                 .endpoint(endpoint)
                 .omitEmptyPayload(omitEmptyPayload())
-                .allowEmptyStructPayload(hasStructPayload(input));
+                .allowEmptyStructPayload(httpBinding().hasStructPayload(input.schema()));
 
         if (operation.inputEventBuilderSupplier() != null) {
             serializer.eventEncoderFactory(getEventEncoderFactory(operation));
@@ -116,17 +114,6 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
     @Override
     protected EventDecoderFactory<AwsEventFrame> getEventDecoderFactory(ApiOperation<?, ?> operation) {
         return AwsEventDecoderFactory.forOutputStream(operation, payloadCodec(), f -> f);
-    }
-
-    private <I extends SerializableStruct> boolean hasStructPayload(I input) {
-        var members = input.schema().members();
-        for (var member : members) {
-            if (member.type().equals(ShapeType.STRUCTURE)
-                    && member.hasTrait(TraitKey.HTTP_PAYLOAD_TRAIT)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public static final class Factory implements ClientProtocolFactory<RestJson1Trait> {

--- a/client/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
+++ b/client/client-http-binding/src/main/java/software/amazon/smithy/java/client/http/binding/HttpBindingClientProtocol.java
@@ -22,7 +22,6 @@ import software.amazon.smithy.java.http.binding.HttpBinding;
 import software.amazon.smithy.java.http.binding.RequestSerializer;
 import software.amazon.smithy.java.http.binding.ResponseDeserializer;
 import software.amazon.smithy.java.io.uri.SmithyUri;
-import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
@@ -34,7 +33,6 @@ import software.amazon.smithy.model.shapes.ShapeId;
  */
 public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends HttpClientProtocol {
 
-    private static final InternalLogger LOGGER = InternalLogger.getLogger(HttpBindingClientProtocol.class);
     private final HttpBinding httpBinding = new HttpBinding();
 
     public HttpBindingClientProtocol(ShapeId id) {
@@ -95,8 +93,6 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
             throw createError(operation, context, typeRegistry, request, response);
         }
 
-        LOGGER.trace("Deserializing successful response with {}", getClass().getName());
-
         var outputBuilder = operation.outputBuilder();
         ResponseDeserializer deser = httpBinding.responseDeserializer()
                 .payloadCodec(payloadCodec())
@@ -109,9 +105,7 @@ public abstract class HttpBindingClientProtocol<F extends Frame<?>> extends Http
         }
 
         deser.deserialize();
-        O output = outputBuilder.errorCorrection().build();
-        LOGGER.trace("Successfully built {} from HTTP response with {}", output, getClass().getName());
-        return output;
+        return outputBuilder.errorCorrection().build();
     }
 
     /**

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBinding.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBinding.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.java.http.binding;
 
+import software.amazon.smithy.java.core.schema.Schema;
+
 /**
  * Entry point for handling HTTP bindings.
  */
@@ -46,5 +48,17 @@ public final class HttpBinding {
      */
     public ResponseDeserializer responseDeserializer() {
         return new ResponseDeserializer();
+    }
+
+    /**
+     * Whether the given input-struct schema's request binding has an {@code @httpPayload}
+     * member whose target is a {@code STRUCTURE} — i.e., the request body is a single
+     * codec-serialized struct rather than headers + member-derived body fields.
+     *
+     * @param inputSchema the operation input struct schema.
+     * @return {@code true} iff the schema has a struct-typed @httpPayload member.
+     */
+    public boolean hasStructPayload(Schema inputSchema) {
+        return HttpBindingSchemaExtensions.structBindingsOf(inputSchema).request().hasStructPayload;
     }
 }

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSchemaExtensions.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSchemaExtensions.java
@@ -191,6 +191,8 @@ public final class HttpBindingSchemaExtensions
         final Schema payloadMember;
         final boolean hasBody;
         final boolean hasPayload;
+        // True iff the request struct has an {@code @httpPayload} member whose target is a {@code STRUCTURE}.
+        final boolean hasStructPayload;
         // Set of all declared header wire names. Used by HttpPrefixHeadersSerializer to skip
         // map keys that already collide with explicit @httpHeader members.
         final Set<String> headerWireNames;
@@ -215,6 +217,7 @@ public final class HttpBindingSchemaExtensions
                 Schema payloadMember,
                 boolean hasBody,
                 boolean hasPayload,
+                boolean hasStructPayload,
                 Set<String> headerWireNames,
                 boolean inputContentTypeHeader,
                 int headerCount
@@ -232,6 +235,7 @@ public final class HttpBindingSchemaExtensions
             this.payloadMember = payloadMember;
             this.hasBody = hasBody;
             this.hasPayload = hasPayload;
+            this.hasStructPayload = hasStructPayload;
             this.headerWireNames = headerWireNames;
             this.inputContentTypeHeader = inputContentTypeHeader;
             this.headerCount = headerCount;
@@ -570,6 +574,9 @@ public final class HttpBindingSchemaExtensions
         // over-allocating for AWS-S3-style structs that declare 50+ headers but populate few.
         int headerCount = Math.min(headers.size() + prefixHeaders.size() + 4, 32);
 
+        // True iff the @httpPayload member targets a STRUCTURE shape
+        boolean hasStructPayload = payload != null && payload.type() == ShapeType.STRUCTURE;
+
         return new RequestBinding(
                 bindings,
                 memberBindings,
@@ -584,6 +591,7 @@ public final class HttpBindingSchemaExtensions
                 payload,
                 hasBody,
                 hasPayload,
+                hasStructPayload,
                 headerWireNames,
                 hasContentTypeHeader,
                 headerCount);


### PR DESCRIPTION
Removes the need for this check on every repeated use of an operation, and pre-computing is cheap since we already have the payload handy during precompute anyway. Shaves off ~5% on operations with a large number of members, like restJson1_CopyObjectRequest_Baseline.

Also remove some chatty log statements

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
