### PR TITLE
Fixed checking for external type property on symbol

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/EnumGenerator.java
@@ -37,7 +37,7 @@ public final class EnumGenerator<T extends ShapeDirective<Shape, CodeGenerationC
 
     @Override
     public void accept(T directive) {
-        if (directive.symbol().getProperty(SymbolProperties.EXTERNAL_TYPE).isPresent()) {
+        if (directive.symbol().getProperty(SymbolProperties.EXTERNAL_TYPE).orElse(false)) {
             // skip external types
             return;
         }

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -90,7 +90,7 @@ public final class StructureGenerator<
     public void accept(T directive) {
         if (directive.shape().hasTrait(UnitTypeTrait.class) || directive.symbol()
                 .getProperty(SymbolProperties.EXTERNAL_TYPE)
-                .isPresent()) {
+                .orElse(false)) {
             // Skip Unit structures or external types.
             return;
         }

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/UnionGenerator.java
@@ -37,7 +37,7 @@ public final class UnionGenerator
 
     @Override
     public void accept(GenerateUnionDirective<CodeGenerationContext, JavaCodegenSettings> directive) {
-        if (directive.symbol().getProperty(SymbolProperties.EXTERNAL_TYPE).isPresent()) {
+        if (directive.symbol().getProperty(SymbolProperties.EXTERNAL_TYPE).orElse(false)) {
             // Skip external types.
             return;
         }


### PR DESCRIPTION
### What behavior changes?

The PR fixes a bug when custom integration's symbol provider set `SymbolProperties.EXTERNAL_TYPE` to `false` on a symbol but the codegen still ignores the symbol/shape from generating the code.

### Why is this change needed?

Creating a codegen integration allows to override symbol provider. If a symbol provider sets `false` for `SymbolProperties.EXTERNAL_TYPE` the codegen skips generating code for this shape completely. This is due to a wrong property check is some places.

### How was this validated?

Run tests, built locally and validated the output with the integration.

### What should reviewers focus on?

Not much, its a 3 lines PR. But changes in this PR align with other changes in the repo already, e.g.:
- https://github.com/smithy-lang/smithy-java/blob/964c6d3edf920e11cec94fa0fbf0023605544f4e/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaIndexGenerator.java#L196
- https://github.com/smithy-lang/smithy-java/blob/964c6d3edf920e11cec94fa0fbf0023605544f4e/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaIndexGenerator.java#L75
- https://github.com/smithy-lang/smithy-java/blob/964c6d3edf920e11cec94fa0fbf0023605544f4e/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/SchemaFieldOrder.java#L78

### Additional Links

_(this PR is somewhat related to https://github.com/smithy-lang/smithy-java/issues/1198, but isn't really)_

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
