### PR TITLE
Add auto-format CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,72 @@ on:
 permissions:
   pull-requests: write
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    name: Auto-format
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.PR_TOKEN }}
+
+      - name: Check if last commit is from bot
+        id: check-bot
+        run: |
+          LAST_AUTHOR=$(git log -1 --format='%an')
+          if [ "$LAST_AUTHOR" = "github-actions[bot]" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up JDK 21
+        if: steps.check-bot.outputs.skip != 'true'
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'corretto'
+
+      - name: Cache compiled buildscripts
+        if: steps.check-bot.outputs.skip != 'true'
+        uses: actions/cache@v5
+        with:
+            key: ${{ runner.os }}-gradle-${{ hashFiles('buildSrc/**/*.kts') }}
+            path: |
+              ./buildSrc/build
+
+      - name: Setup Gradle
+        if: steps.check-bot.outputs.skip != 'true'
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle-home-cache-includes: |
+            caches
+
+      - name: Run spotlessApply
+        if: steps.check-bot.outputs.skip != 'true'
+        run: ./gradlew spotlessApply
+
+      - name: Commit formatting changes
+        if: steps.check-bot.outputs.skip != 'true'
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "Auto-format: apply spotless formatting"
+            git push
+          fi
+
   build:
+    needs: [format]
+    if: always() && !cancelled()
     runs-on: ${{ matrix.os }}
     name: Java ${{ matrix.java }} ${{ matrix.os }}
     strategy:

--- a/core/src/main/java/software/amazon/smithy/java/core/Version.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/Version.java
@@ -26,11 +26,11 @@ public final class Version {
 
     static String getVersion() {
         try (InputStream is = Objects.requireNonNull(Version.class.getResourceAsStream(VERSION_RESOURCE_FILE))) {
-                var properties = new Properties();
-                    properties.load(is);
-                        return properties.get(VERSION_PROPERTY).toString();
+            var properties = new Properties();
+            properties.load(is);
+            return properties.get(VERSION_PROPERTY).toString();
         } catch (IOException e) {
-                throw new UncheckedIOException(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/core/Version.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/Version.java
@@ -26,11 +26,11 @@ public final class Version {
 
     static String getVersion() {
         try (InputStream is = Objects.requireNonNull(Version.class.getResourceAsStream(VERSION_RESOURCE_FILE))) {
-            var properties = new Properties();
-            properties.load(is);
-            return properties.get(VERSION_PROPERTY).toString();
+                var properties = new Properties();
+                    properties.load(is);
+                        return properties.get(VERSION_PROPERTY).toString();
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+                throw new UncheckedIOException(e);
         }
     }
 

--- a/core/src/main/java/software/amazon/smithy/java/core/VersionCheck.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/VersionCheck.java
@@ -30,7 +30,7 @@ import software.amazon.smithy.java.versionspi.SmithyVersionProvider;
  */
 public final class VersionCheck {
     private static final InternalLogger LOGGER = InternalLogger.getLogger(VersionCheck.class);
-    private static final String SKIP_PROPERTY = "smithy.java.skipVersionCheck";
+    private static final String SKIP_VERSION_CHECK_PROPERTY = "smithy.java.skipVersionCheck";
     private static final AtomicBoolean CHECKED = new AtomicBoolean(false);
 
     private VersionCheck() {}
@@ -47,11 +47,11 @@ public final class VersionCheck {
         if (CHECKED.get()) {
             return;
         }
-        if (Boolean.getBoolean(SKIP_PROPERTY)) {
+        if (Boolean.getBoolean(SKIP_VERSION_CHECK_PROPERTY)) {
             LOGGER.warn("Smithy Java version compatibility check is disabled via '{}'. "
                     + "This is not recommended and should only be used as a temporary workaround. "
                     + "Running with mismatched module versions may cause unexpected runtime errors.",
-                    SKIP_PROPERTY);
+                    SKIP_VERSION_CHECK_PROPERTY);
             CHECKED.set(true);
             return;
         }
@@ -120,4 +120,5 @@ public final class VersionCheck {
     static void reset() {
         CHECKED.set(false);
     }
+
 }


### PR DESCRIPTION
### What behavior changes?

Spotless failures break CI builds, this makes the CI auto-format code.

### Why is this change needed?

Stop having CI builds fail on trivial things.

### How was this validated?

Look at this PR, first a commit was made which had spotless violations, the CI fixed it. Then another commit was made which didn't have any CI violations and the CI did nothing

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
