### PR TITLE
Find the exact end of a JSON string with one SWAR mask

### DIFF
--- a/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonStringDeserializeBenchmark.java
+++ b/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonStringDeserializeBenchmark.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.nio.charset.StandardCharsets;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.json.smithy.SmithyJsonSerdeProvider;
+
+@State(Scope.Benchmark)
+public class JsonStringDeserializeBenchmark {
+
+    private static final int COUNT = 32;
+
+    @Param({
+            "ascii_7",
+            "ascii_8",
+            "ascii_15",
+            "ascii_16",
+            "ascii_120",
+            "nonAsciiShort",
+            "nonAsciiLong",
+            "escapedShort",
+            "escapedLong",
+    })
+    public String testCaseId;
+
+    private JsonCodec codec;
+    private byte[] payload;
+
+    @Setup
+    public void setup() {
+        codec = JsonCodec.builder()
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .build();
+        payload = buildPayload(testCaseId);
+    }
+
+    private static byte[] buildPayload(String testCaseId) {
+        var result = new StringBuilder("[");
+        for (int i = 0; i < COUNT; i++) {
+            if (i > 0) {
+                result.append(',');
+            }
+            result.append('"').append(value(testCaseId, i)).append('"');
+        }
+        return result.append(']').toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String value(String testCaseId, int i) {
+        return switch (testCaseId) {
+            case "ascii_7" -> String.format("%07d", i);
+            case "ascii_8" -> String.format("k%07d", i);
+            case "ascii_15" -> String.format("value-%09d", i);
+            case "ascii_16" -> String.format("values-%09d", i);
+            case "ascii_120" -> "a".repeat(112) + String.format("%08d", i);
+            case "nonAsciiShort" -> String.format("é%02d", i);
+            case "nonAsciiLong" -> "中文字符串测试内容值".repeat(2) + i;
+            case "escapedShort" -> String.format("\\n%02d", i);
+            case "escapedLong" -> "a".repeat(48) + String.format("\\\"%06d", i);
+            default -> throw new IllegalArgumentException("Unknown test case: " + testCaseId);
+        };
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(COUNT)
+    public void deserialize(Blackhole bh) {
+        var deserializer = codec.createDeserializer(payload);
+        deserializer.readList(PreludeSchemas.DOCUMENT, bh, (sink, listDeserializer) -> {
+            sink.consume(listDeserializer.readString(PreludeSchemas.STRING));
+        });
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
@@ -246,61 +246,112 @@ final class JsonReadUtils {
             throw new SerializationException("Expected '\"', found: " + describePos(buf, pos, end));
         }
         pos++; // skip opening quote
-
-        // Fast path: SWAR scan 8 bytes at a time for closing quote, backslash, or control chars.
         int start = pos;
 
-        while (pos + 8 <= end) {
-            long word = (long) LONG_HANDLE.get(buf, pos);
-            if (hasSpecialStringByte(word)) {
-                break; // found something, fall through to scalar loop
+        // Stop on the exact lane containing a quote, backslash, control byte, or non-ASCII byte.
+        while (pos + Long.BYTES <= end) {
+            long stops = stringStopMask((long) LONG_HANDLE.get(buf, pos));
+            if (stops == 0) {
+                pos += Long.BYTES;
+                continue;
             }
-            pos += 8;
+            int stop = pos + stopOffset(stops);
+            byte b = buf[stop];
+            if (b == '"') {
+                deser.parsedString = deser.decodeAsciiCached(buf, start, stop - start);
+                deser.parsedEndPos = stop + 1;
+                return;
+            }
+            if (b == '\\') {
+                parseStringWithEscapes(buf, start, stop, end, deser);
+                return;
+            }
+            if (b >= 0) {
+                throw unescapedControlCharacter(b);
+            }
+            parseStringNonAscii(buf, start, stop + 1, end, deser);
+            return;
         }
 
-        // Scalar loop for remaining bytes and to find the exact special byte
+        parseStringTail(buf, start, pos, end, true, deser);
+    }
+
+    private static void parseStringNonAscii(byte[] buf, int start, int pos, int end, SmithyJsonDeserializer deser) {
+        while (pos + Long.BYTES <= end) {
+            long stops = nonAsciiStringStopMask((long) LONG_HANDLE.get(buf, pos));
+            if (stops == 0) {
+                pos += Long.BYTES;
+                continue;
+            }
+            int stop = pos + stopOffset(stops);
+            byte b = buf[stop];
+            if (b == '"') {
+                deser.parsedString = deser.decodeUtf8Cached(buf, start, stop - start);
+                deser.parsedEndPos = stop + 1;
+                return;
+            }
+            if (b == '\\') {
+                parseStringWithEscapes(buf, start, stop, end, deser);
+                return;
+            }
+            throw unescapedControlCharacter(b);
+        }
+
+        parseStringTail(buf, start, pos, end, false, deser);
+    }
+
+    private static void parseStringTail(
+            byte[] buf,
+            int start,
+            int pos,
+            int end,
+            boolean ascii,
+            SmithyJsonDeserializer deser
+    ) {
         while (pos < end) {
             byte b = buf[pos];
             if (b == '"') {
-                // No escapes found -- fast path. Dedup short strings through the
-                // deserializer's per-document cache (repeated keys/values are common).
-                deser.parsedString = deser.decodeUtf8Cached(buf, start, pos - start);
+                deser.parsedString = ascii
+                        ? deser.decodeAsciiCached(buf, start, pos - start)
+                        : deser.decodeUtf8Cached(buf, start, pos - start);
                 deser.parsedEndPos = pos + 1;
                 return;
             }
             if (b == '\\') {
-                // Has escapes -- slow path
                 parseStringWithEscapes(buf, start, pos, end, deser);
                 return;
             }
             if ((b & 0xFF) < 0x20) {
-                throw new SerializationException(
-                        "Unescaped control character 0x" + Integer.toHexString(b & 0xFF) + " in string");
+                throw unescapedControlCharacter(b);
             }
+            ascii &= b >= 0;
             pos++;
         }
 
         throw new SerializationException("Unterminated string");
     }
 
-    /**
-     * SWAR check: returns true if any byte in the 8-byte word is '"' (0x22), '\\' (0x5C),
-     * or a control character (< 0x20).
-     */
-    private static boolean hasSpecialStringByte(long word) {
-        // Check for control chars (< 0x20): a byte b < 0x20 means (b - 0x20) sets the high bit
-        // when the original high bit was 0. We use the standard "has byte less than" SWAR trick.
-        long controlCheck = (word - 0x2020202020202020L) & ~word & 0x8080808080808080L;
+    private static long stringStopMask(long word) {
+        // Cross-lane borrows can only affect lanes after the earliest stop.
+        long quoteOrControl = (word ^ 0x0202020202020202L) - 0x2121212121212121L;
+        long backslash = (word ^ 0x5C5C5C5C5C5C5C5CL) - 0x0101010101010101L;
+        return (quoteOrControl | backslash | word) & ASCII_HIGH_BITS;
+    }
 
-        // Check for '"' (0x22) using XOR + has-zero-byte trick
-        long xorQuote = word ^ 0x2222222222222222L;
-        long hasQuote = (xorQuote - 0x0101010101010101L) & ~xorQuote & 0x8080808080808080L;
+    private static long nonAsciiStringStopMask(long word) {
+        long ascii = ~word;
+        long quoteOrControl = ((word ^ 0x0202020202020202L) - 0x2121212121212121L) & ascii;
+        long backslash = ((word ^ 0x5C5C5C5C5C5C5C5CL) - 0x0101010101010101L) & ascii;
+        return (quoteOrControl | backslash) & ASCII_HIGH_BITS;
+    }
 
-        // Check for '\\' (0x5C)
-        long xorBackslash = word ^ 0x5C5C5C5C5C5C5C5CL;
-        long hasBackslash = (xorBackslash - 0x0101010101010101L) & ~xorBackslash & 0x8080808080808080L;
+    private static int stopOffset(long stopMask) {
+        return Long.numberOfTrailingZeros(stopMask) >>> 3;
+    }
 
-        return (controlCheck | hasQuote | hasBackslash) != 0;
+    private static SerializationException unescapedControlCharacter(byte b) {
+        return new SerializationException(
+                "Unescaped control character 0x" + Integer.toHexString(b & 0xFF) + " in string");
     }
 
     private static void parseStringWithEscapes(
@@ -323,8 +374,7 @@ final class JsonReadUtils {
             }
 
             if ((b & 0xFF) < 0x20) {
-                throw new SerializationException(
-                        "Unescaped control character 0x" + Integer.toHexString(b & 0xFF) + " in string");
+                throw unescapedControlCharacter(b);
             }
 
             if (b == '\\') {

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
@@ -143,11 +143,22 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
      * String is cached. Strings longer than 8 bytes bypass the cache.
      */
     String decodeUtf8Cached(byte[] buf, int start, int len) {
+        return decodeCached(buf, start, len, false);
+    }
+
+    String decodeAsciiCached(byte[] buf, int start, int len) {
+        // ISO-8859-1 is identical for ASCII and avoids UTF-8's multi-byte scan.
+        return decodeCached(buf, start, len, true);
+    }
+
+    private String decodeCached(byte[] buf, int start, int len, boolean ascii) {
         if (len == 0) {
             return "";
         }
         if (len > 8) {
-            return new String(buf, start, len, StandardCharsets.UTF_8);
+            return ascii
+                    ? new String(buf, start, len, StandardCharsets.ISO_8859_1)
+                    : new String(buf, start, len, StandardCharsets.UTF_8);
         }
         // Pack bytes into a long. Every content byte is >= 0x20 here (the no-escape fast
         // path rejects control bytes), so leading bytes are non-zero and length is encoded
@@ -168,7 +179,9 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
         if (keys[slot] == key) {
             return vals[slot];
         }
-        String s = new String(buf, start, len, StandardCharsets.UTF_8);
+        String s = ascii
+                ? new String(buf, start, len, StandardCharsets.ISO_8859_1)
+                : new String(buf, start, len, StandardCharsets.UTF_8);
         keys[slot] = key;
         vals[slot] = s;
         return s;

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
@@ -1134,25 +1134,71 @@ public class JsonDeserializerTest extends ProviderTestBase {
     }
 
     @PerProvider
-    public void parsesLongAsciiString(JsonSerdeProvider provider) {
-        // > 8 bytes to exercise SWAR scanning path
-        String longStr = "abcdefghijklmnopqrstuvwxyz0123456789";
+    public void parsesAsciiAtStringScanBoundaries(JsonSerdeProvider provider) {
         try (var codec = codec(provider)) {
-            assertThat(codec.createDeserializer(("\"" + longStr + "\"").getBytes(StandardCharsets.UTF_8))
-                    .readString(PreludeSchemas.STRING), equalTo(longStr));
+            for (int length : List.of(0, 6, 7, 8, 14, 15, 16, 23, 24)) {
+                var value = "a".repeat(length);
+                assertThat(codec.createDeserializer(("\"" + value + "\"").getBytes(StandardCharsets.UTF_8))
+                        .readString(PreludeSchemas.STRING), equalTo(value));
+            }
+
+            for (char value : List.of(' ', '!', '#', (char) 0x7F)) {
+                for (int position : List.of(0, 6, 7, 8, 14, 15, 16)) {
+                    var expected = "a".repeat(position) + value + "z";
+                    assertThat(codec.createDeserializer(("\"" + expected + "\"").getBytes(StandardCharsets.UTF_8))
+                            .readString(PreludeSchemas.STRING), equalTo(expected));
+                }
+            }
         }
     }
 
     @PerProvider
-    public void parsesUtf8MultiByte(JsonSerdeProvider provider) {
-        // 2-byte UTF-8: e-acute (\u00e9)
-        // 3-byte UTF-8: CJK character (\u4e2d)
-        // 4-byte UTF-8: emoji (U+1F600)
-        // Embed directly as UTF-8 bytes with an escape to trigger slow path
-        String input = "\"\u00e9\\n\u4e2d\"";
+    public void parsesEscapesAtStringScanBoundaries(JsonSerdeProvider provider) {
         try (var codec = codec(provider)) {
-            assertThat(codec.createDeserializer(input.getBytes(StandardCharsets.UTF_8))
-                    .readString(PreludeSchemas.STRING), equalTo("\u00e9\n\u4e2d"));
+            for (int position : List.of(0, 6, 7, 8, 14, 15, 16)) {
+                var prefix = "a".repeat(position);
+                var input = "\"" + prefix + "\\nz\"";
+                assertThat(codec.createDeserializer(input.getBytes(StandardCharsets.UTF_8))
+                        .readString(PreludeSchemas.STRING), equalTo(prefix + "\nz"));
+            }
+        }
+    }
+
+    @PerProvider
+    public void parsesUnescapedUtf8AtStringScanBoundaries(JsonSerdeProvider provider) {
+        var values = List.of(
+                "é",
+                "aaaaaé",
+                "aaaaaaé",
+                "aaaaaaaé",
+                "aaaaaaaaé",
+                "aaaaaaa中z",
+                "aaaaaaa😀z",
+                "中文字符串测试内容值中文字符串测试内容值");
+        try (var codec = codec(provider)) {
+            for (var value : values) {
+                assertThat(codec.createDeserializer(("\"" + value + "\"").getBytes(StandardCharsets.UTF_8))
+                        .readString(PreludeSchemas.STRING), equalTo(value));
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("smithyOnly")
+    public void rejectsControlCharactersAfterUnescapedUtf8(JsonSerdeProvider provider) {
+        try (var codec = codec(provider)) {
+            for (int position : List.of(0, 5, 6, 7, 8, 13, 14, 15, 16)) {
+                var input = new ByteArrayOutputStream();
+                input.write('"');
+                input.writeBytes(("é" + "a".repeat(position)).getBytes(StandardCharsets.UTF_8));
+                input.write(0x1F);
+                input.write('"');
+
+                var exception = Assertions.assertThrows(
+                        SerializationException.class,
+                        () -> codec.createDeserializer(input.toByteArray()).readString(PreludeSchemas.STRING));
+                assertThat(exception.getMessage(), containsString("control character 0x1f"));
+            }
         }
     }
 


### PR DESCRIPTION
### What behavior changes?

JSON string parsing now locates the exact quote, escape, control, or non-ASCII byte directly from each word-sized scan. Output and validation stay the same.

### Why is this change needed?

The old path found that a word contained a stop byte and then rescanned it byte by byte. This removes that extra scan.

### How was this validated?

Expanded string tests across ASCII, UTF-8, escapes, controls, truncation, and word boundaries, and added `JsonStringDeserializeBenchmark`.

### What should reviewers focus on?

The stop masks, lane selection, and transitions between ASCII, UTF-8, and escape paths.

### Additional Links

Part of stack #1325.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.