### PR TITLE
Add a max-depth protection to avoid stack-exhaustion

### DIFF
--- a/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborDeserializer.java
+++ b/codecs/cbor-codec/src/main/java/software/amazon/smithy/java/cbor/CborDeserializer.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.document.Document;
 
 final class CborDeserializer implements ShapeDeserializer {
+    private static final int MAX_DEPTH = 1000;
 
     static final class Token {
         public static final byte TAG_FLAG = 1 << 4;
@@ -145,12 +146,14 @@ final class CborDeserializer implements ShapeDeserializer {
     private int itemLength = 0;
     private int overhead = 0; // overhead is [0,8]
     private boolean readingTag = false;
+    private int depth;
 
     CborDeserializer(byte[] payload, CborSettings settings) {
         this.payload = payload;
         this.settings = settings;
         this.end = payload.length;
         this.idx = 0;
+        this.depth = 0;
         advance();
     }
 
@@ -665,13 +668,22 @@ final class CborDeserializer implements ShapeDeserializer {
             case Token.POS_BIGINT, Token.NEG_BIGINT -> Document.of(readBigInteger(null));
             case Token.BIG_DECIMAL -> Document.of(readBigDecimal(null));
             case Token.START_ARRAY -> {
+                depth++;
+                if (depth > MAX_DEPTH) {
+                    throw new SerializationException("Maximum nesting depth exceeded: " + MAX_DEPTH);
+                }
                 List<Document> values = new ArrayList<>();
                 for (token = advance(); token != Token.END_ARRAY; token = advance()) {
                     values.add(readDocument());
                 }
+                depth--;
                 yield Document.of(values);
             }
             case Token.START_OBJECT -> {
+                depth++;
+                if (depth > MAX_DEPTH) {
+                    throw new SerializationException("Maximum nesting depth exceeded: " + MAX_DEPTH);
+                }
                 Map<String, Document> values = new LinkedHashMap<>();
                 for (token = advance(); token != Token.END_OBJECT; token = advance()) {
                     if (token != Token.KEY) {
@@ -682,6 +694,7 @@ final class CborDeserializer implements ShapeDeserializer {
                     advance();
                     values.put(key, readDocument());
                 }
+                depth--;
                 yield CborDocuments.of(values, settings);
             }
             default -> throw new SerializationException("Unexpected token: " + Token.name(token));
@@ -712,7 +725,10 @@ final class CborDeserializer implements ShapeDeserializer {
             readStructEmpty(schema, token);
             return;
         }
-
+        depth++;
+        if (depth > MAX_DEPTH) {
+            throw new SerializationException("Maximum nesting depth exceeded: " + MAX_DEPTH);
+        }
         Schema structSchema = schema.isMember() ? schema.memberTarget() : schema;
         var ext = structSchema.getExtension(CborSchemaExtensions.KEY);
         CborMemberLookup lookup = ext != null ? ext.memberLookup() : null;
@@ -767,6 +783,7 @@ final class CborDeserializer implements ShapeDeserializer {
 
             consumer.accept(state, member, this);
         }
+        depth--;
     }
 
     private void readStructEmpty(Schema schema, byte token) {
@@ -814,6 +831,10 @@ final class CborDeserializer implements ShapeDeserializer {
 
     @Override
     public <T> void readList(Schema schema, T state, ListMemberConsumer<T> consumer) {
+        depth++;
+        if (depth > MAX_DEPTH) {
+            throw new SerializationException("Maximum nesting depth exceeded: " + MAX_DEPTH);
+        }
         byte token = this.token;
         if (token != Token.START_ARRAY) {
             throw badType("list", token);
@@ -822,6 +843,7 @@ final class CborDeserializer implements ShapeDeserializer {
         for (token = advance(); token != Token.END_ARRAY; token = advance()) {
             consumer.accept(state, this);
         }
+        depth--;
     }
 
     @Override
@@ -831,6 +853,10 @@ final class CborDeserializer implements ShapeDeserializer {
 
     @Override
     public <T> void readStringMap(Schema schema, T state, MapMemberConsumer<String, T> consumer) {
+        depth++;
+        if (depth > MAX_DEPTH) {
+            throw new SerializationException("Maximum nesting depth exceeded: " + MAX_DEPTH);
+        }
         byte token = this.token;
         if (token != Token.START_OBJECT) {
             throw badType("struct", token);
@@ -844,6 +870,7 @@ final class CborDeserializer implements ShapeDeserializer {
             advance();
             consumer.accept(state, key, this);
         }
+        depth--;
     }
 
     @Override

--- a/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborDepthLimitTest.java
+++ b/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborDepthLimitTest.java
@@ -39,8 +39,8 @@ class CborDepthLimitTest {
         int pos = 0;
         for (int i = 0; i < depth; i++) {
             payload[pos++] = (byte) 0xBF; // start map
-            payload[pos++] = 0x61;         // text string length 1
-            payload[pos++] = 0x61;         // 'a'
+            payload[pos++] = 0x61; // text string length 1
+            payload[pos++] = 0x61; // 'a'
         }
         payload[pos++] = 0x01; // integer 1 as the innermost value
         for (int i = 0; i < depth; i++) {
@@ -99,12 +99,15 @@ class CborDepthLimitTest {
     void shallowPayloadSucceeds() {
         // {"a": [1, 2, 3]}
         byte[] payload = {
-            (byte) 0xBF,       // start map
-            0x61, 0x61,        // key "a"
-            (byte) 0x9F,       // start array
-            0x01, 0x02, 0x03,  // integers 1, 2, 3
-            (byte) 0xFF,       // end array
-            (byte) 0xFF        // end map
+                (byte) 0xBF, // start map
+                0x61,
+                0x61, // key "a"
+                (byte) 0x9F, // start array
+                0x01,
+                0x02,
+                0x03, // integers 1, 2, 3
+                (byte) 0xFF, // end array
+                (byte) 0xFF // end map
         };
         var de = Rpcv2CborCodec.builder().build().createDeserializer(payload);
         assertNotNull(de.readDocument());

--- a/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborDepthLimitTest.java
+++ b/codecs/cbor-codec/src/test/java/software/amazon/smithy/java/cbor/CborDepthLimitTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.cbor;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.core.serde.SerializationException;
+
+class CborDepthLimitTest {
+
+    private static final int MAX_DEPTH = 1000;
+
+    // CBOR indefinite-length array: 0x9F start, 0xFF break
+    // CBOR indefinite-length map: 0xBF start, 0xFF break
+    // CBOR single-byte text string "a": 0x61 0x61
+
+    private static byte[] nestedArrays(int depth) {
+        // Each level: 0x9F (start array), innermost: 0x01 (integer 1), then depth x 0xFF (breaks)
+        byte[] payload = new byte[depth + 1 + depth];
+        for (int i = 0; i < depth; i++) {
+            payload[i] = (byte) 0x9F;
+        }
+        payload[depth] = 0x01; // integer 1 at the bottom
+        for (int i = 0; i < depth; i++) {
+            payload[depth + 1 + i] = (byte) 0xFF;
+        }
+        return payload;
+    }
+
+    private static byte[] nestedMaps(int depth) {
+        // Each level: 0xBF (start map) + key "a" (0x61 0x61), innermost: 0x01, then depth x 0xFF
+        // Structure: {a: {a: {a: ... 1 ...}}}
+        byte[] payload = new byte[depth * 3 + 1 + depth];
+        int pos = 0;
+        for (int i = 0; i < depth; i++) {
+            payload[pos++] = (byte) 0xBF; // start map
+            payload[pos++] = 0x61;         // text string length 1
+            payload[pos++] = 0x61;         // 'a'
+        }
+        payload[pos++] = 0x01; // integer 1 as the innermost value
+        for (int i = 0; i < depth; i++) {
+            payload[pos++] = (byte) 0xFF; // break
+        }
+        return payload;
+    }
+
+    @Test
+    void nestedArraysAtLimitSucceeds() {
+        byte[] payload = nestedArrays(MAX_DEPTH);
+        var de = Rpcv2CborCodec.builder().build().createDeserializer(payload);
+        assertNotNull(de.readDocument());
+    }
+
+    @Test
+    void nestedArraysOverLimitThrows() {
+        byte[] payload = nestedArrays(MAX_DEPTH + 1);
+        var de = Rpcv2CborCodec.builder().build().createDeserializer(payload);
+        assertThrows(SerializationException.class, de::readDocument);
+    }
+
+    @Test
+    void nestedMapsAtLimitSucceeds() {
+        byte[] payload = nestedMaps(MAX_DEPTH);
+        var de = Rpcv2CborCodec.builder().build().createDeserializer(payload);
+        assertNotNull(de.readDocument());
+    }
+
+    @Test
+    void nestedMapsOverLimitThrows() {
+        byte[] payload = nestedMaps(MAX_DEPTH + 1);
+        var de = Rpcv2CborCodec.builder().build().createDeserializer(payload);
+        assertThrows(SerializationException.class, de::readDocument);
+    }
+
+    @Test
+    void siblingContainersDoNotAccumulateDepth() {
+        // A flat array containing many empty nested arrays should not trigger the limit
+        // Structure: [ [], [], [], ... ] with MAX_DEPTH + 10 siblings
+        int siblings = MAX_DEPTH + 10;
+        // outer 0x9F + siblings * (0x9F 0xFF) + outer 0xFF
+        byte[] payload = new byte[1 + siblings * 2 + 1];
+        int pos = 0;
+        payload[pos++] = (byte) 0x9F; // start outer array
+        for (int i = 0; i < siblings; i++) {
+            payload[pos++] = (byte) 0x9F; // start inner array
+            payload[pos++] = (byte) 0xFF; // end inner array
+        }
+        payload[pos] = (byte) 0xFF; // end outer array
+        var de = Rpcv2CborCodec.builder().build().createDeserializer(payload);
+        assertNotNull(de.readDocument());
+    }
+
+    @Test
+    void shallowPayloadSucceeds() {
+        // {"a": [1, 2, 3]}
+        byte[] payload = {
+            (byte) 0xBF,       // start map
+            0x61, 0x61,        // key "a"
+            (byte) 0x9F,       // start array
+            0x01, 0x02, 0x03,  // integers 1, 2, 3
+            (byte) 0xFF,       // end array
+            (byte) 0xFF        // end map
+        };
+        var de = Rpcv2CborCodec.builder().build().createDeserializer(payload);
+        assertNotNull(de.readDocument());
+    }
+}


### PR DESCRIPTION
### What behavior changes?
CBOR deserialization now throws `SerializationException` when nesting depth exceeds 1000 levels, this matches the current [SmithyJsonDeserializer](https://github.com/smithy-lang/smithy-java/blob/daaa02bd3a9702bf5a25d7e1078f1c61aeb1659a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java#L44) limit. Depth is correctly tracked (incremented on container entry, decremented on exit) so sibling containers don't falsely accumulate.

### Why is this change needed?
Prevents stack overflow from maliciously crafted deeply-nested CBOR payloads.

### How was this validated?
Added `CborDepthLimitTest` with 6 tests: boundary tests at exactly 1000 (pass) and 1001 (fail) for both arrays and maps, a sibling-containers test verifying depth resets correctly, and a shallow payload sanity check.

### What should reviewers focus on?
- `CborDeserializer.java`: depth++ / depth-- pairing in all 5 container paths (`readDocument` array/object, `readStruct`, `readList`, `readStringMap`).

### Additional Links

N/A
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
