### PR TITLE
Print sdk artifact sizes

### DIFF
--- a/codegen/codegen-plugin/build.gradle.kts
+++ b/codegen/codegen-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.Serializable
+
 plugins {
     id("smithy-java.codegen-plugin-conventions")
     id("smithy-java.publishing-conventions")
@@ -95,4 +97,64 @@ tasks.test {
 
 configureIntegTests {
     awsModelTests = true
+}
+
+val artifactStatsDir = project.layout.buildDirectory.dir("reports/artifact-stats")
+
+class PrintArtifactSizeStats(
+    private val statsPath: String,
+) : Action<Task>,
+    Serializable {
+    override fun execute(task: Task) {
+        val statsFile = File(statsPath, "artifact-size-stats.tsv")
+        if (!statsFile.exists()) {
+            return
+        }
+
+        val entries =
+            statsFile
+                .readLines()
+                .filter { it.isNotBlank() }
+                .map { line ->
+                    val (name, size) = line.split('\t')
+                    name to size.toLong()
+                }.sortedBy { it.second }
+
+        if (entries.isEmpty()) {
+            return
+        }
+
+        val total = entries.sumOf { it.second }
+        val avg = total / entries.size
+        val (minName, minSize) = entries.first()
+        val (maxName, maxSize) = entries.last()
+
+        fun humanReadable(bytes: Long): String =
+            when {
+                bytes < 1024 -> "$bytes B"
+                bytes < 1024 * 1024 -> "%.1f KB".format(bytes / 1024.0)
+                else -> "%.1f MB".format(bytes / (1024.0 * 1024.0))
+            }
+
+        println()
+        println("========== Compiled Artifact Size Statistics ==========")
+        println("  SDKs processed: ${entries.size}")
+        println("  Average size:   ${humanReadable(avg)} (%,d bytes)".format(avg))
+        println("  Min size:       ${humanReadable(minSize)} (%,d bytes) -> $minName".format(minSize))
+        println("  Max size:       ${humanReadable(maxSize)} (%,d bytes) -> $maxName".format(maxSize))
+        println("  Total:          ${humanReadable(total)} (%,d bytes)".format(total))
+        println("=======================================================")
+        println()
+        println("Top 5 largest SDKs:")
+        for ((name, size) in entries.takeLast(5).reversed()) {
+            println("  %-50s %s".format(name, humanReadable(size)))
+        }
+    }
+}
+
+tasks.named<Test>("integ") {
+    val statsPath = artifactStatsDir.get().asFile.absolutePath
+    systemProperty("artifactStatsDir", statsPath)
+    outputs.dir(artifactStatsDir)
+    doLast(PrintArtifactSizeStats(statsPath))
 }

--- a/codegen/codegen-plugin/src/it/java/software/amazon/smithy/java/codegen/AwsModelCodegenCompilationTest.java
+++ b/codegen/codegen-plugin/src/it/java/software/amazon/smithy/java/codegen/AwsModelCodegenCompilationTest.java
@@ -20,7 +20,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.tools.Diagnostic;
@@ -33,6 +36,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.parallel.Execution;
@@ -57,10 +61,25 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 @EnabledIfSystemProperty(named = "awsModelsTests", matches = "true")
 class AwsModelCodegenCompilationTest {
 
+    private static final Map<String, Long> artifactSizes = new ConcurrentHashMap<>();
+
     private static final Set<String> IGNORED_SDK_IDS = Set.of(
             "timestream-write",
             "timestream-query",
             "clouddirectory");
+
+    @AfterAll
+    static void writeArtifactSizeStatistics() throws IOException {
+        var sb = new StringBuilder();
+        artifactSizes.forEach((key, value) -> sb.append(key)
+                .append('\t')
+                .append(value)
+                .append('\n'));
+
+        Path outputDir = Path.of(System.getProperty("artifactStatsDir", "build"));
+        Files.createDirectories(outputDir);
+        Files.writeString(outputDir.resolve("artifact-size-stats.tsv"), sb.toString());
+    }
 
     static Stream<Named<URL>> awsModels() {
         return ModelDiscovery.findModels()
@@ -148,6 +167,7 @@ class AwsModelCodegenCompilationTest {
                         fail(Arrays.toString(modes) + " compilation failed for " + service.getId()
                                 + ". Generated sources dumped to: " + dumpFile + "\n" + errors);
                     }
+                    artifactSizes.put(artifactName(modelUrl), fm.getTotalBytesWritten());
                 }
             }
         } catch (Throwable t) {
@@ -201,11 +221,17 @@ class AwsModelCodegenCompilationTest {
     }
 
     /**
-     * In-memory output manager — discards .class bytes.
+     * In-memory output manager — captures .class byte counts.
      */
     private static class InMemoryFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
+        private final AtomicLong totalBytesWritten = new AtomicLong();
+
         InMemoryFileManager(StandardJavaFileManager delegate) {
             super(delegate);
+        }
+
+        long getTotalBytesWritten() {
+            return totalBytesWritten.get();
         }
 
         @Override
@@ -220,7 +246,13 @@ class AwsModelCodegenCompilationTest {
                     kind) {
                 @Override
                 public OutputStream openOutputStream() {
-                    return new ByteArrayOutputStream();
+                    return new ByteArrayOutputStream() {
+                        @Override
+                        public void close() throws IOException {
+                            super.close();
+                            totalBytesWritten.addAndGet(size());
+                        }
+                    };
                 }
             };
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

```
========== Compiled Artifact Size Statistics ==========
  SDKs processed: 423
  Average size:   3.1 MB (3,206,501 bytes)
  Min size:       109.3 KB (111,964 bytes) -> marketplace-reporting
  Max size:       49.7 MB (52,129,916 bytes) -> ec2
  Total:          1293.5 MB (1,356,350,099 bytes)
=======================================================

Top 5 largest SDKs:
  ec2                                                49.7 MB
  sagemaker                                          32.4 MB
  quicksight                                         29.2 MB
  connect                                            25.3 MB
  glue                                               18.6 MB
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
