### PR TITLE
Throw SerializationException for null values in dense collections

### DIFF
--- a/codecs/xml-codec/model/test.smithy
+++ b/codecs/xml-codec/model/test.smithy
@@ -95,6 +95,7 @@ enum Color {
     YELLOW
 }
 
+@sparse
 list StringList {
     member: String
 }

--- a/codecs/xml-codec/src/test/java/software/amazon/smithy/java/xml/GeneratedModelSerdeTest.java
+++ b/codecs/xml-codec/src/test/java/software/amazon/smithy/java/xml/GeneratedModelSerdeTest.java
@@ -715,7 +715,7 @@ public class GeneratedModelSerdeTest extends ProviderTestBase {
 
     @Test
     void selfClosingElementsInListSkippedAsNull() {
-        // Self-closing and empty elements in lists are treated as null (skipped) by the generated code
+        // Self-closing and empty elements in sparse lists are treated as null and preserved
         String xml = "<ComplexStruct><id>1</id><count>1</count><enabled>true</enabled>"
                 + "<ratio>1.0</ratio><score>1.0</score><bigCount>1</bigCount>"
                 + "<nested><field1>a</field1><field2>1</field2></nested>"
@@ -724,7 +724,7 @@ public class GeneratedModelSerdeTest extends ProviderTestBase {
         var staxResult = deserialize(STAX, xml, ComplexStruct.builder());
         var nativeResult = deserialize(NATIVE, xml, ComplexStruct.builder());
         assertThat(nativeResult.getTags()).isEqualTo(staxResult.getTags());
-        assertThat(nativeResult.getTags()).containsExactly("hello");
+        assertThat(nativeResult.getTags()).containsExactly(null, "hello", null);
     }
 
     @PerProvider

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/ListGenerator.java
@@ -85,8 +85,8 @@ public final class ListGenerator
                                                 @Override
                                                 public void accept(${shape:B} state, ${shapeDeserializer:T} deserializer) {
                                                     if (deserializer.isNull()) {
-                                                        ${?sparse}state.add(deserializer.readNull());${/sparse}
-                                                        return;
+                                                        ${?sparse}state.add(deserializer.readNull());
+                                                        return;${/sparse}${^sparse}throw new ${serdeException:T}("Null value found in dense list");${/sparse}
                                                     }
                                                     state.add($memberDeserializer:C);
                                                 }

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
@@ -14,6 +14,7 @@ import software.amazon.smithy.java.codegen.JavaCodegenSettings;
 import software.amazon.smithy.java.codegen.SymbolProperties;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.serde.MapSerializer;
+import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.model.traits.SparseTrait;
@@ -95,8 +96,8 @@ public final class MapGenerator
                                                 @Override
                                                 public void accept(${shape:B} state, ${string:T} key, ${shapeDeserializer:T} deserializer) {
                                                     if (deserializer.isNull()) {
-                                                        ${?sparse}state.put(${?enumKey}${key:T}.from(${/enumKey}key${?enumKey})${/enumKey}, ${/sparse}deserializer.readNull()${?sparse})${/sparse};
-                                                        return;
+                                                        ${?sparse}state.put(${?enumKey}${key:T}.from(${/enumKey}key${?enumKey})${/enumKey}, deserializer.readNull());
+                                                        return;${/sparse}${^sparse}throw new ${serdeException:T}("Null value found in dense map");${/sparse}
                                                     }
                                                     state.put(${?enumKey}${key:T}.from(${/enumKey}key${?enumKey})${/enumKey}, $memberDeserializer:C);
                                                 }
@@ -143,6 +144,7 @@ public final class MapGenerator
                                             .expectShape(directive.shape().getKey().getTarget())
                                             .isEnumShape());
                             writer.putContext("sparse", directive.shape().hasTrait(SparseTrait.class));
+                            writer.putContext("serdeException", SerializationException.class);
                             writer.write(template);
                             writer.popState();
 

--- a/codegen/codegen-plugin/src/it/java/software/amazon/smithy/java/codegen/types/DenseSparseNullTest.java
+++ b/codegen/codegen-plugin/src/it/java/software/amazon/smithy/java/codegen/types/DenseSparseNullTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.codegen.test.model.ListAllTypesInput;
+import software.amazon.smithy.java.codegen.test.model.MapAllTypesInput;
+import software.amazon.smithy.java.codegen.test.model.SparseListsInput;
+import software.amazon.smithy.java.codegen.test.model.SparseMapsInput;
+import software.amazon.smithy.java.core.serde.SerializationException;
+import software.amazon.smithy.java.json.JsonCodec;
+
+/**
+ * Tests that null values in dense collections throw and sparse collections preserve nulls.
+ */
+public class DenseSparseNullTest {
+
+    private static final JsonCodec CODEC = JsonCodec.builder().build();
+
+    @Test
+    void throwsForNullInDenseList() {
+        var json = """
+                {"listOfString":["a",null,"b"]}
+                """;
+        assertThrows(SerializationException.class,
+                () -> CODEC.deserializeShape(json.getBytes(StandardCharsets.UTF_8), ListAllTypesInput.builder()));
+    }
+
+    @Test
+    void throwsForNullInDenseMap() {
+        var json = """
+                {"stringStringMap":{"a":"x","b":null}}
+                """;
+        assertThrows(SerializationException.class,
+                () -> CODEC.deserializeShape(json.getBytes(StandardCharsets.UTF_8), MapAllTypesInput.builder()));
+    }
+
+    @Test
+    void preservesNullInSparseList() {
+        var json = """
+                {"listOfString":["a",null,"b"]}
+                """;
+        var result = CODEC.deserializeShape(json.getBytes(StandardCharsets.UTF_8), SparseListsInput.builder());
+        List<String> list = result.getListOfString();
+        assertEquals(3, list.size());
+        assertEquals("a", list.get(0));
+        assertNull(list.get(1));
+        assertEquals("b", list.get(2));
+    }
+
+    @Test
+    void preservesNullInSparseMap() {
+        var json = """
+                {"stringStringMap":{"a":"x","b":null}}
+                """;
+        var result = CODEC.deserializeShape(json.getBytes(StandardCharsets.UTF_8), SparseMapsInput.builder());
+        Map<String, String> map = result.getStringStringMap();
+        assertEquals(2, map.size());
+        assertEquals("x", map.get("a"));
+        assertNull(map.get("b"));
+    }
+}

--- a/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/utils/PluginTestRunner.java
+++ b/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/utils/PluginTestRunner.java
@@ -63,7 +63,6 @@ public class PluginTestRunner {
         var modelDir = new File(dir, "model");
         var model = Model.assembler()
                 .addImport(modelDir.toPath())
-                .discoverModels()
                 .assemble()
                 .unwrap();
         var manifests = new ArrayList<MockManifest>();

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/expected/CollectionsStruct.java
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/expected/CollectionsStruct.java
@@ -1,0 +1,262 @@
+package software.amazon.smithy.java.example.standalone.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SchemaUtils;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.ToStringSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyGenerated;
+
+@SmithyGenerated
+public final class CollectionsStruct implements SerializableStruct {
+
+    public static final Schema $SCHEMA = Schemas.COLLECTIONS_STRUCT;
+    private static final Schema $SCHEMA_DENSE_LIST = $SCHEMA.member("denseList");
+    private static final Schema $SCHEMA_SPARSE_LIST = $SCHEMA.member("sparseList");
+    private static final Schema $SCHEMA_DENSE_MAP = $SCHEMA.member("denseMap");
+    private static final Schema $SCHEMA_SPARSE_MAP = $SCHEMA.member("sparseMap");
+
+    public static final ShapeId $ID = $SCHEMA.id();
+
+    private final transient List<String> denseList;
+    private final transient List<String> sparseList;
+    private final transient Map<String, String> denseMap;
+    private final transient Map<String, String> sparseMap;
+
+    private CollectionsStruct(Builder builder) {
+        this.denseList = builder.denseList == null ? null : Collections.unmodifiableList(builder.denseList);
+        this.sparseList = builder.sparseList == null ? null : Collections.unmodifiableList(builder.sparseList);
+        this.denseMap = builder.denseMap == null ? null : Collections.unmodifiableMap(builder.denseMap);
+        this.sparseMap = builder.sparseMap == null ? null : Collections.unmodifiableMap(builder.sparseMap);
+    }
+
+    public List<String> getDenseList() {
+        if (denseList == null) {
+            return Collections.emptyList();
+        }
+        return denseList;
+    }
+
+    public boolean hasDenseList() {
+        return denseList != null;
+    }
+
+    public List<String> getSparseList() {
+        if (sparseList == null) {
+            return Collections.emptyList();
+        }
+        return sparseList;
+    }
+
+    public boolean hasSparseList() {
+        return sparseList != null;
+    }
+
+    public Map<String, String> getDenseMap() {
+        if (denseMap == null) {
+            return Collections.emptyMap();
+        }
+        return denseMap;
+    }
+
+    public boolean hasDenseMap() {
+        return denseMap != null;
+    }
+
+    public Map<String, String> getSparseMap() {
+        if (sparseMap == null) {
+            return Collections.emptyMap();
+        }
+        return sparseMap;
+    }
+
+    public boolean hasSparseMap() {
+        return sparseMap != null;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringSerializer.serialize(this);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        CollectionsStruct that = (CollectionsStruct) other;
+        return Objects.equals(this.denseList, that.denseList)
+               && Objects.equals(this.sparseList, that.sparseList)
+               && Objects.equals(this.denseMap, that.denseMap)
+               && Objects.equals(this.sparseMap, that.sparseMap);
+    }
+
+    @Override
+    public int hashCode() {
+        int $hc = Objects.hashCode(denseList);
+        $hc = 31 * $hc + Objects.hashCode(sparseList);
+        $hc = 31 * $hc + Objects.hashCode(denseMap);
+        $hc = 31 * $hc + Objects.hashCode(sparseMap);
+        return $hc;
+    }
+
+    @Override
+    public Schema schema() {
+        return $SCHEMA;
+    }
+
+    @Override
+    public void serializeMembers(ShapeSerializer serializer) {
+        if (denseList != null) {
+            serializer.writeList($SCHEMA_DENSE_LIST, denseList, denseList.size(), SharedSerde.DenseListSerializer.INSTANCE);
+        }
+        if (sparseList != null) {
+            serializer.writeList($SCHEMA_SPARSE_LIST, sparseList, sparseList.size(), SharedSerde.SparseListSerializer.INSTANCE);
+        }
+        if (denseMap != null) {
+            serializer.writeMap($SCHEMA_DENSE_MAP, denseMap, denseMap.size(), SharedSerde.DenseMapSerializer.INSTANCE);
+        }
+        if (sparseMap != null) {
+            serializer.writeMap($SCHEMA_SPARSE_MAP, sparseMap, sparseMap.size(), SharedSerde.SparseMapSerializer.INSTANCE);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getMemberValue(Schema member) {
+        return switch (member.memberIndex()) {
+            case 0 -> (T) SchemaUtils.validateSameMember($SCHEMA_DENSE_LIST, member, denseList);
+            case 1 -> (T) SchemaUtils.validateSameMember($SCHEMA_SPARSE_LIST, member, sparseList);
+            case 2 -> (T) SchemaUtils.validateSameMember($SCHEMA_DENSE_MAP, member, denseMap);
+            case 3 -> (T) SchemaUtils.validateSameMember($SCHEMA_SPARSE_MAP, member, sparseMap);
+            default -> throw new IllegalArgumentException("Attempted to get non-existent member: " + member.id());
+        };
+    }
+
+    /**
+     * Create a new builder containing all the current property values of this object.
+     *
+     * <p><strong>Note:</strong> This method performs only a shallow copy of the original properties.
+     *
+     * @return a builder for {@link CollectionsStruct}.
+     */
+    public Builder toBuilder() {
+        var builder = new Builder();
+        builder.denseList(this.denseList);
+        builder.sparseList(this.sparseList);
+        builder.denseMap(this.denseMap);
+        builder.sparseMap(this.sparseMap);
+        return builder;
+    }
+
+    /**
+     * @return returns a new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link CollectionsStruct}.
+     */
+    public static final class Builder implements ShapeBuilder<CollectionsStruct> {
+        private List<String> denseList;
+        private List<String> sparseList;
+        private Map<String, String> denseMap;
+        private Map<String, String> sparseMap;
+
+        private Builder() {}
+
+        @Override
+        public Schema schema() {
+            return $SCHEMA;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder denseList(List<String> denseList) {
+            this.denseList = denseList;
+            return this;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder sparseList(List<String> sparseList) {
+            this.sparseList = sparseList;
+            return this;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder denseMap(Map<String, String> denseMap) {
+            this.denseMap = denseMap;
+            return this;
+        }
+
+        /**
+         * @return this builder.
+         */
+        public Builder sparseMap(Map<String, String> sparseMap) {
+            this.sparseMap = sparseMap;
+            return this;
+        }
+
+        @Override
+        public CollectionsStruct build() {
+            return new CollectionsStruct(this);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void setMemberValue(Schema member, Object value) {
+            switch (member.memberIndex()) {
+                case 0 -> denseList((List<String>) SchemaUtils.validateSameMember($SCHEMA_DENSE_LIST, member, value));
+                case 1 -> sparseList((List<String>) SchemaUtils.validateSameMember($SCHEMA_SPARSE_LIST, member, value));
+                case 2 -> denseMap((Map<String, String>) SchemaUtils.validateSameMember($SCHEMA_DENSE_MAP, member, value));
+                case 3 -> sparseMap((Map<String, String>) SchemaUtils.validateSameMember($SCHEMA_SPARSE_MAP, member, value));
+                default -> ShapeBuilder.super.setMemberValue(member, value);
+            }
+        }
+
+        @Override
+        public Builder deserialize(ShapeDeserializer decoder) {
+            decoder.readStruct($SCHEMA, this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        @Override
+        public Builder deserializeMember(ShapeDeserializer decoder, Schema schema) {
+            decoder.readStruct(schema.assertMemberTargetIs($SCHEMA), this, $InnerDeserializer.INSTANCE);
+            return this;
+        }
+
+        private static final class $InnerDeserializer implements ShapeDeserializer.StructMemberConsumer<Builder> {
+            private static final $InnerDeserializer INSTANCE = new $InnerDeserializer();
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void accept(Builder builder, Schema member, ShapeDeserializer de) {
+                switch (member.memberIndex()) {
+                    case 0 -> builder.denseList(SharedSerde.deserializeDenseList(member, de));
+                    case 1 -> builder.sparseList(SharedSerde.deserializeSparseList(member, de));
+                    case 2 -> builder.denseMap(SharedSerde.deserializeDenseMap(member, de));
+                    case 3 -> builder.sparseMap(SharedSerde.deserializeSparseMap(member, de));
+                    default -> throw new IllegalArgumentException("Unexpected member: " + member.memberName());
+                }
+            }
+        }
+    }
+}

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/expected/SharedSerde.java
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/expected/SharedSerde.java
@@ -1,0 +1,202 @@
+package software.amazon.smithy.java.example.standalone.model;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.RandomAccess;
+import java.util.function.BiConsumer;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.serde.MapSerializer;
+import software.amazon.smithy.java.core.serde.SerializationException;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+
+
+/**
+ * Defines shared serialization and deserialization methods for map and list shapes.
+ */
+final class SharedSerde {
+
+    static final class SparseMapSerializer implements BiConsumer<Map<String, String>, MapSerializer> {
+        static final SparseMapSerializer INSTANCE = new SparseMapSerializer();
+
+        @Override
+        public void accept(Map<String, String> values, MapSerializer serializer) {
+            var $k = Schemas.SPARSE_MAP.mapKeyMember();
+            for (var valueEntry : values.entrySet()) {
+                serializer.writeEntry(
+                    $k,
+                    valueEntry.getKey(),
+                    valueEntry.getValue(),
+                    SparseMap$ValueSerializer.INSTANCE
+                );
+            }
+        }
+    }
+
+    private static final class SparseMap$ValueSerializer implements BiConsumer<String, ShapeSerializer> {
+        private static final SparseMap$ValueSerializer INSTANCE = new SparseMap$ValueSerializer();
+
+        @Override
+        public void accept(String values, ShapeSerializer serializer) {
+            if (values == null) {
+                serializer.writeNull(Schemas.SPARSE_MAP.mapValueMember());
+                return;
+            }
+            serializer.writeString(Schemas.SPARSE_MAP.mapValueMember(), values);
+        }
+    }
+
+    static Map<String, String> deserializeSparseMap(Schema schema, ShapeDeserializer deserializer) {
+        var size = Math.min(deserializer.containerSize(), deserializer.containerPreAllocationLimit());
+        Map<String, String> result = size == -1 ? new LinkedHashMap<>() : LinkedHashMap.newLinkedHashMap(size);
+        deserializer.readStringMap(schema, result, SparseMap$ValueDeserializer.INSTANCE);
+        return result;
+    }
+
+    private static final class SparseMap$ValueDeserializer implements ShapeDeserializer.MapMemberConsumer<String, Map<String, String>> {
+        static final SparseMap$ValueDeserializer INSTANCE = new SparseMap$ValueDeserializer();
+
+        @Override
+        public void accept(Map<String, String> state, String key, ShapeDeserializer deserializer) {
+            if (deserializer.isNull()) {
+                state.put(key, deserializer.readNull());
+                return;
+            }
+            state.put(key, deserializer.readString(Schemas.SPARSE_MAP.mapValueMember()));
+        }
+    }
+
+    static final class SparseListSerializer implements BiConsumer<List<String>, ShapeSerializer> {
+        static final SparseListSerializer INSTANCE = new SparseListSerializer();
+
+        @Override
+        public void accept(List<String> values, ShapeSerializer serializer) {
+            var $m = Schemas.SPARSE_LIST.listMember();
+            if (values instanceof RandomAccess) {
+                for (int i = 0, size = values.size(); i < size; i++) {
+                    var value = values.get(i);
+                    if (value == null) {
+                        serializer.writeNull($m);
+                        continue;
+                    }
+                    serializer.writeString($m, value);
+                }
+            } else {
+                for (var value : values) {
+                    if (value == null) {
+                        serializer.writeNull($m);
+                        continue;
+                    }
+                    serializer.writeString($m, value);
+                }
+            }
+        }
+    }
+
+    static List<String> deserializeSparseList(Schema schema, ShapeDeserializer deserializer) {
+        var size = Math.min(deserializer.containerSize(), deserializer.containerPreAllocationLimit());
+        List<String> result = size == -1 ? new ArrayList<>() : new ArrayList<>(size);
+        deserializer.readList(schema, result, SparseList$MemberDeserializer.INSTANCE);
+        return result;
+    }
+
+    private static final class SparseList$MemberDeserializer implements ShapeDeserializer.ListMemberConsumer<List<String>> {
+        static final SparseList$MemberDeserializer INSTANCE = new SparseList$MemberDeserializer();
+
+        @Override
+        public void accept(List<String> state, ShapeDeserializer deserializer) {
+            if (deserializer.isNull()) {
+                state.add(deserializer.readNull());
+                return;
+            }
+            state.add(deserializer.readString(Schemas.SPARSE_LIST.listMember()));
+        }
+    }
+
+    static final class DenseMapSerializer implements BiConsumer<Map<String, String>, MapSerializer> {
+        static final DenseMapSerializer INSTANCE = new DenseMapSerializer();
+
+        @Override
+        public void accept(Map<String, String> values, MapSerializer serializer) {
+            var $k = Schemas.DENSE_MAP.mapKeyMember();
+            for (var valueEntry : values.entrySet()) {
+                serializer.writeEntry(
+                    $k,
+                    valueEntry.getKey(),
+                    valueEntry.getValue(),
+                    DenseMap$ValueSerializer.INSTANCE
+                );
+            }
+        }
+    }
+
+    private static final class DenseMap$ValueSerializer implements BiConsumer<String, ShapeSerializer> {
+        private static final DenseMap$ValueSerializer INSTANCE = new DenseMap$ValueSerializer();
+
+        @Override
+        public void accept(String values, ShapeSerializer serializer) {
+            serializer.writeString(Schemas.DENSE_MAP.mapValueMember(), values);
+        }
+    }
+
+    static Map<String, String> deserializeDenseMap(Schema schema, ShapeDeserializer deserializer) {
+        var size = Math.min(deserializer.containerSize(), deserializer.containerPreAllocationLimit());
+        Map<String, String> result = size == -1 ? new LinkedHashMap<>() : LinkedHashMap.newLinkedHashMap(size);
+        deserializer.readStringMap(schema, result, DenseMap$ValueDeserializer.INSTANCE);
+        return result;
+    }
+
+    private static final class DenseMap$ValueDeserializer implements ShapeDeserializer.MapMemberConsumer<String, Map<String, String>> {
+        static final DenseMap$ValueDeserializer INSTANCE = new DenseMap$ValueDeserializer();
+
+        @Override
+        public void accept(Map<String, String> state, String key, ShapeDeserializer deserializer) {
+            if (deserializer.isNull()) {
+                throw new SerializationException("Null value found in dense map");
+            }
+            state.put(key, deserializer.readString(Schemas.DENSE_MAP.mapValueMember()));
+        }
+    }
+
+    static final class DenseListSerializer implements BiConsumer<List<String>, ShapeSerializer> {
+        static final DenseListSerializer INSTANCE = new DenseListSerializer();
+
+        @Override
+        public void accept(List<String> values, ShapeSerializer serializer) {
+            var $m = Schemas.DENSE_LIST.listMember();
+            if (values instanceof RandomAccess) {
+                for (int i = 0, size = values.size(); i < size; i++) {
+                    var value = values.get(i);
+                    serializer.writeString($m, value);
+                }
+            } else {
+                for (var value : values) {
+                    serializer.writeString($m, value);
+                }
+            }
+        }
+    }
+
+    static List<String> deserializeDenseList(Schema schema, ShapeDeserializer deserializer) {
+        var size = Math.min(deserializer.containerSize(), deserializer.containerPreAllocationLimit());
+        List<String> result = size == -1 ? new ArrayList<>() : new ArrayList<>(size);
+        deserializer.readList(schema, result, DenseList$MemberDeserializer.INSTANCE);
+        return result;
+    }
+
+    private static final class DenseList$MemberDeserializer implements ShapeDeserializer.ListMemberConsumer<List<String>> {
+        static final DenseList$MemberDeserializer INSTANCE = new DenseList$MemberDeserializer();
+
+        @Override
+        public void accept(List<String> state, ShapeDeserializer deserializer) {
+            if (deserializer.isNull()) {
+                throw new SerializationException("Null value found in dense list");
+            }
+            state.add(deserializer.readString(Schemas.DENSE_LIST.listMember()));
+        }
+    }
+
+    private SharedSerde() {}
+}

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/model/main.smithy
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/model/main.smithy
@@ -1,0 +1,30 @@
+$version: "2"
+
+namespace smithy.test
+
+list DenseList {
+    member: String
+}
+
+@sparse
+list SparseList {
+    member: String
+}
+
+map DenseMap {
+    key: String
+    value: String
+}
+
+@sparse
+map SparseMap {
+    key: String
+    value: String
+}
+
+structure CollectionsStruct {
+    denseList: DenseList
+    sparseList: SparseList
+    denseMap: DenseMap
+    sparseMap: SparseMap
+}

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/smithy-build.json
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/smithy-build.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "plugins": {
+    "java-codegen": {
+      "namespace": "software.amazon.smithy.java.example.standalone",
+      "modes": ["types"]
+    }
+  }
+}

--- a/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilder.java
+++ b/dynamic-schemas/src/main/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilder.java
@@ -13,6 +13,7 @@ import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SchemaUtils;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.schema.TraitKey;
+import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.core.serde.event.EventStream;
@@ -256,8 +257,12 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<StructDocument> 
 
         @Override
         public void accept(List<Document> state, ShapeDeserializer memberDeserializer) {
-            if (sparse && memberDeserializer.isNull()) {
-                state.add(memberDeserializer.readNull());
+            if (memberDeserializer.isNull()) {
+                if (sparse) {
+                    state.add(memberDeserializer.readNull());
+                } else {
+                    throw new SerializationException("Null value found in dense list: " + schema.id());
+                }
             } else {
                 state.add(deserializeValue(memberDeserializer, schema));
             }
@@ -270,8 +275,12 @@ final class SchemaGuidedDocumentBuilder implements ShapeBuilder<StructDocument> 
 
         @Override
         public void accept(Map<String, Document> state, String key, ShapeDeserializer memberDeserializer) {
-            if (sparse && memberDeserializer.isNull()) {
-                state.put(key, memberDeserializer.readNull());
+            if (memberDeserializer.isNull()) {
+                if (sparse) {
+                    state.put(key, memberDeserializer.readNull());
+                } else {
+                    throw new SerializationException("Null value found in dense map: " + schema.id());
+                }
             } else {
                 state.put(key, deserializeValue(memberDeserializer, schema));
             }

--- a/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilderTest.java
+++ b/dynamic-schemas/src/test/java/software/amazon/smithy/java/dynamicschemas/SchemaGuidedDocumentBuilderTest.java
@@ -12,6 +12,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
@@ -21,7 +23,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.Validator;
 import software.amazon.smithy.java.core.serde.InterceptingSerializer;
+import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.SpecificShapeDeserializer;
 import software.amazon.smithy.java.core.serde.SpecificShapeSerializer;
@@ -491,6 +495,169 @@ public class SchemaGuidedDocumentBuilderTest {
 
         var result = builder.build();
         assertThat(result.getMember("events").asEventStream(), equalTo(es));
+    }
+
+    @Test
+    public void throwsForNullInDenseList() {
+        var testModel = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+                        structure TestShape { values: DenseList }
+                        list DenseList { member: String }
+                        """)
+                .assemble()
+                .unwrap();
+        var converter = new SchemaConverter(testModel);
+        var schema = converter.getSchema(testModel.expectShape(ShapeId.from("smithy.example#TestShape")));
+        var builder = SchemaConverter.createDocumentBuilder(schema);
+        var codec = JsonCodec.builder().build();
+        var json = "{\"values\":[\"a\",null,\"b\"]}".getBytes(StandardCharsets.UTF_8);
+        Assertions.assertThrows(
+                SerializationException.class,
+                () -> codec.deserializeShape(json, builder));
+    }
+
+    @Test
+    public void preservesNullInSparseList() {
+        var testModel = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+                        structure TestShape { values: SparseList }
+                        @sparse list SparseList { member: String }
+                        """)
+                .assemble()
+                .unwrap();
+        var converter = new SchemaConverter(testModel);
+        var schema = converter.getSchema(testModel.expectShape(ShapeId.from("smithy.example#TestShape")));
+        var builder = SchemaConverter.createDocumentBuilder(schema);
+        var codec = JsonCodec.builder().build();
+        var json = "{\"values\":[\"a\",null,\"b\"]}".getBytes(StandardCharsets.UTF_8);
+        var result = codec.deserializeShape(json, builder);
+        var list = result.getMember("values").asList();
+        assertThat(list.size(), equalTo(3));
+        assertThat(list.get(0).asString(), equalTo("a"));
+        assertThat(list.get(1), equalTo(null));
+        assertThat(list.get(2).asString(), equalTo("b"));
+    }
+
+    @Test
+    public void throwsForNullInDenseMap() {
+        var testModel = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+                        structure TestShape { values: DenseMap }
+                        map DenseMap { key: String, value: String }
+                        """)
+                .assemble()
+                .unwrap();
+        var converter = new SchemaConverter(testModel);
+        var schema = converter.getSchema(testModel.expectShape(ShapeId.from("smithy.example#TestShape")));
+        var builder = SchemaConverter.createDocumentBuilder(schema);
+        var codec = JsonCodec.builder().build();
+        var json = "{\"values\":{\"a\":\"x\",\"b\":null}}".getBytes(StandardCharsets.UTF_8);
+        Assertions.assertThrows(
+                SerializationException.class,
+                () -> codec.deserializeShape(json, builder));
+    }
+
+    @Test
+    public void preservesNullInSparseMap() {
+        var testModel = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+                        structure TestShape { values: SparseMap }
+                        @sparse map SparseMap { key: String, value: String }
+                        """)
+                .assemble()
+                .unwrap();
+        var converter = new SchemaConverter(testModel);
+        var schema = converter.getSchema(testModel.expectShape(ShapeId.from("smithy.example#TestShape")));
+        var builder = SchemaConverter.createDocumentBuilder(schema);
+        var codec = JsonCodec.builder().build();
+        var json = "{\"values\":{\"a\":\"x\",\"b\":null}}".getBytes(StandardCharsets.UTF_8);
+        var result = codec.deserializeShape(json, builder);
+        var map = result.getMember("values").asStringMap();
+        assertThat(map.size(), equalTo(2));
+        assertThat(map.get("a").asString(), equalTo("x"));
+        assertThat(map.get("b"), equalTo(null));
+    }
+
+    @Test
+    public void validationFailsForNullInDenseListViaSetMemberValue() {
+        var testModel = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+                        structure TestShape { values: DenseList }
+                        list DenseList { member: String }
+                        """)
+                .assemble()
+                .unwrap();
+        var converter = new SchemaConverter(testModel);
+        var schema = converter.getSchema(testModel.expectShape(ShapeId.from("smithy.example#TestShape")));
+        var builder = SchemaConverter.createDocumentBuilder(schema);
+        var listWithNull = new ArrayList<Document>();
+        listWithNull.add(Document.of("a"));
+        listWithNull.add(null);
+        listWithNull.add(Document.of("b"));
+        builder.setMemberValue(schema.member("values"), Document.of(listWithNull));
+        var result = builder.build();
+        var validator = Validator.builder().build();
+        var errors = validator.validate(result);
+        assertThat(errors.isEmpty(), equalTo(false));
+    }
+
+    @Test
+    public void validationFailsForNullInDenseMapViaSetMemberValue() {
+        var testModel = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+                        structure TestShape { values: DenseMap }
+                        map DenseMap { key: String, value: String }
+                        """)
+                .assemble()
+                .unwrap();
+        var converter = new SchemaConverter(testModel);
+        var schema = converter.getSchema(testModel.expectShape(ShapeId.from("smithy.example#TestShape")));
+        var builder = SchemaConverter.createDocumentBuilder(schema);
+        var mapWithNull = new LinkedHashMap<String, Document>();
+        mapWithNull.put("a", Document.of("x"));
+        mapWithNull.put("b", null);
+        builder.setMemberValue(schema.member("values"), Document.of(mapWithNull));
+        var result = builder.build();
+        var validator = Validator.builder().build();
+        var errors = validator.validate(result);
+        assertThat(errors.isEmpty(), equalTo(false));
+    }
+
+    @Test
+    public void serializingNullInDenseMapDoesNotNpe() {
+        // Reproduces customer scenario: deserializing a response with null in a dense map
+        // Previously this would succeed deserialization but NPE during serialization/getMember.
+        // Now it throws SerializationException during deserialization.
+        var testModel = Model.assembler()
+                .addUnparsedModel("test.smithy", """
+                        $version: "2"
+                        namespace smithy.example
+                        structure TestShape { values: OuterMap }
+                        map OuterMap { key: String, value: InnerMap }
+                        map InnerMap { key: String, value: String }
+                        """)
+                .assemble()
+                .unwrap();
+        var converter = new SchemaConverter(testModel);
+        var schema = converter.getSchema(testModel.expectShape(ShapeId.from("smithy.example#TestShape")));
+        var builder = SchemaConverter.createDocumentBuilder(schema);
+        var codec = JsonCodec.builder().build();
+        var json = "{\"values\":{\"outer\":{\"a\":\"x\",\"b\":null}}}".getBytes(StandardCharsets.UTF_8);
+        Assertions.assertThrows(
+                SerializationException.class,
+                () -> codec.deserializeShape(json, builder));
     }
 
     @Test


### PR DESCRIPTION
Both codegen and dynamic schema deserialization paths now reject null values in non-sparse lists and maps with a SerializationException instead of silently skipping or corrupting data.

### What behavior changes?

- **Deserialization (codegen path):** Previously, null values in dense lists/maps were silently skipped. Now throws `SerializationException`.
- **Deserialization (dynamic schema path):** Previously, null values in dense lists were coerced to the string `"null"`, and null in dense maps flowed through unchecked, causing NPE later during serialization. Now throws `SerializationException`.
- **Sparse collections:** Behavior unchanged, null values are preserved as expected.

### Why is this change needed?

A customer reported an NPE in the MCP server path when a response contained null values in a dense map. The null was silently accepted during deserialization, then caused a `NullPointerException` inside `ContentDocument.serializeContents` when the result was later accessed via `getMember`. The fix fails fast at deserialization time with a clear error message.

### How was this validated?

- **Dynamic schema tests** (`SchemaGuidedDocumentBuilderTest`): 7 new tests covering dense throw, sparse preserve, validation on setMemberValue, and the customer's nested map NPE scenario.
- **Codegen golden file test** (`sparse-vs-dense-collections`): Verifies generated `SharedSerde` emits the correct throw/preserve logic for dense vs sparse collections.
- **Codegen integration test** (`DenseSparseNullTest`): 4 tests exercising generated builders at runtime with null values in dense/sparse lists and maps.
- **XML codec tests** updated: `StringList` in the test model marked `@sparse` since those tests exercise null-in-list behavior.

### What should reviewers focus on?

- `SchemaGuidedDocumentBuilder.java`; `ListConsumer` and `MapConsumer` null handling (the core fix for dynamic schemas).
- `ListGenerator.java` / `MapGenerator.java`; template changes for codegen (the `${^sparse}throw...${/sparse}` pattern).
- `PluginTestRunner.java`; removed `discoverModels()` to make golden file tests deterministic.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
