### PR TITLE
Fixed deserialization of string httpPayload when the response is readonly buffer

### DIFF
--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PayloadDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PayloadDeserializer.java
@@ -120,9 +120,13 @@ final class PayloadDeserializer implements ShapeDeserializer {
         }
 
         var buffer = body.asByteBuffer();
-        int pos = buffer.arrayOffset() + buffer.position();
-        int len = buffer.remaining();
-        return new String(buffer.array(), pos, len, StandardCharsets.UTF_8);
+        if (buffer.hasArray()) {
+            int pos = buffer.arrayOffset() + buffer.position();
+            int len = buffer.remaining();
+            return new String(buffer.array(), pos, len, StandardCharsets.UTF_8);
+        }
+
+        return StandardCharsets.UTF_8.decode(buffer).toString();
     }
 
     @Override

--- a/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/PayloadDeserializerTest.java
+++ b/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/PayloadDeserializerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.binding;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.ApiService;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.java.http.api.HttpHeaders;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.http.api.HttpVersion;
+import software.amazon.smithy.java.io.datastream.DataStream;
+import software.amazon.smithy.java.json.JsonCodec;
+import software.amazon.smithy.model.pattern.UriPattern;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.HttpPayloadTrait;
+import software.amazon.smithy.model.traits.HttpTrait;
+
+public class PayloadDeserializerTest {
+    private static final Codec CODEC = JsonCodec.builder().useJsonName(true).build();
+
+    @Test
+    public void stringPayloadIsReadWhenResponseIsReadonlyBuffer() {
+        var data = deserializeBody(StringPayloadInput.OPERATION, "string value");
+
+        assertThat(data.getMemberValue(StringPayloadInput.VALUE), equalTo("string value"));
+    }
+
+    private static SerializableStruct deserializeBody(ApiOperation<?, ?> operation, String bodyContent) {
+        var builder = operation.outputBuilder();
+        var bodyReadOnlyBuffer = DataStream.ofString(bodyContent).asByteBuffer().asReadOnlyBuffer();
+        var response = HttpResponse.of(HttpVersion.HTTP_1_0, 200, HttpHeaders.ofModifiable().toUnmodifiable(), DataStream.ofByteBuffer(bodyReadOnlyBuffer));
+        new HttpBinding().responseDeserializer()
+                .payloadCodec(CODEC)
+                .payloadMediaType("application/json")
+                .outputShapeBuilder(builder)
+                .response(response)
+                .deserialize();
+
+        return builder.build();
+    }
+
+    private static HttpTrait postTrait() {
+        return HttpTrait.builder().method("POST").uri(UriPattern.parse("/op")).code(200).build();
+    }
+
+    private record StringPayloadInput(String value) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#StringPayloadInput"))
+                .putMember("value", PreludeSchemas.STRING, new HttpPayloadTrait())
+                .build();
+        static final Schema VALUE = SCHEMA.member("value");
+        static final ApiOperation<?, ?> OPERATION = operation("StringPayloadOperation", SCHEMA);
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeString(VALUE, value);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return "value".equals(member.memberName()) ? (T) value : null;
+        }
+    }
+
+    /**
+     * Build a minimal POST operation whose input is {@code inputSchema}. The operation schema carries the
+     * {@code @http} trait that drives request-direction HTTP binding.
+     */
+    private static ApiOperation<?, ?> operation(String name, Schema inputSchema) {
+        var operationSchema = Schema.createOperation(ShapeId.from("smithy.example#" + name), postTrait());
+        return new ApiOperation<>() {
+            @Override
+            public ShapeBuilder<SerializableStruct> inputBuilder() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ShapeBuilder<SerializableStruct> outputBuilder() {
+                return new ShapeBuilder<>() {
+                    private AtomicReference<String> value = new AtomicReference<>();
+
+                    @Override
+                    public SerializableStruct build() {
+                        return new StringPayloadInput(value.get());
+                    }
+
+                    @Override
+                    public ShapeBuilder<SerializableStruct> deserialize(ShapeDeserializer decoder) {
+                        decoder.readStruct(StringPayloadInput.SCHEMA, value, (AtomicReference<String> state, Schema memberSchema, ShapeDeserializer memberDeserializer) -> {
+                            state.set(memberDeserializer.readString(StringPayloadInput.VALUE));
+                        });
+                        return this;
+                    }
+
+                    @Override
+                    public Schema schema() {
+                        return inputSchema;
+                    }
+                };
+            }
+
+            @Override
+            public Schema schema() {
+                return operationSchema;
+            }
+
+            @Override
+            public Schema inputSchema() {
+                return inputSchema;
+            }
+
+            @Override
+            public Schema outputSchema() {
+                return inputSchema;
+            }
+
+            @Override
+            public TypeRegistry errorRegistry() {
+                return TypeRegistry.builder().build();
+            }
+
+            @Override
+            public List<ShapeId> effectiveAuthSchemes() {
+                return List.of();
+            }
+
+            @Override
+            public List<Schema> errorSchemas() {
+                return List.of();
+            }
+
+            @Override
+            public ApiService service() {
+                return null;
+            }
+        };
+    }
+}

