### PR TITLE
Optimize dynamic schemas

### DIFF
--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/ContentDocument.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/ContentDocument.java
@@ -11,10 +11,14 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.RandomAccess;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableShape;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.MapSerializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -22,10 +26,28 @@ import software.amazon.smithy.model.shapes.ShapeType;
 /**
  * A wrapper around another document that changes the serialized schema.
  *
- * @param document Document to wrap.
- * @param schema Schema to use instead.
  */
-record ContentDocument(Document document, Schema schema) implements Document {
+final class ContentDocument implements Document {
+
+    private final Schema schema;
+    private final Object value;
+
+    ContentDocument(Schema schema, Object value) {
+        this.schema = schema;
+        this.value = value;
+    }
+
+    Object rawValue() {
+        return value;
+    }
+
+    boolean isScalar() {
+        return switch (schema.type()) {
+            case LIST, SET, MAP -> false;
+            default -> true;
+        };
+    }
+
     @Override
     public ShapeType type() {
         return schema.type();
@@ -33,155 +55,424 @@ record ContentDocument(Document document, Schema schema) implements Document {
 
     @Override
     public void serialize(ShapeSerializer serializer) {
-        // If it is literally a document, then don't unwrap it.
-        if (type() == ShapeType.DOCUMENT) {
-            serializer.writeDocument(schema, this);
-        } else {
-            serializeContents(serializer);
-        }
+        serializeContents(serializer);
     }
 
     @Override
     public void serializeContents(ShapeSerializer serializer) {
-        switch (type()) {
-            case BOOLEAN -> serializer.writeBoolean(schema, asBoolean());
-            case BYTE -> serializer.writeByte(schema, asByte());
-            case SHORT -> serializer.writeShort(schema, asShort());
-            case INTEGER, INT_ENUM -> serializer.writeInteger(schema, asInteger());
-            case LONG -> serializer.writeLong(schema, asLong());
-            case FLOAT -> serializer.writeFloat(schema, asFloat());
-            case DOUBLE -> serializer.writeDouble(schema, asDouble());
-            case BIG_INTEGER -> serializer.writeBigInteger(schema, asBigInteger());
-            case BIG_DECIMAL -> serializer.writeBigDecimal(schema, asBigDecimal());
-            case STRING, ENUM -> serializer.writeString(schema, asString());
-            case TIMESTAMP -> serializer.writeTimestamp(schema, asTimestamp());
-            case BLOB -> serializer.writeBlob(schema, asBlob());
-            case DOCUMENT -> document.serializeContents(serializer);
-            case LIST, SET -> {
-                serializer.writeList(schema, asList(), size(), (values, ser) -> {
-                    for (var element : values) {
-                        if (element == null) {
-                            ser.writeNull(schema.listMember());
-                        } else {
-                            element.serialize(ser);
-                        }
+        // Keep in sync with serializeScalar, split for C2 inline budget.
+        var s = schema;
+        switch (s.type()) {
+            case STRING, ENUM -> serializer.writeString(s, (String) value);
+            case BOOLEAN -> serializer.writeBoolean(s, (Boolean) value);
+            case INTEGER, INT_ENUM -> serializer.writeInteger(s, ((Number) value).intValue());
+            case LONG -> serializer.writeLong(s, ((Number) value).longValue());
+            case DOUBLE -> serializer.writeDouble(s, ((Number) value).doubleValue());
+            case FLOAT -> serializer.writeFloat(s, ((Number) value).floatValue());
+            case BYTE -> serializer.writeByte(s, ((Number) value).byteValue());
+            case SHORT -> serializer.writeShort(s, ((Number) value).shortValue());
+            case TIMESTAMP -> serializer.writeTimestamp(s, (Instant) value);
+            default -> serializeNonScalar(serializer, s);
+        }
+    }
+
+    // Keep in sync with serializeContents, used for raw union values without a ContentDocument wrapper.
+    static void serializeScalar(ShapeSerializer serializer, Schema schema, Object value) {
+        switch (schema.type()) {
+            case STRING, ENUM -> serializer.writeString(schema, (String) value);
+            case BOOLEAN -> serializer.writeBoolean(schema, (Boolean) value);
+            case INTEGER, INT_ENUM -> serializer.writeInteger(schema, ((Number) value).intValue());
+            case LONG -> serializer.writeLong(schema, ((Number) value).longValue());
+            case DOUBLE -> serializer.writeDouble(schema, ((Number) value).doubleValue());
+            case FLOAT -> serializer.writeFloat(schema, ((Number) value).floatValue());
+            case BYTE -> serializer.writeByte(schema, ((Number) value).byteValue());
+            case SHORT -> serializer.writeShort(schema, ((Number) value).shortValue());
+            case TIMESTAMP -> serializer.writeTimestamp(schema, (Instant) value);
+            case BLOB -> serializer.writeBlob(schema, (ByteBuffer) value);
+            case BIG_INTEGER -> serializer.writeBigInteger(schema, toBigInteger(value));
+            case BIG_DECIMAL -> serializer.writeBigDecimal(schema, toBigDecimal(value));
+            default -> throw new UnsupportedOperationException("Unsupported scalar type: " + schema.type());
+        }
+    }
+
+    private static BigInteger toBigInteger(Object value) {
+        return value instanceof BigInteger bi ? bi : BigInteger.valueOf(((Number) value).longValue());
+    }
+
+    private static BigDecimal toBigDecimal(Object value) {
+        return value instanceof BigDecimal bd ? bd : BigDecimal.valueOf(((Number) value).doubleValue());
+    }
+
+    private void serializeNonScalar(ShapeSerializer serializer, Schema s) {
+        switch (s.type()) {
+            case BLOB -> serializer.writeBlob(s, (ByteBuffer) value);
+            case BIG_INTEGER -> serializer.writeBigInteger(s, asBigInteger());
+            case BIG_DECIMAL -> serializer.writeBigDecimal(s, asBigDecimal());
+            case LIST, SET -> serializer.writeList(s, this, size(), ContentDocument::serializeListContents);
+            case MAP -> serializer.writeMap(s, this, size(), ContentDocument::serializeMapContents);
+            default -> throw new UnsupportedOperationException("Unsupported type: " + s.type());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void serializeListContents(ContentDocument doc, ShapeSerializer ser) {
+        Schema member = doc.schema.listMember();
+        List<Document> list = (List<Document>) doc.value;
+        // String/enum fast-path: monomorphic writeString loop, avoids per-element Document.serialize dispatch.
+        ShapeType memberType = member.type();
+        if (memberType == ShapeType.STRING || memberType == ShapeType.ENUM) {
+            writeStringList(ser, list, member);
+        } else {
+            if (list instanceof RandomAccess) {
+                for (int i = 0, n = list.size(); i < n; i++) {
+                    Document e = list.get(i);
+                    if (e == null) {
+                        ser.writeNull(member);
+                    } else {
+                        e.serialize(ser);
                     }
-                });
-            }
-            case MAP -> {
-                serializer.writeMap(schema, asStringMap(), size(), (members, s) -> {
-                    var key = schema.mapKeyMember();
-                    for (var entry : members.entrySet()) {
-                        if (entry.getValue() == null) {
-                            s.writeEntry(key, entry.getKey(), null, (t, v) -> v.writeNull(schema.mapValueMember()));
-                        } else {
-                            s.writeEntry(key, entry.getKey(), entry.getValue(), Document::serialize);
-                        }
+                }
+            } else {
+                for (Document e : list) {
+                    if (e == null) {
+                        ser.writeNull(member);
+                    } else {
+                        e.serialize(ser);
                     }
-                });
+                }
             }
-            // Note that Structure and Union are always going to be a StructDocument and appear here.
-            default -> throw new UnsupportedOperationException("Unsupported type: " + type());
+        }
+    }
+
+    private static void writeStringList(ShapeSerializer ser, List<Document> list, Schema member) {
+        if (list instanceof RandomAccess) {
+            for (int i = 0, n = list.size(); i < n; i++) {
+                Document e = list.get(i);
+                if (e == null) {
+                    ser.writeNull(member);
+                } else {
+                    ser.writeString(member, e.asString());
+                }
+            }
+        } else {
+            for (Document e : list) {
+                if (e == null) {
+                    ser.writeNull(member);
+                } else {
+                    ser.writeString(member, e.asString());
+                }
+            }
+        }
+    }
+
+    // Non-capturing, concretely-typed consumers for MapSerializer#writeEntry, keeps value-write monomorphic.
+    private static final BiConsumer<Schema, ShapeSerializer> NULL_VALUE_WRITER = (vm, ser) -> ser.writeNull(vm);
+    private static final BiConsumer<StructDocument, ShapeSerializer> STRUCT_VALUE_WRITER =
+            (d, ser) -> ser.writeStruct(d.schema(), d);
+    private static final BiConsumer<ContentDocument, ShapeSerializer> STRING_VALUE_WRITER =
+            (d, ser) -> ser.writeString(d.schema, (String) d.value);
+
+    @SuppressWarnings("unchecked")
+    private static void serializeMapContents(ContentDocument doc, MapSerializer ms) {
+        Schema key = doc.schema.mapKeyMember();
+        Schema valueMember = doc.schema.mapValueMember();
+        Map<String, Document> map = (Map<String, Document>) doc.value;
+        switch (valueMember.type()) {
+            case STRUCTURE, UNION -> {
+                for (var entry : map.entrySet()) {
+                    var v = entry.getValue();
+                    if (v == null) {
+                        ms.writeEntry(key, entry.getKey(), valueMember, NULL_VALUE_WRITER);
+                    } else {
+                        ms.writeEntry(key, entry.getKey(), (StructDocument) v, STRUCT_VALUE_WRITER);
+                    }
+                }
+            }
+            case STRING, ENUM -> {
+                for (var entry : map.entrySet()) {
+                    var v = entry.getValue();
+                    if (v == null) {
+                        ms.writeEntry(key, entry.getKey(), valueMember, NULL_VALUE_WRITER);
+                    } else {
+                        ms.writeEntry(key, entry.getKey(), (ContentDocument) v, STRING_VALUE_WRITER);
+                    }
+                }
+            }
+            default -> {
+                for (var entry : map.entrySet()) {
+                    var v = entry.getValue();
+                    if (v == null) {
+                        ms.writeEntry(key, entry.getKey(), valueMember, NULL_VALUE_WRITER);
+                    } else {
+                        ms.writeEntry(key, entry.getKey(), v, Document::serialize);
+                    }
+                }
+            }
         }
     }
 
     @Override
     public BigDecimal asBigDecimal() {
-        return document.asBigDecimal();
+        if (value instanceof BigDecimal bd) {
+            return bd;
+        }
+        return BigDecimal.valueOf(((Number) value).doubleValue());
     }
 
     @Override
     public BigInteger asBigInteger() {
-        return document.asBigInteger();
+        if (value instanceof BigInteger bi) {
+            return bi;
+        }
+        return BigInteger.valueOf(((Number) value).longValue());
     }
 
     @Override
     public ByteBuffer asBlob() {
-        return document.asBlob();
+        return (ByteBuffer) value;
     }
 
     @Override
     public boolean asBoolean() {
-        return document.asBoolean();
+        return (Boolean) value;
     }
 
     @Override
     public byte asByte() {
-        return document.asByte();
+        return ((Number) value).byteValue();
     }
 
     @Override
     public double asDouble() {
-        return document.asDouble();
+        return ((Number) value).doubleValue();
     }
 
     @Override
     public float asFloat() {
-        return document.asFloat();
+        return ((Number) value).floatValue();
     }
 
     @Override
     public int asInteger() {
-        return document.asInteger();
+        return ((Number) value).intValue();
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public List<Document> asList() {
-        return document.asList();
+        return (List<Document>) value;
     }
 
     @Override
     public long asLong() {
-        return document.asLong();
+        return ((Number) value).longValue();
     }
 
     @Override
     public Number asNumber() {
-        return document.asNumber();
+        return (Number) value;
     }
 
     @Override
     public Object asObject() {
-        return document.asObject();
-    }
-
-    @Override
-    public <T extends SerializableShape> T asShape(ShapeBuilder<T> builder) {
-        return document.asShape(builder);
+        return switch (schema.type()) {
+            case LIST, SET, MAP -> Document.super.asObject();
+            // String, Boolean, boxed Number, Instant, ByteBuffer are all already valid asObject() results.
+            default -> value;
+        };
     }
 
     @Override
     public short asShort() {
-        return document.asShort();
+        return ((Number) value).shortValue();
     }
 
     @Override
     public String asString() {
-        return document.asString();
+        return (String) value;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Map<String, Document> asStringMap() {
-        return document.asStringMap();
+        return (Map<String, Document>) value;
     }
 
     @Override
     public Instant asTimestamp() {
-        return document.asTimestamp();
+        return (Instant) value;
     }
 
     @Override
     public int size() {
-        return document.size();
+        return switch (schema.type()) {
+            case LIST, SET -> ((List<?>) value).size();
+            case MAP -> ((Map<?, ?>) value).size();
+            default -> -1;
+        };
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Document getMember(String memberName) {
-        return document.getMember(memberName);
+        if (schema.type() == ShapeType.MAP) {
+            return ((Map<String, Document>) value).get(memberName);
+        }
+        return Document.super.getMember(memberName);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Set<String> getMemberNames() {
-        return document.getMemberNames();
+        if (schema.type() == ShapeType.MAP) {
+            return ((Map<String, Document>) value).keySet();
+        }
+        return Document.super.getMemberNames();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ContentDocument that)) {
+            return false;
+        }
+        return schema.equals(that.schema) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * schema.hashCode() + Objects.hashCode(value);
+    }
+
+    /**
+     * Wraps another {@link Document} to give it a {@code document}-typed model {@link Schema}, delegating all value
+     * accessors to the wrapped document.
+     *
+     * <p>Used only for members whose modeled shape is an (untyped) {@code document}: the inner value can be any
+     * document kind, so unlike {@link ContentDocument} (which holds an already-unwrapped scalar/collection value for a
+     * known scalar/aggregate schema) this type must forward every accessor. Document-typed members are uncommon and
+     * never on the scalar/aggregate hot path, so the extra delegation here is not performance sensitive.
+     */
+    record SchemaDocument(Schema schema, Document document) implements Document {
+        @Override
+        public ShapeType type() {
+            return schema.type();
+        }
+
+        @Override
+        public void serialize(ShapeSerializer serializer) {
+            if (schema.type() == ShapeType.DOCUMENT) {
+                serializer.writeDocument(schema, this);
+            } else {
+                serializeContents(serializer);
+            }
+        }
+
+        @Override
+        public void serializeContents(ShapeSerializer serializer) {
+            document.serializeContents(serializer);
+        }
+
+        @Override
+        public BigDecimal asBigDecimal() {
+            return document.asBigDecimal();
+        }
+
+        @Override
+        public BigInteger asBigInteger() {
+            return document.asBigInteger();
+        }
+
+        @Override
+        public ByteBuffer asBlob() {
+            return document.asBlob();
+        }
+
+        @Override
+        public boolean asBoolean() {
+            return document.asBoolean();
+        }
+
+        @Override
+        public byte asByte() {
+            return document.asByte();
+        }
+
+        @Override
+        public double asDouble() {
+            return document.asDouble();
+        }
+
+        @Override
+        public float asFloat() {
+            return document.asFloat();
+        }
+
+        @Override
+        public int asInteger() {
+            return document.asInteger();
+        }
+
+        @Override
+        public List<Document> asList() {
+            return document.asList();
+        }
+
+        @Override
+        public long asLong() {
+            return document.asLong();
+        }
+
+        @Override
+        public Number asNumber() {
+            return document.asNumber();
+        }
+
+        @Override
+        public Object asObject() {
+            return document.asObject();
+        }
+
+        @Override
+        public <T extends SerializableShape> T asShape(ShapeBuilder<T> builder) {
+            return document.asShape(builder);
+        }
+
+        @Override
+        public short asShort() {
+            return document.asShort();
+        }
+
+        @Override
+        public String asString() {
+            return document.asString();
+        }
+
+        @Override
+        public Map<String, Document> asStringMap() {
+            return document.asStringMap();
+        }
+
+        @Override
+        public Instant asTimestamp() {
+            return document.asTimestamp();
+        }
+
+        @Override
+        public int size() {
+            return document.size();
+        }
+
+        @Override
+        public Document getMember(String memberName) {
+            return document.getMember(memberName);
+        }
+
+        @Override
+        public Set<String> getMemberNames() {
+            return document.getMemberNames();
+        }
     }
 }

--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilder.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilder.java
@@ -6,8 +6,8 @@
 package software.amazon.smithy.java.dynamicschemas;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SchemaUtils;
@@ -25,9 +25,15 @@ import software.amazon.smithy.model.shapes.ShapeType;
  */
 final class SchemaGuidedDocumentBuilder implements ShapeBuilder<StructDocument> {
 
+    private static final int DEFAULT_COLLECTION_CAPACITY = 16;
+
     private final ShapeId service;
     private final Schema target;
-    private final Map<String, Document> map = new LinkedHashMap<>();
+    private final Document[] values;
+    private final StructConsumer structConsumer = new StructConsumer();
+    private final UnionConsumer unionConsumer = new UnionConsumer();
+    private final ListConsumer listConsumer = new ListConsumer();
+    private final MapConsumer mapConsumer = new MapConsumer();
 
     SchemaGuidedDocumentBuilder(Schema target, ShapeId service) {
         if (target.type() != ShapeType.STRUCTURE && target.type() != ShapeType.UNION) {
@@ -37,6 +43,7 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<StructDocument> 
 
         this.target = target;
         this.service = service;
+        this.values = new Document[target.members().size()];
     }
 
     @Override
@@ -46,12 +53,19 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<StructDocument> 
 
     @Override
     public StructDocument build() {
-        if (map.isEmpty() && target.type() == ShapeType.UNION) {
-            throw new IllegalArgumentException("No value set for union document: " + schema().id());
-        } else {
-            // Use "new" here since the document is already properly wrapped throughout.
-            return new StructDocument(target, map, service);
+        if (target.type() == ShapeType.UNION) {
+            boolean hasValue = false;
+            for (Document v : values) {
+                if (v != null) {
+                    hasValue = true;
+                    break;
+                }
+            }
+            if (!hasValue) {
+                throw new IllegalArgumentException("No value set for union document: " + schema().id());
+            }
         }
+        return new StructDocument(target, values);
     }
 
     @Override
@@ -59,75 +73,100 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<StructDocument> 
         SchemaUtils.validateMemberInSchema(target, member, value);
 
         Document convertedValue = switch (value) {
-            // Convert the given document so it matches the required schema.
             case Document d -> StructDocument.convertDocument(member, d, service);
             case DataStream ds -> Document.of(member, ds);
             case EventStream<?> es -> Document.of(member, es);
-            // Convert the object to a document and then wrap it with the correct schema.
             case null, default -> StructDocument.convertDocument(member, Document.ofObject(value), service);
         };
 
-        map.put(member.memberName(), convertedValue);
+        values[member.memberIndex()] = convertedValue;
     }
 
     @Override
     public ShapeBuilder<StructDocument> deserialize(ShapeDeserializer decoder) {
-        map.putAll(deserialize(decoder, target).asStringMap());
+        populateFromDecoder(decoder, target);
         return this;
     }
 
     @Override
     public ShapeBuilder<StructDocument> deserializeMember(ShapeDeserializer decoder, Schema schema) {
-        map.putAll(deserialize(decoder, schema.assertMemberTargetIs(target)).asStringMap());
+        populateFromDecoder(decoder, schema.assertMemberTargetIs(target));
         return this;
     }
 
-    private Document deserialize(ShapeDeserializer decoder, Schema schema) {
+    private void populateFromDecoder(ShapeDeserializer decoder, Schema schema) {
+        decoder.readStruct(schema, values, structConsumer);
+    }
+
+    // Common scalars inline here; rare scalars and aggregates split out to stay under C2's FreqInlineSize.
+    private Document deserializeValue(ShapeDeserializer decoder, Schema schema) {
         return switch (schema.type()) {
+            case STRING, ENUM -> new ContentDocument(schema, decoder.readString(schema));
+            case BOOLEAN -> new ContentDocument(schema, decoder.readBoolean(schema));
+            case INTEGER, INT_ENUM -> new ContentDocument(schema, decoder.readInteger(schema));
+            case LONG -> new ContentDocument(schema, decoder.readLong(schema));
+            case DOUBLE -> new ContentDocument(schema, decoder.readDouble(schema));
+            case LIST, MAP, STRUCTURE, UNION -> deserializeAggregate(decoder, schema);
+            default -> deserializeRareScalar(decoder, schema);
+        };
+    }
+
+    // Union variant: returns raw boxed scalars (no ContentDocument wrapper) to avoid per-union allocation.
+    private Object deserializeUnionValue(ShapeDeserializer decoder, Schema schema) {
+        return switch (schema.type()) {
+            case STRING, ENUM -> decoder.readString(schema);
+            case BOOLEAN -> decoder.readBoolean(schema);
+            case INTEGER, INT_ENUM -> decoder.readInteger(schema);
+            case LONG -> decoder.readLong(schema);
+            case DOUBLE -> decoder.readDouble(schema);
+            case LIST, MAP, STRUCTURE, UNION -> deserializeAggregate(decoder, schema);
+            default -> deserializeRareUnionScalar(decoder, schema);
+        };
+    }
+
+    private Object deserializeRareUnionScalar(ShapeDeserializer decoder, Schema schema) {
+        return switch (schema.type()) {
+            case FLOAT -> decoder.readFloat(schema);
+            case BYTE -> decoder.readByte(schema);
+            case SHORT -> decoder.readShort(schema);
+            case TIMESTAMP -> decoder.readTimestamp(schema);
+            case BIG_DECIMAL -> decoder.readBigDecimal(schema);
+            case BIG_INTEGER -> decoder.readBigInteger(schema);
             case BLOB -> {
                 if (schema.hasTrait(TraitKey.STREAMING_TRAIT)) {
                     yield Document.of(schema, decoder.readDataStream(schema));
                 }
-                yield new ContentDocument(Document.of(decoder.readBlob(schema)), schema);
+                yield decoder.readBlob(schema);
             }
-            case BOOLEAN -> new ContentDocument(Document.of(decoder.readBoolean(schema)), schema);
-            case STRING, ENUM -> new ContentDocument(Document.of(decoder.readString(schema)), schema);
-            case TIMESTAMP -> new ContentDocument(Document.of(decoder.readTimestamp(schema)), schema);
-            case BYTE -> new ContentDocument(Document.ofNumber(decoder.readByte(schema)), schema);
-            case SHORT -> new ContentDocument(Document.ofNumber(decoder.readShort(schema)), schema);
-            case INTEGER, INT_ENUM -> new ContentDocument(Document.ofNumber(decoder.readInteger(schema)), schema);
-            case LONG -> new ContentDocument(Document.ofNumber(decoder.readLong(schema)), schema);
-            case FLOAT -> new ContentDocument(Document.ofNumber(decoder.readFloat(schema)), schema);
-            case DOCUMENT -> new ContentDocument(decoder.readDocument(), schema);
-            case DOUBLE -> new ContentDocument(Document.ofNumber(decoder.readDouble(schema)), schema);
-            case BIG_DECIMAL -> new ContentDocument(Document.ofNumber(decoder.readBigDecimal(schema)), schema);
-            case BIG_INTEGER -> new ContentDocument(Document.ofNumber(decoder.readBigInteger(schema)), schema);
-            case LIST -> {
-                var sparse = schema.hasTrait(TraitKey.SPARSE_TRAIT);
-                var items = new SchemaList(schema.listMember());
-                decoder.readList(schema, items, (it, memberDeserializer) -> {
-                    // A null element (only valid in @sparse lists) is retained as null; otherwise read the value.
-                    if (sparse && memberDeserializer.isNull()) {
-                        it.add(memberDeserializer.readNull());
-                    } else {
-                        it.add(deserialize(memberDeserializer, it.schema));
-                    }
-                });
-                yield new ContentDocument(Document.of(items), schema);
+            // DOCUMENT members keep their Document wrapper (SchemaDocument); they're not scalars.
+            case DOCUMENT -> new ContentDocument.SchemaDocument(schema, decoder.readDocument());
+            default -> throw new UnsupportedOperationException("Unsupported target type: " + schema.type());
+        };
+    }
+
+    private Document deserializeRareScalar(ShapeDeserializer decoder, Schema schema) {
+        return switch (schema.type()) {
+            case FLOAT -> new ContentDocument(schema, decoder.readFloat(schema));
+            case BYTE -> new ContentDocument(schema, decoder.readByte(schema));
+            case SHORT -> new ContentDocument(schema, decoder.readShort(schema));
+            case TIMESTAMP -> new ContentDocument(schema, decoder.readTimestamp(schema));
+            case BIG_DECIMAL -> new ContentDocument(schema, decoder.readBigDecimal(schema));
+            case BIG_INTEGER -> new ContentDocument(schema, decoder.readBigInteger(schema));
+            case DOCUMENT -> new ContentDocument.SchemaDocument(schema, decoder.readDocument());
+            case BLOB -> {
+                if (schema.hasTrait(TraitKey.STREAMING_TRAIT)) {
+                    yield Document.of(schema, decoder.readDataStream(schema));
+                }
+                yield new ContentDocument(schema, decoder.readBlob(schema));
             }
-            case MAP -> {
-                var sparse = schema.hasTrait(TraitKey.SPARSE_TRAIT);
-                var map = new SchemaMap(schema);
-                decoder.readStringMap(schema, map, (state, mapKey, memberDeserializer) -> {
-                    // A null value (only valid in @sparse maps) is retained as null; otherwise read the value.
-                    if (sparse && memberDeserializer.isNull()) {
-                        state.put(mapKey, memberDeserializer.readNull());
-                    } else {
-                        state.put(mapKey, deserialize(memberDeserializer, state.schema.mapValueMember()));
-                    }
-                });
-                yield new ContentDocument(Document.of(map), schema);
-            }
+            default -> throw new UnsupportedOperationException("Unsupported target type: " + schema.type());
+        };
+    }
+
+    private Document deserializeAggregate(ShapeDeserializer decoder, Schema schema) {
+        return switch (schema.type()) {
+            case LIST -> deserializeList(decoder, schema);
+            case MAP -> deserializeMap(decoder, schema);
             case STRUCTURE -> createStructDocument(decoder, schema);
             case UNION -> {
                 if (schema.hasTrait(TraitKey.STREAMING_TRAIT)) {
@@ -139,12 +178,51 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<StructDocument> 
         };
     }
 
+    private Document deserializeList(ShapeDeserializer decoder, Schema schema) {
+        Schema savedSchema = listConsumer.schema;
+        boolean savedSparse = listConsumer.sparse;
+        listConsumer.schema = schema.listMember();
+        listConsumer.sparse = schema.hasTrait(TraitKey.SPARSE_TRAIT);
+        int size = decoder.containerSize();
+        var items = size >= 0 && size <= decoder.containerPreAllocationLimit()
+                ? new ArrayList<Document>(size)
+                : new ArrayList<Document>(DEFAULT_COLLECTION_CAPACITY);
+        decoder.readList(schema, items, listConsumer);
+        listConsumer.schema = savedSchema;
+        listConsumer.sparse = savedSparse;
+        return new ContentDocument(schema, items);
+    }
+
+    private Document deserializeMap(ShapeDeserializer decoder, Schema schema) {
+        Schema savedSchema = mapConsumer.schema;
+        boolean savedSparse = mapConsumer.sparse;
+        mapConsumer.schema = schema.mapValueMember();
+        mapConsumer.sparse = schema.hasTrait(TraitKey.SPARSE_TRAIT);
+        int size = decoder.containerSize();
+        // LinkedHashMap: O(N) iteration (no empty-bucket scanning) and preserves wire order.
+        var map = size >= 0 && size <= decoder.containerPreAllocationLimit()
+                ? LinkedHashMap.<String, Document>newLinkedHashMap(size)
+                : new LinkedHashMap<String, Document>(DEFAULT_COLLECTION_CAPACITY);
+        decoder.readStringMap(schema, map, mapConsumer);
+        mapConsumer.schema = savedSchema;
+        mapConsumer.sparse = savedSparse;
+        return new ContentDocument(schema, map);
+    }
+
     private StructDocument createStructDocument(ShapeDeserializer decoder, Schema schema) {
-        var map = new LinkedHashMap<String, Document>();
-        decoder.readStruct(schema, map, (state, memberSchema, memberDeserializer) -> {
-            state.put(memberSchema.memberName(), deserialize(memberDeserializer, memberSchema));
-        });
-        return new StructDocument(schema, map, service);
+        if (schema.type() == ShapeType.UNION) {
+            return createUnionDocument(decoder, schema);
+        }
+        Document[] nestedValues = new Document[schema.members().size()];
+        decoder.readStruct(schema, nestedValues, structConsumer);
+        return new StructDocument(schema, nestedValues);
+    }
+
+    private StructDocument createUnionDocument(ShapeDeserializer decoder, Schema schema) {
+        unionConsumer.value = null;
+        unionConsumer.memberSchema = null;
+        decoder.readStruct(schema, null, unionConsumer);
+        return new StructDocument(schema, unionConsumer.value, unionConsumer.memberSchema);
     }
 
     @Override
@@ -153,21 +231,50 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<StructDocument> 
         return this;
     }
 
-    // Captures the schema of a list to pass to a closure.
-    private static final class SchemaList extends ArrayList<Document> {
-        private final Schema schema;
-
-        SchemaList(Schema schema) {
-            this.schema = schema;
+    private final class StructConsumer implements ShapeDeserializer.StructMemberConsumer<Document[]> {
+        @Override
+        public void accept(Document[] state, Schema memberSchema, ShapeDeserializer memberDeserializer) {
+            state[memberSchema.memberIndex()] = deserializeValue(memberDeserializer, memberSchema);
         }
     }
 
-    // Captures the schema of a map to pass to a closure.
-    private static final class SchemaMap extends HashMap<String, Document> {
-        private final Schema schema;
+    private final class UnionConsumer implements ShapeDeserializer.StructMemberConsumer<Object> {
+        // Object, not Document: scalar members are stored raw (no ContentDocument wrapper); aggregates as Document.
+        Object value;
+        Schema memberSchema;
 
-        SchemaMap(Schema schema) {
-            this.schema = schema;
+        @Override
+        public void accept(Object state, Schema memberSchema, ShapeDeserializer memberDeserializer) {
+            value = deserializeUnionValue(memberDeserializer, memberSchema);
+            this.memberSchema = memberSchema;
+        }
+    }
+
+    private final class ListConsumer implements ShapeDeserializer.ListMemberConsumer<List<Document>> {
+        Schema schema;
+        boolean sparse;
+
+        @Override
+        public void accept(List<Document> state, ShapeDeserializer memberDeserializer) {
+            if (sparse && memberDeserializer.isNull()) {
+                state.add(memberDeserializer.readNull());
+            } else {
+                state.add(deserializeValue(memberDeserializer, schema));
+            }
+        }
+    }
+
+    private final class MapConsumer implements ShapeDeserializer.MapMemberConsumer<String, Map<String, Document>> {
+        Schema schema;
+        boolean sparse;
+
+        @Override
+        public void accept(Map<String, Document> state, String key, ShapeDeserializer memberDeserializer) {
+            if (sparse && memberDeserializer.isNull()) {
+                state.put(key, memberDeserializer.readNull());
+            } else {
+                state.put(key, deserializeValue(memberDeserializer, schema));
+            }
         }
     }
 }

--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/StructDocument.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/StructDocument.java
@@ -6,16 +6,17 @@
 package software.amazon.smithy.java.dynamicschemas;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.document.Document;
-import software.amazon.smithy.java.core.serde.document.DocumentUtils;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 
@@ -29,13 +30,63 @@ import software.amazon.smithy.model.shapes.ShapeType;
 public final class StructDocument implements Document, SerializableStruct {
 
     private final Schema schema;
-    private final ShapeId service;
-    private final Map<String, Document> members;
+    // Structure: member-indexed array. Union: always null (uses unionValue/unionMemberSchema instead).
+    private final Document[] values;
+    // Union only: the set member's value. Object (not Document) so scalars can be stored raw, skipping
+    // the ContentDocument wrapper — the biggest allocation win for union-dense payloads (e.g. DynamoDB AttributeValue).
+    private final Object unionValue;
+    // Union only: cached schema of the set member (avoids re-resolving on every serialize).
+    private final Schema unionMemberSchema;
+    private Map<String, Document> mapView;
 
-    StructDocument(Schema schema, Map<String, Document> members, ShapeId service) {
-        this.service = service;
+    StructDocument(Schema schema, Document[] values) {
         this.schema = schema;
-        this.members = members;
+        if (schema.type() == ShapeType.UNION) {
+            // Collapse the per-member array down to the single set value; unions never retain the array.
+            int idx = findSetMember(values);
+            this.values = null;
+            this.unionValue = idx >= 0 ? unwrapScalar(values[idx]) : null;
+            this.unionMemberSchema = idx >= 0 ? schema.members().get(idx) : null;
+        } else {
+            this.values = values;
+            this.unionValue = null;
+            this.unionMemberSchema = null;
+        }
+    }
+
+    StructDocument(Schema schema, Object unionValue, Schema unionMemberSchema) {
+        this.schema = schema;
+        this.values = null;
+        this.unionValue = unionValue;
+        this.unionMemberSchema = unionMemberSchema;
+    }
+
+    private static int findSetMember(Document[] values) {
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != null) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static Object unwrapScalar(Document d) {
+        if (d instanceof ContentDocument cd && cd.isScalar()) {
+            return cd.rawValue();
+        }
+        return d;
+    }
+
+    // Cold path: re-wraps a raw scalar union value as a Document for the accessor API.
+    private Document unionValueAsDocument() {
+        Object uv = unionValue;
+        if (uv == null) {
+            return null;
+        }
+        if (uv instanceof Document d) {
+            return d;
+        }
+        return new ContentDocument(unionMemberSchema, uv);
     }
 
     /**
@@ -76,14 +127,28 @@ public final class StructDocument implements Document, SerializableStruct {
     }
 
     private static Document convertStructureDocument(Schema schema, Document delegate, ShapeId service) {
-        Map<String, Document> result = new LinkedHashMap<>();
-        for (var member : schema.members()) {
+        List<Schema> schemaMembers = schema.members();
+        if (schema.type() == ShapeType.UNION) {
+            for (int i = 0, n = schemaMembers.size(); i < n; i++) {
+                Schema member = schemaMembers.get(i);
+                var value = delegate.getMember(member.memberName());
+                if (value != null) {
+                    return new StructDocument(schema,
+                            unwrapScalar(convertDocument(member, value, service)),
+                            member);
+                }
+            }
+            return new StructDocument(schema, (Object) null, (Schema) null);
+        }
+        Document[] result = new Document[schemaMembers.size()];
+        for (int i = 0, n = schemaMembers.size(); i < n; i++) {
+            Schema member = schemaMembers.get(i);
             var value = delegate.getMember(member.memberName());
             if (value != null) {
-                result.put(member.memberName(), convertDocument(member, value, service));
+                result[member.memberIndex()] = convertDocument(member, value, service);
             }
         }
-        return new StructDocument(schema, result, service);
+        return new StructDocument(schema, result);
     }
 
     static Document convertDocument(Schema schema, Document delegate, ShapeId service) {
@@ -105,7 +170,7 @@ public final class StructDocument implements Document, SerializableStruct {
                         result.put(entry.getKey(), convertDocument(valueMember, entry.getValue(), service));
                     }
                 }
-                yield new ContentDocument(Document.of(result), schema);
+                yield new ContentDocument(schema, result);
             }
             case LIST, SET -> {
                 List<Document> result = new ArrayList<>();
@@ -117,20 +182,20 @@ public final class StructDocument implements Document, SerializableStruct {
                         result.add(convertDocument(valueMember, value, service));
                     }
                 }
-                yield new ContentDocument(Document.of(result), schema);
+                yield new ContentDocument(schema, result);
             }
-            case BOOLEAN -> new ContentDocument(Document.of(delegate.asBoolean()), schema);
-            case STRING, ENUM -> new ContentDocument(Document.of(delegate.asString()), schema);
-            case TIMESTAMP -> new ContentDocument(Document.of(delegate.asTimestamp()), schema);
+            case BOOLEAN -> new ContentDocument(schema, delegate.asBoolean());
+            case STRING, ENUM -> new ContentDocument(schema, delegate.asString());
+            case TIMESTAMP -> new ContentDocument(schema, delegate.asTimestamp());
             case BYTE, SHORT, INTEGER, INT_ENUM,
                     LONG, FLOAT, DOUBLE, BIG_INTEGER, BIG_DECIMAL ->
-                new ContentDocument(Document.ofNumber(delegate.asNumber()), schema);
-            case DOCUMENT -> new ContentDocument(delegate, schema);
+                new ContentDocument(schema, delegate.asNumber());
+            case DOCUMENT -> new ContentDocument.SchemaDocument(schema, delegate);
             case BLOB -> {
                 if (schema.hasTrait(TraitKey.STREAMING_TRAIT)) {
                     yield Document.of(schema, delegate.asDataStream());
                 }
-                yield new ContentDocument(Document.of(delegate.asBlob()), schema);
+                yield new ContentDocument(schema, delegate.asBlob());
             }
             default -> throw new IllegalArgumentException("Unsupported schema type: " + schema);
         };
@@ -153,20 +218,52 @@ public final class StructDocument implements Document, SerializableStruct {
 
     @Override
     public void serializeMembers(ShapeSerializer serializer) {
-        for (var name : getMemberNames()) {
-            var value = getMember(name);
-            if (value != null) {
-                var member = schema.member(name);
-                if (member != null) {
+        Document[] values = this.values;
+        if (values != null) {
+            for (int i = 0; i < values.length; i++) {
+                Document value = values[i];
+                if (value != null) {
                     value.serialize(serializer);
                 }
+            }
+        } else {
+            Object uv = unionValue;
+            if (uv instanceof Document d) {
+                // Aggregate / struct / document union member: serialize through the Document.
+                d.serialize(serializer);
+            } else if (uv != null) {
+                // Scalar union member stored raw (no ContentDocument wrapper): write it directly against the member
+                // schema. Skips both the wrapper allocation and the extra virtual ContentDocument.serialize hop.
+                ContentDocument.serializeScalar(serializer, unionMemberSchema, uv);
             }
         }
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T getMemberValue(Schema member) {
-        return DocumentUtils.getMemberValue(this, schema, member);
+        SchemaUtils.validateMemberInSchema(schema, member, null);
+        Object value;
+        if (values != null) {
+            int idx = member.memberIndex();
+            value = idx < values.length ? values[idx] : null;
+        } else {
+            value = unionMemberSchema != null && member.memberIndex() == unionMemberSchema.memberIndex()
+                    ? unionValue
+                    : null;
+        }
+        if (value == null) {
+            return null;
+        }
+        try {
+            // A raw scalar union value is already a valid asObject() result (String/Number/Boolean/Instant/...);
+            // a Document (structure, aggregate, document member, or any structure member value) is unwrapped.
+            return (T) (value instanceof Document d ? d.asObject() : value);
+        } catch (ClassCastException e) {
+            throw new ClassCastException(
+                    "Unable to cast document member `" + member.id() + "` from document with schema `"
+                            + schema.id() + "`: " + e.getMessage());
+        }
     }
 
     @Override
@@ -181,30 +278,84 @@ public final class StructDocument implements Document, SerializableStruct {
 
     @Override
     public int size() {
-        return members.size();
+        Document[] values = this.values;
+        if (values != null) {
+            int count = 0;
+            for (Document v : values) {
+                if (v != null) {
+                    count++;
+                }
+            }
+            return count;
+        }
+        return unionValue != null ? 1 : 0;
     }
 
     @Override
     public Map<String, Document> asStringMap() {
-        return members;
-    }
-
-    @Override
-    public Object asObject() {
-        Map<String, Object> result = new LinkedHashMap<>();
-        for (var entry : members.entrySet()) {
-            result.put(entry.getKey(), entry.getValue().asObject());
+        Map<String, Document> result = mapView;
+        if (result == null) {
+            Document[] values = this.values;
+            if (values != null) {
+                result = new LinkedHashMap<>();
+                List<Schema> schemaMembers = schema.members();
+                for (int i = 0, n = schemaMembers.size(); i < n; i++) {
+                    Document value = i < values.length ? values[i] : null;
+                    if (value != null) {
+                        result.put(schemaMembers.get(i).memberName(), value);
+                    }
+                }
+                result = Collections.unmodifiableMap(result);
+            } else {
+                result = unionValue != null
+                        ? Map.of(unionMemberSchema.memberName(), unionValueAsDocument())
+                        : Map.of();
+            }
+            mapView = result;
         }
         return result;
     }
 
     @Override
+    public Object asObject() {
+        Document[] values = this.values;
+        if (values != null) {
+            Map<String, Object> result = new LinkedHashMap<>();
+            List<Schema> schemaMembers = schema.members();
+            for (int i = 0, n = schemaMembers.size(); i < n; i++) {
+                Document value = i < values.length ? values[i] : null;
+                if (value != null) {
+                    result.put(schemaMembers.get(i).memberName(), value.asObject());
+                }
+            }
+            return result;
+        }
+        if (unionValue == null) {
+            return Map.of();
+        }
+        Object uv = unionValue;
+        Object asObject = uv instanceof Document d ? d.asObject() : uv;
+        return Map.of(unionMemberSchema.memberName(), asObject);
+    }
+
+    @Override
     public Document getMember(String memberName) {
-        return members.get(memberName);
+        Schema memberSchema = schema.member(memberName);
+        if (memberSchema == null) {
+            return null;
+        }
+        int idx = memberSchema.memberIndex();
+        Document[] values = this.values;
+        if (values != null) {
+            return idx < values.length ? values[idx] : null;
+        }
+        return unionMemberSchema != null && idx == unionMemberSchema.memberIndex()
+                ? unionValueAsDocument()
+                : null;
     }
 
     @Override
     public Set<String> getMemberNames() {
-        return members.keySet();
+        return asStringMap().keySet();
     }
 }


### PR DESCRIPTION
  ### What behavior changes?
  No observable behavior change. Dynamic-schema document serde produces the same
  output for the same input. This is purely internal: less allocation and faster
  serialize/deserialize for StructDocument / ContentDocument, especially for
  union-dense payloads (e.g. DynamoDB AttributeValue) and string/enum lists.

  ### Why is this change needed?
  Performance. The old path wrapped every leaf value in a second Document and
  stored struct members in a LinkedHashMap keyed by member name. This added an
  allocation per leaf plus map overhead per struct. The hot serialize call site
  was also megamorphic, so C2 couldn't inline it.

  ### How was this validated?
  - Existing dynamic-schemas unit tests pass (./gradlew :dynamic-schemas:test).
  - Serde benchmarks (the dynamic-client serde bench) used to measure the
    allocation / throughput wins.
  - Protocol tests pass.

  ### What should reviewers focus on?
  - ContentDocument: now stores the raw unwrapped value (String/Number/Boolean/
    Instant/ByteBuffer/List/Map) instead of wrapping a Document. Look at
    serializeContents / serializeScalar (kept in sync by hand) and the
    string/enum list fast-path in serializeListContents.
  - StructDocument + SchemaGuidedDocumentBuilder: struct members now live in a
    member-index-keyed Document[] instead of a LinkedHashMap; unions store the
    single set value raw (no ContentDocument wrapper). Reusable consumer objects
    replace per-call closures.
  - SchemaDocument: the one case that still wraps a Document (untyped
    document-typed members).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
