### PR TITLE
Add customizeSettings to JavaCodegenIntegration

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenIntegration.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenIntegration.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.codegen;
 
 import java.util.List;
+import software.amazon.smithy.codegen.core.CodegenContext;
 import software.amazon.smithy.codegen.core.SmithyIntegration;
 import software.amazon.smithy.java.codegen.writer.JavaWriter;
 import software.amazon.smithy.model.traits.Trait;
@@ -23,4 +24,25 @@ public interface JavaCodegenIntegration
     default List<TraitInitializer<? extends Trait>> traitInitializers() {
         return List.of();
     }
+
+    /**
+     * Customizes {@link JavaCodegenSettings} before code generation begins.
+     *
+     * <p>This is invoked once per integration immediately after the {@link CodeGenerationContext} is
+     * created and <em>before</em> any interceptors are registered or shapes are generated. It is the
+     * correct place to programmatically register
+     * {@linkplain JavaCodegenSettings#addDefaultPlugin(String) default plugins} or
+     * {@linkplain JavaCodegenSettings#addDefaultSetting(String) default settings}, because those values
+     * are read while the client builder is generated.
+     *
+     * <p>Mutating settings from {@link #customize(CodegenContext)} is too late: by the time
+     * {@code customize} runs the client builder has already been generated and the change has no effect.
+     *
+     * <p>The full context is provided so implementations can inspect the model (for example, to register
+     * a plugin only for services that use a particular auth scheme). Use
+     * {@link CodeGenerationContext#settings()} to register defaults.
+     *
+     * @param context code generation context whose settings may be customized.
+     */
+    default void customizeSettings(CodeGenerationContext context) {}
 }

