### PR TITLE
Inline generated builder presence tracking

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureGenerator.java
@@ -652,6 +652,10 @@ public final class StructureGenerator<
     }
 
     private static final class StructureBuilderGenerator extends BuilderGenerator {
+        private static final int INLINE_PRESENCE_LIMIT = Long.SIZE;
+        private final List<MemberShape> requiredMembers;
+        private final boolean usesInlinePresence;
+        private final long requiredMask;
 
         StructureBuilderGenerator(
                 JavaWriter writer,
@@ -661,6 +665,17 @@ public final class StructureGenerator<
                 Map<ShapeId, String> renames
         ) {
             super(writer, shape, symbolProvider, model, renames);
+            this.requiredMembers = shape.members()
+                    .stream()
+                    .filter(CodegenUtils::isRequiredWithNoDefault)
+                    .toList();
+            this.usesInlinePresence = !requiredMembers.isEmpty()
+                    && requiredMembers.size() <= INLINE_PRESENCE_LIMIT;
+            this.requiredMask = usesInlinePresence
+                    ? requiredMembers.size() == Long.SIZE
+                            ? -1L
+                            : (1L << requiredMembers.size()) - 1L
+                    : 0L;
         }
 
         // Required shapes marked with clientOptional should not be required to create the type. For these shapes,
@@ -681,9 +696,7 @@ public final class StructureGenerator<
                 writer.openBlock("private Builder() {", "}", () -> {
                     writer.write("// Tell the tracker to assume clientOptional members are present.");
                     for (var member : requiredClientOptional) {
-                        var memberName = symbolProvider.toMemberName(member);
-                        var schemaName = CodegenUtils.toMemberSchemaName(memberName);
-                        writer.write("tracker.setMember($L);", schemaName);
+                        writeSetMember(writer, member);
                     }
                 });
             }
@@ -700,13 +713,14 @@ public final class StructureGenerator<
                     """
                             @Override
                             public ${sdkShapeBuilder:T}<${shape:T}> errorCorrection() {
-                                if (tracker.allSet()) {
+                                if ($C) {
                                     return this;
                                 }
                                 ${C|}
                                 return this;
                             }
                             """,
+                    writer.consumer(this::writeAllRequiredSet),
                     writer.consumer(this::writeErrorCorrectionMembers));
         }
 
