### PR TITLE
Add maxRetries and retryDelay for jreleaser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,8 @@ jreleaser {
                     active = Active.ALWAYS
                     url = "https://central.sonatype.com/api/v1/publisher"
                     stagingRepository(rootProject.layout.buildDirectory.dir("staging").get().asFile.path)
+                    maxRetries = 100
+                    retryDelay = 60
                 }
             }
         }


### PR DESCRIPTION
Add maxRetries and retryDelay for jreleaser. This is mirroing the setting in [Smithy repo](https://github.com/smithy-lang/smithy/blob/012a454aff0375ed9ce27925755ffaa10341c304/build.gradle.kts#L110) to prevent timeout in new release process.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
