### PR TITLE
Reserve exact encoded size when writing JSON strings

### DIFF
--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonWriteUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonWriteUtils.java
@@ -72,9 +72,45 @@ final class JsonWriteUtils {
     }
 
     /**
-     * Writes a JSON quoted string. Returns new position.
+     * Writes a quoted JSON string. Requires {@link #maxQuotedStringBytes} of capacity.
      */
     static int writeQuotedString(byte[] buf, int pos, String value) {
+        int next = tryWriteQuotedAscii(buf, pos, value);
+        return next >= 0 ? next : writeQuotedStringGeneral(buf, pos, value);
+    }
+
+    /**
+     * Writes a quoted string if every char is unescaped ASCII. Returns {@code -1} otherwise.
+     * Requires {@code value.length() + 2} bytes; on rejection, retry from the original position.
+     */
+    static int tryWriteQuotedAscii(byte[] buf, int pos, String value) {
+        int len = value.length();
+        int p = pos;
+        buf[p++] = '"';
+
+        // The JIT auto-vectorizes this loop on JDK 21.
+        //
+        // Note: we cannot use String.getBytes(int,int,byte[],int) + SWAR here because
+        // that method truncates chars >= 0x100 to their low byte, which can produce
+        // valid-looking ASCII bytes (e.g. U+0123 -> 0x23 '#') indistinguishable from
+        // real ASCII via any byte-level check.
+        for (int i = 0; i < len; i++) {
+            char c = value.charAt(i);
+            if (c >= 0x80 || c < 0x20 || c == '"' || c == '\\') {
+                return -1;
+            }
+            buf[p++] = (byte) c;
+        }
+
+        buf[p++] = '"';
+        return p;
+    }
+
+    /**
+     * Writes a JSON quoted string that may need escaping or multi-byte encoding, from scratch.
+     * Requires {@link #maxQuotedStringBytes} of capacity.
+     */
+    static int writeQuotedStringGeneral(byte[] buf, int pos, String value) {
         int len = value.length();
         buf[pos++] = '"';
 
@@ -83,14 +119,7 @@ final class JsonWriteUtils {
             return pos;
         }
 
-        // Single-pass: write safe ASCII chars directly to buf, bail to slow path
-        // on the first char needing escaping or multi-byte UTF-8 encoding.
-        // The JIT auto-vectorizes this loop on JDK 21.
-        //
-        // Note: we cannot use String.getBytes(int,int,byte[],int) + SWAR here because
-        // that method truncates chars >= 0x100 to their low byte, which can produce
-        // valid-looking ASCII bytes (e.g. U+0123 -> 0x23 '#') indistinguishable from
-        // real ASCII via any byte-level check.
+        // Copy the safe ASCII prefix before using the per-char encoder.
         int i = 0;
         for (; i < len; i++) {
             char c = value.charAt(i);

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonSerializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonSerializer.java
@@ -107,6 +107,20 @@ final class SmithyJsonSerializer implements ShapeSerializer {
         buf = Arrays.copyOf(buf, Math.max(buf.length * 2, pos + needed));
     }
 
+    /** Writes with the exact ASCII reservation, widening only when needed. */
+    private void writeQuotedStringExact(String value) {
+        writeQuotedStringExact(value, 0);
+    }
+
+    private void writeQuotedStringExact(String value, int trailingBytes) {
+        int next = JsonWriteUtils.tryWriteQuotedAscii(buf, pos, value);
+        if (next < 0) {
+            ensureCapacity(JsonWriteUtils.maxQuotedStringBytes(value) + trailingBytes);
+            next = JsonWriteUtils.writeQuotedStringGeneral(buf, pos, value);
+        }
+        pos = next;
+    }
+
     @Override
     public void flush() {
         try {
@@ -202,8 +216,8 @@ final class SmithyJsonSerializer implements ShapeSerializer {
 
     @Override
     public void writeString(Schema schema, String value) {
-        ensureCapacity(JsonWriteUtils.maxQuotedStringBytes(value));
-        pos = JsonWriteUtils.writeQuotedString(buf, pos, value);
+        ensureCapacity(value.length() + 2);
+        writeQuotedStringExact(value);
     }
 
     @Override
@@ -486,9 +500,9 @@ final class SmithyJsonSerializer implements ShapeSerializer {
         @Override
         public void writeString(Schema schema, String value) {
             byte[] nameBytes = resolveFieldNameBytes(schema);
-            ensureCapacity(nameBytes.length + 1 + JsonWriteUtils.maxQuotedStringBytes(value));
+            ensureCapacity(nameBytes.length + 1 + value.length() + 2);
             writeFieldNameBytesUnchecked(nameBytes);
-            pos = JsonWriteUtils.writeQuotedString(buf, pos, value);
+            writeQuotedStringExact(value);
         }
 
         @Override
@@ -645,8 +659,8 @@ final class SmithyJsonSerializer implements ShapeSerializer {
                 BiConsumer<T, ShapeSerializer> valueSerializer
         ) {
             writeCommaIfNeeded();
-            ensureCapacity(JsonWriteUtils.maxQuotedStringBytes(key) + 1);
-            pos = JsonWriteUtils.writeQuotedString(buf, pos, key);
+            ensureCapacity(key.length() + 2 + 1);
+            writeQuotedStringExact(key, 1);
             buf[pos++] = ':';
             valueSerializer.accept(state, SmithyJsonSerializer.this);
         }
@@ -671,12 +685,10 @@ final class SmithyJsonSerializer implements ShapeSerializer {
             if (parent.settings.serializeTypeInDocuments()) {
                 parent.needsComma[parent.depth] = true;
                 String typeValue = schema.id().toString();
-                parent.ensureCapacity(JsonWriteUtils.maxQuotedStringBytes("__type")
-                        + 1
-                        + JsonWriteUtils.maxQuotedStringBytes(typeValue));
-                parent.pos = JsonWriteUtils.writeQuotedString(parent.buf, parent.pos, "__type");
+                parent.ensureCapacity("__type".length() + 2 + 1 + typeValue.length() + 2);
+                parent.writeQuotedStringExact("__type");
                 parent.buf[parent.pos++] = ':';
-                parent.pos = JsonWriteUtils.writeQuotedString(parent.buf, parent.pos, typeValue);
+                parent.writeQuotedStringExact(typeValue);
             }
             struct.serializeMembers(parent.structSerializer);
             parent.depth--;

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
@@ -534,6 +534,32 @@ public class JsonSerializerTest extends ProviderTestBase {
         }
     }
 
+    @Test
+    public void smithySerializerHandlesExactStringCapacityBoundary() throws Exception {
+        String value = "x".repeat(8191);
+        try (var codec = codec(SMITHY); var output = new ByteArrayOutputStream()) {
+            try (var serializer = codec.createSerializer(output)) {
+                serializer.writeString(PreludeSchemas.STRING, value);
+            }
+            var de = codec.createDeserializer(output.toByteArray());
+            assertThat(de.readString(PreludeSchemas.STRING), equalTo(value));
+        }
+    }
+
+    @Test
+    public void smithySerializerReservesColonAfterWidenedMapKey() throws Exception {
+        String key = "\u0000".repeat(5000);
+        Document value = Document.of(Map.of(key, Document.of("value")));
+
+        try (var codec = codec(SMITHY); var output = new ByteArrayOutputStream()) {
+            try (var serializer = codec.createSerializer(output)) {
+                serializer.writeDocument(PreludeSchemas.DOCUMENT, value);
+            }
+            var result = codec.createDeserializer(output.toByteArray()).readDocument();
+            assertThat(result.asStringMap().get(key).asString(), equalTo("value"));
+        }
+    }
+
     @PerProvider
     public void doubleSerializationRoundtrips(JsonSerdeProvider provider) throws Exception {
         for (double v : new double[] {0.0, 1.0, -1.0, 3.14, 1e100, Double.MIN_VALUE, Double.MAX_VALUE}) {

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/JsonWriteUtilsTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/JsonWriteUtilsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class JsonWriteUtilsTest {
+
+    private static final byte FILL = (byte) 0xEE;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "a", "plain ASCII 123", "\u007f"})
+    public void acceptedStringFitsExactReservationAtAnyOffset(String value) {
+        for (int pos = 0; pos <= 8; pos++) {
+            var buf = new byte[pos + value.length() + 2];
+            Arrays.fill(buf, FILL);
+
+            int end = JsonWriteUtils.tryWriteQuotedAscii(buf, pos, value);
+
+            assertThat(end).isEqualTo(buf.length);
+            assertThat(new String(buf, pos, value.length() + 2, StandardCharsets.UTF_8))
+                    .isEqualTo('"' + value + '"');
+            for (int i = 0; i < pos; i++) {
+                assertThat(buf[i]).isEqualTo(FILL);
+            }
+        }
+    }
+
+    @Test
+    public void acceptsExactlySingleByteUnescapedCharacters() {
+        for (char c = 0; c < 0x200; c++) {
+            boolean expectAccept = c >= 0x20 && c < 0x80 && c != '"' && c != '\\';
+            var buf = new byte[3];
+
+            int end = JsonWriteUtils.tryWriteQuotedAscii(buf, 0, String.valueOf(c));
+
+            assertThat(end >= 0)
+                    .as("U+%04X should %s", (int) c, expectAccept ? "be accepted" : "be rejected")
+                    .isEqualTo(expectAccept);
+            if (expectAccept) {
+                assertThat(end).isEqualTo(3);
+                assertThat(buf[1]).isEqualTo((byte) c);
+            }
+        }
+    }
+
+    @Test
+    public void rejectionStaysInsideExactReservation() {
+        for (char bad : rejectingChars()) {
+            String value = "abc" + bad;
+            int pos = 5;
+            var buf = new byte[pos + value.length() + 2];
+            Arrays.fill(buf, FILL);
+
+            int end = JsonWriteUtils.tryWriteQuotedAscii(buf, pos, value);
+
+            assertThat(end).as("char U+%04X", (int) bad).isEqualTo(-1);
+            for (int i = pos + value.length(); i < buf.length; i++) {
+                assertThat(buf[i]).as("byte %d after rejection", i).isEqualTo(FILL);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("hostileStrings")
+    public void generalPathRewritesFromOriginalPosition(String value, String expectedJson) {
+        int pos = 5;
+        var exact = new byte[pos + value.length() + 2];
+        Arrays.fill(exact, FILL);
+        assertThat(JsonWriteUtils.tryWriteQuotedAscii(exact, pos, value)).isEqualTo(-1);
+
+        var widened = Arrays.copyOf(exact, pos + JsonWriteUtils.maxQuotedStringBytes(value));
+        int end = JsonWriteUtils.writeQuotedStringGeneral(widened, pos, value);
+
+        assertThat(new String(widened, pos, end - pos, StandardCharsets.UTF_8)).isEqualTo(expectedJson);
+        assertThat(widened[pos - 1]).isEqualTo(FILL);
+    }
+
+    @ParameterizedTest
+    @MethodSource("fieldNameTokens")
+    public void encodesFieldNameToken(String fieldName, String expectedJson) {
+        assertThat(new String(JsonWriteUtils.encodeFieldNameToken(fieldName), StandardCharsets.UTF_8))
+                .isEqualTo(expectedJson);
+    }
+
+    private static List<Character> rejectingChars() {
+        return List.of(
+                '"',
+                '\\',
+                '\n',
+                '\0',
+                '\u001f',
+                '\u0080',
+                '\u00e9',
+                '\u20ac',
+                '\uffff',
+                '\ud83d');
+    }
+
+    static List<Arguments> hostileStrings() {
+        return List.of(
+                Arguments.of("\"", "\"\\\"\""),
+                Arguments.of("\0", "\"\\u0000\""),
+                Arguments.of("\u00e9", "\"\u00e9\""),
+                Arguments.of("\ud83d\ude00", "\"\ud83d\ude00\""),
+                Arguments.of("\ud83d", "\"\\ud83d\""),
+                Arguments.of("abc\"", "\"abc\\\"\""),
+                Arguments.of("a".repeat(200) + "\"", "\"" + "a".repeat(200) + "\\\"\""));
+    }
+
+    static List<Arguments> fieldNameTokens() {
+        return List.of(
+                Arguments.of("plain", "\"plain\":"),
+                Arguments.of("\u0001", "\"\\u0001\":"));
+    }
+}

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyMemberLookupTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyMemberLookupTest.java
@@ -96,10 +96,4 @@ public class SmithyMemberLookupTest {
         assertThat(lookup(l, "WriteCapacityUnits")).isNull();
     }
 
-    @Test
-    public void encodeFieldNameTokenExactlySizedEscapedFieldName() {
-        var result = JsonWriteUtils.encodeFieldNameToken("\u0001");
-
-        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("\"\\u0001\":");
-    }
 }


### PR DESCRIPTION
### What behavior changes?

JSON output is unchanged. The serializer now reserves the exact ASCII size first and grows only when escaping or UTF-8 expansion is needed.

### Why is this change needed?

Most strings are plain ASCII, so reserving the worst-case size does extra allocation work on the common path.

### How was this validated?

Added focused `JsonWriteUtils` and serializer tests for ASCII, escaping, UTF-8, and buffer growth.

### What should reviewers focus on?

The fast-path retry contract and capacity calculations around `writeQuotedStringExact`.

### Additional Links

Part of stack #1325.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.