### PR TITLE
Use deferred writes to avoid interpreting dollar sign as format

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/StringTraitInitializer.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/integrations/core/StringTraitInitializer.java
@@ -17,7 +17,6 @@ final class StringTraitInitializer implements TraitInitializer<StringTrait> {
 
     @Override
     public void accept(JavaWriter writer, StringTrait stringTrait) {
-        var stringValue = stringTrait.getValue().replace("£", "££");
-        writer.writeInline("new $T($S)", stringTrait.getClass(), stringValue);
+        writer.writeInline("new $T($S)", stringTrait.getClass(), stringTrait.getValue());
     }
 }

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/writer/DeferredSymbolWriter.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/writer/DeferredSymbolWriter.java
@@ -25,11 +25,6 @@ public abstract class DeferredSymbolWriter<W extends SymbolWriter<W, I>, I exten
         super(importContainer);
     }
 
-    @Override
-    public String toString() {
-        return format(super.toString());
-    }
-
     /**
      * Add symbol to symbol table, so potential type name conflicts can be detected and
      * handled.

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/writer/JavaWriter.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/writer/JavaWriter.java
@@ -30,7 +30,6 @@ import software.amazon.smithy.utils.StringUtils;
  */
 @SmithyUnstableApi
 public final class JavaWriter extends DeferredSymbolWriter<JavaWriter, JavaImportContainer> {
-    private static final char PLACEHOLDER_FORMAT_CHAR = '£';
     private final String packageNamespace;
     private final JavaCodegenSettings settings;
     private final String filename;
@@ -81,19 +80,12 @@ public final class JavaWriter extends DeferredSymbolWriter<JavaWriter, JavaImpor
         }
 
         putNameContext();
-        setExpressionStart(PLACEHOLDER_FORMAT_CHAR);
         String header = settings.header();
         String headerPrefix = (header != null && !header.isEmpty()) ? header + "\n" : "";
-        return format(
-                """
-                        £Lpackage £L;
-
-                        £L
-                        £L""",
-                headerPrefix,
-                packageNamespace,
-                getImportContainer(),
-                super.toString());
+        return headerPrefix
+                + "package " + packageNamespace + ";\n\n"
+                + getImportContainer() + "\n"
+                + super.toString();
     }
 
     /**
@@ -101,8 +93,7 @@ public final class JavaWriter extends DeferredSymbolWriter<JavaWriter, JavaImpor
      */
     public String toContentString() {
         putNameContext();
-        setExpressionStart(PLACEHOLDER_FORMAT_CHAR);
-        return format("£L", super.toString());
+        return super.toString();
     }
 
     /**
@@ -228,9 +219,10 @@ public final class JavaWriter extends DeferredSymbolWriter<JavaWriter, JavaImpor
             addImport(normalizedSymbol);
             addToSymbolTable(normalizedSymbol);
 
-            // Return a placeholder value that will be filled when toString is called
+            // Return a deferred value that resolves the type name at toString() time
             // [] is replaced with "Array" to ensure array types don't break formatter.
-            return format("$L{$L:L}", PLACEHOLDER_FORMAT_CHAR, symbol.getFullName().replace("[]", "Array"));
+            String fullName = symbol.getFullName().replace("[]", "Array");
+            return defer(() -> format("${" + fullName + ":L}"));
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit5 = "6.0.3"
 hamcrest = "3.0"
-smithy = "1.70.0"
+smithy = "1.71.0"
 jmh = "0.7.3"
 test-logger-plugin = "4.0.0"
 spotbugs = "6.0.22"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


This change uses deferred writes to defer the writing of types until we can decide if we should use a FQN or a simple name with an import. Similar to the change made to smithy for trait codegen [#3096](https://github.com/smithy-lang/smithy/pull/3096)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
