### PR TITLE
Allow config in chain, a region override, and rename CredentialChain to IdentityChain

### DIFF
--- a/aws/aws-credential-chain/src/main/java/software/amazon/smithy/java/aws/credentials/chain/ChainSetup.java
+++ b/aws/aws-credential-chain/src/main/java/software/amazon/smithy/java/aws/credentials/chain/ChainSetup.java
@@ -18,7 +18,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Mutable assembly context passed to each {@link ChainIdentityProvider#setup} during
- * credential chain construction.
+ * {@link IdentityChain} construction.
  *
  * <p>Providers use this to:
  * <ul>
@@ -37,6 +37,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public final class ChainSetup {
     private final ScheduledExecutorService executor;
     private final String profileNameOverride;
+    private final String regionOverride;
     private final Context properties;
     private final List<NamedResolver> resolvers = new ArrayList<>();
     private final Function<String, String> envFn;
@@ -48,6 +49,7 @@ public final class ChainSetup {
     private ChainSetup(Builder builder) {
         this.executor = builder.executor;
         this.profileNameOverride = builder.profileNameOverride;
+        this.regionOverride = builder.regionOverride;
         this.properties = Context.create();
         this.envFn = builder.envFn;
         this.profileFile = builder.profileFile;
@@ -80,6 +82,19 @@ public final class ChainSetup {
      */
     public String profileNameOverride() {
         return profileNameOverride;
+    }
+
+    /**
+     * Returns the client-specified region override used by providers that resolve credentials via a service call
+     * (e.g., STS, SSO), or {@code null} to fall back to the {@code AWS_REGION}/{@code AWS_DEFAULT_REGION}
+     * environment variables and the profile {@code region} property.
+     *
+     * <p>This affects only which regional endpoint those providers call; it does not parameterize the chain itself.
+     *
+     * @return the region override, or {@code null}.
+     */
+    public String regionOverride() {
+        return regionOverride;
     }
 
     /**
@@ -214,6 +229,7 @@ public final class ChainSetup {
     public static final class Builder {
         private ScheduledExecutorService executor;
         private String profileNameOverride;
+        private String regionOverride;
         private Function<String, String> envFn = System::getenv;
         private AwsProfileFile profileFile;
 
@@ -239,6 +255,19 @@ public final class ChainSetup {
          */
         public Builder profileNameOverride(String profileNameOverride) {
             this.profileNameOverride = profileNameOverride;
+            return this;
+        }
+
+        /**
+         * Sets the region override. When set, providers that resolve credentials via a service call (e.g., STS,
+         * SSO) use this region for their endpoint instead of resolving it from {@code AWS_REGION},
+         * {@code AWS_DEFAULT_REGION}, or the profile {@code region} property.
+         *
+         * @param regionOverride the region to use, e.g. {@code "us-west-2"}.
+         * @return this builder.
+         */
+        public Builder regionOverride(String regionOverride) {
+            this.regionOverride = regionOverride;
             return this;
         }
 

--- a/aws/aws-credential-chain/src/main/java/software/amazon/smithy/java/aws/credentials/chain/IdentityChain.java
+++ b/aws/aws-credential-chain/src/main/java/software/amazon/smithy/java/aws/credentials/chain/IdentityChain.java
@@ -67,11 +67,33 @@ public final class IdentityChain<I extends Identity> implements IdentityResolver
      * @throws IllegalStateException if two providers claim the same standard slot.
      */
     public static <I extends Identity> IdentityChain<I> create(Class<I> identityType) {
-        return create(identityType, Executors.newSingleThreadScheduledExecutor(r2 -> {
+        return create(identityType, defaultExecutor(), null, null);
+    }
+
+    /**
+     * Create an identity chain by discovering providers via ServiceLoader, using a caller-supplied AWS
+     * config/credentials file and region, with a default background-refresh executor.
+     *
+     * @param identityType Identity type to resolve.
+     * @param profileFile Already-parsed profile file to use, or {@code null} to load from the default locations.
+     * @param regionOverride Region for service-calling providers to use, or {@code null} to resolve it normally.
+     * @return the assembled chain.
+     * @throws IllegalStateException if two providers claim the same standard slot.
+     */
+    public static <I extends Identity> IdentityChain<I> create(
+            Class<I> identityType,
+            AwsProfileFile profileFile,
+            String regionOverride
+    ) {
+        return create(identityType, defaultExecutor(), profileFile, regionOverride);
+    }
+
+    private static ScheduledExecutorService defaultExecutor() {
+        return Executors.newSingleThreadScheduledExecutor(r2 -> {
             Thread t = new Thread(r2, "aws-credential-chain-refresh");
             t.setDaemon(true);
             return t;
-        }));
+        });
     }
 
     /**
@@ -83,33 +105,43 @@ public final class IdentityChain<I extends Identity> implements IdentityResolver
      * @throws IllegalStateException if two providers claim the same standard slot.
      */
     public static <I extends Identity> IdentityChain<I> create(Class<I> identityType, ScheduledExecutorService ex) {
-        return create(identityType, ex, null);
+        return create(identityType, ex, null, null);
     }
 
     /**
      * Create an identity chain by discovering providers via ServiceLoader, using a caller-supplied AWS
-     * config/credentials file.
+     * config/credentials file and region.
      *
      * <p>When {@code profileFile} is non-null, the {@code SHARED_CONFIG} provider uses it instead of reading
      * {@code ~/.aws/config} and {@code ~/.aws/credentials} from disk. Use this when the file has already been
      * loaded, or to point the chain at a non-default location.
      *
+     * <p>When {@code regionOverride} is non-null, providers that resolve credentials via a service call (e.g.,
+     * STS, SSO) use it for their endpoint instead of resolving the region from the environment or profile. This is
+     * how a client's configured region flows into credential resolution.
+     *
      * @param identityType Identity type to resolve.
      * @param ex Executor used for background resolution.
      * @param profileFile Already-parsed profile file to use, or {@code null} to load from the default locations.
+     * @param regionOverride Region for service-calling providers to use, or {@code null} to resolve it normally.
      * @return the assembled chain.
      * @throws IllegalStateException if two providers claim the same standard slot.
      */
     public static <I extends Identity> IdentityChain<I> create(
             Class<I> identityType,
             ScheduledExecutorService ex,
-            AwsProfileFile profileFile
+            AwsProfileFile profileFile,
+            String regionOverride
     ) {
         List<ChainIdentityProvider> registrations = new ArrayList<>();
         for (ChainIdentityProvider r : ServiceLoader.load(ChainIdentityProvider.class)) {
             registrations.add(r);
         }
-        ChainSetup setup = ChainSetup.builder().executor(ex).profileFile(profileFile).build();
+        ChainSetup setup = ChainSetup.builder()
+                .executor(ex)
+                .profileFile(profileFile)
+                .regionOverride(regionOverride)
+                .build();
         return assemble(identityType, registrations, ex, setup);
     }
 

--- a/aws/aws-credential-chain/src/main/java/software/amazon/smithy/java/aws/credentials/chain/IdentityChain.java
+++ b/aws/aws-credential-chain/src/main/java/software/amazon/smithy/java/aws/credentials/chain/IdentityChain.java
@@ -24,31 +24,32 @@ import software.amazon.smithy.java.context.Context;
 import software.amazon.smithy.java.logging.InternalLogger;
 
 /**
- * A credential provider chain.
+ * A chain of identity providers, parameterized by the {@link Identity} type it resolves (e.g.,
+ * {@code AwsCredentialsIdentity} or {@code TokenIdentity}).
  *
  * <p>Discovers {@link ChainIdentityProvider} implementations via {@link ServiceLoader}, assembles them into an
- * ordered chain based on {@link StandardProvider} slots and relative ordering constraints, and resolves
- * credentials by trying each provider in order.
+ * ordered chain based on {@link StandardProvider} slots and relative ordering constraints, and resolves an
+ * identity by trying each provider in order.
  *
  * <p>Usage:
- * {@snippet lang="java" :
- * var chain = CredentialChain.create();
+ * {@snippet lang = "java":
+ * var chain = IdentityChain.create();
  * var result = chain.resolveIdentity(Context.empty());
- * }
+ *}
  *
  * <p>The chain is assembled once at creation time. Providers that are not on the classpath simply don't
- * participate: their slots are skipped. If no provider in the chain can resolve credentials, the chain returns an
+ * participate: their slots are skipped. If no provider in the chain can resolve an identity, the chain returns an
  * error result describing which providers were tried.
  */
-public final class CredentialChain<I extends Identity> implements IdentityResolver<I>, AutoCloseable {
+public final class IdentityChain<I extends Identity> implements IdentityResolver<I>, AutoCloseable {
 
-    private static final InternalLogger LOGGER = InternalLogger.getLogger(CredentialChain.class);
+    private static final InternalLogger LOGGER = InternalLogger.getLogger(IdentityChain.class);
 
     private final Class<I> identityType;
     private final List<ChainSetup.NamedResolver> resolvers;
     private final ScheduledExecutorService executor;
 
-    private CredentialChain(
+    private IdentityChain(
             Class<I> identityType,
             List<ChainSetup.NamedResolver> resolvers,
             ScheduledExecutorService executor
@@ -59,13 +60,13 @@ public final class CredentialChain<I extends Identity> implements IdentityResolv
     }
 
     /**
-     * Create a credential chain by discovering providers via ServiceLoader.
+     * Create an identity chain by discovering providers via ServiceLoader.
      *
      * @param identityType Identity type to resolve.
      * @return the assembled chain.
      * @throws IllegalStateException if two providers claim the same standard slot.
      */
-    public static <I extends Identity> CredentialChain<I> create(Class<I> identityType) {
+    public static <I extends Identity> IdentityChain<I> create(Class<I> identityType) {
         return create(identityType, Executors.newSingleThreadScheduledExecutor(r2 -> {
             Thread t = new Thread(r2, "aws-credential-chain-refresh");
             t.setDaemon(true);
@@ -74,19 +75,19 @@ public final class CredentialChain<I extends Identity> implements IdentityResolv
     }
 
     /**
-     * Create a credential chain by discovering providers via ServiceLoader.
+     * Create an identity chain by discovering providers via ServiceLoader.
      *
      * @param identityType Identity type to resolve.
      * @param ex Executor used for background resolution.
      * @return the assembled chain.
      * @throws IllegalStateException if two providers claim the same standard slot.
      */
-    public static <I extends Identity> CredentialChain<I> create(Class<I> identityType, ScheduledExecutorService ex) {
+    public static <I extends Identity> IdentityChain<I> create(Class<I> identityType, ScheduledExecutorService ex) {
         return create(identityType, ex, null);
     }
 
     /**
-     * Create a credential chain by discovering providers via ServiceLoader, using a caller-supplied AWS
+     * Create an identity chain by discovering providers via ServiceLoader, using a caller-supplied AWS
      * config/credentials file.
      *
      * <p>When {@code profileFile} is non-null, the {@code SHARED_CONFIG} provider uses it instead of reading
@@ -99,7 +100,7 @@ public final class CredentialChain<I extends Identity> implements IdentityResolv
      * @return the assembled chain.
      * @throws IllegalStateException if two providers claim the same standard slot.
      */
-    public static <I extends Identity> CredentialChain<I> create(
+    public static <I extends Identity> IdentityChain<I> create(
             Class<I> identityType,
             ScheduledExecutorService ex,
             AwsProfileFile profileFile
@@ -112,7 +113,7 @@ public final class CredentialChain<I extends Identity> implements IdentityResolv
         return assemble(identityType, registrations, ex, setup);
     }
 
-    static <I extends Identity> CredentialChain<I> assemble(
+    static <I extends Identity> IdentityChain<I> assemble(
             Class<I> identityType,
             List<ChainIdentityProvider> registrations,
             ScheduledExecutorService executor
@@ -124,7 +125,7 @@ public final class CredentialChain<I extends Identity> implements IdentityResolv
      * Assemble a chain using a caller-supplied {@link ChainSetup}. Lets tests inject a deterministic environment
      * and profile rather than reading the real process environment and config files.
      */
-    static <I extends Identity> CredentialChain<I> assemble(
+    static <I extends Identity> IdentityChain<I> assemble(
             Class<I> identityType,
             List<ChainIdentityProvider> registrations,
             ScheduledExecutorService executor,
@@ -153,7 +154,7 @@ public final class CredentialChain<I extends Identity> implements IdentityResolv
         var ordered = setup.resolvers();
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Assembled credential chain: {}",
+            LOGGER.debug("Assembled identity chain: {}",
                     ordered.stream().map(ChainSetup.NamedResolver::name).collect(Collectors.joining(", ")));
         }
 
@@ -168,7 +169,7 @@ public final class CredentialChain<I extends Identity> implements IdentityResolv
             }
         }
         warnDetectedButUnclaimed(claimed);
-        return new CredentialChain<>(identityType, Collections.unmodifiableList(ordered), executor);
+        return new IdentityChain<>(identityType, Collections.unmodifiableList(ordered), executor);
     }
 
     private static List<ChainIdentityProvider> sortByOrdering(List<ChainIdentityProvider> providers) {

--- a/aws/aws-credential-chain/src/main/java/software/amazon/smithy/java/aws/credentials/chain/OrderingConstraint.java
+++ b/aws/aws-credential-chain/src/main/java/software/amazon/smithy/java/aws/credentials/chain/OrderingConstraint.java
@@ -6,7 +6,7 @@
 package software.amazon.smithy.java.aws.credentials.chain;
 
 /**
- * Describes where a {@link ChainIdentityProvider} sits in the credential chain.
+ * Describes where a {@link ChainIdentityProvider} sits in the {@link IdentityChain}.
  *
  * <p>Three forms:
  * <ul>

--- a/aws/aws-credential-chain/src/test/java/software/amazon/smithy/java/aws/credentials/chain/FeatureIdTest.java
+++ b/aws/aws-credential-chain/src/test/java/software/amazon/smithy/java/aws/credentials/chain/FeatureIdTest.java
@@ -24,7 +24,7 @@ class FeatureIdTest {
 
     @Test
     void successfulProviderEmitsFeatureId() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         provider("env",
                                 StandardProvider.ENVIRONMENT,
@@ -44,7 +44,7 @@ class FeatureIdTest {
 
     @Test
     void failedProviderDoesNotEmitFeatureId() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         provider("env",
                                 StandardProvider.ENVIRONMENT,
@@ -68,7 +68,7 @@ class FeatureIdTest {
 
     @Test
     void multipleFeatureIdsEmitted() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         provider("proc",
                                 StandardProvider.SHARED_CONFIG,
@@ -93,7 +93,7 @@ class FeatureIdTest {
 
     @Test
     void noFeatureIdsWhenContextKeyNotSet() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         provider("env",
                                 StandardProvider.ENVIRONMENT,

--- a/aws/aws-credential-chain/src/test/java/software/amazon/smithy/java/aws/credentials/chain/IdentityChainTest.java
+++ b/aws/aws-credential-chain/src/test/java/software/amazon/smithy/java/aws/credentials/chain/IdentityChainTest.java
@@ -19,10 +19,10 @@ import software.amazon.smithy.java.auth.api.identity.IdentityResult;
 import software.amazon.smithy.java.aws.auth.api.identity.AwsCredentialsIdentity;
 import software.amazon.smithy.java.context.Context;
 
-class AwsCredentialChainTest {
+class IdentityChainTest {
     @Test
     void standardProvidersAreOrderedByEnumOrder() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         registration("imds",
                                 new OrderingConstraint.Standard(StandardProvider.EC2_INSTANCE_METADATA),
@@ -40,7 +40,7 @@ class AwsCredentialChainTest {
 
     @Test
     void firstSuccessfulProviderWins() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         registration("env",
                                 new OrderingConstraint.Standard(StandardProvider.ENVIRONMENT),
@@ -57,7 +57,7 @@ class AwsCredentialChainTest {
 
     @Test
     void allFailReturnsAggregatedError() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         registration("env",
                                 new OrderingConstraint.Standard(StandardProvider.ENVIRONMENT),
@@ -76,7 +76,7 @@ class AwsCredentialChainTest {
     @Test
     void duplicateSlotThrows() {
         assertThrows(IllegalStateException.class,
-                () -> CredentialChain.assemble(AwsCredentialsIdentity.class,
+                () -> IdentityChain.assemble(AwsCredentialsIdentity.class,
                         List.of(
                                 registration("a",
                                         new OrderingConstraint.Standard(StandardProvider.ENVIRONMENT),
@@ -89,7 +89,7 @@ class AwsCredentialChainTest {
 
     @Test
     void relativeAfterInsertsCorrectly() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         registration("env",
                                 new OrderingConstraint.Standard(StandardProvider.ENVIRONMENT),
@@ -107,7 +107,7 @@ class AwsCredentialChainTest {
 
     @Test
     void relativeBeforeInsertsCorrectly() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         registration("env",
                                 new OrderingConstraint.Standard(StandardProvider.ENVIRONMENT),
@@ -125,7 +125,7 @@ class AwsCredentialChainTest {
 
     @Test
     void relativeToUnclaimedSlotAppendsAtEnd() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class,
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class,
                 List.of(
                         registration("env",
                                 new OrderingConstraint.Standard(StandardProvider.ENVIRONMENT),
@@ -141,7 +141,7 @@ class AwsCredentialChainTest {
     @Test
     void duplicateNameThrows() {
         assertThrows(IllegalStateException.class,
-                () -> CredentialChain.assemble(AwsCredentialsIdentity.class,
+                () -> IdentityChain.assemble(AwsCredentialsIdentity.class,
                         List.of(
                                 registration("env",
                                         new OrderingConstraint.Standard(StandardProvider.ENVIRONMENT),
@@ -154,7 +154,7 @@ class AwsCredentialChainTest {
 
     @Test
     void emptyChainReturnsDescriptiveError() {
-        var chain = CredentialChain.assemble(AwsCredentialsIdentity.class, List.of(), null);
+        var chain = IdentityChain.assemble(AwsCredentialsIdentity.class, List.of(), null);
         IdentityResult<AwsCredentialsIdentity> result = chain.resolveIdentity(Context.empty());
 
         assertNull(result.identity());
@@ -182,7 +182,7 @@ class AwsCredentialChainTest {
     }
 
     private static IdentityResolver<AwsCredentialsIdentity> errorResolver(String msg) {
-        IdentityResult<AwsCredentialsIdentity> result = IdentityResult.ofError(AwsCredentialChainTest.class, msg);
+        IdentityResult<AwsCredentialsIdentity> result = IdentityResult.ofError(IdentityChainTest.class, msg);
         return new IdentityResolver<>() {
             public IdentityResult<AwsCredentialsIdentity> resolveIdentity(Context ctx) {
                 return result;

--- a/aws/aws-credentials-sts/src/main/java/software/amazon/smithy/java/aws/credentials/sts/StsAssumeRoleResolver.java
+++ b/aws/aws-credentials-sts/src/main/java/software/amazon/smithy/java/aws/credentials/sts/StsAssumeRoleResolver.java
@@ -48,6 +48,11 @@ final class StsAssumeRoleResolver implements IdentityResolver<AwsCredentialsIden
         return AwsCredentialsIdentity.class;
     }
 
+    // Visible for testing: the STS endpoint configuration this resolver was assembled with.
+    StsEndpointConfig endpoint() {
+        return endpoint;
+    }
+
     @Override
     public IdentityResult<AwsCredentialsIdentity> resolveIdentity(Context ctx) {
         AwsCredentialsIdentity sourceCredentials = resolveSourceCredentials(source, new HashSet<>());

--- a/aws/aws-credentials-sts/src/main/java/software/amazon/smithy/java/aws/credentials/sts/StsEndpointConfig.java
+++ b/aws/aws-credentials-sts/src/main/java/software/amazon/smithy/java/aws/credentials/sts/StsEndpointConfig.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.java.aws.credentials.chain.ChainSetup;
  * <ol>
  *   <li>The region attached to the credential source (profile-level
  *       {@code region} carried on {@code AssumeRole} / {@code WebIdentityToken}).</li>
+ *   <li>The client-specified region override ({@link ChainSetup#regionOverride()}).</li>
  *   <li>{@code AWS_REGION} env var.</li>
  *   <li>{@code AWS_DEFAULT_REGION} env var.</li>
  *   <li>The active profile's {@code region} property.</li>
@@ -37,6 +38,9 @@ record StsEndpointConfig(String region, boolean useGlobalEndpoint) {
 
     static StsEndpointConfig resolve(String sourceRegion, ChainSetup setup) {
         String region = sourceRegion;
+        if (region == null) {
+            region = setup.regionOverride();
+        }
         if (region == null) {
             region = setup.getenv("AWS_REGION");
         }

--- a/aws/aws-credentials-sts/src/test/java/software/amazon/smithy/java/aws/credentials/sts/ProfileAssumeRoleProviderTest.java
+++ b/aws/aws-credentials-sts/src/test/java/software/amazon/smithy/java/aws/credentials/sts/ProfileAssumeRoleProviderTest.java
@@ -65,6 +65,34 @@ class ProfileAssumeRoleProviderTest {
     }
 
     @Test
+    void regionOverrideFlowsIntoStsEndpoint(@TempDir Path tmp) throws IOException {
+        Path config = tmp.resolve("config");
+        Files.writeString(config, """
+                [default]
+                role_arn = arn:aws:iam::123456789:role/RoleA
+                source_profile = creds
+
+                [profile creds]
+                aws_access_key_id = AK
+                aws_secret_access_key = SK
+                """);
+
+        var profileFile = AwsProfileFile.builder().configFile(config).credentialsFile(null).build();
+        // No AWS_REGION/profile region; the client's region override should drive the STS endpoint.
+        var setup = ChainSetup.builder().env(k -> null).regionOverride("eu-central-1").build();
+        setup.setProfileFile(profileFile);
+        setup.setProfile(profileFile.activeProfile(k -> null));
+        var provider = new ProfileAssumeRoleProvider();
+        setup.setCurrentProvider(provider);
+
+        provider.setup(AwsCredentialsIdentity.class, setup);
+
+        assertEquals(1, setup.resolvers().size());
+        var resolver = (StsAssumeRoleResolver) setup.resolvers().get(0).resolver();
+        assertEquals("eu-central-1", resolver.endpoint().region());
+    }
+
+    @Test
     void skipsWhenNoRoleArn(@TempDir Path tmp) throws IOException {
         Path config = tmp.resolve("config");
         Files.writeString(config, """

--- a/aws/aws-credentials-sts/src/test/java/software/amazon/smithy/java/aws/credentials/sts/StsEndpointConfigTest.java
+++ b/aws/aws-credentials-sts/src/test/java/software/amazon/smithy/java/aws/credentials/sts/StsEndpointConfigTest.java
@@ -30,6 +30,23 @@ class StsEndpointConfigTest {
     }
 
     @Test
+    void regionOverrideWinsOverEnvAndProfile(@TempDir Path tmp) throws IOException {
+        var setup = setupWith(
+                Map.of("AWS_REGION", "us-west-2"),
+                profileWith(tmp, "region = eu-west-1"),
+                "ap-southeast-2");
+        var cfg = StsEndpointConfig.resolve(null, setup);
+        assertEquals("ap-southeast-2", cfg.region());
+    }
+
+    @Test
+    void sourceRegionWinsOverRegionOverride(@TempDir Path tmp) throws IOException {
+        var setup = setupWith(Map.of(), null, "ap-southeast-2");
+        var cfg = StsEndpointConfig.resolve("ap-south-1", setup);
+        assertEquals("ap-south-1", cfg.region());
+    }
+
+    @Test
     void awsRegionEnvWinsOverDefaultRegionAndProfile(@TempDir Path tmp) throws IOException {
         var setup = setupWith(
                 Map.of("AWS_REGION", "us-west-2", "AWS_DEFAULT_REGION", "us-east-2"),
@@ -98,8 +115,12 @@ class StsEndpointConfigTest {
     }
 
     private static ChainSetup setupWith(Map<String, String> env, AwsProfileFile profileFile) {
+        return setupWith(env, profileFile, null);
+    }
+
+    private static ChainSetup setupWith(Map<String, String> env, AwsProfileFile profileFile, String regionOverride) {
         Map<String, String> envCopy = new HashMap<>(env);
-        var setup = ChainSetup.builder().env(envCopy::get).build();
+        var setup = ChainSetup.builder().env(envCopy::get).regionOverride(regionOverride).build();
         if (profileFile != null) {
             setup.setProfileFile(profileFile);
             setup.setProfile(profileFile.activeProfile(k -> null));

--- a/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/AwsCredentialChainPlugin.java
+++ b/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/AwsCredentialChainPlugin.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.java.aws.client.core;
 
 import software.amazon.smithy.java.auth.api.identity.IdentityResolver;
 import software.amazon.smithy.java.aws.auth.api.identity.AwsCredentialsIdentity;
-import software.amazon.smithy.java.aws.credentials.chain.CredentialChain;
+import software.amazon.smithy.java.aws.credentials.chain.IdentityChain;
 import software.amazon.smithy.java.client.core.ClientConfig;
 import software.amazon.smithy.java.client.core.ClientPlugin;
 import software.amazon.smithy.java.client.core.auth.scheme.AuthScheme;
@@ -38,7 +38,7 @@ public final class AwsCredentialChainPlugin implements ClientPlugin {
     @Override
     public void configureClient(ClientConfig.Builder config) {
         if (needsAwsCredentials(config) && !hasAwsCredentialsResolver(config)) {
-            var chain = CredentialChain.create(AwsCredentialsIdentity.class);
+            var chain = IdentityChain.create(AwsCredentialsIdentity.class);
             config.addIdentityResolver(chain);
             config.addInterceptor(new InvalidateOnAuthFailureInterceptor(chain));
         }

--- a/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/AwsCredentialChainPlugin.java
+++ b/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/AwsCredentialChainPlugin.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.java.aws.client.core;
 
 import software.amazon.smithy.java.auth.api.identity.IdentityResolver;
 import software.amazon.smithy.java.aws.auth.api.identity.AwsCredentialsIdentity;
+import software.amazon.smithy.java.aws.client.core.settings.RegionSetting;
 import software.amazon.smithy.java.aws.credentials.chain.IdentityChain;
 import software.amazon.smithy.java.client.core.ClientConfig;
 import software.amazon.smithy.java.client.core.ClientPlugin;
@@ -32,13 +33,19 @@ import software.amazon.smithy.java.client.core.auth.scheme.AuthScheme;
 public final class AwsCredentialChainPlugin implements ClientPlugin {
     @Override
     public Phase getPluginPhase() {
-        return Phase.DEFAULTS;
+        // Run after DEFAULTS so the client's region (and any other defaults) are populated on the config before we
+        // read them to assemble the chain.
+        return Phase.AFTER_DEFAULTS;
     }
 
     @Override
     public void configureClient(ClientConfig.Builder config) {
         if (needsAwsCredentials(config) && !hasAwsCredentialsResolver(config)) {
-            var chain = IdentityChain.create(AwsCredentialsIdentity.class);
+            // Pass the client's configured region so credential providers that make a service call (STS, SSO) use
+            // the same region as the client. Null when no region is configured, in which case the providers fall
+            // back to the environment and profile.
+            String region = config.context().get(RegionSetting.REGION);
+            var chain = IdentityChain.create(AwsCredentialsIdentity.class, null, region);
             config.addIdentityResolver(chain);
             config.addInterceptor(new InvalidateOnAuthFailureInterceptor(chain));
         }

--- a/aws/client/aws-client-core/src/test/java/software/amazon/smithy/java/aws/client/core/identity/IdentityChainFallthroughTest.java
+++ b/aws/client/aws-client-core/src/test/java/software/amazon/smithy/java/aws/client/core/identity/IdentityChainFallthroughTest.java
@@ -10,10 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.java.aws.auth.api.identity.AwsCredentialsIdentity;
 import software.amazon.smithy.java.aws.credentials.chain.ChainSetup;
-import software.amazon.smithy.java.aws.credentials.chain.CredentialChain;
+import software.amazon.smithy.java.aws.credentials.chain.IdentityChain;
 
 /**
- * Demonstrates that the assembled credential chain fails to fall through past the
+ * Demonstrates that the assembled {@link IdentityChain} fails to fall through past the
  * {@code JAVA_SYSTEM_PROPERTIES} slot.
  *
  * <p>{@link SystemPropertiesCredentialProvider} registers its resolver via
@@ -23,7 +23,7 @@ import software.amazon.smithy.java.aws.credentials.chain.CredentialChain;
  *
  * <p>This test encodes the correct behavior and therefore fails against the current implementation.
  */
-public class CredentialChainFallthroughTest {
+public class IdentityChainFallthroughTest {
 
     /**
      * When system properties are absent, the assembled chain should contain the {@code Environment} provider so
@@ -37,7 +37,7 @@ public class CredentialChainFallthroughTest {
         // no aws.accessKeyId/aws.secretAccessKey system properties, then restore.
         String savedAccessKey = System.clearProperty("aws.accessKeyId");
         String savedSecretKey = System.clearProperty("aws.secretAccessKey");
-        try (var chain = CredentialChain.create(AwsCredentialsIdentity.class)) {
+        try (var chain = IdentityChain.create(AwsCredentialsIdentity.class)) {
             var providers = chain.providerNames();
             assertTrue(providers.contains("Environment"),
                     "Environment provider was dropped from the chain. SystemPropertiesCredentialProvider "

--- a/aws/client/aws-client-core/src/test/java/software/amazon/smithy/java/aws/credentials/chain/IdentityChainEndToEndTest.java
+++ b/aws/client/aws-client-core/src/test/java/software/amazon/smithy/java/aws/credentials/chain/IdentityChainEndToEndTest.java
@@ -28,19 +28,19 @@ import software.amazon.smithy.java.context.Context;
 
 /**
  * End-to-end assembly + resolution test that wires the <em>real</em> credential providers together through the
- * real {@link CredentialChain#assemble} and exercises fall-through across the sources.
+ * real {@link IdentityChain#assemble} and exercises fall-through across the sources.
  *
  * <p>Scope: this module ({@code aws-client-core}) sees the system-property, environment, and profile
  * (static/session keys) providers. It does not depend on {@code aws-credentials-sts} or
  * {@code aws-credentials-imds}, so the STS and IMDS slots are not covered here — a fuller test spanning those
  * would need a module that depends on all of them.
  *
- * <p>Determinism comes from the package-private {@link CredentialChain#assemble} overload that accepts a
+ * <p>Determinism comes from the package-private {@link IdentityChain#assemble} overload that accepts a
  * caller-built {@link ChainSetup}: the environment is injected and the profile is pre-set, so nothing reads the
  * real process environment or {@code ~/.aws} files. The profile is set directly rather than via
  * {@code SharedConfigProvider} (which loads real config files and cannot be pointed at a temp path).
  */
-class CredentialChainEndToEndTest {
+class IdentityChainEndToEndTest {
 
     private static final List<ChainIdentityProvider> PROVIDERS = List.of(
             new SystemPropertiesCredentialProvider(),
@@ -103,7 +103,7 @@ class CredentialChainEndToEndTest {
         assertNull(result.identity());
     }
 
-    private static CredentialChain<AwsCredentialsIdentity> assembleWith(
+    private static IdentityChain<AwsCredentialsIdentity> assembleWith(
             Function<String, String> env,
             AwsProfileFile profileFile
     ) {
@@ -112,7 +112,7 @@ class CredentialChainEndToEndTest {
             setup.setProfileFile(profileFile);
             setup.setProfile(profileFile.profile("default"));
         }
-        return CredentialChain.assemble(AwsCredentialsIdentity.class, PROVIDERS, null, setup);
+        return IdentityChain.assemble(AwsCredentialsIdentity.class, PROVIDERS, null, setup);
     }
 
     private static AwsProfileFile writeConfig(Path tmp, String contents) throws IOException {


### PR DESCRIPTION
### What behavior changes?
Describe the observable difference in behavior before and after this change.

Incoporates feedback: allow config in chain, a region override, and rename CredentialChain to IdentityChain

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

People might already have a config available and want to pass it in. People might need to use a specific region rather than an environment region. IdentityResolver is the recommended name change from review.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
