### PR TITLE
Skip auto-format for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
   format:
     runs-on: ubuntu-latest
     name: Auto-format
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: >
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### What behavior changes?
Dependabot PRs don't fail CI anymore.


### Why is this change needed?
For PRs opened by Dependabot, GitHub deliberately runs the pull_request workflow with a restricted context: repository secrets (secrets.*) are not available, they live in a separate "Dependabot secrets" store. So `secrets.PR_TOKEN` resolves to an empty string, and passing an empty `token` to actions/checkout triggers ` Error: Input required and not supplied: token`

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
