### PR TITLE
Read whole-number doubles without the floating-point parser

### DIFF
--- a/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonNumberDeserializeBenchmark.java
+++ b/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonNumberDeserializeBenchmark.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.nio.charset.StandardCharsets;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.json.smithy.SmithyJsonSerdeProvider;
+
+@State(Scope.Benchmark)
+public class JsonNumberDeserializeBenchmark {
+
+    private static final int COUNT = 32;
+
+    @Param({
+            "numbers_WholeSmall",
+            "numbers_WholeLong",
+            "numbers_Fractional",
+            "numbers_Exponent",
+            "numbers_OverBudget",
+    })
+    public String testCaseId;
+
+    private JsonCodec codec;
+    private byte[] payload;
+
+    @Setup
+    public void setup() {
+        codec = JsonCodec.builder()
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .build();
+        payload = buildPayload(testCaseId);
+    }
+
+    private static byte[] buildPayload(String testCaseId) {
+        var sb = new StringBuilder("[");
+        for (int i = 0; i < COUNT; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            switch (testCaseId) {
+                case "numbers_WholeSmall" -> sb.append(1000 + i);
+                case "numbers_WholeLong" -> sb.append(123_456_789_012_345_000L + i);
+                case "numbers_Fractional" -> sb.append(1000 + i).append(".5");
+                case "numbers_Exponent" -> sb.append(1000 + i).append(".25e7");
+                case "numbers_OverBudget" -> sb.append(1_234_567_890_123_456_789L + i);
+                default -> throw new IllegalArgumentException("Unknown test case: " + testCaseId);
+            }
+        }
+        return sb.append(']').toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Benchmark
+    public void deserializeDouble(Blackhole bh) {
+        var de = codec.createDeserializer(payload);
+        de.readList(PreludeSchemas.DOCUMENT, bh, (sink, listDe) -> {
+            sink.consume(listDe.readDouble(PreludeSchemas.DOUBLE));
+        });
+    }
+
+    @Benchmark
+    public void deserializeDocument(Blackhole bh) {
+        bh.consume(codec.createDeserializer(payload).readDocument());
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
@@ -37,6 +37,8 @@ final class JsonReadUtils {
     private static final long ASCII_NINES = 0x3939393939393939L;
     private static final long ASCII_HIGH_BITS = 0x8080808080808080L;
 
+    private static final int MAX_SAFE_LONG_DIGITS = 18;
+
     // Hex digit lookup table: -1 means invalid hex digit
     private static final int[] HEX_VALUES = new int[128];
 
@@ -153,7 +155,8 @@ final class JsonReadUtils {
     static void parseDouble(byte[] buf, int pos, int end, SmithyJsonDeserializer deser) {
         int start = pos;
 
-        if (pos < end && buf[pos] == '-') {
+        boolean negative = pos < end && buf[pos] == '-';
+        if (negative) {
             pos++;
         }
 
@@ -161,6 +164,7 @@ final class JsonReadUtils {
             throw new SerializationException("Unexpected end of input while parsing number");
         }
 
+        int digitStart = pos;
         byte first = buf[pos];
         if (first < '0' || first > '9') {
             throw new SerializationException("Expected digit, found: " + describeChar(first));
@@ -176,8 +180,10 @@ final class JsonReadUtils {
                 pos++;
             }
         }
+        boolean wholeNumber = pos - digitStart <= MAX_SAFE_LONG_DIGITS;
 
         if (pos < end && buf[pos] == '.') {
+            wholeNumber = false;
             pos++;
             if (pos >= end || buf[pos] < '0' || buf[pos] > '9') {
                 throw new SerializationException("Expected digit after decimal point");
@@ -188,6 +194,7 @@ final class JsonReadUtils {
         }
 
         if (pos < end && (buf[pos] == 'e' || buf[pos] == 'E')) {
+            wholeNumber = false;
             pos++;
             if (pos < end && (buf[pos] == '+' || buf[pos] == '-')) {
                 pos++;
@@ -200,7 +207,16 @@ final class JsonReadUtils {
             }
         }
 
-        deser.parsedDouble = NumberCodec.parseDouble(buf, start, pos - start);
+        if (wholeNumber) {
+            long value = 0;
+            for (int i = digitStart; i < pos; i++) {
+                value = value * 10 + (buf[i] - '0');
+            }
+            // Applying the sign after conversion preserves negative zero.
+            deser.parsedDouble = negative ? -(double) value : (double) value;
+        } else {
+            deser.parsedDouble = NumberCodec.parseDouble(buf, start, pos - start);
+        }
         deser.parsedEndPos = pos;
     }
 

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
@@ -131,6 +131,54 @@ public class JsonDeserializerTest extends ProviderTestBase {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("wholeNumberDoubles")
+    public void deserializesWholeNumberDoubleExactly(JsonSerdeProvider provider, String json) {
+        long expected = Double.doubleToRawLongBits(Double.parseDouble(json));
+
+        try (var codec = codec(provider)) {
+            double actual = codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8))
+                    .readDouble(PreludeSchemas.DOUBLE);
+
+            assertThat(Double.doubleToRawLongBits(actual), is(expected));
+        }
+    }
+
+    static List<Arguments> wholeNumberDoubles() {
+        var result = new ArrayList<Arguments>();
+        var values = List.of(
+                "0",
+                "1",
+                "-1",
+                "9007199254740991",
+                "9007199254740992",
+                "9007199254740993",
+                "123456789012345678",
+                "999999999999999999",
+                "-999999999999999999",
+                "1000000000000000000",
+                "9223372036854775807",
+                "9223372036854775808",
+                "123456789012345678901234567890");
+        for (var provider : List.of(SMITHY, JACKSON)) {
+            for (var value : values) {
+                result.add(Arguments.of(provider, value));
+            }
+        }
+        return result;
+    }
+
+    @ParameterizedTest
+    @MethodSource("smithyOnly")
+    public void preservesNegativeWholeNumberZero(JsonSerdeProvider provider) {
+        try (var codec = codec(provider)) {
+            double actual = codec.createDeserializer("-0".getBytes(StandardCharsets.UTF_8))
+                    .readDouble(PreludeSchemas.DOUBLE);
+
+            assertThat(Double.doubleToRawLongBits(actual), is(Double.doubleToRawLongBits(-0.0d)));
+        }
+    }
+
     @PerProvider
     public void normalDoublesCannotBeStrings(JsonSerdeProvider provider) {
         try (var codec = codec(provider)) {


### PR DESCRIPTION
### What behavior changes?

Whole-number JSON doubles with up to 18 digits now use integer accumulation before conversion to `double`. Decimal and exponent forms keep using the floating-point parser.

### Why is this change needed?

Whole numbers are common, and the small integer path is cheaper than calling the general parser.

### How was this validated?

Added integer, negative-zero, boundary, and fallback coverage plus `JsonNumberDeserializeBenchmark`.

### What should reviewers focus on?

The safe digit limit, sign handling, and fallback conditions.

### Additional Links

Part of stack #1325.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.