### PR TITLE
Fixed flaky tests when running with UK locale

### DIFF
--- a/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/TimestampCodecTest.java
+++ b/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/TimestampCodecTest.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 class TimestampCodecTest {
 
     private static final DateTimeFormatter HTTP_FORMATTER =
-            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(ZoneOffset.UTC);
+            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'")
+                    .withZone(ZoneOffset.UTC)
+                    .withLocale(Locale.US);
 
     private static Instant parse8601(String s) {
         byte[] buf = s.getBytes(StandardCharsets.US_ASCII);


### PR DESCRIPTION
### What behavior changes?
Describe the observable difference in behavior before and after this change.

No tests failures when running with non-US locale.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

Apparently September has different short versions depending on the locate you're in 😄 To reduce tests flakiness.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

Run tests.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

https://stackoverflow.com/questions/69267710/septembers-short-form-sep-no-longer-parses-in-java-17-in-en-gb-locale

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
