### PR TITLE
Added client call decorator feature

### DIFF
--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
@@ -82,7 +82,13 @@ public abstract class Client implements Closeable {
             RequestOverrideConfig overrideConfig
     ) {
         if (callDecorator != null) {
-            return callDecorator.apply(this, operation, input, overrideConfig, this::doCall);
+            return callDecorator.apply(
+                    this,
+                    operation,
+                    input,
+                    overrideConfig,
+                    overrideConfig == null ? null : overrideConfig.context(),
+                    this::doCall);
         }
 
         return this.doCall(input, operation, overrideConfig);

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/Client.java
@@ -43,7 +43,9 @@ public abstract class Client implements Closeable {
     private final ClientInterceptor interceptor;
     private final IdentityResolvers identityResolvers;
     private final RetryStrategy retryStrategy;
+    private final ClientCallDecorator<Client> callDecorator;
 
+    @SuppressWarnings("unchecked")
     protected Client(Builder<?, ?> builder) {
         ClientConfig.Builder configBuilder = builder.configBuilder();
         this.config = configBuilder.build();
@@ -61,6 +63,7 @@ public abstract class Client implements Closeable {
         if (retryStrategy instanceof Claimable c) {
             c.claim(this);
         }
+        this.callDecorator = (ClientCallDecorator<Client>) this.config.callDecorator();
     }
 
     /**
@@ -74,6 +77,18 @@ public abstract class Client implements Closeable {
      * @return Returns the deserialized output.
      */
     protected <I extends SerializableStruct, O extends SerializableStruct> O call(
+            I input,
+            ApiOperation<I, O> operation,
+            RequestOverrideConfig overrideConfig
+    ) {
+        if (callDecorator != null) {
+            return callDecorator.apply(this, operation, input, overrideConfig, this::doCall);
+        }
+
+        return this.doCall(input, operation, overrideConfig);
+    }
+
+    private <I extends SerializableStruct, O extends SerializableStruct> O doCall(
             I input,
             ApiOperation<I, O> operation,
             RequestOverrideConfig overrideConfig
@@ -367,7 +382,7 @@ public abstract class Client implements Closeable {
          * plugin class. Plugins are applied in a sorted {@link ClientPlugin.Phase} and insertion order.
          *
          * @see ClientConfig.Builder#pluginPredicate()
-         * @see ClientConfig.Builder#addPlugin(ClientPlugin) 
+         * @see ClientConfig.Builder#addPlugin(ClientPlugin)
          * @param plugin Plugin to add.
          * @return the builder.
          */
@@ -415,6 +430,18 @@ public abstract class Client implements Closeable {
                     return AutoPlugin.INSTANCE != plugin;
                 }
             }.and(configBuilder.pluginPredicate()));
+        }
+
+        /**
+         * Sets the decorator to wrap client call execution.
+         *
+         * @param callDecorator the client call decorator.
+         * @return the builder.
+         */
+        @SuppressWarnings("unchecked")
+        public B callDecorator(ClientCallDecorator<I> callDecorator) {
+            configBuilder.callDecorator(callDecorator);
+            return (B) this;
         }
 
         /**

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCallDecorator.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCallDecorator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core;
+
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+
+/**
+ * A decorator that wraps client call execution, allowing cross-cutting behavior to be applied
+ * around operation invocations.
+ *
+ * <p>Implementations can inspect or modify the input, add logging, metrics, caching, or other
+ * concerns before delegating to the next invoker in the chain.
+ *
+ * @param <C> the client type this decorator is applied to.
+ */
+@FunctionalInterface
+public interface ClientCallDecorator<C> {
+    /**
+     * Applies decoration logic around a client call.
+     *
+     * @param client the client instance making the call.
+     * @param operation the API operation being invoked.
+     * @param input the operation input.
+     * @param overrideConfig optional per-request configuration overrides, or {@code null}.
+     * @param next the next invoker in the chain to delegate the actual call to.
+     * @param <I> the input type.
+     * @param <O> the output type.
+     * @return the operation output.
+     */
+    <I extends SerializableStruct, O extends SerializableStruct> O apply(
+            C client,
+            ApiOperation<I, O> operation,
+            I input,
+            RequestOverrideConfig overrideConfig,
+            ClientCallInvoker next
+    );
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCallDecorator.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCallDecorator.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.client.core;
 
+import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 
@@ -26,6 +27,7 @@ public interface ClientCallDecorator<C> {
      * @param operation the API operation being invoked.
      * @param input the operation input.
      * @param overrideConfig optional per-request configuration overrides, or {@code null}.
+     * @param overrideContext optional per-request context overrides, or {@code null}.
      * @param next the next invoker in the chain to delegate the actual call to.
      * @param <I> the input type.
      * @param <O> the output type.
@@ -36,6 +38,7 @@ public interface ClientCallDecorator<C> {
             ApiOperation<I, O> operation,
             I input,
             RequestOverrideConfig overrideConfig,
+            Context overrideContext,
             ClientCallInvoker next
     );
 }

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCallInvoker.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCallInvoker.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.client.core;
+
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+
+/**
+ * Invokes a client operation call with the given input and configuration.
+ *
+ * <p>This functional interface represents the core call execution logic that a
+ * {@link ClientCallDecorator} delegates to after applying its decoration.
+ */
+@FunctionalInterface
+public interface ClientCallInvoker {
+    /**
+     * Invokes the operation.
+     *
+     * @param input the operation input.
+     * @param operation the API operation being invoked.
+     * @param overrideConfig optional per-request configuration overrides, or {@code null}.
+     * @param <I> the input type.
+     * @param <O> the output type.
+     * @return the operation output.
+     */
+    <I extends SerializableStruct, O extends SerializableStruct> O invoke(
+            I input,
+            ApiOperation<I, O> operation,
+            RequestOverrideConfig overrideConfig
+    );
+}

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientConfig.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientConfig.java
@@ -53,6 +53,7 @@ public final class ClientConfig {
     private final RetryStrategy retryStrategy;
     private final String retryScope;
     private final Set<Class<? extends ClientPlugin>> appliedPluginClasses;
+    private final ClientCallDecorator<?> callDecorator;
 
     private ClientConfig(Builder builder) {
         // Collect and apply plugins, updating builder.appliedPluginClasses as we go
@@ -95,6 +96,7 @@ public final class ClientConfig {
 
         this.context = Context.unmodifiableCopy(builder.context);
         this.service = Objects.requireNonNull(builder.service, "Missing required service schema");
+        this.callDecorator = builder.callDecorator;
     }
 
     private static List<ClientPlugin> collectPlugins(
@@ -223,6 +225,10 @@ public final class ClientConfig {
         return retryScope;
     }
 
+    ClientCallDecorator<?> callDecorator() {
+        return callDecorator;
+    }
+
     /**
      * Create a new builder to build {@link ClientConfig}.
      *
@@ -322,6 +328,7 @@ public final class ClientConfig {
         private final Map<Class<? extends ClientPlugin>, ClientPlugin> plugins = new LinkedHashMap<>();
         // Mutable set that tracks which plugin classes have been applied to this builder
         private final Set<Class<? extends ClientPlugin>> appliedPluginClasses = new HashSet<>();
+        private ClientCallDecorator<?> callDecorator;
 
         public Builder() {
             plugins.put(DefaultPlugin.class, DefaultPlugin.INSTANCE);
@@ -657,6 +664,17 @@ public final class ClientConfig {
          */
         public Builder addPluginPredicate(Predicate<ClientPlugin> pluginPredicate) {
             return pluginPredicate(this.pluginPredicate.and(pluginPredicate));
+        }
+
+        /**
+         * Sets the decorator to wrap client call execution.
+         *
+         * @param callDecorator the client call decorator.
+         * @return the builder.
+         */
+        public Builder callDecorator(ClientCallDecorator<?> callDecorator) {
+            this.callDecorator = callDecorator;
+            return this;
         }
 
         /**

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/RequestOverrideConfig.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/RequestOverrideConfig.java
@@ -74,12 +74,7 @@ public final class RequestOverrideConfig {
         return identityResolvers;
     }
 
-    /**
-     * Get the context of the override request config.
-     *
-     * @return the context.
-     */
-    public Context context() {
+    Context context() {
         return context;
     }
 

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/RequestOverrideConfig.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/RequestOverrideConfig.java
@@ -74,7 +74,12 @@ public final class RequestOverrideConfig {
         return identityResolvers;
     }
 
-    Context context() {
+    /**
+     * Get the context of the override request config.
+     *
+     * @return the context.
+     */
+    public Context context() {
         return context;
     }
 

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
@@ -36,6 +36,7 @@ import software.amazon.smithy.java.client.http.plugins.ApplyHttpRetryInfoPlugin;
 import software.amazon.smithy.java.client.http.plugins.HttpChecksumPlugin;
 import software.amazon.smithy.java.client.http.plugins.RequestCompressionPlugin;
 import software.amazon.smithy.java.client.http.plugins.UserAgentPlugin;
+import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.document.Document;
@@ -321,9 +322,10 @@ public class ClientTest {
                             ApiOperation<I, O> operation,
                             I input,
                             RequestOverrideConfig overrideConfig,
+                            Context overrideContext,
                             ClientCallInvoker next
                     ) {
-                        assertThat(overrideConfig.context().get(ClientContext.APPLICATION_ID), equalTo("foo"));
+                        assertThat(overrideContext.get(ClientContext.APPLICATION_ID), equalTo("foo"));
                         throw new IllegalStateException("Prevent calling the service");
                     }
                 }))

--- a/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
+++ b/client/client-core/src/test/java/software/amazon/smithy/java/client/core/ClientTest.java
@@ -36,6 +36,8 @@ import software.amazon.smithy.java.client.http.plugins.ApplyHttpRetryInfoPlugin;
 import software.amazon.smithy.java.client.http.plugins.HttpChecksumPlugin;
 import software.amazon.smithy.java.client.http.plugins.RequestCompressionPlugin;
 import software.amazon.smithy.java.client.http.plugins.UserAgentPlugin;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.dynamicclient.DynamicClient;
 import software.amazon.smithy.java.dynamicclient.plugins.DetectProtocolPlugin;
@@ -300,5 +302,41 @@ public class ClientTest {
                 .build();
 
         c.call("GetSprocket");
+    }
+
+    @Test
+    public void setsCallDecorator() throws URISyntaxException {
+        var queue = new MockQueue();
+        queue.enqueue(HttpResponse.create().setStatusCode(200).toUnmodifiable());
+
+        DynamicClient c = DynamicClient.builder()
+                .model(MODEL)
+                .serviceId(SERVICE)
+                .protocol(new RestJsonClientProtocol(SERVICE))
+                .addPlugin(MockPlugin.builder().addQueue(queue).build())
+                .addPlugin(config -> config.callDecorator(new ClientCallDecorator<DynamicClient>() {
+                    @Override
+                    public <I extends SerializableStruct, O extends SerializableStruct> O apply(
+                            DynamicClient client,
+                            ApiOperation<I, O> operation,
+                            I input,
+                            RequestOverrideConfig overrideConfig,
+                            ClientCallInvoker next
+                    ) {
+                        assertThat(overrideConfig.context().get(ClientContext.APPLICATION_ID), equalTo("foo"));
+                        throw new IllegalStateException("Prevent calling the service");
+                    }
+                }))
+                .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+                .endpointResolver(EndpointResolver.staticEndpoint(new URI("http://localhost")))
+                .build();
+
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            c.call("GetSprocket",
+                    Document.ofObject(new HashMap<>()),
+                    RequestOverrideConfig.builder()
+                            .putConfig(ClientContext.APPLICATION_ID, "foo")
+                            .build());
+        }, "Prevent calling the service");
     }
 }


### PR DESCRIPTION
*Issue #, if available:* fixes #1197

*Description of changes:*

Added support for client call decorator override described in https://github.com/smithy-lang/smithy-java/issues/1197#issuecomment-4504310850.

~Also marked `RequestOverrideConfig.context` so that it would become available in call decorators (happy to remove/change it if you think this is not what should be available).~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
