### PR TITLE
Escape special characters in JSON field names

### DIFF
--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonWriteUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonWriteUtils.java
@@ -6,8 +6,8 @@
 package software.amazon.smithy.java.json.smithy;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Arrays;
 import software.amazon.smithy.java.codecs.commons.NumberCodec;
 import software.amazon.smithy.java.codecs.commons.TimestampCodec;
 import software.amazon.smithy.java.io.ByteBufferUtils;
@@ -74,7 +74,6 @@ final class JsonWriteUtils {
     /**
      * Writes a JSON quoted string. Returns new position.
      */
-    @SuppressWarnings("deprecation")
     static int writeQuotedString(byte[] buf, int pos, String value) {
         int len = value.length();
         buf[pos++] = '"';
@@ -160,20 +159,8 @@ final class JsonWriteUtils {
         return pos;
     }
 
-    /**
-     * Writes a double value as JSON. Handles integer-valued doubles optimization.
-     * Returns new position.
-     */
-    static int writeDouble(byte[] buf, int pos, double value) {
-        return NumberCodec.writeDouble(buf, pos, value);
-    }
-
     static int writeEpochSeconds(byte[] buf, int pos, long epochSecond, int nano) {
         return TimestampCodec.writeEpochSeconds(buf, pos, epochSecond, nano);
-    }
-
-    static int writeFloat(byte[] buf, int pos, float value) {
-        return NumberCodec.writeFloat(buf, pos, value);
     }
 
     static int writeIso8601Timestamp(byte[] buf, int pos, Instant value) {
@@ -188,16 +175,6 @@ final class JsonWriteUtils {
         pos = TimestampCodec.writeHttpDate(buf, pos, value);
         buf[pos++] = '"';
         return pos;
-    }
-
-    /**
-     * Writes an ASCII string directly to the buffer without quoting.
-     * Used for number-to-string conversions (Double.toString, BigDecimal.toString, etc).
-     */
-    static int writeAsciiString(byte[] buf, int pos, String s) {
-        int len = s.length();
-        s.getBytes(0, len, buf, pos);
-        return pos + len;
     }
 
     /**
@@ -232,18 +209,15 @@ final class JsonWriteUtils {
         return ((dataLen + 2) / 3) * 4 + 2;
     }
 
-    /**
-     * Pre-computes the UTF-8 byte representation of a JSON field name prefix.
-     * The result includes the opening quote, the field name, the closing quote, and the colon.
-     * Example: for field name "foo", returns bytes for {@code "foo":}
-     */
-    static byte[] precomputeFieldNameBytes(String fieldName) {
-        byte[] nameUtf8 = fieldName.getBytes(StandardCharsets.UTF_8);
-        byte[] result = new byte[nameUtf8.length + 3];
-        result[0] = '"';
-        System.arraycopy(nameUtf8, 0, result, 1, nameUtf8.length);
-        result[nameUtf8.length + 1] = '"';
-        result[nameUtf8.length + 2] = ':';
-        return result;
+    /// Computes the UTF-8 byte representation of a JSON field name prefix. The result includes the opening quote, the
+    /// field name, the closing quote, and the colon. Example: for field name "foo", returns bytes for `"foo":`
+    ///
+    /// The name is escaped like any other JSON string. Smithy member names are alphanumeric identifiers, but a
+    /// `@jsonName` trait can carry any character, including `"` and `\\`, which would otherwise emit invalid JSON.
+    static byte[] encodeFieldNameToken(String fieldName) {
+        byte[] scratch = new byte[maxQuotedStringBytes(fieldName) + 1];
+        int pos = writeQuotedString(scratch, 0, fieldName);
+        scratch[pos++] = ':';
+        return Arrays.copyOf(scratch, pos);
     }
 }

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
@@ -575,10 +575,12 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
 
             // Slow path: scan for closing quote and look up member by hash
             int nameStart = -1, nameEnd = -1;
+            boolean escapedName = false;
             if (member == null) {
                 nameStart = p;
                 while (p < localEnd && localBuf[p] != '"') {
                     if (localBuf[p] == '\\') {
+                        escapedName = true;
                         p++; // skip escaped char
                     }
                     p++;
@@ -591,6 +593,13 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
                 p++; // skip closing quote
             }
 
+            // An escaped field name cannot be compared against the lookup table, decode it first.
+            String decodedName = null;
+            if (escapedName) {
+                JsonReadUtils.parseString(localBuf, nameStart - 1, localEnd, this);
+                decodedName = this.parsedString;
+            }
+
             p = JsonReadUtils.skipWhitespace(localBuf, p, localEnd);
             if (p >= localEnd || localBuf[p] != ':') {
                 this.pos = p;
@@ -601,10 +610,13 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
             p = JsonReadUtils.skipWhitespace(localBuf, p, localEnd);
 
             // Slow path member lookup (only when speculative check missed)
-            if (member == null) {
-                member = lookup != null
-                        ? lookup.lookup(localBuf, nameStart, nameEnd, expectedNext)
-                        : null;
+            if (member == null && lookup != null) {
+                if (decodedName != null) {
+                    byte[] nameBytes = decodedName.getBytes(StandardCharsets.UTF_8);
+                    member = lookup.lookup(nameBytes, 0, nameBytes.length, expectedNext);
+                } else {
+                    member = lookup.lookup(localBuf, nameStart, nameEnd, expectedNext);
+                }
                 if (member != null) {
                     expectedNext = member.memberIndex() + 1;
                 }
@@ -627,9 +639,14 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
             } else {
                 // Unknown field -- validate field name bytes per RFC 8259
                 // (control chars, escape sequences). This is the cold path only.
-                validateSkippedString(localBuf, nameStart, nameEnd);
+                String fieldName;
+                if (decodedName != null) {
+                    fieldName = decodedName; // already validated and unescaped by parseString
+                } else {
+                    validateSkippedString(localBuf, nameStart, nameEnd);
+                    fieldName = new String(localBuf, nameStart, nameEnd - nameStart, StandardCharsets.UTF_8);
+                }
                 this.pos = p;
-                String fieldName = new String(localBuf, nameStart, nameEnd - nameStart, StandardCharsets.UTF_8);
 
                 if (schema.type() == ShapeType.STRUCTURE) {
                     structMemberConsumer.unknownMember(state, fieldName);

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonSchemaExtensions.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonSchemaExtensions.java
@@ -65,8 +65,8 @@ public final class SmithyJsonSchemaExtensions
         var jsonNameTrait = schema.getTrait(TraitKey.JSON_NAME_TRAIT);
         String jsonName = jsonNameTrait != null ? jsonNameTrait.getValue() : schema.memberName();
 
-        byte[] jsonNameBytes = JsonWriteUtils.precomputeFieldNameBytes(jsonName);
-        byte[] memberNameBytes = JsonWriteUtils.precomputeFieldNameBytes(schema.memberName());
+        byte[] jsonNameBytes = JsonWriteUtils.encodeFieldNameToken(jsonName);
+        byte[] memberNameBytes = JsonWriteUtils.encodeFieldNameToken(schema.memberName());
 
         return new NativeJsonExtension(jsonNameBytes, memberNameBytes, null, null, null, null);
     }
@@ -92,8 +92,8 @@ public final class SmithyJsonSchemaExtensions
             int idx = m.memberIndex();
             var jsonNameTrait = m.getTrait(TraitKey.JSON_NAME_TRAIT);
             String jsonName = jsonNameTrait != null ? jsonNameTrait.getValue() : m.memberName();
-            jsonFieldNameTable[idx] = JsonWriteUtils.precomputeFieldNameBytes(jsonName);
-            memberFieldNameTable[idx] = JsonWriteUtils.precomputeFieldNameBytes(m.memberName());
+            jsonFieldNameTable[idx] = JsonWriteUtils.encodeFieldNameToken(jsonName);
+            memberFieldNameTable[idx] = JsonWriteUtils.encodeFieldNameToken(m.memberName());
         }
 
         return new NativeJsonExtension(

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
@@ -630,9 +630,7 @@ public class JsonDeserializerTest extends ProviderTestBase {
         Assertions.assertThrows(SerializationException.class, () -> {
             try (var codec = codec(provider)) {
                 var de = codec.createDeserializer(input);
-                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> {
-                    deser.readString(member);
-                });
+                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> deser.readString(member));
             }
         });
     }
@@ -644,9 +642,7 @@ public class JsonDeserializerTest extends ProviderTestBase {
             try (var codec = codec(provider)) {
                 var de = codec.createDeserializer(
                         "{\"x\":00.5,\"name\":\"Sam\"}".getBytes(StandardCharsets.UTF_8));
-                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> {
-                    deser.readString(member);
-                });
+                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> deser.readString(member));
             }
         });
     }
@@ -658,9 +654,7 @@ public class JsonDeserializerTest extends ProviderTestBase {
             try (var codec = codec(provider)) {
                 var de = codec.createDeserializer(
                         "{\"x\":1e2e3,\"name\":\"Sam\"}".getBytes(StandardCharsets.UTF_8));
-                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> {
-                    deser.readString(member);
-                });
+                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> deser.readString(member));
             }
         });
     }
