### PR TITLE
Emit empty payload for RPC protocol event encoding

### DIFF
--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventEncoderFactory.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventEncoderFactory.java
@@ -23,6 +23,7 @@ public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEven
     private final Schema schema;
     private final Codec codec;
     private final String payloadMediaType;
+    private final boolean emitEmptyPayload;
     private final Function<Throwable, EventStreamingException> exceptionHandler;
 
     private AwsEventEncoderFactory(
@@ -30,12 +31,14 @@ public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEven
             Schema schema,
             Codec codec,
             String payloadMediaType,
+            boolean emitEmptyPayload,
             Function<Throwable, EventStreamingException> exceptionHandler
     ) {
         this.initialEventType = Objects.requireNonNull(initialEventType, "initialEventType");
         this.schema = Objects.requireNonNull(schema, "schema").isMember() ? schema.memberTarget() : schema;
         this.codec = Objects.requireNonNull(codec, "codec");
         this.payloadMediaType = Objects.requireNonNull(payloadMediaType, "payloadMediaType");
+        this.emitEmptyPayload = emitEmptyPayload;
         this.exceptionHandler = Objects.requireNonNull(exceptionHandler, "exceptionHandler");
     }
 
@@ -45,6 +48,7 @@ public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEven
      * @param operation        The input operation for the factory
      * @param codec            The protocol codec to decode the payload
      * @param payloadMediaType The payload media type
+     * @param emitEmptyPayload Whether to emit an empty payload when there are no payload members
      * @param exceptionHandler The handler to convert exceptions for event streaming
      * @return A new event encoder factory
      */
@@ -52,12 +56,14 @@ public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEven
             ApiOperation<?, ?> operation,
             Codec codec,
             String payloadMediaType,
+            boolean emitEmptyPayload,
             Function<Throwable, EventStreamingException> exceptionHandler
     ) {
         return new AwsEventEncoderFactory(InitialEventType.INITIAL_REQUEST,
                 operation.inputStreamMember(),
                 codec,
                 payloadMediaType,
+                emitEmptyPayload,
                 exceptionHandler);
     }
 
@@ -67,6 +73,7 @@ public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEven
      * @param operation        The output operation for the factory
      * @param codec            The protocol codec to decode the payload
      * @param payloadMediaType The payload media type
+     * @param emitEmptyPayload Whether to emit an empty payload when there are no payload members
      * @param exceptionHandler The handler to convert exceptions for event streaming
      * @return A new event encoder factory
      */
@@ -74,12 +81,14 @@ public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEven
             ApiOperation<?, ?> operation,
             Codec codec,
             String payloadMediaType,
+            boolean emitEmptyPayload,
             Function<Throwable, EventStreamingException> exceptionHandler
     ) {
         return new AwsEventEncoderFactory(InitialEventType.INITIAL_RESPONSE,
                 operation.outputStreamMember(),
                 codec,
                 payloadMediaType,
+                emitEmptyPayload,
                 exceptionHandler);
     }
 
@@ -89,6 +98,7 @@ public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEven
                 schema,
                 codec,
                 payloadMediaType,
