### PR TITLE
Make BDD tracing use a factory method

### DIFF
--- a/aws/client/aws-client-rulesengine/src/jmh/java/software/amazon/smithy/java/aws/client/rulesengine/S3EndpointBenchmark.java
+++ b/aws/client/aws-client-rulesengine/src/jmh/java/software/amazon/smithy/java/aws/client/rulesengine/S3EndpointBenchmark.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.dynamicclient.DynamicClient;
+import software.amazon.smithy.java.endpoints.Endpoint;
 import software.amazon.smithy.java.endpoints.EndpointResolver;
 import software.amazon.smithy.java.endpoints.EndpointResolverParams;
 import software.amazon.smithy.java.rulesengine.BddTrace;
@@ -383,10 +384,10 @@ public class S3EndpointBenchmark {
         }
 
         @Override
-        public void condition(int conditionId, boolean satisfied, boolean branch) {}
+        public void node(int nodeRef, int conditionId, boolean satisfied, boolean branch) {}
 
         @Override
-        public void result(int resultId) {}
+        public void result(int resultId, Endpoint endpoint) {}
     }
 
     @Benchmark

--- a/aws/client/aws-client-rulesengine/src/main/java/software/amazon/smithy/java/aws/client/rulesengine/AwsRulesFunction.java
+++ b/aws/client/aws-client-rulesengine/src/main/java/software/amazon/smithy/java/aws/client/rulesengine/AwsRulesFunction.java
@@ -7,6 +7,8 @@ package software.amazon.smithy.java.aws.client.rulesengine;
 
 import software.amazon.smithy.java.rulesengine.PropertyGetter;
 import software.amazon.smithy.java.rulesengine.RulesFunction;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.rulesengine.aws.language.functions.AwsArn;
 import software.amazon.smithy.rulesengine.aws.language.functions.AwsPartition;
 import software.amazon.smithy.rulesengine.aws.language.functions.IsVirtualHostableS3Bucket;
