### PR TITLE
Bundle STS model in credential provider

### DIFF
--- a/aws/aws-credentials-sts/build.gradle.kts
+++ b/aws/aws-credentials-sts/build.gradle.kts
@@ -7,6 +7,37 @@ description = "STS-based credential providers (assume-role, web identity token).
 extra["displayName"] = "Smithy :: Java :: AWS :: Credentials :: STS"
 extra["moduleName"] = "software.amazon.smithy.java.aws.credentials.sts"
 
+// Resolvable-only configuration used solely to vendor the STS model into this
+// package's JAR. It is intentionally not extended into implementation/runtime, so
+// the public STS model artifact never becomes a real dependency of this package.
+val stsModel: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+// Extract only the STS model JSON to a private (non-discoverable) resource path.
+// The model's META-INF/smithy manifest is deliberately not extracted so this package
+// stays invisible to Smithy classpath discovery. StsClientFactory loads the model by
+// explicit resource and relies on discoverModels only for trait definitions.
+val extractStsModel by tasks.registering(Copy::class) {
+    from(zipTree(stsModel.singleFile)) {
+        include("META-INF/smithy/2011-06-15/sts-2011-06-15.json")
+        // Relocate to the package path StsClientFactory loads it from.
+        eachFile {
+            relativePath = RelativePath(
+                true,
+                "software", "amazon", "smithy", "java", "aws", "credentials", "sts", name
+            )
+        }
+    }
+    into(layout.buildDirectory.dir("generated-resources/sts-model"))
+    includeEmptyDirs = false
+}
+
+sourceSets.main {
+    resources.srcDir(extractStsModel)
+}
+
 dependencies {
     implementation(project(":aws:aws-credential-chain"))
     implementation(project(":aws:aws-config"))
@@ -21,7 +52,7 @@ dependencies {
     implementation(project(":aws:client:aws-client-awsquery"))
     implementation(project(":codecs:json-codec", configuration = "shadow"))
     implementation(project(":logging"))
-    implementation("software.amazon.api.models:sts:1.0.7")
+    stsModel("software.amazon.api.models:sts:1.0.7") { isTransitive = false }
     testImplementation(project(":client:client-mock-plugin"))
     testImplementation(project(":http:http-api"))
 }

--- a/aws/aws-credentials-sts/src/main/java/software/amazon/smithy/java/aws/credentials/sts/StsClientFactory.java
+++ b/aws/aws-credentials-sts/src/main/java/software/amazon/smithy/java/aws/credentials/sts/StsClientFactory.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.aws.credentials.sts;
 
+import java.util.Objects;
 import software.amazon.smithy.java.auth.api.identity.IdentityResolver;
 import software.amazon.smithy.java.aws.auth.api.identity.AwsCredentialsIdentity;
 import software.amazon.smithy.java.aws.client.awsquery.AwsQueryClientProtocol;
@@ -65,6 +66,9 @@ final class StsClientFactory {
     private static final class ModelHolder {
         static final Model MODEL = Model.assembler()
                 .discoverModels(StsClientFactory.class.getClassLoader())
+                .addImport(Objects.requireNonNull(
+                        StsClientFactory.class.getResource("sts-2011-06-15.json"),
+                        "Bundled STS model resource not found"))
                 .assemble()
                 .unwrap();
     }


### PR DESCRIPTION
### What behavior changes?

This updates the sts credential provider to bundle the model at build time. This will help prevent it from clashing with a dependency in a customer's application. Since it's still pulling from the published source, we don't have to commit the whole model and updating is trivial.

I *really* didn't want to just commit the model to the repo, or put it anywhere it was going to be discovered automatically by Smithy's model discovery because I don't want it leaking into places it shouldn't.

### Why is this change needed?

It prevents clashing with a customer's dependency on the same model, and lets us import into environments without having to also separately import the model.

### How was this validated?

Tests run and still pass.

### What should reviewers focus on?

I'm importing the specific model file by name. In theory it could change, but it hasn't in 15 years so we're probably good. And if it does it probably signals something we need to be aware of anyway.

### Additional Links

The cli does something similar, though more broadly to for smithy aws traits.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
