### PR TITLE
Add cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,45 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+      time: "10:00"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "software.amazon.smithy:smithy-model"
+        - "software.amazon.smithy:smithy-codegen-core"
+        - "software.amazon.smithy:smithy-aws-traits"
+        - "software.amazon.smithy:smithy-protocol-traits"
+        - "software.amazon.smithy:smithy-protocol-test-traits"
+        - "software.amazon.smithy:smithy-aws-protocol-tests"
+        - "software.amazon.smithy:smithy-protocol-tests"
+        - "software.amazon.smithy:smithy-validation-model"
+        - "software.amazon.smithy:smithy-jmespath"
+        - "software.amazon.smithy:smithy-jmespath-tests"
+        - "software.amazon.smithy:smithy-waiters"
+        - "software.amazon.smithy:smithy-utils"
+        - "software.amazon.smithy:smithy-trait-codegen"
+        - "software.amazon.smithy:smithy-rules-engine"
+        - "software.amazon.smithy:smithy-aws-endpoints"
+        - "software.amazon.smithy:smithy-aws-smoke-test-model"
+        - "software.amazon.smithy:smithy-aws-smoke-test-traits"
+        - "software.amazon.awssdk:retries-spi"
+        - "software.amazon.awssdk:retries"
+        - "software.amazon.awssdk:sdk-core"
+        - "software.amazon.awssdk:auth"
     groups:
       gradle:
         update-types:
           - "minor"
           - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
+      time: "10:00"
+    cooldown:
+      default-days: 7
     groups:
       github:
         update-types:


### PR DESCRIPTION
### What behavior changes?
Describe the observable difference in behavior before and after this change.

This adds a cooldown setting to dependabot to have it wait a week before pulling in any given update, excluding the smithy deps. It also sets the time consistently to fire early enough that EU folks see it in the morning.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

Having a cooldown is generally good, if not perfect. But more importantly, GitHub recently set a default cooldown for dependabot of 3 days. We don't want to be waiting for first-party dependencies like the smithy libraries, so having an explicit config that excludes them makes sure we get those updates asap.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

We could do longer. Or configure per-semver-type. But I don't think it's that big of a deal.

### Additional Links
Related issues, design docs, or prior art.

https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