@@ -716,11 +730,10 @@ public final class StructureGenerator<
                 var target = model.expectShape(member.getTarget());
                 if (CodegenUtils.isRequiredWithNoDefault(member)) {
                     var memberName = symbolProvider.toMemberName(member);
-                    var schemaName = CodegenUtils.toMemberSchemaName(memberName);
                     visitor.memberShape = member;
-                    writer.openBlock("if (!tracker.checkMember($L)) {", "}", schemaName, () -> {
+                    writer.openBlock("if ($C) {", "}", writer.consumer(w -> writeMemberNotSet(w, member)), () -> {
                         if (assumeShapeHasErrorCorrectedDefault(target, member, symbolProvider, model)) {
-                            writer.write("tracker.setMember($1L);", schemaName);
+                            writeSetMember(writer, member);
                         } else {
                             writer.write("$L($C);", memberName, visitor);
                         }
@@ -860,8 +873,12 @@ public final class StructureGenerator<
 
             // Add presence tracker if any members are required by validation.
             if (shape.members().stream().anyMatch(CodegenUtils::isRequiredWithNoDefault)) {
-                writer.putContext("tracker", PresenceTracker.class);
-                writer.write("private final ${tracker:T} tracker = ${tracker:T}.of($$SCHEMA);");
+                if (usesInlinePresence()) {
+                    writer.write("private long $$setMembers;");
+                } else {
+                    writer.putContext("tracker", PresenceTracker.class);
+                    writer.write("private final ${tracker:T} tracker = ${tracker:T}.of($$SCHEMA);");
+                }
             }
 
             // Add non-static builder properties
@@ -903,12 +920,13 @@ public final class StructureGenerator<
                 writer.putContext("check", CodegenUtils.requiresSetterNullCheck(symbolProvider, member));
                 writer.putContext("isNullable", CodegenUtils.isNullableMember(model, member));
                 writer.putContext("schemaName", CodegenUtils.toMemberSchemaName(symbolProvider.toMemberName(member)));
+                writer.putContext("setPresence", writer.consumer(w -> writeSetMember(w, member)));
 
                 writer.write(
                         """
                                 public Builder ${memberName:L}(${?isNullable}${memberSymbol:N}${/isNullable}${^isNullable}${memberSymbol:T}${/isNullable} ${memberName:L}) {
                                     this.${memberName:L} = ${?check}${objects:T}.requireNonNull(${/check}${memberName:L}${?check}, "${memberName:L} cannot be null")${/check};${?tracked}
-                                    tracker.setMember(${schemaName:L});${/tracked}
+                                    ${setPresence:C|}${/tracked}
                                     return this;
                                 }
                                 """);
@@ -937,18 +955,66 @@ public final class StructureGenerator<
 
         @Override
         protected void generateBuild(JavaWriter writer) {
-            writer.pushState();
-            writer.putContext(
-                    "hasRequiredMembers",
-                    shape.members().stream().anyMatch(CodegenUtils::isRequiredWithNoDefault));
-            writer.write("""
-                    @Override
-                    public ${shape:T} build() {${?hasRequiredMembers}
-                        tracker.validate();${/hasRequiredMembers}
-                        return new ${shape:T}(this);
+            writer.openBlock("@Override\npublic ${shape:T} build() {", "}", () -> {
+                if (!requiredMembers.isEmpty()) {
+                    if (usesInlinePresence()) {
+                        writer.openBlock("if ($$setMembers != $L) {", "}", requiredMaskLiteral(), () -> {
+                            writer.write(
+                                    "$T.validateRequiredMembers($$SCHEMA, $$setMembers);",
+                                    PresenceTracker.class);
+                        });
+                    } else {
+                        writer.write("tracker.validate();");
                     }
-                    """);
-            writer.popState();
+                }
+                writer.write("return new ${shape:T}(this);");
+            });
+        }
+
+        private boolean usesInlinePresence() {
+            return usesInlinePresence;
+        }
+
+        private String requiredMaskLiteral() {
+            return longLiteral(requiredMask);
+        }
+
+        private String memberBitLiteral(MemberShape member) {
+            var index = requiredMembers.indexOf(member);
+            if (index < 0) {
+                throw new IllegalArgumentException("Member is not required by validation: " + member.getId());
+            }
+            return longLiteral(1L << index);
+        }
+
+        private static String longLiteral(long value) {
+            return "0x" + Long.toUnsignedString(value, 16) + "L";
+        }
+
+        private void writeSetMember(JavaWriter writer, MemberShape member) {
+            if (usesInlinePresence()) {
+                writer.write("$$setMembers |= $L;", memberBitLiteral(member));
+            } else {
+                var memberName = symbolProvider.toMemberName(member);
+                writer.write("tracker.setMember($L);", CodegenUtils.toMemberSchemaName(memberName));
+            }
+        }
+
+        private void writeMemberNotSet(JavaWriter writer, MemberShape member) {
+            if (usesInlinePresence()) {
+                writer.writeInline("($$setMembers & $L) == 0L", memberBitLiteral(member));
+            } else {
+                var memberName = symbolProvider.toMemberName(member);
+                writer.writeInline("!tracker.checkMember($L)", CodegenUtils.toMemberSchemaName(memberName));
+            }
+        }
+
+        private void writeAllRequiredSet(JavaWriter writer) {
+            if (usesInlinePresence()) {
+                writer.writeInline("$$setMembers == $L", requiredMaskLiteral());
+            } else {
+                writer.writeInline("tracker.allSet()");
+            }
         }
 
         /**

--- a/codegen/codegen-plugin/src/it/java/software/amazon/smithy/java/codegen/types/RequiredMemberValidationTest.java
+++ b/codegen/codegen-plugin/src/it/java/software/amazon/smithy/java/codegen/types/RequiredMemberValidationTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import smithy.java.codegen.types.test.model.ClientOptionalRequiredMembers;
+import smithy.java.codegen.types.test.model.InterleavedRequiredMembers;
+import smithy.java.codegen.types.test.model.RequiredMembers64;
+import smithy.java.codegen.types.test.model.RequiredMembers65;
+import smithy.java.codegen.types.test.model.RequiredWithDefaultMember;
+import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.SerializationException;
+import software.amazon.smithy.java.json.JsonCodec;
+
+/**
+ * Generated builders track which required members have been set in a {@code long} bitmask when a
+ * shape has 64 or fewer of them, and fall back to {@code PresenceTracker} above that.
+ *
+ * <p>The bit a member gets is its position among the <em>required</em> members, which is what these
+ * tests are really about: nothing in the generated source tells you whether two members ended up
+ * sharing a bit, or whether an optional member consumed one. Both show up here as a build that
+ * either accepts an incomplete shape or names the wrong member as missing.
+ */
+public class RequiredMemberValidationTest {
+
+    private static final JsonCodec CODEC = JsonCodec.builder().build();
+
+    /** Optional members sit between the required ones and must not take bits of their own. */
+    @Test
+    void buildsWhenEveryRequiredMemberIsSet() {
+        var shape = InterleavedRequiredMembers.builder()
+                .requiredA("a")
+                .requiredB("b")
+                .requiredC("c")
+                .build();
+
+        assertThat(shape.getRequiredA()).isEqualTo("a");
+        assertThat(shape.getRequiredB()).isEqualTo("b");
+        assertThat(shape.getRequiredC()).isEqualTo("c");
+        assertThat(shape.getOptionalA()).isNull();
+    }
+
+    /** Setting the optional members alone leaves every required one missing. */
+    @Test
+    void namesEveryMissingRequiredMember() {
+        var builder = InterleavedRequiredMembers.builder().optionalA("a").optionalB("b").optionalC("c");
+
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(SerializationException.class)
+                .hasMessage("Missing required members: [requiredA, requiredB, requiredC]");
+    }
+
+    /**
+     * All but one required member set. If two members shared a bit this would build without
+     * complaint; if the bits were assigned over all members rather than the required ones, the
+     * mask would never be reached and the wrong name would come back.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"requiredA", "requiredB", "requiredC"})
+    void namesOnlyTheMissingRequiredMember(String omitted) {
+        var builder = InterleavedRequiredMembers.builder();
+        if (!omitted.equals("requiredA")) {
+            builder.requiredA("a");
+        }
+        if (!omitted.equals("requiredB")) {
+            builder.requiredB("b");
+        }
+        if (!omitted.equals("requiredC")) {
+            builder.requiredC("c");
+        }
+
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(SerializationException.class)
+                .hasMessage("Missing required members: [" + omitted + "]");
+    }
+
+    /** Presence is a bit, not a count: setting a member twice is the same as setting it once. */
+    @Test
+    void toleratesSettingTheSameMemberTwice() {
+        var shape = InterleavedRequiredMembers.builder()
+                .requiredA("first")
+                .requiredA("second")
+                .requiredB("b")
+                .requiredC("c")
+                .build();
+
+        assertThat(shape.getRequiredA()).isEqualTo("second");
+    }
+
+    /** A required member with a default is not validated, so it must not take a bit either. */
+    @Test
+    void requiredMemberWithDefaultIsNotValidated() {
+        var shape = RequiredWithDefaultMember.builder().plain("p").build();
+
+        assertThat(shape.getPlain()).isEqualTo("p");
+        assertThat(shape.getWithDefault()).isEqualTo("d");
+        assertThatThrownBy(() -> RequiredWithDefaultMember.builder().withDefault("x").build())
+                .isInstanceOf(SerializationException.class)
+                .hasMessage("Missing required members: [plain]");
+    }
+
+    /** A required clientOptional member is marked present by the builder's constructor. */
+    @Test
+    void clientOptionalRequiredMemberIsAssumedPresent() {
+        var shape = ClientOptionalRequiredMembers.builder().strict("s").build();
+
+        assertThat(shape.getStrict()).isEqualTo("s");
+        assertThat(shape.getLenient()).isNull();
+        assertThatThrownBy(() -> ClientOptionalRequiredMembers.builder().build())
+                .isInstanceOf(SerializationException.class)
+                .hasMessage("Missing required members: [strict]");
+    }
+
+    /**
+     * 64 required members is the largest count that still uses the inline mask, so it is the only
+     * one that exercises the highest bit and the all-ones mask.
+     */
+    @Test
+    void buildsWithAll64RequiredMembersSet() {
+        var shape = strictBuild(RequiredMembers64.builder(), json(64, -1));
+
+        assertThat(shape.getM0()).isEqualTo("v0");
+        assertThat(shape.getM63()).isEqualTo("v63");
+    }
+
+    /**
+     * Every member of the 64-member shape, omitted in turn. This is the sweep that would catch a
+     * duplicated bit anywhere in the mask, including bit 63.
+     */
+    @ParameterizedTest
+    @MethodSource("indexesOf64")
+    void namesTheOneMissingMemberOf64(int omitted) {
+        assertThatThrownBy(() -> strictBuild(RequiredMembers64.builder(), json(64, omitted)))
+                .isInstanceOf(SerializationException.class)
+                .hasMessage("Missing required members: [m" + omitted + "]");
+    }
+
+    /**
+     * The same sweep through {@code errorCorrection()}, which reads the bits one at a time rather
+     * than comparing the whole mask. Only the omitted member may be filled in: a wrong bit there
+     * either leaves it unset (and {@code build()} throws) or overwrites a member that was present.
+     */
+    @ParameterizedTest
+    @MethodSource("indexesOf64")
+    void errorCorrectionFillsInOnlyTheMissingMemberOf64(int omitted) {
+        var shape = CODEC.deserializeShape(json(64, omitted), RequiredMembers64.builder());
+
+        assertEachMemberIs(shape, 64, omitted);
+    }
+
+    static Stream<Integer> indexesOf64() {
+        return IntStream.range(0, 64).boxed();
+    }
+
+    /** One member past the inline limit falls back to the tracker, which must behave the same. */
+    @Test
+    void buildsWithAll65RequiredMembersSet() {
+        var shape = strictBuild(RequiredMembers65.builder(), json(65, -1));
+
+        assertThat(shape.getM0()).isEqualTo("v0");
+        assertThat(shape.getM64()).isEqualTo("v64");
+    }
+
+    /** Every member holds its parsed value except {@code omitted}, which error correction blanked. */
+    private static void assertEachMemberIs(SerializableStruct shape, int count, int omitted) {
+        for (int i = 0; i < count; i++) {
+            String value = shape.getMemberValue(shape.schema().member("m" + i));
+            assertThat(value).as("m%d", i).isEqualTo(i == omitted ? "" : "v" + i);
+        }
+    }
+
+    /** Builds without the error correction {@link Codec#deserializeShape} applies. */
+    private static <T extends SerializableShape> T strictBuild(ShapeBuilder<T> builder, byte[] json) {
+        return builder.deserialize(CODEC.createDeserializer(json)).build();
+    }
+
+    /** JSON for {@code count} members named {@code m0..} with the one at {@code omitted} left out. */
+    private static byte[] json(int count, int omitted) {
+        var sb = new StringBuilder("{");
+        for (int i = 0; i < count; i++) {
+            if (i == omitted) {
+                continue;
+            }
+            if (sb.length() > 1) {
+                sb.append(',');
+            }
+            sb.append("\"m").append(i).append("\":\"v").append(i).append('"');
+        }
+        return sb.append('}').toString().getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/codegen/codegen-plugin/src/it/resources/META-INF/smithy/manifest
+++ b/codegen/codegen-plugin/src/it/resources/META-INF/smithy/manifest
@@ -58,3 +58,4 @@ bdd-test.smithy
 a.smithy
 b.smithy
 nested/c.smithy
+required-members.smithy

--- a/codegen/codegen-plugin/src/it/resources/META-INF/smithy/required-members.smithy
+++ b/codegen/codegen-plugin/src/it/resources/META-INF/smithy/required-members.smithy
@@ -1,0 +1,437 @@
+$version: "2.0"
+
+namespace smithy.java.codegen.types.test
+
+/// Three required members with optional ones interleaved between them. Bits are assigned by
+/// position among the *required* members only, so the optional members must not consume any.
+structure InterleavedRequiredMembers {
+    optionalA: String
+
+    @required
+    requiredA: String
+
+    optionalB: String
+
+    @required
+    requiredB: String
+
+    optionalC: String
+
+    @required
+    requiredC: String
+}
+
+/// A required member that has a default is not validated, so it must not take a bit either.
+structure RequiredWithDefaultMember {
+    @required
+    @default("d")
+    withDefault: String
+
+    @required
+    plain: String
+}
+
+/// A required member that is also clientOptional is assumed present from construction.
+structure ClientOptionalRequiredMembers {
+    @required
+    @clientOptional
+    lenient: String
+
+    @required
+    strict: String
+}
+
+/// Exactly 64 required members: the most that still fit in a long, and the only size that
+/// exercises the highest bit and the all-ones mask.
+structure RequiredMembers64 {
+    @required
+    m0: String
+
+    @required
+    m1: String
+
+    @required
+    m2: String
+
+    @required
+    m3: String
+
+    @required
+    m4: String
+
+    @required
+    m5: String
+
+    @required
+    m6: String
+
+    @required
+    m7: String
+
+    @required
+    m8: String
+
+    @required
+    m9: String
+
+    @required
+    m10: String
+
+    @required
+    m11: String
+
+    @required
+    m12: String
+
+    @required
+    m13: String
+
+    @required
+    m14: String
+
+    @required
+    m15: String
+
+    @required
+    m16: String
+
+    @required
+    m17: String
+
+    @required
+    m18: String
+
+    @required
+    m19: String
+
+    @required
+    m20: String
+
+    @required
+    m21: String
+
+    @required
+    m22: String
+
+    @required
+    m23: String
+
+    @required
+    m24: String
+
+    @required
+    m25: String
+
+    @required
+    m26: String
+
+    @required
+    m27: String
+
+    @required
+    m28: String
+
+    @required
+    m29: String
+
+    @required
+    m30: String
+
+    @required
+    m31: String
+
+    @required
+    m32: String
+
+    @required
+    m33: String
+
+    @required
+    m34: String
+
+    @required
+    m35: String
+
+    @required
+    m36: String
+
+    @required
+    m37: String
+
+    @required
+    m38: String
+
+    @required
+    m39: String
+
+    @required
+    m40: String
+
+    @required
+    m41: String
+
+    @required
+    m42: String
+
+    @required
+    m43: String
+
+    @required
+    m44: String
+
+    @required
+    m45: String
+
+    @required
+    m46: String
+
+    @required
+    m47: String
+
+    @required
+    m48: String
+
+    @required
+    m49: String
+
+    @required
+    m50: String
+
+    @required
+    m51: String
+
+    @required
+    m52: String
+
+    @required
+    m53: String
+
+    @required
+    m54: String
+
+    @required
+    m55: String
+
+    @required
+    m56: String
+
+    @required
+    m57: String
+
+    @required
+    m58: String
+
+    @required
+    m59: String
+
+    @required
+    m60: String
+
+    @required
+    m61: String
+
+    @required
+    m62: String
+
+    @required
+    m63: String
+}
+
+/// One required member more than fits in a long, so this falls back to PresenceTracker.
+/// It exists to check that the fallback behaves exactly like the inline mask.
+structure RequiredMembers65 {
+    @required
+    m0: String
+
+    @required
+    m1: String
+
+    @required
+    m2: String
+
+    @required
+    m3: String
+
+    @required
+    m4: String
+
+    @required
+    m5: String
+
+    @required
+    m6: String
+
+    @required
+    m7: String
+
+    @required
+    m8: String
+
+    @required
+    m9: String
+
+    @required
+    m10: String
+
+    @required
+    m11: String
+
+    @required
+    m12: String
+
+    @required
+    m13: String
+
+    @required
+    m14: String
+
+    @required
+    m15: String
+
+    @required
+    m16: String
+
+    @required
+    m17: String
+
+    @required
+    m18: String
+
+    @required
+    m19: String
+
+    @required
+    m20: String
+
+    @required
+    m21: String
+
+    @required
+    m22: String
+
+    @required
+    m23: String
+
+    @required
+    m24: String
+
+    @required
+    m25: String
+
+    @required
+    m26: String
+
+    @required
+    m27: String
+
+    @required
+    m28: String
+
+    @required
+    m29: String
+
+    @required
+    m30: String
+
+    @required
+    m31: String
+
+    @required
+    m32: String
+
+    @required
+    m33: String
+
+    @required
+    m34: String
+
+    @required
+    m35: String
+
+    @required
+    m36: String
+
+    @required
+    m37: String
+
+    @required
+    m38: String
+
+    @required
+    m39: String
+
+    @required
+    m40: String
+
+    @required
+    m41: String
+
+    @required
+    m42: String
+
+    @required
+    m43: String
+
+    @required
+    m44: String
+
+    @required
+    m45: String
+
+    @required
+    m46: String
+
+    @required
+    m47: String
+
+    @required
+    m48: String
+
+    @required
+    m49: String
+
+    @required
+    m50: String
+
+    @required
+    m51: String
+
+    @required
+    m52: String
+
+    @required
+    m53: String
+
+    @required
+    m54: String
+
+    @required
+    m55: String
+
+    @required
+    m56: String
+
+    @required
+    m57: String
+
+    @required
+    m58: String
+
+    @required
+    m59: String
+
+    @required
+    m60: String
+
+    @required
+    m61: String
+
+    @required
+    m62: String
+
+    @required
+    m63: String
+
+    @required
+    m64: String
+}

--- a/codegen/codegen-plugin/src/jmh/java/software/amazon/smithy/java/codegen/BuilderPresenceBench.java
+++ b/codegen/codegen-plugin/src/jmh/java/software/amazon/smithy/java/codegen/BuilderPresenceBench.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codegen;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import smithy.java.codegen.types.test.model.InterleavedRequiredMembers;
+import smithy.java.codegen.types.test.model.RequiredMembers64;
+import smithy.java.codegen.types.test.model.RequiredMembers65;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+@Fork(1)
+public class BuilderPresenceBench {
+
+    private static final String V = "v";
+
+    /** Three required members, the common shape size. */
+    @Benchmark
+    public InterleavedRequiredMembers few() {
+        return InterleavedRequiredMembers.builder()
+                .requiredA(V)
+                .requiredB(V)
+                .requiredC(V)
+                .build();
+    }
+
+    /** 64 required members: the largest shape that tracks presence in a long. */
+    @Benchmark
+    public RequiredMembers64 mask64() {
+        return RequiredMembers64.builder()
+                .m0(V)
+                .m1(V)
+                .m2(V)
+                .m3(V)
+                .m4(V)
+                .m5(V)
+                .m6(V)
+                .m7(V)
+                .m8(V)
+                .m9(V)
+                .m10(V)
+                .m11(V)
+                .m12(V)
+                .m13(V)
+                .m14(V)
+                .m15(V)
+                .m16(V)
+                .m17(V)
+                .m18(V)
+                .m19(V)
+                .m20(V)
+                .m21(V)
+                .m22(V)
+                .m23(V)
+                .m24(V)
+                .m25(V)
+                .m26(V)
+                .m27(V)
+                .m28(V)
+                .m29(V)
+                .m30(V)
+                .m31(V)
+                .m32(V)
+                .m33(V)
+                .m34(V)
+                .m35(V)
+                .m36(V)
+                .m37(V)
+                .m38(V)
+                .m39(V)
+                .m40(V)
+                .m41(V)
+                .m42(V)
+                .m43(V)
+                .m44(V)
+                .m45(V)
+                .m46(V)
+                .m47(V)
+                .m48(V)
+                .m49(V)
+                .m50(V)
+                .m51(V)
+                .m52(V)
+                .m53(V)
+                .m54(V)
+                .m55(V)
+                .m56(V)
+                .m57(V)
+                .m58(V)
+                .m59(V)
+                .m60(V)
+                .m61(V)
+                .m62(V)
+                .m63(V)
+                .build();
+    }
+
+    /** 65 required members: the smallest shape that falls back to a PresenceTracker. */
+    @Benchmark
+    public RequiredMembers65 tracker65() {
+        return RequiredMembers65.builder()
+                .m0(V)
+                .m1(V)
+                .m2(V)
+                .m3(V)
+                .m4(V)
+                .m5(V)
+                .m6(V)
+                .m7(V)
+                .m8(V)
+                .m9(V)
+                .m10(V)
+                .m11(V)
+                .m12(V)
+                .m13(V)
+                .m14(V)
+                .m15(V)
+                .m16(V)
+                .m17(V)
+                .m18(V)
+                .m19(V)
+                .m20(V)
+                .m21(V)
+                .m22(V)
+                .m23(V)
+                .m24(V)
+                .m25(V)
+                .m26(V)
+                .m27(V)
+                .m28(V)
+                .m29(V)
+                .m30(V)
+                .m31(V)
+                .m32(V)
+                .m33(V)
+                .m34(V)
+                .m35(V)
+                .m36(V)
+                .m37(V)
+                .m38(V)
+                .m39(V)
+                .m40(V)
+                .m41(V)
+                .m42(V)
+                .m43(V)
+                .m44(V)
+                .m45(V)
+                .m46(V)
+                .m47(V)
+                .m48(V)
+                .m49(V)
+                .m50(V)
+                .m51(V)
+                .m52(V)
+                .m53(V)
+                .m54(V)
+                .m55(V)
+                .m56(V)
+                .m57(V)
+                .m58(V)
+                .m59(V)
+                .m60(V)
+                .m61(V)
+                .m62(V)
+                .m63(V)
+                .m64(V)
+                .build();
+    }
+}

--- a/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
+++ b/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/integrations/javadoc/JavadocIntegrationTest.java
@@ -247,7 +247,7 @@ public class JavadocIntegrationTest extends AbstractCodegenFileTest {
                                  */
                                 public Builder required(String required) {
                                     this.required = Objects.requireNonNull(required, "required cannot be null");
-                                    tracker.setMember($SCHEMA_REQUIRED);
+                                    $setMembers |= 0x1L;
                                     return this;
                                 }
                         """));

--- a/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/types/CodegenTest.java
+++ b/codegen/codegen-plugin/src/test/java/software/amazon/smithy/java/codegen/types/CodegenTest.java
@@ -171,4 +171,85 @@ public class CodegenTest {
                 .hasMessageContaining("cannot be combined with the inline");
     }
 
+    @Test
+    void inlinesPresenceTrackingForUpTo64RequiredMembers() {
+        var source = generateStructureSource(requiredStructure("InlinePresence", 64), "InlinePresence.java");
+
+        assertThat(source)
+                .contains("private long $setMembers;")
+                .contains("$setMembers |= 0x8000000000000000L;")
+                .contains("if ($setMembers != 0xffffffffffffffffL)")
+                .contains("PresenceTracker.validateRequiredMembers($SCHEMA, $setMembers);")
+                .doesNotContain("private final PresenceTracker tracker");
+    }
+
+    @Test
+    void retainsPresenceTrackerForMoreThan64RequiredMembers() {
+        var source = generateStructureSource(requiredStructure("TrackedPresence", 65), "TrackedPresence.java");
+
+        assertThat(source)
+                .contains("private final PresenceTracker tracker = PresenceTracker.of($SCHEMA);")
+                .contains("tracker.validate();")
+                .contains("if (tracker.allSet())")
+                .contains("if (!tracker.checkMember($SCHEMA_MEMBER0))")
+                .doesNotContain("private long $setMembers;");
+    }
+
+    @Test
+    void premarksRequiredClientOptionalMembers() {
+        var source = generateStructureSource(
+                """
+                        $version: "2"
+                        namespace smithy.java.codegen.presence
+
+                        structure ClientOptionalPresence {
+                            @required
+                            @clientOptional
+                            value: String
+                        }
+                        """,
+                "ClientOptionalPresence.java");
+
+        assertThat(source)
+                .contains("private Builder() {")
+                .contains("$setMembers |= 0x1L;")
+                .contains("if ($setMembers != 0x1L)");
+    }
+
+    private String generateStructureSource(String modelSource, String fileName) {
+        var generatedModel = Model.assembler()
+                .addUnparsedModel("presence.smithy", modelSource)
+                .assemble()
+                .unwrap();
+        var settings = settingsBuilder.build();
+        var context = PluginContext.builder()
+                .fileManifest(manifest)
+                .model(generatedModel)
+                .settings(settings)
+                .build();
+        plugin.execute(context);
+        var path = manifest.getFiles()
+                .stream()
+                .filter(file -> file.getFileName().toString().equals(fileName))
+                .findFirst()
+                .orElseThrow();
+        return manifest.expectFileString(path);
+    }
+
+    private static String requiredStructure(String name, int memberCount) {
+        var result = new StringBuilder()
+                .append("$version: \"2\"\n")
+                .append("namespace smithy.java.codegen.presence\n\n")
+                .append("structure ")
+                .append(name)
+                .append(" {\n");
+        for (int i = 0; i < memberCount; i++) {
+            result.append("    @required\n")
+                    .append("    member")
+                    .append(i)
+                    .append(": String\n");
+        }
+        return result.append("}\n").toString();
+    }
+
 }

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/jspecify/expected/CollectionStruct.java
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/jspecify/expected/CollectionStruct.java
@@ -265,7 +265,7 @@ public final class CollectionStruct implements SerializableStruct {
      * Builder for {@link CollectionStruct}.
      */
     public static final class Builder implements ShapeBuilder<CollectionStruct> {
-        private final PresenceTracker tracker = PresenceTracker.of($SCHEMA);
+        private long $setMembers;
         private List<String> nonSparseList;
         private List<@Nullable String> sparseList;
         private Map<String, String> nonSparseMap;
@@ -300,7 +300,7 @@ public final class CollectionStruct implements SerializableStruct {
          */
         public Builder sparseList(List<@Nullable String> sparseList) {
             this.sparseList = Objects.requireNonNull(sparseList, "sparseList cannot be null");
-            tracker.setMember($SCHEMA_SPARSE_LIST);
+            $setMembers |= 0x1L;
             return this;
         }
 
@@ -322,7 +322,7 @@ public final class CollectionStruct implements SerializableStruct {
          */
         public Builder sparseMap(Map<String, @Nullable String> sparseMap) {
             this.sparseMap = Objects.requireNonNull(sparseMap, "sparseMap cannot be null");
-            tracker.setMember($SCHEMA_SPARSE_MAP);
+            $setMembers |= 0x2L;
             return this;
         }
 
@@ -344,7 +344,7 @@ public final class CollectionStruct implements SerializableStruct {
          */
         public Builder sparseListOfSparseMap(List<@Nullable Map<String, @Nullable String>> sparseListOfSparseMap) {
             this.sparseListOfSparseMap = Objects.requireNonNull(sparseListOfSparseMap, "sparseListOfSparseMap cannot be null");
-            tracker.setMember($SCHEMA_SPARSE_LIST_OF_SPARSE_MAP);
+            $setMembers |= 0x4L;
             return this;
         }
 
@@ -366,13 +366,15 @@ public final class CollectionStruct implements SerializableStruct {
          */
         public Builder nonSparseListOfNonSparseMap(List<Map<String, String>> nonSparseListOfNonSparseMap) {
             this.nonSparseListOfNonSparseMap = Objects.requireNonNull(nonSparseListOfNonSparseMap, "nonSparseListOfNonSparseMap cannot be null");
-            tracker.setMember($SCHEMA_NON_SPARSE_LIST_OF_NON_SPARSE_MAP);
+            $setMembers |= 0x8L;
             return this;
         }
 
         @Override
         public CollectionStruct build() {
-            tracker.validate();
+            if ($setMembers != 0xfL) {
+                PresenceTracker.validateRequiredMembers($SCHEMA, $setMembers);
+            }
             return new CollectionStruct(this);
         }
 
@@ -394,19 +396,19 @@ public final class CollectionStruct implements SerializableStruct {
 
         @Override
         public ShapeBuilder<CollectionStruct> errorCorrection() {
-            if (tracker.allSet()) {
+            if ($setMembers == 0xfL) {
                 return this;
             }
-            if (!tracker.checkMember($SCHEMA_SPARSE_LIST)) {
+            if (($setMembers & 0x1L) == 0L) {
                 sparseList(Collections.emptyList());
             }
-            if (!tracker.checkMember($SCHEMA_SPARSE_MAP)) {
+            if (($setMembers & 0x2L) == 0L) {
                 sparseMap(Collections.emptyMap());
             }
-            if (!tracker.checkMember($SCHEMA_SPARSE_LIST_OF_SPARSE_MAP)) {
+            if (($setMembers & 0x4L) == 0L) {
                 sparseListOfSparseMap(Collections.emptyList());
             }
-            if (!tracker.checkMember($SCHEMA_NON_SPARSE_LIST_OF_NON_SPARSE_MAP)) {
+            if (($setMembers & 0x8L) == 0L) {
                 nonSparseListOfNonSparseMap(Collections.emptyList());
             }
             return this;

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/jspecify/expected/JSpecifyStruct.java
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/jspecify/expected/JSpecifyStruct.java
@@ -151,7 +151,7 @@ public final class JSpecifyStruct implements SerializableStruct {
      * Builder for {@link JSpecifyStruct}.
      */
     public static final class Builder implements ShapeBuilder<JSpecifyStruct> {
-        private final PresenceTracker tracker = PresenceTracker.of($SCHEMA);
+        private long $setMembers;
         private String requiredString;
         private String optionalString;
         private boolean requiredPrimitive;
@@ -170,7 +170,7 @@ public final class JSpecifyStruct implements SerializableStruct {
          */
         public Builder requiredString(String requiredString) {
             this.requiredString = Objects.requireNonNull(requiredString, "requiredString cannot be null");
-            tracker.setMember($SCHEMA_REQUIRED_STRING);
+            $setMembers |= 0x1L;
             return this;
         }
 
@@ -188,7 +188,7 @@ public final class JSpecifyStruct implements SerializableStruct {
          */
         public Builder requiredPrimitive(boolean requiredPrimitive) {
             this.requiredPrimitive = requiredPrimitive;
-            tracker.setMember($SCHEMA_REQUIRED_PRIMITIVE);
+            $setMembers |= 0x2L;
             return this;
         }
 
@@ -202,7 +202,9 @@ public final class JSpecifyStruct implements SerializableStruct {
 
         @Override
         public JSpecifyStruct build() {
-            tracker.validate();
+            if ($setMembers != 0x3L) {
+                PresenceTracker.validateRequiredMembers($SCHEMA, $setMembers);
+            }
             return new JSpecifyStruct(this);
         }
 
@@ -220,14 +222,14 @@ public final class JSpecifyStruct implements SerializableStruct {
 
         @Override
         public ShapeBuilder<JSpecifyStruct> errorCorrection() {
-            if (tracker.allSet()) {
+            if ($setMembers == 0x3L) {
                 return this;
             }
-            if (!tracker.checkMember($SCHEMA_REQUIRED_STRING)) {
+            if (($setMembers & 0x1L) == 0L) {
                 requiredString("");
             }
-            if (!tracker.checkMember($SCHEMA_REQUIRED_PRIMITIVE)) {
-                tracker.setMember($SCHEMA_REQUIRED_PRIMITIVE);
+            if (($setMembers & 0x2L) == 0L) {
+                $setMembers |= 0x2L;
             }
             return this;
         }

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/primitive-types/expected/PrimitivesNotNullable.java
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/primitive-types/expected/PrimitivesNotNullable.java
@@ -170,7 +170,7 @@ public final class PrimitivesNotNullable implements SerializableStruct {
      * Builder for {@link PrimitivesNotNullable}.
      */
     public static final class Builder implements ShapeBuilder<PrimitivesNotNullable> {
-        private final PresenceTracker tracker = PresenceTracker.of($SCHEMA);
+        private long $setMembers;
         private byte byteMember;
         private short shortMember;
         private int intMember;
@@ -192,7 +192,7 @@ public final class PrimitivesNotNullable implements SerializableStruct {
          */
         public Builder byteMember(byte byteMember) {
             this.byteMember = byteMember;
-            tracker.setMember($SCHEMA_BYTE_MEMBER);
+            $setMembers |= 0x1L;
             return this;
         }
 
@@ -202,7 +202,7 @@ public final class PrimitivesNotNullable implements SerializableStruct {
          */
         public Builder shortMember(short shortMember) {
             this.shortMember = shortMember;
-            tracker.setMember($SCHEMA_SHORT_MEMBER);
+            $setMembers |= 0x2L;
             return this;
         }
 
@@ -212,7 +212,7 @@ public final class PrimitivesNotNullable implements SerializableStruct {
          */
         public Builder intMember(int intMember) {
             this.intMember = intMember;
-            tracker.setMember($SCHEMA_INT_MEMBER);
+            $setMembers |= 0x4L;
             return this;
         }
 
@@ -222,7 +222,7 @@ public final class PrimitivesNotNullable implements SerializableStruct {
          */
         public Builder longMember(long longMember) {
             this.longMember = longMember;
-            tracker.setMember($SCHEMA_LONG_MEMBER);
+            $setMembers |= 0x8L;
             return this;
         }
 
@@ -232,7 +232,7 @@ public final class PrimitivesNotNullable implements SerializableStruct {
          */
         public Builder floatMember(float floatMember) {
             this.floatMember = floatMember;
-            tracker.setMember($SCHEMA_FLOAT_MEMBER);
+            $setMembers |= 0x10L;
             return this;
         }
 
@@ -242,7 +242,7 @@ public final class PrimitivesNotNullable implements SerializableStruct {
          */
         public Builder doubleMember(double doubleMember) {
             this.doubleMember = doubleMember;
-            tracker.setMember($SCHEMA_DOUBLE_MEMBER);
+            $setMembers |= 0x20L;
             return this;
         }
 
@@ -252,13 +252,15 @@ public final class PrimitivesNotNullable implements SerializableStruct {
          */
         public Builder booleanMember(boolean booleanMember) {
             this.booleanMember = booleanMember;
-            tracker.setMember($SCHEMA_BOOLEAN_MEMBER);
+            $setMembers |= 0x40L;
             return this;
         }
 
         @Override
         public PrimitivesNotNullable build() {
-            tracker.validate();
+            if ($setMembers != 0x7fL) {
+                PresenceTracker.validateRequiredMembers($SCHEMA, $setMembers);
+            }
             return new PrimitivesNotNullable(this);
         }
 
@@ -279,29 +281,29 @@ public final class PrimitivesNotNullable implements SerializableStruct {
 
         @Override
         public ShapeBuilder<PrimitivesNotNullable> errorCorrection() {
-            if (tracker.allSet()) {
+            if ($setMembers == 0x7fL) {
                 return this;
             }
-            if (!tracker.checkMember($SCHEMA_BYTE_MEMBER)) {
-                tracker.setMember($SCHEMA_BYTE_MEMBER);
+            if (($setMembers & 0x1L) == 0L) {
+                $setMembers |= 0x1L;
             }
-            if (!tracker.checkMember($SCHEMA_SHORT_MEMBER)) {
-                tracker.setMember($SCHEMA_SHORT_MEMBER);
+            if (($setMembers & 0x2L) == 0L) {
+                $setMembers |= 0x2L;
             }
-            if (!tracker.checkMember($SCHEMA_INT_MEMBER)) {
-                tracker.setMember($SCHEMA_INT_MEMBER);
+            if (($setMembers & 0x4L) == 0L) {
+                $setMembers |= 0x4L;
             }
-            if (!tracker.checkMember($SCHEMA_LONG_MEMBER)) {
-                tracker.setMember($SCHEMA_LONG_MEMBER);
+            if (($setMembers & 0x8L) == 0L) {
+                $setMembers |= 0x8L;
             }
-            if (!tracker.checkMember($SCHEMA_FLOAT_MEMBER)) {
-                tracker.setMember($SCHEMA_FLOAT_MEMBER);
+            if (($setMembers & 0x10L) == 0L) {
+                $setMembers |= 0x10L;
             }
-            if (!tracker.checkMember($SCHEMA_DOUBLE_MEMBER)) {
-                tracker.setMember($SCHEMA_DOUBLE_MEMBER);
+            if (($setMembers & 0x20L) == 0L) {
+                $setMembers |= 0x20L;
             }
-            if (!tracker.checkMember($SCHEMA_BOOLEAN_MEMBER)) {
-                tracker.setMember($SCHEMA_BOOLEAN_MEMBER);
+            if (($setMembers & 0x40L) == 0L) {
+                $setMembers |= 0x40L;
             }
             return this;
         }

--- a/core/src/main/java/software/amazon/smithy/java/core/schema/PresenceTracker.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/schema/PresenceTracker.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.java.core.schema;
 
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.Set;
@@ -56,6 +57,39 @@ public abstract sealed class PresenceTracker {
         if (!allSet()) {
             throw new SerializationException("Missing required members: " + getMissingMembers());
         }
+    }
+
+    /**
+     * Validates an inline bitfield used by generated builders.
+     *
+     * @param schema structure schema to validate
+     * @param setBitfields bitfield of required members that were set
+     * @throws IllegalArgumentException if the schema has more than 64 required members
+     * @throws SerializationException if any required members are not set
+     */
+    public static void validateRequiredMembers(Schema schema, long setBitfields) {
+        if (schema.requiredMemberCount() > Long.SIZE) {
+            throw new IllegalArgumentException("Cannot validate more than 64 required members with a long");
+        }
+        long missingBits = schema.requiredStructureMemberBitfield() & ~setBitfields;
+        int missingCount = Long.bitCount(missingBits);
+        if (missingCount == 0) {
+            return;
+        } else if (missingCount == 1) {
+            int memberIndex = Long.numberOfTrailingZeros(missingBits);
+            throw new SerializationException(
+                    "Missing required members: [" + schema.member(memberIndex).memberName() + "]");
+        }
+
+        String[] missing = new String[missingCount];
+        int missingIndex = 0;
+        while (missingBits != 0L) {
+            int memberIndex = Long.numberOfTrailingZeros(missingBits);
+            missing[missingIndex++] = schema.member(memberIndex).memberName();
+            missingBits &= missingBits - 1;
+        }
+        Arrays.sort(missing);
+        throw new SerializationException("Missing required members: " + Arrays.toString(missing));
     }
 
     /**

--- a/core/src/test/java/software/amazon/smithy/java/core/schema/PresenceTrackerTest.java
+++ b/core/src/test/java/software/amazon/smithy/java/core/schema/PresenceTrackerTest.java
@@ -5,16 +5,52 @@
 
 package software.amazon.smithy.java.core.schema;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static software.amazon.smithy.java.core.schema.ValidatorTest.createBigRequiredSchema;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.smithy.java.core.serde.SerializationException;
 
 public class PresenceTrackerTest {
+
+    @Test
+    void validatesInlineRequiredMemberBitfield() {
+        var schema = createBigRequiredSchema(3, 3, 0);
+
+        var exception = assertThrows(
+                SerializationException.class,
+                () -> PresenceTracker.validateRequiredMembers(schema, 0b101L));
+        assertEquals("Missing required members: [member1]", exception.getMessage());
+        assertDoesNotThrow(() -> PresenceTracker.validateRequiredMembers(
+                schema,
+                schema.requiredStructureMemberBitfield()));
+    }
+
+    @Test
+    void sortsMissingInlineRequiredMembersByName() {
+        var schema = createBigRequiredSchema(12, 12, 0);
+        long setMembers = schema.requiredStructureMemberBitfield() & ~((1L << 2) | (1L << 10));
+
+        var exception = assertThrows(
+                SerializationException.class,
+                () -> PresenceTracker.validateRequiredMembers(schema, setMembers));
+
+        assertEquals("Missing required members: [member10, member2]", exception.getMessage());
+    }
+
+    @Test
+    void rejectsOversizedInlineRequiredMemberBitfield() {
+        var schema = createBigRequiredSchema(65, 65, 0);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PresenceTracker.validateRequiredMembers(schema, 0L));
+    }
 
     @ParameterizedTest
     @ValueSource(ints = {1, 63, 64, 65, 128})


### PR DESCRIPTION
### What behavior changes?

Generated builders with up to 64 required members now track presence in a `long`. Larger structures keep using `PresenceTracker`.

### Why is this change needed?

The inline bitfield avoids an extra tracker allocation and virtual calls for the usual builder shape.

### How was this validated?

Added unit, codegen integration, and generated-output tests, plus a JMH benchmark.

### What should reviewers focus on?

The 64-member boundary, fallback behavior, and missing-member diagnostics.

### Additional Links

Part of stack #1325.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.