### PR TITLE
Add authorization and transfer-encoding exclusions

### DIFF
--- a/aws/aws-sigv4/src/main/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4Signer.java
+++ b/aws/aws-sigv4/src/main/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4Signer.java
@@ -536,7 +536,10 @@ final class SigV4Signer implements Signer<HttpRequest, AwsCredentialsIdentity> {
 
     private static boolean isIgnoredHeader(String name) {
         return switch (name) {
-            case "connection", "content-length", "x-amzn-trace-id", "user-agent", "expect" -> true;
+            // "authorization" is the output of signing; ignoring it keeps re-signing a reused request idempotent.
+            case "authorization", "connection", "content-length", "transfer-encoding", "x-amzn-trace-id",
+                    "user-agent", "expect" ->
+                true;
             default -> false;
         };
     }

--- a/aws/aws-sigv4/src/test/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4SignerTest.java
+++ b/aws/aws-sigv4/src/test/java/software/amazon/smithy/java/aws/client/auth/scheme/sigv4/SigV4SignerTest.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.aws.client.auth.scheme.sigv4;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 import java.net.URI;
 import java.time.Clock;
@@ -50,5 +51,45 @@ class SigV4SignerTest {
         assertThat(signed.headers().firstValue("x-amz-date"), equalTo("20260601T235959Z"));
         assertThat(signed.headers().firstValue("authorization"),
                 containsString("Credential=AKID/20260601/us-east-1/service/aws4_request"));
+    }
+
+    @Test
+    void ignoresPreexistingAuthorizationHeader() {
+        var context = Context.create()
+                .put(SigV4Settings.REGION, "us-east-1")
+                .put(SigV4Settings.SIGNING_NAME, "service")
+                .put(SigV4Settings.CLOCK, Clock.fixed(Instant.parse("2026-06-01T23:59:59Z"), ZoneOffset.UTC));
+        var identity = AwsCredentialsIdentity.create("AKID", "secret");
+
+        var clean = HttpRequest.create()
+                .setMethod("GET")
+                .setHttpVersion(HttpVersion.HTTP_1_1)
+                .setUri(URI.create("https://example.amazonaws.com/"))
+                .setHeaders(HttpHeaders.of(Map.of("Host", List.of("example.amazonaws.com"))))
+                .toUnmodifiable();
+        var withStaleAuth = HttpRequest.create()
+                .setMethod("GET")
+                .setHttpVersion(HttpVersion.HTTP_1_1)
+                .setUri(URI.create("https://example.amazonaws.com/"))
+                .setHeaders(HttpHeaders.of(Map.of(
+                        "Host",
+                        List.of("example.amazonaws.com"),
+                        "Authorization",
+                        List.of("AWS4-HMAC-SHA256 Credential=STALE/garbage, SignedHeaders=host, Signature=deadbeef"))))
+                .toUnmodifiable();
+
+        String cleanAuth;
+        String staleAuth;
+        try (var signer = SigV4Signer.create()) {
+            cleanAuth = signer.sign(clean, identity, context).signedRequest().headers().firstValue("authorization");
+            staleAuth = signer.sign(withStaleAuth, identity, context)
+                    .signedRequest()
+                    .headers()
+                    .firstValue("authorization");
+        }
+
+        // A stale Authorization header must not change SignedHeaders or the resulting signature.
+        assertThat(staleAuth, not(containsString("authorization")));
+        assertThat(staleAuth, equalTo(cleanAuth));
     }
 }


### PR DESCRIPTION
### What behavior changes?
Describe the observable difference in behavior before and after this change.

Explicitly deny authorization and transfer-encoding headers from appearing in a canonical string to sign in case a mutable request is reused after signing. Authorization is needed to exclude it from the signature when resigned, and transfer-encoding is another addition to keep transient headers out of the signed request.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

Sigv4 signing can be corrupted on a retry.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

Added a failing test to test the hypothesis, then fixed it, then the test passed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