+                emitEmptyPayload,
                 exceptionHandler);
     }
 

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventEncoderFactory.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventEncoderFactory.java
@@ -45,6 +45,28 @@ public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEven
     /**
      * Creates a new input stream encoder factory.
      *
+     * <p>By default, events with no payload members will not emit a body or content-type header.
+     * This is the correct behavior for REST protocols. For RPC protocols that require an empty
+     * payload, use {@link #forInputStream(ApiOperation, Codec, String, boolean, Function)}.
+     *
+     * @param operation        The input operation for the factory
+     * @param codec            The protocol codec to decode the payload
+     * @param payloadMediaType The payload media type
+     * @param exceptionHandler The handler to convert exceptions for event streaming
+     * @return A new event encoder factory
+     */
+    public static AwsEventEncoderFactory forInputStream(
+            ApiOperation<?, ?> operation,
+            Codec codec,
+            String payloadMediaType,
+            Function<Throwable, EventStreamingException> exceptionHandler
+    ) {
+        return forInputStream(operation, codec, payloadMediaType, false, exceptionHandler);
+    }
+
+    /**
+     * Creates a new input stream encoder factory.
+     *
      * @param operation        The input operation for the factory
      * @param codec            The protocol codec to decode the payload
      * @param payloadMediaType The payload media type
@@ -65,6 +87,28 @@ public final class AwsEventEncoderFactory implements EventEncoderFactory<AwsEven
                 payloadMediaType,
                 emitEmptyPayload,
                 exceptionHandler);
+    }
+
+    /**
+     * Creates a new output stream encoder factory.
+     *
+     * <p>By default, events with no payload members will not emit a body or content-type header.
+     * This is the correct behavior for REST protocols. For RPC protocols that require an empty
+     * payload, use {@link #forOutputStream(ApiOperation, Codec, String, boolean, Function)}.
+     *
+     * @param operation        The output operation for the factory
+     * @param codec            The protocol codec to decode the payload
+     * @param payloadMediaType The payload media type
+     * @param exceptionHandler The handler to convert exceptions for event streaming
+     * @return A new event encoder factory
+     */
+    public static AwsEventEncoderFactory forOutputStream(
+            ApiOperation<?, ?> operation,
+            Codec codec,
+            String payloadMediaType,
+            Function<Throwable, EventStreamingException> exceptionHandler
+    ) {
+        return forOutputStream(operation, codec, payloadMediaType, false, exceptionHandler);
     }
 
     /**

--- a/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoder.java
+++ b/aws/aws-event-streams/src/main/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoder.java
@@ -40,6 +40,7 @@ final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
     private final InitialEventType initialEventType;
     private final Codec codec;
     private final String payloadMediaType;
+    private final boolean emitEmptyPayload;
     private final Set<String> possibleTypes;
     private final Map<ShapeId, Schema> possibleExceptions;
     private final Function<Throwable, EventStreamingException> exceptionHandler;
@@ -49,11 +50,13 @@ final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
             Schema eventSchema,
             Codec codec,
             String payloadMediaType,
+            boolean emitEmptyPayload,
             Function<Throwable, EventStreamingException> exceptionHandler
     ) {
         this.initialEventType = Objects.requireNonNull(initialEventType, "initialEventType");
         this.codec = Objects.requireNonNull(codec, "codec");
         this.payloadMediaType = Objects.requireNonNull(payloadMediaType, "payloadMediaType");
+        this.emitEmptyPayload = emitEmptyPayload;
         this.possibleTypes = possibleTypes(Objects.requireNonNull(eventSchema, "eventSchema"),
                 initialEventType.value());
         this.possibleExceptions = possibleExceptions(Objects.requireNonNull(eventSchema, "eventSchema"));
@@ -116,7 +119,7 @@ final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
             Holder<String> contentEncodingHolder
     ) {
         var out = new ByteArrayOutputStream();
-        var baseSerializer = createSerializer(out, codec, headers, contentEncodingHolder);
+        var baseSerializer = createSerializer(out, codec, headers, emitEmptyPayload, contentEncodingHolder);
         if (isInitialRequest(item.schema())) {
             // The initial event is serialized fully instead of just a single member as for events.
             typeHolder.set(initialEventType.value());
@@ -148,7 +151,7 @@ final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
             Holder<String> contentEncodingHolder
     ) {
         var out = new ByteArrayOutputStream();
-        var baseSerializer = createSerializer(out, codec, headers, contentEncodingHolder);
+        var baseSerializer = createSerializer(out, codec, headers, emitEmptyPayload, contentEncodingHolder);
         item.serialize(baseSerializer);
         return out.toByteArray();
     }
@@ -186,10 +189,11 @@ final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
             OutputStream out,
             Codec codec,
             HeadersBuilder headers,
+            boolean emitEmptyPayload,
             Holder<String> contentTypeHolder
     ) {
         var eventSerializer = new EventHeaderSerializer(headers);
-        return new EventSerializer(out, codec, eventSerializer, contentTypeHolder);
+        return new EventSerializer(out, codec, eventSerializer, emitEmptyPayload, contentTypeHolder);
     }
 
     /**
@@ -292,17 +296,20 @@ final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
         private final OutputStream out;
         private final Codec codec;
         private final EventHeaderSerializer headerSerializer;
+        private final boolean emitEmptyPayload;
         private final Holder<String> contentTypeHolder;
 
         public EventSerializer(
                 OutputStream out,
                 Codec codec,
                 EventHeaderSerializer headerSerializer,
+                boolean emitEmptyPayload,
                 Holder<String> contentTypeHolder
         ) {
             this.out = out;
             this.codec = codec;
             this.headerSerializer = headerSerializer;
+            this.emitEmptyPayload = emitEmptyPayload;
             this.contentTypeHolder = contentTypeHolder;
         }
 
@@ -314,7 +321,7 @@ final class AwsEventShapeEncoder implements EventEncoder<AwsEventFrame> {
                             .serializeMembers(serializer);
                 }
             } else {
-                if (hasPayloadMembers(schema)) {
+                if (emitEmptyPayload || hasPayloadMembers(schema)) {
                     try (var serializer = codec.createSerializer(out)) {
                         ShapeUtils.withFilteredMembers(schema, struct, AwsEventShapeEncoder::isPayloadMember)
                                 .serialize(serializer);

--- a/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoderTest.java
+++ b/aws/aws-event-streams/src/test/java/software/amazon/smithy/java/aws/events/AwsEventShapeEncoderTest.java
@@ -172,6 +172,7 @@ class AwsEventShapeEncoderTest {
                 operation.outputStreamMember(), // event schema
                 createJsonCodec(), // codec
                 "text/json",
+                false,
                 (e) -> new EventStreamingException("InternalServerException", "Internal Server Error"));
     }
 

--- a/aws/client/aws-client-awsjson/src/main/java/software/amazon/smithy/java/aws/client/awsjson/AwsJsonProtocol.java
+++ b/aws/client/aws-client-awsjson/src/main/java/software/amazon/smithy/java/aws/client/awsjson/AwsJsonProtocol.java
@@ -131,6 +131,7 @@ abstract sealed class AwsJsonProtocol extends HttpClientProtocol permits AwsJson
         return AwsEventEncoderFactory.forInputStream(operation,
                 payloadCodec(),
                 contentType(),
+                true,
                 (e) -> new EventStreamingException("InternalServerException", "Internal Server Error"));
     }
 

--- a/aws/client/aws-client-restjson/src/main/java/software/amazon/smithy/java/aws/client/restjson/RestJsonClientProtocol.java
+++ b/aws/client/aws-client-restjson/src/main/java/software/amazon/smithy/java/aws/client/restjson/RestJsonClientProtocol.java
@@ -108,6 +108,7 @@ public final class RestJsonClientProtocol extends HttpBindingClientProtocol<AwsE
                 operation,
                 payloadCodec(),
                 payloadMediaType(),
+                false,
                 (e) -> new EventStreamingException("InternalServerException", "Internal Server Error"));
     }
 

--- a/aws/client/aws-client-restxml/src/main/java/software/amazon/smithy/java/aws/client/restxml/RestXmlClientProtocol.java
+++ b/aws/client/aws-client-restxml/src/main/java/software/amazon/smithy/java/aws/client/restxml/RestXmlClientProtocol.java
@@ -94,6 +94,7 @@ public final class RestXmlClientProtocol extends HttpBindingClientProtocol<AwsEv
                 operation,
                 payloadCodec(),
                 payloadMediaType(),
+                false,
                 (e) -> new EventStreamingException("InternalServerException", "Internal Server Error"));
     }
 

--- a/client/client-rpcv2/src/main/java/software/amazon/smithy/java/client/rpcv2/AbstractRpcV2ClientProtocol.java
+++ b/client/client-rpcv2/src/main/java/software/amazon/smithy/java/client/rpcv2/AbstractRpcV2ClientProtocol.java
@@ -166,6 +166,7 @@ public abstract class AbstractRpcV2ClientProtocol extends HttpClientProtocol {
         return AwsEventEncoderFactory.forInputStream(operation,
                 codec(),
                 payloadMediaType,
+                true,
                 (e) -> new EventStreamingException("InternalServerException", "Internal Server Error"));
     }
 


### PR DESCRIPTION
### What behavior changes?
RPC protocols (awsJson, rpcv2-cbor) now emit an empty payload (e.g., `{}`) and set the content-type header for events with no payload members. REST protocol (restJson) continue to omit the body and content-type as before.

### Why is this change needed?
RPC protocols must always serialize a body even when there are no payload members, unlike REST protocols which omit it.

### How was this validated?
* Existing unit tests pass. Compilation verified across all affected modules.
* Tested against the internal server using REST and RPCv2


### What should reviewers focus on?
- The consolidated condition in `EventSerializer.writeStruct` (`emitEmptyPayload || hasPayloadMembers`)
- Correct `true`/`false` values passed at each protocol call site

### Additional Links

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
