### PR TITLE
Pass retry token to call Context

### DIFF
--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/CallContext.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/CallContext.java
@@ -11,6 +11,7 @@ import software.amazon.smithy.java.auth.api.identity.Identity;
 import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.endpoints.Endpoint;
 import software.amazon.smithy.java.endpoints.EndpointResolver;
+import software.amazon.smithy.java.retries.api.RetryToken;
 
 /**
  * Context parameters made available to underlying transports like HTTP clients.
@@ -50,6 +51,17 @@ public final class CallContext {
      * <p>This is a read-only value; modifying this value has no effect on a request.
      */
     public static final Context.Key<Integer> RETRY_MAX = Context.key("Max retries");
+
+    /**
+     * The opaque retry token for the current in-progress attempt, if a retry strategy is in use.
+     *
+     * <p>The token is acquired before the first attempt and refreshed after each retryable failure, so the value
+     * observed by an interceptor is always the token in effect for the current attempt. It is {@code null} once the
+     * call completes and the token is released.
+     *
+     * <p>This is a read-only value; modifying this value has no effect on a request.
+     */
+    public static final Context.Key<RetryToken> RETRY_TOKEN = Context.key("Retry token");
 
     /**
      * The idempotency token used with the call, if any.

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCall.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientCall.java
@@ -110,6 +110,17 @@ final class ClientCall<I extends SerializableStruct, O extends SerializableStruc
     }
 
     /**
+     * Set the retry token for the call, keeping {@link CallContext#RETRY_TOKEN} in sync so interceptors observe the
+     * token in effect for the current attempt.
+     *
+     * @param retryToken the token to associate with the call, or {@code null} once the token is released.
+     */
+    void setRetryToken(RetryToken retryToken) {
+        this.retryToken = retryToken;
+        this.context.put(CallContext.RETRY_TOKEN, retryToken);
+    }
+
+    /**
      * Check if a retry is disallowed for this call.
      *
      * <p>Currently only looks at whether a non-replayable stream is used in the input.

--- a/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientPipeline.java
+++ b/client/client-core/src/main/java/software/amazon/smithy/java/client/core/ClientPipeline.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.java.auth.api.identity.IdentityResolvers;
 import software.amazon.smithy.java.auth.api.identity.IdentityResult;
 import software.amazon.smithy.java.client.core.auth.scheme.AuthScheme;
 import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeOption;
+import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolver;
 import software.amazon.smithy.java.client.core.auth.scheme.AuthSchemeResolverParams;
 import software.amazon.smithy.java.client.core.interceptors.ClientInterceptor;
 import software.amazon.smithy.java.client.core.interceptors.InputHook;
@@ -136,20 +137,15 @@ final class ClientPipeline<RequestT, ResponseT> {
             ClientCall<I, O> call,
             RequestHook<I, O, RequestT> requestHook
     ) {
-        try {
-            // 8. RetryStrategy: Invoke AcquireRetryToken.
-            //    Can potentially short-circuit the request.
-            var result = call.retryStrategy.acquireInitialToken(new AcquireInitialTokenRequest(call.retryScope));
-            call.retryToken = result.token();
-            // Delay if the initial request is pre-emptively throttled.
-            if (result.delay().toMillis() > 0) {
-                sleep(result.delay());
-            }
-            return doSendOrRetry(call, requestHook);
-        } catch (TokenAcquisitionFailedException e) {
-            // Don't send the request if the circuit breaker prevents it.
-            throw e;
+        // 8. RetryStrategy: Invoke AcquireRetryToken.
+        //    Can potentially short-circuit the request.
+        var result = call.retryStrategy.acquireInitialToken(new AcquireInitialTokenRequest(call.retryScope));
+        call.setRetryToken(result.token());
+        // Delay if the initial request is pre-emptively throttled.
+        if (result.delay().toMillis() > 0) {
+            sleep(result.delay());
         }
+        return doSendOrRetry(call, requestHook);
     }
 
     private <I extends SerializableStruct, O extends SerializableStruct> O doSendOrRetry(
@@ -459,7 +455,7 @@ final class ClientPipeline<RequestT, ResponseT> {
 
         // Clear out the retry token.
         var token = call.retryToken;
-        call.retryToken = null;
+        call.setRetryToken(null);
 
         // 9.c.i If successful: RetryStrategy: Invoke RecordSuccess.
         if (error == null) {
@@ -509,7 +505,7 @@ final class ClientPipeline<RequestT, ResponseT> {
             Duration after
     ) {
         // Associate the retry token with the call.
-        call.retryToken = retryToken;
+        call.setRetryToken(retryToken);
         // Adjust the current retry count on the context (e.g., protocols can use this to add retry headers).
         call.context.put(CallContext.RETRY_ATTEMPT, ++call.attemptCount);
 


### PR DESCRIPTION
Use `hook.context().get(CallContext.RETRY_TOKEN)`

Closes #1124

### What behavior changes?
Describe the observable difference in behavior before and after this change.

Passes retry token to interceptors via context

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

See #1124 

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
