### PR TITLE
Fix jitter to exclude zero, ensuring non-zero backoff delay

### DIFF
--- a/retries/src/main/java/software/amazon/smithy/java/retries/ExponentialDelayWithJitter.java
+++ b/retries/src/main/java/software/amazon/smithy/java/retries/ExponentialDelayWithJitter.java
@@ -48,8 +48,8 @@ final class ExponentialDelayWithJitter {
         if (delay <= 0) {
             return Duration.ZERO;
         }
-        var jitter = randomSupplier.get().nextDouble();
-        return Duration.ofMillis((long) (jitter * delay));
+        var jitter = 1.0 - randomSupplier.get().nextDouble();
+        return Duration.ofMillis(Math.max(1L, (long) (jitter * delay)));
     }
 
     int calculateExponentialDelay(int attempt) {

--- a/retries/src/test/java/software/amazon/smithy/java/retries/ExponentialDelayWithJitterTest.java
+++ b/retries/src/test/java/software/amazon/smithy/java/retries/ExponentialDelayWithJitterTest.java
@@ -15,9 +15,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ExponentialDelayWithJitterTest {
-    static final ComputedNextDouble MIN_VALUE_RND = new ComputedNextDouble(0.0);
+    // After 1.0 - nextDouble(): 1.0 - 1.0 = 0.0 (min jitter output)
+    static final ComputedNextDouble MIN_VALUE_RND = new ComputedNextDouble(1.0);
     static final ComputedNextDouble MID_VALUE_RND = new ComputedNextDouble(0.5);
-    static final ComputedNextDouble MAX_VALUE_RND = new ComputedNextDouble(1.0);
+    // After 1.0 - nextDouble(): 1.0 - 0.0 = 1.0 (max jitter output)
+    static final ComputedNextDouble MAX_VALUE_RND = new ComputedNextDouble(0.0);
     static final Duration BASE_DELAY = Duration.ofMillis(23);
     static final Duration MAX_DELAY = Duration.ofSeconds(20);
 
@@ -87,7 +89,7 @@ class ExponentialDelayWithJitterTest {
                         .configureRandom(MID_VALUE_RND)
                         .givenAttempt(13)
                         .expectDelayInMs(10000),
-                // --- Using random that returns: 0.0 (no jitter)
+                // --- Using random that returns: 0.0 (min jitter, floor of 1ms)
                 new TestCase()
                         .configureRandom(MIN_VALUE_RND)
                         .givenAttempt(1)
@@ -95,27 +97,27 @@ class ExponentialDelayWithJitterTest {
                 new TestCase()
                         .configureRandom(MIN_VALUE_RND)
                         .givenAttempt(2)
-                        .expectDelayInMs(0),
+                        .expectDelayInMs(1),
                 new TestCase()
                         .configureRandom(MIN_VALUE_RND)
                         .givenAttempt(3)
-                        .expectDelayInMs(0),
+                        .expectDelayInMs(1),
                 new TestCase()
                         .configureRandom(MIN_VALUE_RND)
                         .givenAttempt(5)
-                        .expectDelayInMs(0),
+                        .expectDelayInMs(1),
                 new TestCase()
                         .configureRandom(MIN_VALUE_RND)
                         .givenAttempt(7)
-                        .expectDelayInMs(0),
+                        .expectDelayInMs(1),
                 new TestCase()
                         .configureRandom(MIN_VALUE_RND)
                         .givenAttempt(11)
-                        .expectDelayInMs(0),
+                        .expectDelayInMs(1),
                 new TestCase()
                         .configureRandom(MIN_VALUE_RND)
                         .givenAttempt(13)
-                        .expectDelayInMs(0));
+                        .expectDelayInMs(1));
     }
 
     static class TestCase {

--- a/retries/src/test/java/software/amazon/smithy/java/retries/SepRetryStrategyTest.java
+++ b/retries/src/test/java/software/amazon/smithy/java/retries/SepRetryStrategyTest.java
@@ -26,11 +26,11 @@ import software.amazon.smithy.java.retries.api.TokenAcquisitionFailedException;
  */
 class SepRetryStrategyTest {
 
-    // Fixed jitter that always returns 1.0 (exponential_base: 1)
+    // Fixed jitter that always returns 0.0, so that (1.0 - nextDouble()) = 1.0 (exponential_base: 1)
     private static final Random FIXED_JITTER = new Random() {
         @Override
         public double nextDouble() {
-            return 1.0;
+            return 0.0;
         }
     };
 


### PR DESCRIPTION

### What behavior changes?
Change jitter computation from nextDouble() [0.0, 1.0) to 1.0 - nextDouble() (0.0, 1.0] so that exponential backoff always produces a non-zero delay for attempts > 1. This prevents flaky test failures where jitter could randomly be 0.0 and aligns with the SEP requirement that retries MUST always back off.

### Why is this change needed?
Explain the motivation: bug, feature request, refactor, performance, etc.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