@@ -693,9 +687,7 @@ public class JsonDeserializerTest extends ProviderTestBase {
         Assertions.assertThrows(SerializationException.class, () -> {
             try (var codec = codec(provider)) {
                 var de = codec.createDeserializer(input);
-                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> {
-                    deser.readString(member);
-                });
+                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> deser.readString(member));
             }
         });
     }
@@ -707,11 +699,88 @@ public class JsonDeserializerTest extends ProviderTestBase {
             try (var codec = codec(provider)) {
                 var de = codec.createDeserializer(
                         "{\"a\\eb\":1,\"name\":\"Sam\"}".getBytes(StandardCharsets.UTF_8));
-                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> {
-                    deser.readString(member);
-                });
+                de.readStruct(JsonTestData.BIRD, new LinkedHashSet<>(), (s, member, deser) -> deser.readString(member));
             }
         });
+    }
+
+    @PerProvider
+    public void resolvesEscapedFieldNamesOutOfOrder(JsonSerdeProvider provider) {
+        var json = "{"
+                + "\"héllo\u00e9\":\"e\","
+                + "\"has\\u0001control\":\"d\","
+                + "\"has\\\\slash\":\"b\","
+                + "\"has\\ttab\":\"c\","
+                + "\"has\\\"quote\":\"a\""
+                + "}";
+        Map<String, String> values = new LinkedHashMap<>();
+
+        try (var codec = codecBuilder(provider).useJsonName(true).build()) {
+            codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8))
+                    .readStruct(JsonTestData.ESCAPED_FIELD_NAMES,
+                            values,
+                            (state, member, deser) -> state.put(member.memberName(), deser.readString(member)));
+        }
+
+        assertThat(values,
+                equalTo(Map.of(
+                        "quoted",
+                        "a",
+                        "slashed",
+                        "b",
+                        "tabbed",
+                        "c",
+                        "controlled",
+                        "d",
+                        "unicode",
+                        "e")));
+    }
+
+    @PerProvider
+    public void resolvesGratuitouslyEscapedFieldName(JsonSerdeProvider provider) {
+        var json = "{\"\\u0068as\\\"\\u0071uote\":\"a\"}";
+        Map<String, String> values = new LinkedHashMap<>();
+
+        try (var codec = codecBuilder(provider).useJsonName(true).build()) {
+            codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8))
+                    .readStruct(JsonTestData.ESCAPED_FIELD_NAMES, values, (state, member, deser) -> {
+                        state.put(member.memberName(), deser.readString(member));
+                    });
+        }
+
+        assertThat(values.get("quoted"), equalTo("a"));
+    }
+
+    @PerProvider
+    public void reportsUnknownMemberByDecodedName(JsonSerdeProvider provider) {
+        var json = "{\"un\\tknown\":\"x\",\"has\\\"quote\":\"a\"}";
+        List<String> unknownNames = new ArrayList<>();
+        Map<String, String> values = new LinkedHashMap<>();
+
+        try (var codec = codecBuilder(provider).useJsonName(true).build()) {
+            codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8))
+                    .readStruct(
+                            JsonTestData.ESCAPED_FIELD_NAMES,
+                            values,
+                            new ShapeDeserializer.StructMemberConsumer<>() {
+                                @Override
+                                public void accept(
+                                        Map<String, String> state,
+                                        Schema member,
+                                        ShapeDeserializer deser
+                                ) {
+                                    state.put(member.memberName(), deser.readString(member));
+                                }
+
+                                @Override
+                                public void unknownMember(Map<String, String> state, String memberName) {
+                                    unknownNames.add(memberName);
+                                }
+                            });
+        }
+
+        assertThat(unknownNames, contains("un\tknown"));
+        assertThat(values.get("quoted"), equalTo("a"));
     }
 
     @PerProvider

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
@@ -213,6 +213,46 @@ public class JsonSerializerTest extends ProviderTestBase {
     }
 
     @PerProvider
