### PR TITLE
Make timestamp deser in dynamic like model traits

### DIFF
--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/StructDocument.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/StructDocument.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.dynamicschemas;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -16,6 +17,7 @@ import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.TimestampFormatter;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -186,7 +188,7 @@ public final class StructDocument implements Document, SerializableStruct {
             }
             case BOOLEAN -> new ContentDocument(schema, delegate.asBoolean());
             case STRING, ENUM -> new ContentDocument(schema, delegate.asString());
-            case TIMESTAMP -> new ContentDocument(schema, delegate.asTimestamp());
+            case TIMESTAMP -> new ContentDocument(schema, convertTimestamp(delegate));
             case BYTE, SHORT, INTEGER, INT_ENUM,
                     LONG, FLOAT, DOUBLE, BIG_INTEGER, BIG_DECIMAL ->
                 new ContentDocument(schema, delegate.asNumber());
@@ -199,6 +201,28 @@ public final class StructDocument implements Document, SerializableStruct {
             }
             default -> throw new IllegalArgumentException("Unsupported schema type: " + schema);
         };
+    }
+
+    /**
+     * Coerces an untyped document into an {@link Instant} for a modeled timestamp member.
+     *
+     * <p>The DynamicClient input model is the protocol-agnostic, in-memory Smithy data model, so a timestamp value
+     * is interpreted by its modeled representation rather than any wire format: a number is epoch-seconds and a string
+     * is {@code date-time} (ISO-8601). This mirrors how Smithy interprets timestamp values in model nodes (which also
+     * ignore {@code @timestampFormat}). The protocol's {@code @timestampFormat} is applied later, when the resulting
+     * Instant is serialized onto the wire.
+     */
+    private static Instant convertTimestamp(Document delegate) {
+        var type = delegate.type();
+        if (type == ShapeType.TIMESTAMP) {
+            // Already a typed timestamp document (e.g. an Instant passed via Document.ofObject).
+            return delegate.asTimestamp();
+        } else if (type != ShapeType.STRING) {
+            // Not-string means number, and numbers are epoch-seconds.
+            return TimestampFormatter.Prelude.EPOCH_SECONDS.readFromNumber(delegate.asNumber());
+        } else {
+            return TimestampFormatter.Prelude.DATE_TIME.readFromString(delegate.asString(), false);
+        }
     }
 
     @Override

--- a/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/StructDocumentTest.java
+++ b/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/StructDocumentTest.java
@@ -374,6 +374,94 @@ public class StructDocumentTest {
     }
 
     @Test
+    public void parsesIsoStringForTimestampMember() {
+        var schema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
+                .putMember("when", PreludeSchemas.TIMESTAMP)
+                .build();
+        var document = Document.ofObject(Map.of("when", "2024-01-01T00:00:00Z"));
+
+        var sd = StructDocument.of(schema, document, ShapeId.from("smithy.example#S"));
+
+        var when = sd.getMember("when");
+        assertThat(when.type(), is(ShapeType.TIMESTAMP));
+        assertThat(when.asTimestamp(), equalTo(Instant.parse("2024-01-01T00:00:00Z")));
+    }
+
+    @Test
+    public void readsEpochNumberForTimestampMember() {
+        var schema = Schema.structureBuilder(ShapeId.from("foo#Bar"))
+                .putMember("when", PreludeSchemas.TIMESTAMP)
+                .build();
+        var document = Document.ofObject(Map.of("when", 1704067200));
+
+        var sd = StructDocument.of(schema, document, ShapeId.from("smithy.example#S"));
+
+        assertThat(sd.getMember("when").asTimestamp(), equalTo(Instant.parse("2024-01-01T00:00:00Z")));
+    }
+
+    @Test
+    public void parsesIsoStringsForNestedTimestamps() {
+        var model = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+
+                        structure Foo {
+                            items: ItemList
+                        }
+
+                        list ItemList {
+                            member: Item
+                        }
+
+                        structure Item {
+                            when: Timestamp
+                        }
+                        """)
+                .assemble()
+                .unwrap();
+        var converter = new SchemaConverter(model);
+        var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#Foo")));
+
+        var input = Document.ofObject(Map.of(
+                "items",
+                List.of(
+                        Map.of("when", "2024-01-01T00:00:00Z"),
+                        Map.of("when", "2024-06-22T12:00:00Z"))));
+        var sd = StructDocument.of(schema, input);
+
+        var items = sd.getMember("items").asList();
+        assertThat(items, hasSize(2));
+        assertThat(items.get(0).getMember("when").asTimestamp(), equalTo(Instant.parse("2024-01-01T00:00:00Z")));
+        assertThat(items.get(1).getMember("when").asTimestamp(), equalTo(Instant.parse("2024-06-22T12:00:00Z")));
+    }
+
+    @Test
+    public void ignoresTimestampFormatTraitWhenCoercingInput() {
+        // @timestampFormat is a wire-serialization concern; the protocol-agnostic input model always treats
+        // a string as date-time (ISO-8601), regardless of any trait on the member.
+        var model = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+
+                        structure Foo {
+                            @timestampFormat("epoch-seconds")
+                            when: Timestamp
+                        }
+                        """)
+                .assemble()
+                .unwrap();
+        var converter = new SchemaConverter(model);
+        var schema = converter.getSchema(model.expectShape(ShapeId.from("smithy.example#Foo")));
+
+        var input = Document.ofObject(Map.of("when", "2024-01-01T00:00:00Z"));
+        var sd = StructDocument.of(schema, input);
+
+        assertThat(sd.getMember("when").asTimestamp(), equalTo(Instant.parse("2024-01-01T00:00:00Z")));
+    }
+
+    @Test
     public void convertDocumentPassesThroughDataStream() {
         var model = Model.assembler()
                 .addUnparsedModel("test.smithy", """


### PR DESCRIPTION
### What behavior changes?
Describe the observable difference in behavior before and after this change.

Timestamp deserialization for dynamic clients and schemas needs to be more protocol agnostic like Smithy model traits: string means date-time, and number means epoch seconds. Before passing a string would fail for a timestamp because it fell back to the default of the underlying protocol or epoch-seconds.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

Dynamic schemas are protocol agnostic, similar to Smithy model trait node values.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

Unit tests

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

internal ticket

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