--- a/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/PayloadDeserializerTest.java
+++ b/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/PayloadDeserializerTest.java
@@ -8,7 +8,6 @@ package software.amazon.smithy.java.http.binding;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
@@ -45,7 +44,10 @@ public class PayloadDeserializerTest {
     private static SerializableStruct deserializeBody(ApiOperation<?, ?> operation, String bodyContent) {
         var builder = operation.outputBuilder();
         var bodyReadOnlyBuffer = DataStream.ofString(bodyContent).asByteBuffer().asReadOnlyBuffer();
-        var response = HttpResponse.of(HttpVersion.HTTP_1_0, 200, HttpHeaders.ofModifiable().toUnmodifiable(), DataStream.ofByteBuffer(bodyReadOnlyBuffer));
+        var response = HttpResponse.of(HttpVersion.HTTP_1_0,
+                200,
+                HttpHeaders.ofModifiable().toUnmodifiable(),
+                DataStream.ofByteBuffer(bodyReadOnlyBuffer));
         new HttpBinding().responseDeserializer()
                 .payloadCodec(CODEC)
                 .payloadMediaType("application/json")
@@ -108,9 +110,14 @@ public class PayloadDeserializerTest {
 
                     @Override
                     public ShapeBuilder<SerializableStruct> deserialize(ShapeDeserializer decoder) {
-                        decoder.readStruct(StringPayloadInput.SCHEMA, value, (AtomicReference<String> state, Schema memberSchema, ShapeDeserializer memberDeserializer) -> {
-                            state.set(memberDeserializer.readString(StringPayloadInput.VALUE));
-                        });
+                        decoder.readStruct(StringPayloadInput.SCHEMA,
+                                value,
+                                (
+                                        AtomicReference<String> state,
+                                        Schema memberSchema,
+                                        ShapeDeserializer memberDeserializer) -> {
+                                    state.set(memberDeserializer.readString(StringPayloadInput.VALUE));
+                                });
                         return this;
                     }
 


### PR DESCRIPTION


### What behavior changes?
Describe the observable difference in behavior before and after this change.

Fixed a bug in deserialising string from a readonly buffer.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc

When an output has a string as a httpPayload

```smithy
@output
structure OperationOutput {
    @httpPayload
    body: String
}
```

deserialization of such response fails with:

```
    software.amazon.smithy.java.client.core.error.TransportException
        Caused by:
        java.nio.ReadOnlyBufferException
            at java.base/java.nio.ByteBuffer.arrayOffset(ByteBuffer.java:1535)
            at software.amazon.smithy.java.http.binding.PayloadDeserializer.readString(PayloadDeserializer.java:123)
```

After debugging it turned out that the buffer passed to the deserializer is readonly thus accessing `arrayOffset` is not possible and results in the error. Applying similar logic as in https://github.com/smithy-lang/smithy-java/blob/4ac99cca61c80cfa21e79fbf65b44470d6514548/io/src/main/java/software/amazon/smithy/java/io/datastream/ByteBufferDataStream.java#L64-L70

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

Added tests, tested on local models.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