+    public void escapesSpecialCharactersInFieldNames(JsonSerdeProvider provider) {
+        var value = new SerializableStruct() {
+            @Override
+            public Schema schema() {
+                return JsonTestData.ESCAPED_FIELD_NAMES;
+            }
+
+            @Override
+            public void serializeMembers(ShapeSerializer serializer) {
+                serializer.writeString(schema().member("quoted"), "a");
+                serializer.writeString(schema().member("slashed"), "b");
+                serializer.writeString(schema().member("tabbed"), "c");
+                serializer.writeString(schema().member("controlled"), "d");
+                serializer.writeString(schema().member("unicode"), "e");
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T> T getMemberValue(Schema member) {
+                return (T) switch (member.memberName()) {
+                    case "quoted" -> "a";
+                    case "slashed" -> "b";
+                    case "tabbed" -> "c";
+                    case "controlled" -> "d";
+                    case "unicode" -> "e";
+                    default -> null;
+                };
+            }
+        };
+
+        try (var codec = codecBuilder(provider).useJsonName(true).build()) {
+            var json = StandardCharsets.UTF_8.decode(codec.serialize(value)).toString();
+            assertThat(
+                    json,
+                    equalTo("{\"has\\\"quote\":\"a\",\"has\\\\slash\":\"b\",\"has\\ttab\":\"c\","
+                            + "\"has\\u0001control\":\"d\",\"héllo\u00e9\":\"e\"}"));
+        }
+    }
+
+    @PerProvider
     public void writesNestedStructures(JsonSerdeProvider provider) throws Exception {
         try (var codec = codec(provider); var output = new ByteArrayOutputStream()) {
             try (var serializer = codec.createSerializer(output)) {

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonTestData.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonTestData.java
@@ -22,6 +22,14 @@ public final class JsonTestData {
     static final Schema BIRD_COLOR = BIRD.member("color");
     static final Schema BIRD_NESTED = BIRD.member("nested");
 
+    static final Schema ESCAPED_FIELD_NAMES = Schema.structureBuilder(ShapeId.from("smithy.example#Escaped"))
+            .putMember("quoted", PreludeSchemas.STRING, new JsonNameTrait("has\"quote"))
+            .putMember("slashed", PreludeSchemas.STRING, new JsonNameTrait("has\\slash"))
+            .putMember("tabbed", PreludeSchemas.STRING, new JsonNameTrait("has\ttab"))
+            .putMember("controlled", PreludeSchemas.STRING, new JsonNameTrait("has\u0001control"))
+            .putMember("unicode", PreludeSchemas.STRING, new JsonNameTrait("héllo\u00e9"))
+            .build();
+
     static final ShapeId NESTED_ID = ShapeId.from("smithy.example#Nested");
     static final Schema NESTED = Schema.structureBuilder(NESTED_ID)
             .putMember("number", PreludeSchemas.INTEGER)

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyMemberLookupTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyMemberLookupTest.java
@@ -95,4 +95,11 @@ public class SmithyMemberLookupTest {
         assertThat(lookup(l, "ReadCapacityUnits").memberName()).isEqualTo("ReadCapacityUnits");
         assertThat(lookup(l, "WriteCapacityUnits")).isNull();
     }
+
+    @Test
+    public void encodeFieldNameTokenExactlySizedEscapedFieldName() {
+        var result = JsonWriteUtils.encodeFieldNameToken("\u0001");
+
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("\"\\u0001\":");
+    }
 }


### PR DESCRIPTION
### What behavior changes?

JSON field names are now escaped during serialization, and escaped names are decoded before member lookup during deserialization.

### Why is this change needed?

A `@jsonName` value can contain quotes, backslashes, or other escaped characters. The old path could emit invalid JSON or miss the matching member.

### How was this validated?

Added serializer, deserializer, and member lookup tests for escaped and unknown field names.

### What should reviewers focus on?

The field-name token encoding and the escaped-name lookup slow path.

### Additional Links

Part of stack #1325.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.