### PR TITLE
Add MCP protocol version 2025-11-25

### DIFF
--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/ProtocolVersion.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/ProtocolVersion.java
@@ -10,7 +10,15 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public abstract sealed class ProtocolVersion implements Comparable<ProtocolVersion>
         permits ProtocolVersion.UnknownVersion, ProtocolVersion.v2024_11_05, ProtocolVersion.v2025_03_26,
-        ProtocolVersion.v2025_06_18 {
+        ProtocolVersion.v2025_06_18, ProtocolVersion.v2025_11_25 {
+    public static final class v2025_11_25 extends ProtocolVersion {
+        public static final v2025_11_25 INSTANCE = new v2025_11_25();
+
+        private v2025_11_25() {
+            super("2025-11-25");
+        }
+    }
+
     public static final class v2025_06_18 extends ProtocolVersion {
         public static final v2025_06_18 INSTANCE = new v2025_06_18();
 
@@ -69,6 +77,7 @@ public abstract sealed class ProtocolVersion implements Comparable<ProtocolVersi
             case "2024-11-05" -> v2024_11_05.INSTANCE;
             case "2025-03-26" -> v2025_03_26.INSTANCE;
             case "2025-06-18" -> v2025_06_18.INSTANCE;
+            case "2025-11-25" -> v2025_11_25.INSTANCE;
             default -> new UnknownVersion(identifier);
         };
     }

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
@@ -117,6 +117,44 @@ public class McpServerTest {
     }
 
     @Test
+    public void initializeWithV2025_11_25ProtocolVersion() {
+        server = McpServer.builder()
+                .name("smithy-mcp-server")
+                .input(input)
+                .output(output)
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
+                .build();
+
+        server.start();
+
+        initializeWithProtocolVersion(ProtocolVersion.v2025_11_25.INSTANCE);
+        write("tools/list", Document.of(Map.of()));
+        var response = read();
+        var tools = response.getResult().asStringMap().get("tools").asList();
+        assertEquals(6, tools.size());
+
+        // 2025-11-25 >= 2025-06-18, so outputSchema must be retained. This is the positive
+        // mirror of noOutputSchemaWithUnsupportedProtocolVersion, which asserts it is stripped.
+        var tool = tools.stream()
+                .filter(t -> t.asStringMap().get("name").asString().equals("NoInputOperation"))
+                .findFirst()
+                .orElseThrow()
+                .asStringMap();
+
+        assertEquals("NoInputOperation", tool.get("name").asString());
+        assertNotNull(tool.get("inputSchema"));
+
+        var outputSchema = tool.get("outputSchema").asStringMap();
+        assertEquals("object", outputSchema.get("type").asString());
+        assertTrue(outputSchema.get("properties").asStringMap().containsKey("outputStr"));
+    }
+
+    @Test
     public void noOutputSchemaWithUnsupportedProtocolVersion() {
         server = McpServer.builder()
                 .name("smithy-mcp-server")

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/ProtocolVersionTest.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/ProtocolVersionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.mcp.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ProtocolVersionTest {
+
+    @Test
+    void knownVersionsResolveCorrectly() {
+        assertInstanceOf(ProtocolVersion.v2024_11_05.class, ProtocolVersion.version("2024-11-05"));
+        assertInstanceOf(ProtocolVersion.v2025_03_26.class, ProtocolVersion.version("2025-03-26"));
+        assertInstanceOf(ProtocolVersion.v2025_06_18.class, ProtocolVersion.version("2025-06-18"));
+        assertInstanceOf(ProtocolVersion.v2025_11_25.class, ProtocolVersion.version("2025-11-25"));
+    }
+
+    @Test
+    void unknownVersionReturnsUnknownVersion() {
+        var version = ProtocolVersion.version("9999-01-01");
+        assertInstanceOf(ProtocolVersion.UnknownVersion.class, version);
+        assertEquals("9999-01-01", version.identifier());
+    }
+
+    @Test
+    void nullVersionResolvesToDefault() {
+        var version = ProtocolVersion.version(null);
+        assertEquals(ProtocolVersion.defaultVersion(), version);
+    }
+
+    @Test
+    void defaultVersionIs2025_03_26() {
+        assertEquals("2025-03-26", ProtocolVersion.defaultVersion().identifier());
+    }
+
+    @Test
+    void compareToOrdersChronologically() {
+        assertTrue(ProtocolVersion.v2024_11_05.INSTANCE.compareTo(ProtocolVersion.v2025_03_26.INSTANCE) < 0);
+        assertTrue(ProtocolVersion.v2025_03_26.INSTANCE.compareTo(ProtocolVersion.v2025_06_18.INSTANCE) < 0);
+        assertTrue(ProtocolVersion.v2025_06_18.INSTANCE.compareTo(ProtocolVersion.v2025_11_25.INSTANCE) < 0);
+        assertEquals(0, ProtocolVersion.v2025_11_25.INSTANCE.compareTo(ProtocolVersion.v2025_11_25.INSTANCE));
+    }
+
+    @Test
+    void knownVersionsRankAboveUnknown() {
+        var unknown = ProtocolVersion.version("0000-00-00");
+        assertTrue(ProtocolVersion.v2024_11_05.INSTANCE.compareTo(unknown) > 0);
+        assertTrue(ProtocolVersion.v2025_11_25.INSTANCE.compareTo(unknown) > 0);
+    }
+}


### PR DESCRIPTION
### What behavior changes?

**Before:** When a client sends `"protocolVersion": "2025-11-25"` in the initialize request, the server treats it as `UnknownVersion` and omits `protocolVersion` from the response (falling back to the builder default `"2024-11-05"`). This breaks the handshake for clients expecting the server to echo back `"2025-11-25"`.

**After:** The server recognizes `"2025-11-25"` as a known version and correctly echoes it back in the initialize response.

### Why is this change needed?

Clients like Claude Code and Cursor have adopted MCP spec version `2025-11-25` and are sending it during initialization. The smithy-java MCP server only recognized versions up to `2025-06-18`, causing initialization failures for these clients. The `2025-11-25` spec uses the same handshake model (initialize → response → initialized) as prior versions, so no protocol-level changes are required beyond accepting the version string.

### How was this validated?

- New `ProtocolVersionTest`: validates version resolution, null handling, ordering, and unknown-version behavior
- New `McpServerTest.initializeWithV2025_11_25ProtocolVersion`: end-to-end test confirming the server echoes the version and serves tools/list after handshake
- All 87 existing tests continue to pass

### What should reviewers focus on?

- `ProtocolVersion.java`: The only production change — adds `v2025_11_25` to the sealed class hierarchy and switch statement. Note that `defaultVersion()` intentionally remains at `v2025_03_26` until the new capabilities (tasks, richer elicitation) are implemented.

### Additional Links

- [MCP spec 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25)
- [MCP versioning docs](https://modelcontextprotocol.io/docs/2026-07-28/learn/versioning)
