### PR TITLE
Confirm the in-order JSON field name guess with one masked word compare

### DIFF
--- a/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonFieldNameDeserializeBenchmark.java
+++ b/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/JsonFieldNameDeserializeBenchmark.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.nio.charset.StandardCharsets;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.json.smithy.SmithyJsonSerdeProvider;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+@State(Scope.Benchmark)
+public class JsonFieldNameDeserializeBenchmark {
+
+    private static final int OBJECT_COUNT = 32;
+    private static final int FIELD_COUNT = 8;
+    private static final int FIELD_READS = OBJECT_COUNT * FIELD_COUNT;
+
+    @Param({
+            "inOrder_OneByte",
+            "inOrder_ThreeBytes",
+            "inOrder_FourBytes",
+            "inOrder_SevenBytes",
+            "inOrder_EightBytes",
+            "reverseOrder_SevenBytes",
+    })
+    public String testCaseId;
+
+    private JsonCodec codec;
+    private Schema schema;
+    private byte[] payload;
+    private final Counter counter = new Counter();
+
+    @Setup
+    public void setup() {
+        codec = JsonCodec.builder()
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .build();
+        String[] names = names(testCaseId);
+        schema = schema(names);
+        payload = payload(names, testCaseId.startsWith("reverseOrder"));
+    }
+
+    private static String[] names(String testCaseId) {
+        String format = switch (testCaseId) {
+            case "inOrder_OneByte" -> "%c";
+            case "inOrder_ThreeBytes" -> "f%02d";
+            case "inOrder_FourBytes" -> "f%03d";
+            case "inOrder_SevenBytes", "reverseOrder_SevenBytes" -> "field%02d";
+            case "inOrder_EightBytes" -> "field%03d";
+            default -> throw new IllegalArgumentException("Unknown test case: " + testCaseId);
+        };
+
+        String[] names = new String[FIELD_COUNT];
+        for (int i = 0; i < names.length; i++) {
+            names[i] = testCaseId.equals("inOrder_OneByte")
+                    ? format.formatted((char) ('a' + i))
+                    : format.formatted(i);
+        }
+        return names;
+    }
+
+    private static Schema schema(String[] names) {
+        var builder = Schema.structureBuilder(ShapeId.from("smithy.benchmark#Fields"));
+        for (String name : names) {
+            builder.putMember(name, PreludeSchemas.STRING);
+        }
+        return builder.build();
+    }
+
+    private static byte[] payload(String[] names, boolean reverse) {
+        var result = new StringBuilder("[");
+        for (int object = 0; object < OBJECT_COUNT; object++) {
+            if (object > 0) {
+                result.append(',');
+            }
+            result.append('{');
+            for (int field = 0; field < FIELD_COUNT; field++) {
+                if (field > 0) {
+                    result.append(',');
+                }
+                int index = reverse ? FIELD_COUNT - field - 1 : field;
+                result.append('"').append(names[index]).append("\":\"value\"");
+            }
+            result.append('}');
+        }
+        return result.append(']').toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(FIELD_READS)
+    public int deserialize() {
+        counter.total = 0;
+        codec.createDeserializer(payload)
+                .readList(PreludeSchemas.DOCUMENT, counter, (state, listDeserializer) -> {
+                    listDeserializer.readStruct(schema, state, (result, member, structDeserializer) -> {
+                        result.total += structDeserializer.readString(member).length();
+                    });
+                });
+        return counter.total;
+    }
+
+    private static final class Counter {
+        private int total;
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
@@ -349,6 +349,10 @@ final class JsonReadUtils {
         return Long.numberOfTrailingZeros(stopMask) >>> 3;
     }
 
+    static long readWord(byte[] buf, int pos) {
+        return (long) LONG_HANDLE.get(buf, pos);
+    }
+
     private static SerializationException unescapedControlCharacter(byte b) {
         return new SerializationException(
                 "Unescaped control character 0x" + Integer.toHexString(b & 0xFF) + " in string");

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
@@ -582,9 +582,17 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
             if (lookup != null && expectedNext >= 0 && expectedNext < lookup.orderedNameBytes.length) {
                 byte[] expected = lookup.orderedNameBytes[expectedNext];
                 int expLen = expected.length;
-                if (p + expLen < localEnd
-                        && localBuf[p + expLen] == '"'
-                        && Arrays.equals(localBuf, p, p + expLen, expected, 0, expLen)) {
+                long packedName = lookup.orderedPackedNames[expectedNext];
+                boolean matches;
+                if (packedName != 0 && p + Long.BYTES <= localEnd) {
+                    long mask = -1L >>> ((SmithyMemberLookup.PACK_MAX_LEN - expLen) << 3);
+                    matches = (JsonReadUtils.readWord(localBuf, p) & mask) == packedName;
+                } else {
+                    matches = p + expLen < localEnd
+                            && localBuf[p + expLen] == '"'
+                            && Arrays.equals(localBuf, p, p + expLen, expected, 0, expLen);
+                }
+                if (matches) {
                     member = lookup.orderedSchemas[expectedNext];
                     expectedNext = member.memberIndex() + 1;
                     p += expLen + 1; // skip name + closing quote

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyMemberLookup.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyMemberLookup.java
@@ -28,14 +28,7 @@ final class SmithyMemberLookup implements MemberLookup {
     final Schema[] orderedSchemas;
     final byte[][] orderedNameBytes;
 
-    // Field names of length 1..7 packed into a long as ((len << 56) | big-endian bytes).
-    // The length lives in the top byte and the <=7 name bytes in the low 56 bits, so the
-    // packed value is a collision-free identity (encoding length defends against inputs
-    // with leading 0x00 bytes, which the struct field-name scanner does not reject). This
-    // lets the common short-name lookup replace the FNV byte-loop + Arrays.equals with a
-    // handful of `long ==` comparisons. Entry is 0 for names of length 0 or >= 8 (sentinel);
-    // the packed-path is only entered for input lengths 1..7, whose key has a non-zero top
-    // byte and so never matches the 0 sentinel.
+    // The closing quote makes packed names length-sensitive and directly probeable.
     static final int PACK_MAX_LEN = 7;
     final long[] orderedPackedNames;
 
@@ -64,14 +57,10 @@ final class SmithyMemberLookup implements MemberLookup {
         }
     }
 
-    /**
-     * Packs a name of length 1..7 into {@code (len << 56) | big-endian bytes}.
-     * Caller ensures {@code 1 <= len <= 7}.
-     */
     private static long packName(byte[] buf, int start, int len) {
-        long key = (long) len << 56;
+        long key = (long) '"' << (len << 3);
         for (int i = 0; i < len; i++) {
-            key |= (buf[start + i] & 0xFFL) << ((len - 1 - i) << 3);
+            key |= (buf[start + i] & 0xFFL) << (i << 3);
         }
         return key;
     }

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
@@ -41,6 +41,7 @@ import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.TimestampFormatter;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.Trait;
 
@@ -422,6 +423,52 @@ public class JsonDeserializerTest extends ProviderTestBase {
 
             assertThat(members, contains("name", "color"));
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("smithyOnly")
+    public void deserializesFieldNamesAtWordProbeBoundaries(JsonSerdeProvider provider) {
+        var schema = Schema.structureBuilder(ShapeId.from("smithy.test#ProbeBoundaries"))
+                .putMember("shortPrefix", PreludeSchemas.STRING, new JsonNameTrait("a"))
+                .putMember("sevenBytes", PreludeSchemas.STRING, new JsonNameTrait("aaaaaaa"))
+                .putMember("eightBytes", PreludeSchemas.STRING, new JsonNameTrait("aaaaaaaa"))
+                .putMember("sixUtf8Bytes", PreludeSchemas.STRING, new JsonNameTrait("ééé"))
+                .putMember("eightUtf8Bytes", PreludeSchemas.STRING, new JsonNameTrait("éééé"))
+                .build();
+        var json = "{\"aaaaaaaa\":\"8\",\"a\":\"1\",\"aaaaaaa\":\"7\","
+                + "\"ééé\":\"6\",\"éééé\":\"8u\"}";
+        Map<String, String> values = new LinkedHashMap<>();
+
+        try (var codec = codecBuilder(provider).useJsonName(true).build()) {
+            codec.createDeserializer(json.getBytes(StandardCharsets.UTF_8))
+                    .readStruct(schema,
+                            values,
+                            (state, member, deser) -> state.put(member.memberName(), deser.readString(member)));
+        }
+
+        assertThat(values,
+                equalTo(Map.of(
+                        "shortPrefix", "1",
+                        "sevenBytes", "7",
+                        "eightBytes", "8",
+                        "sixUtf8Bytes", "6",
+                        "eightUtf8Bytes", "8u")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("smithyOnly")
+    public void fallsBackWhenFieldNameIsTooCloseToBufferEndForWordRead(JsonSerdeProvider provider) {
+        var schema = Schema.structureBuilder(ShapeId.from("smithy.test#ShortBuffer"))
+                .putMember("a", PreludeSchemas.INTEGER)
+                .build();
+        AtomicReference<Integer> value = new AtomicReference<>();
+
+        try (var codec = codec(provider)) {
+            codec.createDeserializer("{\"a\":0}".getBytes(StandardCharsets.UTF_8))
+                    .readStruct(schema, value, (state, member, deser) -> state.set(deser.readInteger(member)));
+        }
+
+        assertThat(value.get(), equalTo(0));
     }
 
     @PerProvider

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
@@ -448,11 +448,16 @@ public class JsonDeserializerTest extends ProviderTestBase {
 
         assertThat(values,
                 equalTo(Map.of(
-                        "shortPrefix", "1",
-                        "sevenBytes", "7",
-                        "eightBytes", "8",
-                        "sixUtf8Bytes", "6",
-                        "eightUtf8Bytes", "8u")));
+                        "shortPrefix",
+                        "1",
+                        "sevenBytes",
+                        "7",
+                        "eightBytes",
+                        "8",
+                        "sixUtf8Bytes",
+                        "6",
+                        "eightUtf8Bytes",
+                        "8u")));
     }
 
     @ParameterizedTest

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyMemberLookupTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyMemberLookupTest.java
@@ -16,11 +16,6 @@ import software.amazon.smithy.model.shapes.ShapeId;
 
 /**
  * Tests the packed-long short-name fast path in {@link SmithyMemberLookup#lookup}.
- *
- * <p>Names of length 1..7 are matched by packing their bytes into a long together with
- * the length; these tests guard that this packing is an exact identity (no collisions
- * across different lengths or against control-byte inputs) and that longer names still
- * resolve via the FNV fallback.
  */
 public class SmithyMemberLookupTest {
 
@@ -81,6 +76,8 @@ public class SmithyMemberLookupTest {
     public void boundaryLengthsSevenAndEight() {
         // 7 bytes uses the packed path; 8 bytes falls back to FNV. Both must resolve.
         var l = lookupOf("seven77", "eight888");
+        assertThat(l.orderedPackedNames[0]).isEqualTo(0x2237376e65766573L);
+        assertThat(l.orderedPackedNames[1]).isZero();
         assertThat(lookup(l, "seven77").memberName()).isEqualTo("seven77");
         assertThat(lookup(l, "eight888").memberName()).isEqualTo("eight888");
         assertThat(lookup(l, "seven78")).isNull();


### PR DESCRIPTION
### What behavior changes?

Short JSON field names in their expected order are now checked with one masked word comparison. Longer or out-of-order names keep the existing lookup path.

### Why is this change needed?

Generated payloads usually keep schema order, so the common field lookup can avoid a byte loop and `Arrays.equals`.

### How was this validated?

Added ordered, out-of-order, short-name, and fallback tests plus `JsonFieldNameDeserializeBenchmark`.

### What should reviewers focus on?

The quote-inclusive packed names, length mask, and fallback behavior.

### Additional Links

Part of stack #1325.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.