### PR TITLE
Generate version provider into module-specific package

### DIFF
--- a/buildSrc/src/main/kotlin/GenerateVersionProviderTask.kt
+++ b/buildSrc/src/main/kotlin/GenerateVersionProviderTask.kt
@@ -6,6 +6,9 @@ import java.io.File
 
 /**
  * Gradle task that generates a SmithyVersionProvider SPI implementation for a module.
+ *
+ * The implementation is generated into the module's own package to avoid classpath
+ * conflicts when multiple modules are on the classpath.
  */
 abstract class GenerateVersionProviderTask : DefaultTask() {
 
@@ -19,7 +22,7 @@ abstract class GenerateVersionProviderTask : DefaultTask() {
     var outputDir: File = project.layout.buildDirectory.dir("generated/version-provider").get().asFile
 
     companion object {
-        private const val PACKAGE = "software.amazon.smithy.java.versionspi"
+        private const val SPI_PACKAGE = "software.amazon.smithy.java.versionspi"
         private const val INTERFACE_NAME = "SmithyVersionProvider"
         private const val RECORD_NAME = "ModuleVersion"
         private const val IMPL_NAME = "GeneratedVersionProvider"
@@ -32,13 +35,22 @@ abstract class GenerateVersionProviderTask : DefaultTask() {
         val minor = parts.getOrElse(1) { "0" }
         val patch = parts.getOrElse(2) { "0" }.replace(Regex("[^0-9].*"), "")
 
-        val packageDir = File(outputDir, "java/${PACKAGE.replace('.', '/')}")
+        // Use the module's own package for the implementation class
+        val implPackage = moduleName
+        val packageDir = File(outputDir, "java/${implPackage.replace('.', '/')}")
         packageDir.mkdirs()
 
-        // Generate the implementation
+        val fqInterface = "$SPI_PACKAGE.$INTERFACE_NAME"
+        val fqRecord = "$SPI_PACKAGE.$RECORD_NAME"
+        val fqImpl = "$implPackage.$IMPL_NAME"
+
+        // Generate the implementation in the module's own package
         File(packageDir, "$IMPL_NAME.java").writeText(
             """
-            |package $PACKAGE;
+            |package $implPackage;
+            |
+            |import $fqInterface;
+            |import $fqRecord;
             |
             |public final class $IMPL_NAME implements $INTERFACE_NAME {
             |    private static final $RECORD_NAME VERSION = new $RECORD_NAME("$moduleName", $major, $minor, $patch);
@@ -54,8 +66,8 @@ abstract class GenerateVersionProviderTask : DefaultTask() {
         // Generate META-INF/services file
         val servicesDir = File(outputDir, "resources/META-INF/services")
         servicesDir.mkdirs()
-        File(servicesDir, "$PACKAGE.$INTERFACE_NAME").writeText(
-            "$PACKAGE.$IMPL_NAME\n"
+        File(servicesDir, fqInterface).writeText(
+            "$fqImpl\n"
         )
     }
 }


### PR DESCRIPTION

### What behavior changes?
The GeneratedVersionProvider was being generated into the shared versionspi package in every module, causing duplicate class conflicts. Generate it into each module's own package instead so every JAR has a unique FQCN.

### Why is this change needed?
Avoids classpath conflicts.

### How was this validated?
n/a

### What should reviewers focus on?
n/a

### Additional Links
#1213 was a previous attempt to fix this issue.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
