### PR TITLE
Fixed deserialising string/blob payloads when transferred with chunked-encoding

### DIFF
--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializer.java
@@ -235,7 +235,7 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
             if (bb.remaining() > 0) {
                 structMemberConsumer.accept(state, member, payloadCodec.createDeserializer(bb));
             }
-        } else if (body != null && body.contentLength() > 0) {
+        } else if (body != null && body.contentLength() != 0) {
             structMemberConsumer.accept(state, member, new PayloadDeserializer(payloadCodec, body));
         }
     }


### PR DESCRIPTION
Fixes #1291

### What behavior changes?
Describe the observable difference in behavior before and after this change.

Fixed handling string/blob http payloads with chunked encoding.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

Negative (-1) content length is a valid value which indicates that the value just isn't known ahead of time. If a server responds with chunked encoding, the value will not be known ahead of time and it will result in the response being ignored (only when http payloads on string/blob was being used).

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

Run tests, built and test locally.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

I guess it might be possible that whilst the content length is not known ahead of time but it resolves to empty response in the end it might cause some issues?

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
