### PR TITLE
Fix PathSerializer support for non-strings

### DIFF
--- a/client/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicClientHttpBindingTest.java
+++ b/client/dynamic-client/src/test/java/software/amazon/smithy/java/dynamicclient/DynamicClientHttpBindingTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.dynamicclient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.aws.client.restjson.RestJsonClientProtocol;
+import software.amazon.smithy.java.client.core.ClientTransport;
+import software.amazon.smithy.java.client.core.MessageExchange;
+import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
+import software.amazon.smithy.java.client.http.HttpMessageExchange;
+import software.amazon.smithy.java.context.Context;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.endpoints.EndpointResolver;
+import software.amazon.smithy.java.http.api.HttpRequest;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.http.api.HttpVersion;
+import software.amazon.smithy.java.io.datastream.DataStream;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Verifies that HTTP header, query, and label bindings serialize correctly when the input is a document-backed
+ * struct (the DynamicClient path), including enum-typed members. This is the sibling of the path-label coverage in
+ * {@code PathSerializerTest}: the header/query serializer is push-based (it dispatches typed {@code writeX} calls
+ * via {@code serializeMembers}), so it should never see a raw {@code Document}/{@code SmithyEnum}, but we assert it
+ * end-to-end to be sure.
+ */
+public class DynamicClientHttpBindingTest {
+
+    private static final ShapeId SERVICE = ShapeId.from("smithy.example#Widgets");
+
+    private static Model model;
+
+    @BeforeAll
+    public static void setup() {
+        model = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+
+                        use aws.protocols#restJson1
+
+                        @restJson1
+                        @smithy.rules#endpointRuleSet(
+                            version: "1.0",
+                            serviceId: "widgets",
+                            parameters: {},
+                            rules: [
+                                {
+                                    "documentation": "Static endpoint",
+                                    "type": "endpoint",
+                                    "conditions": [],
+                                    "endpoint": {"url": "https://example.com"}
+                                }
+                            ]
+                        )
+                        service Widgets {
+                            operations: [GetWidget]
+                        }
+
+                        enum Color {
+                            RED
+                            GREEN
+                        }
+
+                        @http(method: "GET", uri: "/widgets/{id}")
+                        operation GetWidget {
+                            input := {
+                                @required
+                                @httpLabel
+                                id: String
+
+                                @httpHeader("x-color")
+                                headerColor: Color
+
+                                @httpHeader("x-name")
+                                headerName: String
+
+                                @httpQuery("color")
+                                queryColor: Color
+
+                                @httpQuery("count")
+                                queryCount: Integer
+                            }
+                            output := {}
+                        }
+                        """)
+                .discoverModels()
+                .assemble()
+                .unwrap();
+    }
+
+    @Test
+    public void serializesHeaderAndQueryBindingsFromDocument() {
+        var captured = new AtomicReference<HttpRequest>();
+        var client = DynamicClient.builder()
+                .serviceId(SERVICE)
+                .model(model)
+                .protocol(new RestJsonClientProtocol(SERVICE))
+                .authSchemeResolver(AuthSchemeResolver.NO_AUTH)
+                .transport(capturingTransport(captured))
+                .endpointResolver(EndpointResolver.staticEndpoint("https://example.com"))
+                .build();
+
+        client.call("GetWidget",
+                Document.ofObject(Map.of(
+                        "id",
+                        "abc",
+                        "headerColor",
+                        "RED",
+                        "headerName",
+                        "gizmo",
+                        "queryColor",
+                        "GREEN",
+                        "queryCount",
+                        7)));
+
+        var request = captured.get();
+        // Enum and string headers serialize as their wire values, not toString() of a wrapper.
+        assertThat(request.headers().firstValue("x-color"), equalTo("RED"));
+        assertThat(request.headers().firstValue("x-name"), equalTo("gizmo"));
+
+        // Path label.
+        assertThat(request.uri().getPath(), equalTo("/widgets/abc"));
+
+        // Query params (enum + integer).
+        var query = request.uri().getQuery();
+        assertThat(query, equalTo("color=GREEN&count=7"));
+    }
+
+    private static ClientTransport<HttpRequest, HttpResponse> capturingTransport(AtomicReference<HttpRequest> sink) {
+        return new ClientTransport<>() {
+            @Override
+            public MessageExchange<HttpRequest, HttpResponse> messageExchange() {
+                return HttpMessageExchange.INSTANCE;
+            }
+
+            @Override
+            public HttpResponse send(Context context, HttpRequest request) {
+                sink.set(request);
+                return HttpResponse.create()
+                        .setHttpVersion(HttpVersion.HTTP_1_1)
+                        .setStatusCode(200)
+                        .setBody(DataStream.ofString("{}"))
+                        .toUnmodifiable();
+            }
+        };
+    }
+}

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PathSerializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PathSerializer.java
@@ -10,7 +10,10 @@ import java.util.ArrayList;
 import java.util.List;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.SmithyEnum;
+import software.amazon.smithy.java.core.schema.SmithyIntEnum;
 import software.amazon.smithy.java.core.serde.SerializationException;
+import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.io.uri.URLEncoding;
 import software.amazon.smithy.model.traits.HttpTrait;
 
@@ -138,28 +141,51 @@ final class PathSerializer {
             throw emptyLabel(labelSchema);
         }
 
+        // HTTP labels support string, enum, intEnum, boolean, byte/short/integer/long/float/double/bigInteger/
+        // bigDecimal, and timestamp. The value can arrive in three shapes depending on the source struct:
+        //   - a raw Java value (String, Integer, Instant, ...) for generated shapes,
+        //   - a SmithyEnum/SmithyIntEnum for enum and intEnum members,
+        //   - a Document for any type when the value comes from a document-backed struct (e.g. DynamicClient).
+        // Normalize all three down to the formatting below.
         return switch (labelSchema.type()) {
             case STRING, ENUM -> {
-                var s = (String) value;
+                var s = switch (value) {
+                    case String str -> str;
+                    case SmithyEnum e -> e.getValue();
+                    case Document d -> d.asString();
+                    default -> throw unsupportedLabelValue(labelSchema, value);
+                };
                 if (s.isEmpty()) {
                     throw emptyLabel(labelSchema);
                 }
                 yield s;
             }
-            case BOOLEAN -> Boolean.toString((boolean) value);
-            case BYTE -> Byte.toString((byte) value);
-            case SHORT -> Short.toString((short) value);
-            case INTEGER, INT_ENUM -> Integer.toString((int) value);
-            case LONG -> Long.toString((long) value);
-            case FLOAT -> Float.toString((float) value);
-            case DOUBLE -> Double.toString((double) value);
-            case BIG_INTEGER, BIG_DECIMAL -> value.toString();
+            case BOOLEAN -> Boolean.toString(value instanceof Document d ? d.asBoolean() : (boolean) value);
+            case BYTE -> Byte.toString(value instanceof Document d ? d.asByte() : (byte) value);
+            case SHORT -> Short.toString(value instanceof Document d ? d.asShort() : (short) value);
+            case INTEGER -> Integer.toString(value instanceof Document d ? d.asInteger() : (int) value);
+            case INT_ENUM -> Integer.toString(switch (value) {
+                case Integer i -> i;
+                case SmithyIntEnum e -> e.getValue();
+                case Document d -> d.asInteger();
+                default -> throw unsupportedLabelValue(labelSchema, value);
+            });
+            case LONG -> Long.toString(value instanceof Document d ? d.asLong() : (long) value);
+            case FLOAT -> Float.toString(value instanceof Document d ? d.asFloat() : (float) value);
+            case DOUBLE -> Double.toString(value instanceof Document d ? d.asDouble() : (double) value);
+            case BIG_INTEGER -> (value instanceof Document d ? d.asBigInteger() : value).toString();
+            case BIG_DECIMAL -> (value instanceof Document d ? d.asBigDecimal() : value).toString();
             case TIMESTAMP -> HttpBindingSchemaExtensions.memberBindingOf(labelSchema)
                     .timestampFormatter()
-                    .writeString((Instant) value);
+                    .writeString(value instanceof Document d ? d.asTimestamp() : (Instant) value);
             default -> throw new SerializationException(
                     "Unsupported HTTP label type " + labelSchema.type() + " for `" + labelSchema.id() + "`");
         };
+    }
+
+    private static SerializationException unsupportedLabelValue(Schema labelSchema, Object value) {
+        return new SerializationException(
+                "Unsupported HTTP label value " + value.getClass() + " for `" + labelSchema.id() + "`");
     }
 
     private static SerializationException emptyLabel(Schema labelSchema) {

--- a/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/PathSerializerTest.java
+++ b/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/PathSerializerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.binding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.SmithyEnum;
+import software.amazon.smithy.java.core.schema.SmithyIntEnum;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.model.pattern.UriPattern;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.HttpLabelTrait;
+import software.amazon.smithy.model.traits.HttpTrait;
+
+public class PathSerializerTest {
+
+    private static final ShapeId INPUT_ID = ShapeId.from("smithy.example#Input");
+    private static final ShapeId COLOR_ID = ShapeId.from("smithy.example#Color");
+    private static final ShapeId COUNT_ID = ShapeId.from("smithy.example#Count");
+
+    private static HttpTrait httpTrait(String uri) {
+        return HttpTrait.builder().method("GET").uri(UriPattern.parse(uri)).build();
+    }
+
+    // Each case binds a single member `v` as a label and asserts the serialized path. Cases cover every label type
+    // supported by HTTP bindings (string, enum, intEnum, boolean, the numerics, and timestamp) in each of the three
+    // value shapes a struct can hand back: a raw Java value, a SmithyEnum/SmithyIntEnum, and a wrapping Document.
+    static List<Arguments> labelCases() {
+        var ts = Instant.parse("2020-01-02T03:04:05Z");
+        return List.of(
+                // string
+                Arguments.of(PreludeSchemas.STRING, "abc", "/foo/abc"),
+                Arguments.of(PreludeSchemas.STRING, Document.of("abc"), "/foo/abc"),
+                // enum
+                Arguments.of(enumSchema(), (SmithyEnum) () -> "RED", "/foo/RED"),
+                Arguments.of(enumSchema(), Document.of("RED"), "/foo/RED"),
+                // boolean
+                Arguments.of(PreludeSchemas.BOOLEAN, true, "/foo/true"),
+                Arguments.of(PreludeSchemas.BOOLEAN, Document.of(true), "/foo/true"),
+                // byte
+                Arguments.of(PreludeSchemas.BYTE, (byte) 7, "/foo/7"),
+                Arguments.of(PreludeSchemas.BYTE, Document.of((byte) 7), "/foo/7"),
+                // short
+                Arguments.of(PreludeSchemas.SHORT, (short) 8, "/foo/8"),
+                Arguments.of(PreludeSchemas.SHORT, Document.of((short) 8), "/foo/8"),
+                // integer
+                Arguments.of(PreludeSchemas.INTEGER, 9, "/foo/9"),
+                Arguments.of(PreludeSchemas.INTEGER, Document.of(9), "/foo/9"),
+                // intEnum
+                Arguments.of(intEnumSchema(), (SmithyIntEnum) () -> 2, "/foo/2"),
+                Arguments.of(intEnumSchema(), Document.of(2), "/foo/2"),
+                // long
+                Arguments.of(PreludeSchemas.LONG, 10L, "/foo/10"),
+                Arguments.of(PreludeSchemas.LONG, Document.of(10L), "/foo/10"),
+                // float
+                Arguments.of(PreludeSchemas.FLOAT, 1.5f, "/foo/1.5"),
+                Arguments.of(PreludeSchemas.FLOAT, Document.of(1.5f), "/foo/1.5"),
+                // double
+                Arguments.of(PreludeSchemas.DOUBLE, 2.5d, "/foo/2.5"),
+                Arguments.of(PreludeSchemas.DOUBLE, Document.of(2.5d), "/foo/2.5"),
+                // bigInteger
+                Arguments.of(PreludeSchemas.BIG_INTEGER, BigInteger.valueOf(11), "/foo/11"),
+                Arguments.of(PreludeSchemas.BIG_INTEGER, Document.of(BigInteger.valueOf(11)), "/foo/11"),
+                // bigDecimal
+                Arguments.of(PreludeSchemas.BIG_DECIMAL, new BigDecimal("12.5"), "/foo/12.5"),
+                Arguments.of(PreludeSchemas.BIG_DECIMAL, Document.of(new BigDecimal("12.5")), "/foo/12.5"),
+                // timestamp (default date-time / ISO-8601 format for a path label; ':' is percent-encoded)
+                Arguments.of(PreludeSchemas.TIMESTAMP, ts, "/foo/2020-01-02T03%3A04%3A05Z"),
+                Arguments.of(PreludeSchemas.TIMESTAMP, Document.of(ts), "/foo/2020-01-02T03%3A04%3A05Z"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("labelCases")
+    public void serializesLabel(Schema memberTarget, Object value, String expected) {
+        var schema = Schema.structureBuilder(INPUT_ID)
+                .putMember("v", memberTarget, new HttpLabelTrait())
+                .build();
+        var serializer = new PathSerializer(httpTrait("/foo/{v}"), schema);
+
+        assertEquals(expected, serializer.serialize(struct(schema, Map.of("v", value))));
+    }
+
+    private static Schema enumSchema() {
+        return Schema.createEnum(COLOR_ID, Set.of("RED", "GREEN"));
+    }
+
+    private static Schema intEnumSchema() {
+        return Schema.createIntEnum(COUNT_ID, Set.of(1, 2));
+    }
+
+    private static SerializableStruct struct(Schema schema, Map<String, Object> values) {
+        return new SerializableStruct() {
+            @Override
+            public Schema schema() {
+                return schema;
+            }
+
+            @Override
+            public void serializeMembers(ShapeSerializer serializer) {
+                // Not exercised by PathSerializer.
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> T getMemberValue(Schema member) {
+                return (T) values.get(member.memberName());
+            }
+        };
+    }
+}


### PR DESCRIPTION
### What behavior changes?
PathSerializer now supports strings, documents, SmithyEnum, numbers, etc.

### Why is this change needed?
PathSerializer needs to support all possible values.

### How was this validated?
Added tests

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
