### PR TITLE
Remove retries from invalidation

### DIFF
--- a/auth-api/src/main/java/software/amazon/smithy/java/auth/api/identity/IdentityResolver.java
+++ b/auth-api/src/main/java/software/amazon/smithy/java/auth/api/identity/IdentityResolver.java
@@ -34,7 +34,7 @@ public interface IdentityResolver<IdentityT extends Identity> {
      * Invalidate any cached identity, forcing the next call to {@link #resolveIdentity(Context)} to fetch fresh
      * credentials from the underlying source.
      *
-     * <p>This is typically called by retry logic or interceptors when a service returns an authentication error
+     * <p>This is typically called by an interceptor when a service returns an expired- or invalid-credential error
      * (e.g., {@code ExpiredTokenException}), indicating that the currently cached identity is no longer valid.
      *
      * <p>The default implementation is a no-op. Caching resolvers (such as {@link CachingIdentityResolver}) override

--- a/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/AwsCredentialChainPlugin.java
+++ b/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/AwsCredentialChainPlugin.java
@@ -47,7 +47,7 @@ public final class AwsCredentialChainPlugin implements ClientPlugin {
             String region = config.context().get(RegionSetting.REGION);
             var chain = IdentityChain.create(AwsCredentialsIdentity.class, null, region);
             config.addIdentityResolver(chain);
-            config.addInterceptor(new InvalidateOnAuthFailureInterceptor(chain));
+            config.addInterceptor(new InvalidateCredentialsInterceptor(chain));
         }
     }
 

--- a/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/InvalidateCredentialsInterceptor.java
+++ b/aws/client/aws-client-core/src/main/java/software/amazon/smithy/java/aws/client/core/InvalidateCredentialsInterceptor.java
@@ -12,32 +12,30 @@ import software.amazon.smithy.java.client.core.interceptors.OutputHook;
 import software.amazon.smithy.java.core.error.ModeledException;
 
 /**
- * Interceptor that invalidates cached credentials when a service returns an authentication error
- * (HTTP 401 or 403), forcing the next retry attempt to resolve fresh credentials.
+ * Interceptor that invalidates cached credentials when a service returns an expired- or
+ * invalid-credential error, so the stale credentials are cleared and the next request resolves
+ * fresh ones.
  */
-final class InvalidateOnAuthFailureInterceptor implements ClientInterceptor {
+final class InvalidateCredentialsInterceptor implements ClientInterceptor {
 
     private final IdentityResolver<?> resolver;
 
     // well-known error names. Ideally the wire would have signal so we don't need this.
-    private static final Set<String> EXPIRED_NAMES = Set.of(
-            "ExpiredToken",
-            "InvalidToken",
-            "AuthFailure");
+    private static final Set<String> EXPIRED_NAMES = Set.of("ExpiredToken", "InvalidToken");
 
-    InvalidateOnAuthFailureInterceptor(IdentityResolver<?> resolver) {
+    InvalidateCredentialsInterceptor(IdentityResolver<?> resolver) {
         this.resolver = resolver;
     }
 
     @Override
     public void readAfterAttempt(OutputHook<?, ?, ?, ?> hook, RuntimeException error) {
-        if (isAuthError(error)) {
+        if (shouldInvalidate(error)) {
             resolver.invalidate();
         }
     }
 
-    private static boolean isAuthError(RuntimeException error) {
-        // Check for common auth failure error names.
+    private static boolean shouldInvalidate(RuntimeException error) {
+        // Check for well-known expired- or invalid-credential error names.
         if (error instanceof ModeledException me) {
             var name = me.schema().id().getName();
             return EXPIRED_NAMES.contains(name);

--- a/aws/client/aws-client-core/src/test/java/software/amazon/smithy/java/aws/client/core/InvalidateCredentialsInterceptorTest.java
+++ b/aws/client/aws-client-core/src/test/java/software/amazon/smithy/java/aws/client/core/InvalidateCredentialsInterceptorTest.java
@@ -18,30 +18,39 @@ import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.model.shapes.ShapeId;
 
-class InvalidateOnAuthFailureInterceptorTest {
+class InvalidateCredentialsInterceptorTest {
 
     @Test
     void invalidatesOnExpiredToken() {
         var counter = new CountingResolver();
-        var interceptor = new InvalidateOnAuthFailureInterceptor(counter);
+        var interceptor = new InvalidateCredentialsInterceptor(counter);
 
-        interceptor.readAfterAttempt(null, authError("ExpiredToken"));
+        interceptor.readAfterAttempt(null, credentialError("ExpiredToken"));
         assertEquals(1, counter.invalidateCount.get());
     }
 
     @Test
-    void invalidatesOnAuthFailure() {
+    void invalidatesOnInvalidToken() {
         var counter = new CountingResolver();
-        var interceptor = new InvalidateOnAuthFailureInterceptor(counter);
+        var interceptor = new InvalidateCredentialsInterceptor(counter);
 
-        interceptor.readAfterAttempt(null, authError("AuthFailure"));
+        interceptor.readAfterAttempt(null, credentialError("InvalidToken"));
         assertEquals(1, counter.invalidateCount.get());
     }
 
     @Test
-    void doesNotInvalidateOnNonAuthError() {
+    void doesNotInvalidateOnOtherModeledError() {
         var counter = new CountingResolver();
-        var interceptor = new InvalidateOnAuthFailureInterceptor(counter);
+        var interceptor = new InvalidateCredentialsInterceptor(counter);
+
+        interceptor.readAfterAttempt(null, credentialError("AccessDenied"));
+        assertEquals(0, counter.invalidateCount.get());
+    }
+
+    @Test
+    void doesNotInvalidateOnNonModeledError() {
+        var counter = new CountingResolver();
+        var interceptor = new InvalidateCredentialsInterceptor(counter);
 
         interceptor.readAfterAttempt(null, new RuntimeException("network error"));
         assertEquals(0, counter.invalidateCount.get());
@@ -50,13 +59,13 @@ class InvalidateOnAuthFailureInterceptorTest {
     @Test
     void doesNotInvalidateOnNull() {
         var counter = new CountingResolver();
-        var interceptor = new InvalidateOnAuthFailureInterceptor(counter);
+        var interceptor = new InvalidateCredentialsInterceptor(counter);
 
         interceptor.readAfterAttempt(null, null);
         assertEquals(0, counter.invalidateCount.get());
     }
 
-    private static RuntimeException authError(String errorName) {
+    private static RuntimeException credentialError(String errorName) {
         Schema schema = Schema.createString(ShapeId.from("com.example#" + errorName));
         return new ModeledException(schema, errorName + " error") {
             @Override


### PR DESCRIPTION
### What behavior changes?
Describe the observable difference in behavior before and after this change.

Invalidation should not ever retry, and AuthFailure isn't necessarily a revoked token as EC2 uses it for other things too.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

It's used for other auth issues than expiration or revocation.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