--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/JavaCodegenSettings.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.codegen;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -96,7 +97,7 @@ public final class JavaCodegenSettings {
         this.transportName = builder.transportName;
         this.transportSettings = builder.transportSettings;
         this.defaultPlugins = new ArrayList<>(builder.defaultPlugins);
-        this.defaultSettings = Collections.unmodifiableList(builder.defaultSettings);
+        this.defaultSettings = new ArrayList<>(builder.defaultSettings);
         this.relativeDate = builder.relativeDate;
         this.relativeVersion = builder.relativeVersion;
         this.edition = Objects.requireNonNullElse(builder.edition, SmithyJavaCodegenEdition.LATEST);
@@ -167,16 +168,62 @@ public final class JavaCodegenSettings {
         return transportSettings;
     }
 
+    /**
+     * Fully-qualified class names of {@code ClientPlugin}s applied by default to generated clients.
+     *
+     * @return an unmodifiable view of the configured default plugins.
+     */
     public List<String> defaultPlugins() {
         return Collections.unmodifiableList(defaultPlugins);
     }
 
+    /**
+     * Registers a {@code ClientPlugin} to apply by default to generated clients.
+     *
+     * <p>The plugin must have a public, zero-arg constructor. Integrations should call this from
+     * {@link JavaCodegenIntegration#customizeSettings(CodeGenerationContext)}, which runs before the
+     * client builder is generated; calling it later (for example from
+     * {@link JavaCodegenIntegration#customize(CodeGenerationContext)}) has no effect because the default
+     * plugins have already been read.
+     *
+     * @param pluginClass fully-qualified class name of the plugin to add.
+     */
     public void addDefaultPlugin(String pluginClass) {
         defaultPlugins.add(pluginClass);
     }
 
+    /**
+     * Fully-qualified class names of {@code ClientSetting}s applied by default to generated client builders.
+     *
+     * @return an unmodifiable view of the configured default settings.
+     */
     public List<String> defaultSettings() {
-        return defaultSettings;
+        return Collections.unmodifiableList(defaultSettings);
+    }
+
+    /**
+     * Registers a {@code ClientSetting} to apply by default to generated client builders.
+     *
+     * <p>Integrations should call this from
+     * {@link JavaCodegenIntegration#customizeSettings(CodeGenerationContext)}, which runs before the
+     * client builder is generated; calling it later (for example from
+     * {@link JavaCodegenIntegration#customize(CodeGenerationContext)}) has no effect because the default
+     * settings have already been read.
+     *
+     * @param settingClass fully-qualified class name of the setting to add.
+     */
+    public void addDefaultSetting(String settingClass) {
+        defaultSettings.add(settingClass);
+    }
+
+    /**
+     * Registers {@code ClientSetting}s to apply by default to generated client builders.
+     *
+     * @param settingClasses fully-qualified class names of the settings to add.
+     * @see #addDefaultSetting(String)
+     */
+    public void addDefaultSettings(Collection<String> settingClasses) {
+        defaultSettings.addAll(settingClasses);
     }
 
     public String relativeDate() {

--- a/codegen/codegen-plugin/src/main/java/software/amazon/smithy/java/codegen/DirectedJavaCodegen.java
+++ b/codegen/codegen-plugin/src/main/java/software/amazon/smithy/java/codegen/DirectedJavaCodegen.java
@@ -78,6 +78,10 @@ final class DirectedJavaCodegen
     ) {
         String pluginName = getPluginName();
         this.context = new CodeGenerationContext(directive, pluginName);
+        // Allow integrations to customize settings
+        for (var integration : directive.integrations()) {
+            integration.customizeSettings(context);
+        }
         return context;
     }
 

--- a/codegen/codegen-plugin/src/main/java/software/amazon/smithy/java/codegen/client/integrations/aws/AwsCredentialChainIntegration.java
+++ b/codegen/codegen-plugin/src/main/java/software/amazon/smithy/java/codegen/client/integrations/aws/AwsCredentialChainIntegration.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.codegen.client.integrations.aws;
 import software.amazon.smithy.java.codegen.CodeGenerationContext;
 import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
 import software.amazon.smithy.java.codegen.JavaCodegenSettings;
+import software.amazon.smithy.java.logging.InternalLogger;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -21,18 +22,40 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class AwsCredentialChainIntegration implements JavaCodegenIntegration {
 
+    private static final InternalLogger LOGGER = InternalLogger.getLogger(AwsCredentialChainIntegration.class);
     private static final String PLUGIN_CLASS = "software.amazon.smithy.java.aws.client.core.AwsCredentialChainPlugin";
     private static final ShapeId SIGV4 = ShapeId.from("aws.auth#sigv4");
     private static final ShapeId SIGV4A = ShapeId.from("aws.auth#sigv4a");
 
     @Override
-    public void customize(CodeGenerationContext context) {
+    public void customizeSettings(CodeGenerationContext context) {
         Model model = context.model();
         JavaCodegenSettings settings = context.settings();
         var service = model.expectShape(settings.service(), ServiceShape.class);
         var authSchemes = ServiceIndex.of(model).getEffectiveAuthSchemes(service);
         if (authSchemes.containsKey(SIGV4) || authSchemes.containsKey(SIGV4A)) {
-            settings.addDefaultPlugin(PLUGIN_CLASS);
+            // Only register the plugin if it is actually on the codegen classpath. A model can carry AWS auth
+            // traits without depending on the AWS client runtime (e.g. serde benchmarks), in which case the
+            // plugin cannot be resolved and we skip it rather than failing the build.
+            if (isPluginOnClasspath()) {
+                settings.addDefaultPlugin(PLUGIN_CLASS);
+            } else {
+                LOGGER.warn(
+                        "Service {} uses an AWS auth scheme but {} is not on the classpath; "
+                                + "skipping the default credential chain plugin. Add a dependency on "
+                                + "'aws-client-core' to enable it.",
+                        service.getId(),
+                        PLUGIN_CLASS);
+            }
+        }
+    }
+
+    private static boolean isPluginOnClasspath() {
+        try {
+            Class.forName(PLUGIN_CLASS, false, AwsCredentialChainIntegration.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
 }

--- a/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/client/integrations/settings/DefaultPluginSettingsIntegration.java
+++ b/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/client/integrations/settings/DefaultPluginSettingsIntegration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client.integrations.settings;
+
+import software.amazon.smithy.java.codegen.CodeGenerationContext;
+import software.amazon.smithy.java.codegen.JavaCodegenIntegration;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Test integration used to verify the lifecycle ordering of settings customization.
+ *
+ * <p>It registers one default plugin from {@link #customizeSettings(CodeGenerationContext)} (which
+ * runs before the client builder is generated and should take effect) and another from
+ * {@link #customize(CodeGenerationContext)} (which runs after generation and should be a no-op).
+ *
+ * <p>This integration is discovered via {@code ServiceLoader} for every codegen run in this module,
+ * so it only acts when the marker service is being generated to avoid perturbing other tests.
+ */
+public final class DefaultPluginSettingsIntegration implements JavaCodegenIntegration {
+
+    private static final ShapeId MARKER_SERVICE =
+            ShapeId.from("smithy.java.codegen.settings#DefaultPluginSettingsService");
+
+    @Override
+    public String name() {
+        return "default-plugin-settings-test";
+    }
+
+    @Override
+    public void customizeSettings(CodeGenerationContext context) {
+        if (context.settings().service().equals(MARKER_SERVICE)) {
+            context.settings().addDefaultPlugin(EarlyDefaultPlugin.class.getCanonicalName());
+        }
+    }
+
+    @Override
+    public void customize(CodeGenerationContext context) {
+        if (context.settings().service().equals(MARKER_SERVICE)) {
+            context.settings().addDefaultPlugin(LateDefaultPlugin.class.getCanonicalName());
+        }
+    }
+}

--- a/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/client/integrations/settings/DefaultPluginSettingsIntegrationTest.java
+++ b/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/client/integrations/settings/DefaultPluginSettingsIntegrationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client.integrations.settings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.nio.file.Paths;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.java.codegen.JavaCodegenPlugin;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.ObjectNode;
+
+/**
+ * Verifies that {@link software.amazon.smithy.java.codegen.JavaCodegenIntegration#customizeSettings}
+ * is invoked early enough for default plugins registered there to be wired into generated clients,
+ * while default plugins registered from {@code customize} (which runs after generation) are not.
+ *
+ * <p>The wiring is driven by {@link DefaultPluginSettingsIntegration}, discovered via {@code ServiceLoader}.
+ */
+public class DefaultPluginSettingsIntegrationTest {
+
+    private final MockManifest manifest = new MockManifest();
+
+    @BeforeEach
+    public void setup() {
+        var model = Model.assembler()
+                .addImport(Objects.requireNonNull(
+                        DefaultPluginSettingsIntegrationTest.class.getResource("default-plugin-settings.smithy")))
+                .assemble()
+                .unwrap();
+        var context = PluginContext.builder()
+                .fileManifest(manifest)
+                .settings(ObjectNode.builder()
+                        .withMember("service", "smithy.java.codegen.settings#DefaultPluginSettingsService")
+                        .withMember("namespace", "smithy.java.codegen.settings")
+                        .withMember("modes", ArrayNode.fromStrings("client"))
+                        .build())
+                .model(model)
+                .build();
+        new JavaCodegenPlugin().execute(context);
+        assertFalse(manifest.getFiles().isEmpty());
+    }
+
+    @Test
+    void pluginAddedFromCustomizeSettingsIsWiredIntoClient() {
+        var client = clientInterfaceSource();
+        // Registered from customizeSettings() -> present as a default plugin.
+        assertThat(client, containsString("new EarlyDefaultPlugin()"));
+        assertThat(client,
+                containsString("private final List<ClientPlugin> defaultPlugins = List.of(earlyDefaultPlugin)"));
+    }
+
+    @Test
+    void pluginAddedFromCustomizeIsTooLateAndIgnored() {
+        var client = clientInterfaceSource();
+        // Registered from customize() -> too late, never wired in.
+        assertThat(client, not(containsString("LateDefaultPlugin")));
+    }
+
+    private String clientInterfaceSource() {
+        return manifest.getFiles()
+                .stream()
+                .map(Object::toString)
+                .filter(p -> p.endsWith("DefaultPluginSettingsServiceClient.java"))
+                .findFirst()
+                .flatMap(p -> manifest.getFileString(Paths.get(p)))
+                .orElseThrow(
+                        () -> new AssertionError("Generated client interface not found in " + manifest.getFiles()));
+    }
+}

--- a/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/client/integrations/settings/EarlyDefaultPlugin.java
+++ b/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/client/integrations/settings/EarlyDefaultPlugin.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client.integrations.settings;
+
+import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.ClientPlugin;
+
+/**
+ * Test plugin registered as a default plugin from
+ * {@code JavaCodegenIntegration#customizeSettings} (which runs early enough to take effect).
+ */
+public final class EarlyDefaultPlugin implements ClientPlugin {
+    @Override
+    public void configureClient(ClientConfig.Builder config) {
+        // no-op
+    }
+}

--- a/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/client/integrations/settings/LateDefaultPlugin.java
+++ b/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/client/integrations/settings/LateDefaultPlugin.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.client.integrations.settings;
+
+import software.amazon.smithy.java.client.core.ClientConfig;
+import software.amazon.smithy.java.client.core.ClientPlugin;
+
+/**
+ * Test plugin registered as a default plugin from {@code JavaCodegenIntegration#customize}, which
+ * runs <em>after</em> the client builder has already been generated and therefore has no effect.
+ */
+public final class LateDefaultPlugin implements ClientPlugin {
+    @Override
+    public void configureClient(ClientConfig.Builder config) {
+        // no-op
+    }
+}

--- a/codegen/codegen-plugin/src/test/resources/META-INF/services/software.amazon.smithy.java.codegen.JavaCodegenIntegration
+++ b/codegen/codegen-plugin/src/test/resources/META-INF/services/software.amazon.smithy.java.codegen.JavaCodegenIntegration
@@ -1,0 +1,1 @@
+software.amazon.smithy.java.codegen.client.integrations.settings.DefaultPluginSettingsIntegration

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/client/integrations/settings/default-plugin-settings.smithy
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/client/integrations/settings/default-plugin-settings.smithy
@@ -1,0 +1,14 @@
+$version: "2"
+
+namespace smithy.java.codegen.settings
+
+service DefaultPluginSettingsService {
+    operations: [
+        NoOpOperation
+    ]
+}
+
+operation NoOpOperation {
+    input := {}
+    output := {}
+}


### PR DESCRIPTION
This allows integrations to customize things like default settings and default plugins before interceptors() run.

Closes #1212

### What behavior changes?
Describe the observable difference in behavior before and after this change.

This change makes it so you customize the settings of the generator before codegen begins.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

We previously did not have a reliable way to add default settings or default plugins during codegen using a codegen integration. See #1212. It also exposed a latent bug in how we were ignoring the addition of adding the AWS credential chain by default when AWS traits are detected.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

Added unit tests

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