@@ -33,7 +35,7 @@ enum AwsRulesFunction implements RulesFunction {
         // Most of the entries aren't needed for evaluating rules, so map entries are created lazily (something that
         // isn't needed when evaluating rules), and accessing map values is done using a switch (something that is
         // essentially compiled into a map lookup via a lookupswitch).
-        private record PartitionMap(Partition partition) implements PropertyGetter {
+        private record PartitionMap(Partition partition) implements PropertyGetter, ToNode {
             @Override
             public Object getProperty(String name) {
                 return switch (name) {
@@ -45,6 +47,12 @@ enum AwsRulesFunction implements RulesFunction {
                     case "implicitGlobalRegion" -> partition.getOutputs().getImplicitGlobalRegion();
                     default -> null;
                 };
+            }
+
+            // Lets a consumer (e.g. a trace) render this as structured data rather than a stringified blob.
+            @Override
+            public Node toNode() {
+                return partition.toNode();
             }
         }
     },

--- a/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/BddTrace.java
+++ b/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/BddTrace.java
@@ -5,35 +5,43 @@
 
 package software.amazon.smithy.java.rulesengine;
 
+import software.amazon.smithy.java.endpoints.Endpoint;
+
 /**
  * Records the step-by-step trace of a single BDD endpoint resolution. Created by
  * {@link BddTraceSink#begin} and used by exactly one resolution on one thread, so it needs no
  * synchronization and can freely accumulate per-resolution state.
  *
- * <p>Call order: {@link #condition} per evaluated condition in visitation order, then one
- * {@link #result}. Condition and result ids index the bytecode passed to {@link BddTraceSink#begin}
- * (and, in the same order, {@link software.amazon.smithy.rulesengine.traits.EndpointBddTrait#getConditions()}
- * / {@code getResults()}).
+ * <p>Call order: {@link #node} per visited BDD node in traversal order, then one {@link #result}.
+ * Condition and result ids index the bytecode passed to {@link BddTraceSink#begin} (and, in the same
+ * order, {@link software.amazon.smithy.rulesengine.traits.EndpointBddTrait#getConditions()} /
+ * {@code getResults()}). Node references follow the BDD's own convention (see {@link #node}), so the
+ * sequence of visited nodes reconstructs the path taken through the graph.
  *
  * <p>To inspect parameter/variable values, read the live view handed to {@link BddTraceSink#begin}
- * during a callback: it reflects current register state, so at {@link #condition} time it shows values
- * as of that condition, and at {@link #result} time it includes variables assigned during traversal.
+ * during a callback: it reflects current register state, so at {@link #node} time it shows values as of
+ * that node, and at {@link #result} time it includes variables assigned during traversal.
  */
 public interface BddTrace {
     /**
-     * A condition was evaluated.
+     * A BDD node was visited and its condition evaluated.
      *
-     * @param conditionId index of the condition.
+     * @param nodeRef the visited node's reference, in the BDD's signed convention (a negative value is a
+     *                complemented edge to the node, a value over 100M is a result ID).
+     * @param conditionId index of the condition tested at this node.
      * @param satisfied the condition's own truth value.
      * @param branch the edge taken after applying complement state ({@code true} = high/true edge);
      *               differs from {@code satisfied} only on complemented nodes.
      */
-    void condition(int conditionId, boolean satisfied, boolean branch);
+    void node(int nodeRef, int conditionId, boolean satisfied, boolean branch);
 
     /**
-     * Resolution terminated.
+     * Resolution terminated. Reported after the endpoint is built, so the trace concludes with the
+     * concrete outcome, not just the result rule's id.
      *
      * @param resultId index of the matched result rule, or {@code -1} for no match.
+     * @param endpoint the resolved endpoint (uri, auth schemes, properties), or {@code null} when there
+     *                 was no match.
      */
-    void result(int resultId);
+    void result(int resultId, Endpoint endpoint);
 }

--- a/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/BddTraceSink.java
+++ b/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/BddTraceSink.java
@@ -21,10 +21,12 @@ public interface BddTraceSink {
      * Begins tracing one resolution, or returns {@code null} to skip it.
      *
      * @param bytecode the compiled BDD program being evaluated.
-     * @param parameters resolved input parameters (name to value). This is a live, zero-allocation view
-     *                   over the evaluator's registers; the returned {@link BddTrace} may hold it and
-     *                   re-read it during later callbacks, since its contents evolve as resolution
-     *                   proceeds. Copy it (e.g. {@code new LinkedHashMap<>(parameters)}) to retain.
+     * @param parameters live view of the named registers (name to value): the resolved input parameters
+     *                   at first, plus any variables assigned during evaluation (e.g. {@code
+     *                   partitionResult}) as they are set. This is a live, zero-allocation view over the
+     *                   evaluator's registers; the returned {@link BddTrace} may hold it and re-read it
+     *                   during later callbacks, since its contents evolve as resolution proceeds. Copy it
+     *                   (e.g. {@code new LinkedHashMap<>(parameters)}) to retain.
      * @return a recorder for this resolution, or {@code null} to not trace it.
      */
     BddTrace begin(Bytecode bytecode, Map<String, Object> parameters);

--- a/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/Bytecode.java
+++ b/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/Bytecode.java
@@ -504,6 +504,20 @@ public final class Bytecode {
         return inputRegisterMap;
     }
 
+    /**
+     * Name-to-index map for <em>all</em> named registers, including temps (variables assigned during
+     * evaluation, e.g. {@code partitionResult}). Unlike {@link #getInputRegisterMap}, which is limited to
+     * declared input parameters for register filling, this is for inspecting the full variable set (e.g.
+     * a trace's variable view). Built on demand; not used on the resolution hot path.
+     */
+    Map<String, Integer> getRegisterNameMap() {
+        Map<String, Integer> map = new HashMap<>(registerDefinitions.length);
+        for (int i = 0; i < registerDefinitions.length; i++) {
+            map.put(registerDefinitions[i].name(), i);
+        }
+        return map;
+    }
+
     private static Map<String, Integer> createInputRegisterMap(RegisterDefinition[] definitions) {
         Map<String, Integer> map = new HashMap<>();
         for (int i = 0; i < definitions.length; i++) {
@@ -551,6 +565,32 @@ public final class Bytecode {
     @Override
     public String toString() {
         return new BytecodeDisassembler(this).disassemble();
+    }
+
+    /**
+     * Disassembles a single condition to human-readable text (e.g. for tracing a {@code conditionId}
+     * reported to a {@link BddTraceSink}). Decodes straight from the compiled bytecode, so it needs no
+     * source trait and works regardless of how this bytecode was obtained.
+     *
+     * @param conditionId index of the condition, in {@code [0, getConditionCount())}.
+     * @return the disassembled condition.
+     * @throws IndexOutOfBoundsException if {@code conditionId} is out of range.
+     */
+    public String describeCondition(int conditionId) {
+        return new BytecodeDisassembler(this).disassembleCondition(conditionId);
+    }
+
+    /**
+     * Disassembles a single result rule to human-readable text (e.g. for tracing a {@code resultId}
+     * reported to a {@link BddTraceSink}). Decodes straight from the compiled bytecode, so it needs no
+     * source trait and works regardless of how this bytecode was obtained.
+     *
+     * @param resultId index of the result, in {@code [0, getResultCount())}.
+     * @return the disassembled result.
+     * @throws IndexOutOfBoundsException if {@code resultId} is out of range.
+     */
+    public String describeResult(int resultId) {
+        return new BytecodeDisassembler(this).disassembleResult(resultId);
     }
 
     @Override

--- a/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/BytecodeDisassembler.java
+++ b/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/BytecodeDisassembler.java
@@ -213,6 +213,28 @@ final class BytecodeDisassembler {
         return s.toString();
     }
 
+    /** Disassembles a single condition section by id, with no surrounding headers. */
+    String disassembleCondition(int conditionId) {
+        if (conditionId < 0 || conditionId >= bytecode.getConditionCount()) {
+            throw new IndexOutOfBoundsException("No condition with id " + conditionId
+                    + " (count=" + bytecode.getConditionCount() + ")");
+        }
+        StringBuilder s = new StringBuilder();
+        disassembleSection(s, bytecode.getConditionStartOffset(conditionId), "");
+        return s.toString().stripTrailing();
+    }
+
+    /** Disassembles a single result section by id, with no surrounding headers. */
+    String disassembleResult(int resultId) {
+        if (resultId < 0 || resultId >= bytecode.getResultCount()) {
+            throw new IndexOutOfBoundsException("No result with id " + resultId
+                    + " (count=" + bytecode.getResultCount() + ")");
+        }
+        StringBuilder s = new StringBuilder();
+        disassembleSection(s, bytecode.getResultOffset(resultId), "");
+        return s.toString().stripTrailing();
+    }
+
     private void disassembleSection(StringBuilder s, int startOffset, String indent) {
         try {
             disassembleSectionUnsafe(s, startOffset, indent);

--- a/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/BytecodeEvaluator.java
+++ b/rulesengine/src/main/java/software/amazon/smithy/java/rulesengine/BytecodeEvaluator.java
@@ -56,7 +56,7 @@ final class BytecodeEvaluator implements ConditionEvaluator {
         this.bytecode = bytecode;
         this.extensions = extensions;
         this.registers = new Object[bytecode.getRegisterDefinitions().length];
-        this.registerView = new RegisterView(registers, bytecode.getInputRegisterMap());
+        this.registerView = new RegisterView(registers, bytecode.getRegisterNameMap());
         this.registerFiller = registerFiller;
         this.registerSink = new ContextProvider.RegisterSink(registers.length, bytecode.getInputRegisterMap());
     }
@@ -126,7 +126,9 @@ final class BytecodeEvaluator implements ConditionEvaluator {
                 default -> test(condIdx);
             };
 
-            ref = (result ^ (ref < 0)) ? nodes[base + 1] : nodes[base + 2];
+            // `branch` applies the node's complement bit to the condition result to pick high/low.
+            boolean branch = result ^ (ref < 0);
+            ref = branch ? nodes[base + 1] : nodes[base + 2];
         }
 
         if (Bdd.isTerminal(ref)) {
@@ -136,9 +138,11 @@ final class BytecodeEvaluator implements ConditionEvaluator {
     }
 
     /**
-     * Traced twin of {@link #evaluateBdd()}: same traversal, but reports each step to {@code sink}. Kept
-     * as a separate method so the fast path above stays free of any per-node trace branch; the resolver
-     * picks this only when a sink is present.
+     * Traced twin of {@link #evaluateBdd()}. The traversal loop is intentionally kept line-for-line
+     * identical to the fast path, differing only by the {@link BddTrace#node} / {@link BddTrace#result}
+     * callbacks: keep the two in sync if either changes. It is a separate method (rather than a flag in
+     * the fast loop) so the hot path carries no per-node trace branch; the resolver calls this only when
+     * a sink is present, and it falls back to {@link #evaluateBdd()} if the sink declines to trace.
      */
     Endpoint evaluateBddTraced(BddTraceSink sink) {
         BddTrace trace = sink.begin(bytecode, registerView);
@@ -173,22 +177,22 @@ final class BytecodeEvaluator implements ConditionEvaluator {
                 default -> test(condIdx);
             };
 
-            // `branch` is the post-complement edge selector (true -> high, false -> low); `result` is the
-            // condition's own truth value. They differ only when the node ref is complemented.
+            // `branch` applies the node's complement bit to the condition result to pick high/low.
+            // Reported to the trace alongside `result` (they differ only on a complemented node ref).
             boolean branch = result ^ (ref < 0);
-            trace.condition(condIdx, result, branch);
+            trace.node(ref, condIdx, result, branch);
             ref = branch ? nodes[base + 1] : nodes[base + 2];
         }
 
         if (Bdd.isTerminal(ref)) {
-            trace.result(-1);
+            trace.result(-1, null);
             return null;
         }
+
         int resultId = ref - Bdd.RESULT_OFFSET;
-        // The trace can read the live register view (inputs plus variables assigned during traversal)
-        // that drove this result during its result() callback.
-        trace.result(resultId);
-        return resolveResult(resultId);
+        Endpoint endpoint = resolveResult(resultId);
+        trace.result(resultId, endpoint);
+        return endpoint;
     }
 
     public Endpoint resolveResult(int resultIndex) {

--- a/rulesengine/src/test/java/software/amazon/smithy/java/rulesengine/BytecodeDisassemblerTest.java
+++ b/rulesengine/src/test/java/software/amazon/smithy/java/rulesengine/BytecodeDisassemblerTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.containsString;
 
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class BytecodeDisassemblerTest {
@@ -187,6 +188,73 @@ class BytecodeDisassemblerTest {
         assertThat(result, containsString("conditions:"));
         assertThat(result, containsString("results:"));
         assertThat(result, containsString("root:"));
+    }
+
+    @Test
+    void describesSingleConditionAndResultById() {
+        BytecodeWriter writer = new BytecodeWriter();
+
+        // Condition 0: isSet(register 0), return.
+        writer.markConditionStart();
+        writer.writeByte(Opcodes.TEST_REGISTER_ISSET);
+        writer.writeByte(0);
+        writer.writeByte(Opcodes.RETURN_VALUE);
+
+        // Result 0: load a constant URL and return an endpoint.
+        writer.markResultStart();
+        writer.writeByte(Opcodes.LOAD_CONST);
+        writer.writeByte(0);
+        writer.writeByte(Opcodes.RETURN_ENDPOINT);
+        writer.writeByte(0);
+
+        RegisterDefinition[] registers = {
+                new RegisterDefinition("region", true, null, null, false)
+        };
+        Bytecode bytecode = writer.build(registers, new RulesFunction[0], new int[] {-1, 1, -1}, 1);
+
+        String condition = bytecode.describeCondition(0);
+        String result = bytecode.describeResult(0);
+
+        // Per-id output names the relevant opcodes...
+        assertThat(condition, containsString("TEST_REGISTER_ISSET"));
+        assertThat(result, containsString("RETURN_ENDPOINT"));
+        // ...and carries no surrounding program headers (it's just the one section).
+        Assertions.assertFalse(condition.contains("=== "));
+        Assertions.assertFalse(result.contains("=== "));
+
+        // The per-id text is consistent with the matching section of the full disassembly.
+        String full = bytecode.toString();
+        assertThat(full, containsString("TEST_REGISTER_ISSET"));
+        assertThat(full, containsString("RETURN_ENDPOINT"));
+    }
+
+    @Test
+    void describeRejectsOutOfRangeIds() {
+        BytecodeWriter writer = new BytecodeWriter();
+        writer.markConditionStart();
+        writer.writeByte(Opcodes.TEST_REGISTER_ISSET);
+        writer.writeByte(0);
+        writer.writeByte(Opcodes.RETURN_VALUE);
+        writer.markResultStart();
+        writer.writeByte(Opcodes.LOAD_CONST);
+        writer.writeByte(0);
+        writer.writeByte(Opcodes.RETURN_ENDPOINT);
+        writer.writeByte(0);
+        Bytecode bytecode = writer.build(
+                new RegisterDefinition[] {new RegisterDefinition("region", true, null, null, false)},
+                new RulesFunction[0],
+                new int[] {-1, 1, -1},
+                1);
+
+        // One condition (id 0) and one result (id 0); anything else is out of range.
+        Assertions.assertThrows(IndexOutOfBoundsException.class,
+                () -> bytecode.describeCondition(1));
+        Assertions.assertThrows(IndexOutOfBoundsException.class,
+                () -> bytecode.describeCondition(-1));
+        Assertions.assertThrows(IndexOutOfBoundsException.class,
+                () -> bytecode.describeResult(1));
+        Assertions.assertThrows(IndexOutOfBoundsException.class,
+                () -> bytecode.describeResult(-1));
     }
 
     @Test

--- a/rulesengine/src/test/java/software/amazon/smithy/java/rulesengine/BytecodeEndpointResolverTest.java
+++ b/rulesengine/src/test/java/software/amazon/smithy/java/rulesengine/BytecodeEndpointResolverTest.java
@@ -363,11 +363,16 @@ class BytecodeEndpointResolverTest {
         assertEquals("us-east-1", sink.inputs.get("region"));
         // One condition evaluated: region is set -> true, and (uncomplemented node) the high edge taken.
         assertEquals(1, sink.conditions.size());
-        assertEquals(0, sink.conditions.get(0).id);
-        assertTrue(sink.conditions.get(0).satisfied);
-        assertTrue(sink.conditions.get(0).branch);
-        // Terminated at result 1 with the variable snapshot available.
+        var step = sink.conditions.get(0);
+        assertEquals(0, step.id);
+        assertTrue(step.satisfied);
+        assertTrue(step.branch);
+        // Node path: root ref 2 (node idx 1); the high edge leads to result 1, reported by result().
+        assertEquals(2, step.nodeRef);
+        // Terminated at result 1 with the resolved endpoint and variable snapshot available.
         assertEquals(1, sink.resultId);
+        assertNotNull(sink.resultEndpoint);
+        assertEquals("https://example.com", sink.resultEndpoint.uri().toString());
         assertEquals("us-east-1", sink.variables.get("region"));
     }
 
@@ -431,10 +436,10 @@ class BytecodeEndpointResolverTest {
         Object[] readAtResult = new Object[1];
         BddTraceSink sink = (bytecode, view) -> new BddTrace() {
             @Override
-            public void condition(int conditionId, boolean satisfied, boolean branch) {}
+            public void node(int nodeRef, int conditionId, boolean satisfied, boolean branch) {}
 
             @Override
-            public void result(int resultId) {
+            public void result(int resultId, Endpoint endpoint) {
                 // Read the same held view at result time; it reflects current register state.
                 readAtResult[0] = view.get("region");
             }
@@ -474,6 +479,95 @@ class BytecodeEndpointResolverTest {
         assertEquals("https://example.com", endpoint.uri().toString());
     }
 
+    @Test
+    void traceSeesVariableAssignedDuringTraversal() {
+        // The second condition assigns `style` mid-traversal via SET_REG_RETURN. The live param view
+        // should not have it at the start but should have it by result time.
+        Bytecode bc = assignsVariableBytecode();
+        BytecodeEndpointResolver resolver = new BytecodeEndpointResolver(bc, List.of(), Map.of());
+
+        RecordingSink sink = new RecordingSink();
+        Context context = Context.create().put(RulesEngineSettings.BDD_TRACE_SINK, sink);
+        Endpoint endpoint = resolver.resolveEndpoint(createParams("us-east-1", "my-bucket", context));
+
+        // Endpoint built from region + "." + style.
+        assertNotNull(endpoint);
+        assertEquals("us-east-1.virtual", endpoint.uri().toString());
+        // `style` wasn't an input...
+        assertNull(sink.inputs.get("style"));
+        // ...but the live view picked it up once the condition assigned it (captured at result time).
+        assertEquals("virtual", sink.variables.get("style"));
+    }
+
+    /**
+     * Bytecode with two conditions where the second assigns a variable, so a trace can show a variable
+     * diff. cond 0 = isSet(region); cond 1 assigns style="virtual" (and is truthy). On the all-true path
+     * the endpoint URI is built as {@code region + "." + style}.
+     *
+     * <pre>
+     *   registers: 0=region, 1=bucket, 2=style (assigned during traversal)
+     *   constants: 0=null, 1="virtual", 2="."
+     *   BDD: root -&gt; cond0 ? cond1 : result0 ;  cond1 ? result1 : result0
+     * </pre>
+     */
+    private static Bytecode assignsVariableBytecode() {
+        byte[] cond0 = {Opcodes.TEST_REGISTER_ISSET, 0, Opcodes.RETURN_VALUE};
+        // Load "virtual" and store it into register 2 (style); SET_REG_RETURN returns the stored value,
+        // which is truthy, so the condition is satisfied.
+        byte[] cond1 = {Opcodes.LOAD_CONST, 1, Opcodes.SET_REG_RETURN, 2};
+        byte[] result0 = {Opcodes.LOAD_CONST, 0, Opcodes.RETURN_VALUE};
+        byte[] result1 = {
+                Opcodes.LOAD_REGISTER,
+                0, // region
+                Opcodes.LOAD_CONST,
+                2, // "."
+                Opcodes.LOAD_REGISTER,
+                2, // style
+                Opcodes.RESOLVE_TEMPLATE,
+                3,
+                Opcodes.RETURN_ENDPOINT,
+                0
+        };
+
+        byte[] program = new byte[cond0.length + cond1.length + result0.length + result1.length];
+        int p = 0;
+        System.arraycopy(cond0, 0, program, p, cond0.length);
+        p += cond0.length;
+        System.arraycopy(cond1, 0, program, p, cond1.length);
+        p += cond1.length;
+        int result0Off = p;
+        System.arraycopy(result0, 0, program, p, result0.length);
+        p += result0.length;
+        int result1Off = p;
+        System.arraycopy(result1, 0, program, p, result1.length);
+
+        return new Bytecode(
+                program,
+                new int[] {0, cond0.length}, // condition offsets
+                new int[] {result0Off, result1Off}, // result offsets
+                new RegisterDefinition[] {
+                        new RegisterDefinition("region", false, null, null, false),
+                        new RegisterDefinition("bucket", false, null, null, false),
+                        new RegisterDefinition("style", false, null, null, false)
+                },
+                new Object[] {null, "virtual", "."},
+                new RulesFunction[0],
+                // nodes (3 ints each): idx0 terminal; idx1 cond0 high->idx2(ref3) low->result0;
+                // idx2 cond1 high->result1 low->result0
+                new int[] {
+                        -1,
+                        -1,
+                        -1,
+                        0,
+                        3,
+                        100_000_000,
+                        1,
+                        100_000_001,
+                        100_000_000
+                },
+                2); // root -> idx1 (cond0)
+    }
+
     /** Bytecode: condition 0 = isSet(region); if set return endpoint (result 1), else no match (result 0). */
     private static Bytecode conditionalRegionBytecode() {
         byte[] conditionBytecode = {Opcodes.TEST_REGISTER_ISSET, 0, Opcodes.RETURN_VALUE};
@@ -506,20 +600,21 @@ class BytecodeEndpointResolverTest {
     /** A trace that records nothing, for tests that only care about begin()'s callback. */
     private static final BddTrace NO_OP_TRACE = new BddTrace() {
         @Override
-        public void condition(int conditionId, boolean satisfied, boolean branch) {}
+        public void node(int nodeRef, int conditionId, boolean satisfied, boolean branch) {}
 
         @Override
-        public void result(int resultId) {}
+        public void result(int resultId, Endpoint endpoint) {}
     };
 
     /** Sink that begins a single recorder and remembers it, so tests can assert on what it captured. */
     private static final class RecordingSink implements BddTraceSink {
-        private record Cond(int id, boolean satisfied, boolean branch) {}
+        private record Cond(int nodeRef, int id, boolean satisfied, boolean branch) {}
 
         Bytecode bytecode;
         Map<String, Object> inputs;
         final List<Cond> conditions = new ArrayList<>();
         int resultId = Integer.MIN_VALUE;
+        Endpoint resultEndpoint;
         Map<String, Object> variables;
         // The live view handed to begin(); read it during result() for the final variable set.
         private Map<String, Object> liveView;
@@ -532,13 +627,14 @@ class BytecodeEndpointResolverTest {
             this.inputs = new LinkedHashMap<>(parameters);
             return new BddTrace() {
                 @Override
-                public void condition(int conditionId, boolean satisfied, boolean branch) {
-                    conditions.add(new Cond(conditionId, satisfied, branch));
+                public void node(int nodeRef, int conditionId, boolean satisfied, boolean branch) {
+                    conditions.add(new Cond(nodeRef, conditionId, satisfied, branch));
                 }
 
                 @Override
-                public void result(int resultId) {
+                public void result(int resultId, Endpoint endpoint) {
                     RecordingSink.this.resultId = resultId;
+                    RecordingSink.this.resultEndpoint = endpoint;
                     variables = new LinkedHashMap<>(liveView); // live view; copy to retain
                 }
             };


### PR DESCRIPTION
### What behavior changes?
Describe the observable difference in behavior before and after this change.

This changes the BDD tracing integration to provide more details, and instantiate a new tracer per call. This allows for a much deeper introspection of the BDD route, and still comes with the same performance as before. Since the BDD tracing code hasn't been released, this is not a breaking change.

Also added some new helper functions for better BDD introspection and debugging.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

I am introducing BDD tracing to the Smithy CLI and needed deeper introspection. I also wanted a way to do multi-threaded per/call introspection which the old approach didn't allow.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

Tests, and cross project manual testing.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.


```java
import software.amazon.smithy.java.rulesengine.*;
import software.amazon.smithy.java.endpoints.Endpoint;
import java.util.*;

final class ExplainSink implements BddTraceSink {
    @Override
    public BddTrace begin(Bytecode bytecode, Map<String, Object> params) {
        Map<String, Object> prev = new LinkedHashMap<>(params);
        var log = new StringBuilder("inputs: " + prev + "\n");

        return new BddTrace() {
            @Override
            public void node(int nodeRef, int conditionId, boolean satisfied, boolean branch, int nextRef) {
                log.append("node ").append(nodeRef)
                    .append(": ").append(bytecode.describeCondition(conditionId).replace('\n', ' '))
                    .append(" => ").append(satisfied)
                    .append(" -> ").append(nextRef).append('\n');
                params.forEach((k, v) -> {
                    if (!Objects.equals(prev.get(k), v)) {
                        log.append("    + ").append(k).append(" = ").append(v).append('\n');
                    }
                });
                prev.clear();
                prev.putAll(params);
            }

            @Override
            public void result(int resultId, Endpoint endpoint) {
                log.append(resultId < 0
                        ? "no match\n"
                        : "result " + resultId + " -> " + endpoint.uri() + '\n');
                System.out.print(log);
            }
        };
    }
}

DynamicClient.builder()
          .model(model).serviceId(serviceId)
          .putConfig(RulesEngineSettings.BDD_TRACE_SINK, new ExplainSink())
          // ...
          .build();
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
