### PR TITLE
Added support for getter sections in unions codegen

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -17,6 +17,7 @@ import software.amazon.smithy.java.codegen.CodegenUtils;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.java.codegen.sections.ClassSection;
+import software.amazon.smithy.java.codegen.sections.GetterSection;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SchemaUtils;
@@ -138,11 +139,7 @@ public final class UnionGenerator
                                         ${serializeMember:C};
                                     }
 
-                                    @Override${?hasBoxed}
-                                    @SuppressWarnings("unchecked")${/hasBoxed}
-                                    public ${member:B} getValue() {
-                                        return ${^unit}${memberName:L}${/unit}${?unit}null${/unit};
-                                    }
+                                    ${valueGetter:C|}
 
                                     ${toString:C|}
                                 }
@@ -159,6 +156,17 @@ public final class UnionGenerator
                 writer.putContext("memberSchema", CodegenUtils.toMemberSchemaName(memberName));
                 writer.putContext("schemaClass", Schema.class);
                 writer.putContext("toString", new ToStringGenerator(writer));
+                writer.putContext("valueGetter", writer.consumer((writer) -> {
+                    writer.pushState(new GetterSection(member));
+                    writer.writeInline("""
+                            @Override${?hasBoxed}
+                            @SuppressWarnings("unchecked")${/hasBoxed}
+                            public ${member:B} getValue() {
+                                return ${^unit}${memberName:L}${/unit}${?unit}null${/unit};
+                            }
+                            """);
+                    writer.popState();
+                }));
                 // Use memberName as the field name for serialization
                 writer.putContext(
                         "serializeMember",


### PR DESCRIPTION
### What behavior changes?

This PR adds `GetterSection` to getter of union variant classes.

### Why is this change needed?

One of the places where `GetterSection` helps is when you want to add custom annotations to getters. For instance, when integrating generated code with jakarta validation in Spring Boot, complex fields require to have `@Valid` annotation attached in order to be validated (e.g. to run full depth validation). Currently, `GetterSection` is not "emitted" which means that union member getters aren't being processed and it is possible to add `@Valid` annotation in this case.

### How was this validated?

I changed to code locally, run `gw pTML`, run the codegen, spin up a spring boot application and validated that the request is being validated correctly.

### What should reviewers focus on?

Should I use

```java
writer.pushState();
writer.injectSection(new GetterSection(member));
```

instead to avoid people accidentally removing the content of the method?

Also, should I do the same for enums?

### Additional Links

N/A.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
