### PR TITLE
Parse ten-digit epoch seconds with a single word compare

### DIFF
--- a/codecs/json-codec/build.gradle.kts
+++ b/codecs/json-codec/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("smithy-java.module-conventions")
     id("smithy-java.fuzz-test")
+    id("smithy-java.jmh-conventions")
     id("software.amazon.smithy.gradle.smithy-base")
     id("com.gradleup.shadow")
 }

--- a/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonTimestampDeserializeBenchmark.java
+++ b/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonTimestampDeserializeBenchmark.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.json.smithy.SmithyJsonSerdeProvider;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+
+@State(Scope.Benchmark)
+public class JsonTimestampDeserializeBenchmark {
+
+    private static final int COUNT = 32;
+
+    private static final Schema TIMESTAMP = Schema.createTimestamp(
+            ShapeId.from("smithy.benchmark#EpochSeconds"),
+            new TimestampFormatTrait(TimestampFormatTrait.EPOCH_SECONDS));
+
+    @Param({
+            "epochSeconds_TenDigit",
+            "epochSeconds_NineDigit",
+            "epochSeconds_Fractional",
+    })
+    public String testCaseId;
+
+    private JsonCodec codec;
+    private byte[] payload;
+
+    @Setup
+    public void setup() {
+        codec = JsonCodec.builder()
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .useTimestampFormat(true)
+                .build();
+        payload = buildPayload(testCaseId);
+    }
+
+    private static byte[] buildPayload(String testCaseId) {
+        var sb = new StringBuilder("[");
+        for (int i = 0; i < COUNT; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            switch (testCaseId) {
+                case "epochSeconds_TenDigit" -> sb.append(1_712_345_678L + i);
+                case "epochSeconds_NineDigit" -> sb.append(100_000_000L + i);
+                case "epochSeconds_Fractional" -> sb.append(1_712_345_678L + i).append(".25");
+                default -> throw new IllegalArgumentException("Unknown test case: " + testCaseId);
+            }
+        }
+        return sb.append(']').toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Benchmark
+    public void deserialize(Blackhole bh) {
+        var de = codec.createDeserializer(payload);
+        de.readList(PreludeSchemas.DOCUMENT, bh, (sink, listDe) -> {
+            Instant value = listDe.readTimestamp(TIMESTAMP);
+            sink.consume(value);
+        });
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
@@ -33,6 +33,10 @@ final class JsonReadUtils {
     private static final VarHandle LONG_HANDLE =
             MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
+    private static final long ASCII_ZEROES = 0x3030303030303030L;
+    private static final long ASCII_NINES = 0x3939393939393939L;
+    private static final long ASCII_HIGH_BITS = 0x8080808080808080L;
+
     // Hex digit lookup table: -1 means invalid hex digit
     private static final int[] HEX_VALUES = new int[128];
 
@@ -47,6 +51,42 @@ final class JsonReadUtils {
         for (int i = 'A'; i <= 'F'; i++) {
             HEX_VALUES[i] = 10 + (i - 'A');
         }
+    }
+
+    // Returns -1 when the input is not a positive ten-digit integer.
+    static long tryParseTenDigitEpochSecond(byte[] buf, int pos, int end) {
+        int stop = pos + 10;
+        if (stop > end || (buf[pos] < '1' || buf[pos] > '9')) {
+            return -1;
+        }
+        byte tenthByte = buf[pos + 9];
+        if (tenthByte < '0' || tenthByte > '9') {
+            return -1;
+        }
+        if (stop < end) {
+            byte next = buf[stop];
+            if ((next >= '0' && next <= '9') || next == '.' || next == 'e' || next == 'E') {
+                return -1;
+            }
+        }
+
+        long chunk = (long) LONG_HANDLE.get(buf, pos);
+        long digits = chunk - ASCII_ZEROES;
+        // Subtraction sets a lane's high bit for bytes outside '0'..'9'.
+        if (((digits | (ASCII_NINES - chunk)) & ASCII_HIGH_BITS) != 0) {
+            return -1;
+        }
+        int ninth = buf[pos + 8] - '0';
+        if ((ninth | (9 - ninth)) < 0) {
+            return -1;
+        }
+        int tenth = tenthByte - '0';
+
+        // The little-endian view places the first digit in the low byte.
+        long pairs = (digits * 10 + (digits >>> 8)) & 0x00FF00FF00FF00FFL;
+        long quads = (pairs * 100 + (pairs >>> 16)) & 0x0000FFFF0000FFFFL;
+        long firstEight = (quads & 0xFFFF) * 10_000 + (quads >>> 32);
+        return firstEight * 100 + ninth * 10L + tenth;
     }
 
     /**

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
@@ -379,6 +379,11 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
         if (format == TimestampFormatter.Prelude.EPOCH_SECONDS
                 && pos < end
                 && (buf[pos] == '-' || (buf[pos] >= '0' && buf[pos] <= '9'))) {
+            long tenDigitSecond = JsonReadUtils.tryParseTenDigitEpochSecond(buf, pos, end);
+            if (tenDigitSecond >= 0) {
+                pos += 10;
+                return Instant.ofEpochSecond(tenDigitSecond);
+            }
             // Fast path for epoch-seconds: try integer parsing first.
             // Most epoch-seconds timestamps are whole numbers, so parseLong avoids
             // the expensive FastDoubleParser path entirely.

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
@@ -1294,6 +1294,30 @@ public class JsonDeserializerTest extends ProviderTestBase {
 
     @ParameterizedTest
     @MethodSource("smithyOnly")
+    public void readsMixedEpochSecondsAndMaintainsTheCursor(JsonSerdeProvider provider) {
+        var schema = Schema.createTimestamp(
+                ShapeId.from("smithy.foo#Time"),
+                new TimestampFormatTrait(TimestampFormatTrait.EPOCH_SECONDS));
+        var json = "[1000000000, 1, 1712345678.25, 999999999, 9999999999]";
+
+        try (var codec = codecBuilder(provider).useTimestampFormat(true).build()) {
+            var read = new ArrayList<Instant>();
+            codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8))
+                    .readList(PreludeSchemas.DOCUMENT, read, (sink, de) -> sink.add(de.readTimestamp(schema)));
+
+            assertThat(
+                    read,
+                    contains(
+                            Instant.ofEpochSecond(1_000_000_000L),
+                            Instant.ofEpochSecond(1),
+                            Instant.ofEpochSecond(1_712_345_678L, 250_000_000),
+                            Instant.ofEpochSecond(999_999_999L),
+                            Instant.ofEpochSecond(9_999_999_999L)));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("smithyOnly")
     public void rejectsEpochSecondsOutOfRange(JsonSerdeProvider provider) {
         // Instant.MAX.getEpochSecond() is 31556889864403199; one beyond that overflows
         long outOfRange = Instant.MAX.getEpochSecond() + 1;

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/JsonReadUtilsTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/JsonReadUtilsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class JsonReadUtilsTest {
+
+    private static final byte FILL = (byte) 0xEE;
+
+    @Test
+    public void weightsEveryDigitPosition() {
+        var base = "1234567890".toCharArray();
+        for (int i = 0; i < 10; i++) {
+            for (char d = i == 0 ? '1' : '0'; d <= '9'; d++) {
+                var chars = base.clone();
+                chars[i] = d;
+                var value = new String(chars);
+                assertThat(parse(value)).as("%s (digit %c at %d)", value, d, i).isEqualTo(Long.parseLong(value));
+            }
+        }
+    }
+
+    @Test
+    public void parsesTheRangeEndpoints() {
+        assertThat(parse("1000000000")).isEqualTo(1_000_000_000L);
+        assertThat(parse("9999999999")).isEqualTo(9_999_999_999L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                    "123456789",
+                    "1",
+                    "0",
+                    "0123456789",
+                    "12345678901",
+                    "1234567890123456789",
+                    "-123456789",
+                    "-1234567890",
+                    "1234567890.5",
+                    "1234567890.0",
+                    "1234567890e2",
+                    "1234567890E2",
+                    "1234567890e-2"
+            })
+    public void declinesEverythingThatIsNotTenWholeDigits(String value) {
+        assertThat(parse(value)).isEqualTo(-1);
+    }
+
+    @Test
+    public void rejectsEveryNonDigitByteAtEveryPosition() {
+        var valid = "1234567890".getBytes(StandardCharsets.US_ASCII);
+        for (int pos = 0; pos < valid.length; pos++) {
+            for (int candidate = 0; candidate <= 0xFF; candidate++) {
+                if (candidate >= '0' && candidate <= '9') {
+                    continue;
+                }
+                var value = valid.clone();
+                value[pos] = (byte) candidate;
+                assertThat(JsonReadUtils.tryParseTenDigitEpochSecond(value, 0, value.length))
+                        .as("byte 0x%02X at position %d", candidate, pos)
+                        .isEqualTo(-1);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(chars = {',', '}', ']', ' ', '\t', '\n', '\r'})
+    public void acceptsValidNumberTerminators(char terminator) {
+        assertThat(parse("1712345678" + terminator)).isEqualTo(1_712_345_678L);
+    }
+
+    @Test
+    public void parsesAtAnyOffset() {
+        for (int pos = 0; pos <= 9; pos++) {
+            var buf = new byte[pos + 10 + 4];
+            Arrays.fill(buf, FILL);
+            System.arraycopy("1712345678".getBytes(StandardCharsets.US_ASCII), 0, buf, pos, 10);
+
+            assertThat(JsonReadUtils.tryParseTenDigitEpochSecond(buf, pos, pos + 10))
+                    .as("pos=%d", pos)
+                    .isEqualTo(1_712_345_678L);
+        }
+    }
+
+    @Test
+    public void respectsEndRatherThanTheArrayLength() {
+        var buf = "17123456789999".getBytes(StandardCharsets.US_ASCII);
+
+        for (int end = 0; end < 10; end++) {
+            assertThat(JsonReadUtils.tryParseTenDigitEpochSecond(buf, 0, end)).as("end=%d", end).isEqualTo(-1);
+        }
+        assertThat(JsonReadUtils.tryParseTenDigitEpochSecond(buf, 0, 10)).isEqualTo(1_712_345_678L);
+        assertThat(JsonReadUtils.tryParseTenDigitEpochSecond(buf, 0, 11)).isEqualTo(-1);
+    }
+
+    @Test
+    public void doesNotReadPastTheEndOfTheArray() {
+        var exact = "1712345678".getBytes(StandardCharsets.US_ASCII);
+        assertThat(exact).hasSize(10);
+        assertThat(JsonReadUtils.tryParseTenDigitEpochSecond(exact, 0, exact.length)).isEqualTo(1_712_345_678L);
+
+        for (int len = 0; len < 10; len++) {
+            var shortBuf = Arrays.copyOf(exact, len);
+            assertThat(JsonReadUtils.tryParseTenDigitEpochSecond(shortBuf, 0, len)).as("len=%d", len).isEqualTo(-1);
+        }
+    }
+
+    private static long parse(String value) {
+        var bytes = value.getBytes(StandardCharsets.US_ASCII);
+        return JsonReadUtils.tryParseTenDigitEpochSecond(bytes, 0, bytes.length);
+    }
+}


### PR DESCRIPTION
### What behavior changes?

JSON epoch-second timestamps with exactly ten positive digits now use a dedicated fast path. Other valid forms still use the existing parser.

### Why is this change needed?

Ten-digit epoch seconds are common, and validating the first eight digits as one word avoids the general number parser.

### How was this validated?

Added boundary and fallback tests plus `JsonTimestampDeserializeBenchmark`.

### What should reviewers focus on?

Digit validation, delimiter checks, and cases that must fall back to the regular parser.

### Additional Links

Part of stack #1325.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.