### PR TITLE
Fix NPE in JsonCodec.deserializeShape that suppresses deserialization errors

### DIFF
--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonCodec.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonCodec.java
@@ -56,20 +56,36 @@ public final class JsonCodec implements Codec {
     @Override
     public <T extends SerializableShape> T deserializeShape(byte[] source, ShapeBuilder<T> builder) {
         var deserializer = createDeserializer(source);
+        T result;
         try {
-            return builder.deserialize(deserializer).errorCorrection().build();
-        } finally {
-            deserializer.close();
+            result = builder.deserialize(deserializer).errorCorrection().build();
+        } catch (Exception e) {
+            closeQuietly(deserializer);
+            throw e;
         }
+        deserializer.close();
+        return result;
     }
 
     @Override
     public <T extends SerializableShape> T deserializeShape(ByteBuffer source, ShapeBuilder<T> builder) {
         var deserializer = createDeserializer(source);
+        T result;
         try {
-            return builder.deserialize(deserializer).errorCorrection().build();
-        } finally {
+            result = builder.deserialize(deserializer).errorCorrection().build();
+        } catch (Exception e) {
+            closeQuietly(deserializer);
+            throw e;
+        }
+        deserializer.close();
+        return result;
+    }
+
+    private static void closeQuietly(ShapeDeserializer deserializer) {
+        try {
             deserializer.close();
+        } catch (Exception ignored) {
+            // Don't suppress the original deserialization exception.
         }
     }
 

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonDeserializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/jackson/JacksonJsonDeserializer.java
@@ -51,16 +51,18 @@ final class JacksonJsonDeserializer implements ShapeDeserializer {
     public void close() {
         if (parser != null && !parser.isClosed()) {
             try {
-                // Close the parser, but also ensure there's no trailing garbage input.
                 var nextToken = parser.nextToken();
+                // Capture token description before nulling parser to avoid NPE in describeToken().
+                var tokenDesc = nextToken != null ? JsonToken.valueDescFor(nextToken) : null;
                 parser.close();
                 parser = null;
-                if (nextToken != null) {
-                    throw new SerializationException("Unexpected JSON content: " + describeToken());
+                if (tokenDesc != null) {
+                    throw new SerializationException("Unexpected JSON content: " + tokenDesc);
                 }
             } catch (SerializationException e) {
                 throw e;
             } catch (Exception e) {
+                parser = null;
                 throw new SerializationException(e);
             }
         }

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/GeneratedModelSerdeTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/GeneratedModelSerdeTest.java
@@ -745,4 +745,18 @@ public class GeneratedModelSerdeTest extends ProviderTestBase {
         }
         return arguments.stream();
     }
+
+    @PerProvider
+    void deserializeShapeWithNestedMissingRequiredFieldReportsFieldName(JsonSerdeProvider provider) {
+        var codec = codec(provider);
+        // NestedStruct requires field1 (String) and field2 (Integer).
+        // Omitting field2 from the nested struct inside a list should produce
+        // a SerializationException mentioning the missing field, not an NPE from close().
+        byte[] json =
+                "{\"id\":\"x\",\"count\":1,\"enabled\":true,\"ratio\":1.0,\"score\":1.0,\"bigCount\":1,\"structList\":[{\"field1\":\"hello\"}]}"
+                        .getBytes(StandardCharsets.UTF_8);
+        var e = assertThrows(SerializationException.class,
+                () -> codec.deserializeShape(json, ComplexStruct.builder()));
+        assertThat(e.getMessage()).contains("field2");
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1202

*Description of changes:*

When `deserializeShape()` encounters invalid input (e.g., a nested struct in a list with missing required fields), the builder throws a `SerializationException` mid-parse. The `finally` block in `JsonCodec.deserializeShape()` then calls `close()` on the deserializer, which triggers an NPE that suppresses the original helpful exception.

The NPE occurs in `JacksonJsonDeserializer.close()` because:
1. `parser.nextToken()` returns non-null (unconsumed tokens remain after the aborted parse)
2. `parser.close()` is called, then `parser = null`
3. `describeToken()` is called, which dereferences the now-null `parser` → NPE

**Fix:**
- In `JacksonJsonDeserializer.close()`, capture the token description before nulling the parser reference.
- In `JsonCodec.deserializeShape()`, use `closeQuietly()` on the error path so exceptions from `close()` don't suppress the original deserialization/validation exception.

**Test:** Added `deserializeShapeWithNestedMissingRequiredFieldReportsFieldName` which fails without this fix (NPE suppresses the "Missing required members" exception) and passes with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
