### PR TITLE
Write JSON strings by copying the Latin-1 array in one validate-and-copy pass

### DIFF
--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/CompactStringAccess.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/CompactStringAccess.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class CompactStringAccess {
+    public static final String DISABLE_PROPERTY =
+            "software.amazon.smithy.java.codecs.commons.disableCompactStringAccess";
+
+    private static final Access ACCESS = initialize();
+
+    private CompactStringAccess() {}
+
+    public static boolean isAvailable() {
+        return ACCESS != null;
+    }
+
+    public static byte[] latin1Bytes(String value) {
+        Access access = ACCESS;
+        if (access == null || (byte) access.coder.get(value) != 0) {
+            return null;
+        }
+        return (byte[]) access.value.get(value);
+    }
+
+    private static Access initialize() {
+        if (Boolean.getBoolean(DISABLE_PROPERTY)
+                || System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
+            return null;
+        }
+
+        try {
+            Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+            Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+            theUnsafe.setAccessible(true);
+            Object unsafe = theUnsafe.get(null);
+
+            Field implLookup = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
+            Object base = unsafeClass
+                    .getMethod("staticFieldBase", Field.class)
+                    .invoke(unsafe, implLookup);
+            long offset = (long) unsafeClass
+                    .getMethod("staticFieldOffset", Field.class)
+                    .invoke(unsafe, implLookup);
+            MethodHandles.Lookup trustedLookup =
+                    (MethodHandles.Lookup) unsafeClass
+                            .getMethod("getObject", Object.class, long.class)
+                            .invoke(unsafe, base, offset);
+
+            return new Access(
+                    trustedLookup.findVarHandle(String.class, "value", byte[].class),
+                    trustedLookup.findVarHandle(String.class, "coder", byte.class));
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private record Access(VarHandle value, VarHandle coder) {}
+}

--- a/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/CompactStringAccessTest.java
+++ b/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/CompactStringAccessTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+public class CompactStringAccessTest {
+
+    @Test
+    public void readsExactCompactStringRepresentationsWithoutJvmFlags() {
+        assertThat(CompactStringAccess.isAvailable()).isTrue();
+        assertThat(CompactStringAccess.latin1Bytes("")).isEmpty();
+        assertThat(CompactStringAccess.latin1Bytes("plain ASCII"))
+                .isEqualTo("plain ASCII".getBytes(StandardCharsets.ISO_8859_1));
+        assertThat(CompactStringAccess.latin1Bytes("caf\u00e9"))
+                .isEqualTo("caf\u00e9".getBytes(StandardCharsets.ISO_8859_1));
+        assertThat(CompactStringAccess.latin1Bytes("\u20ac")).isNull();
+    }
+}

--- a/codecs/json-codec/build.gradle.kts
+++ b/codecs/json-codec/build.gradle.kts
@@ -71,6 +71,49 @@ afterEvaluate {
     }
 }
 
+val compactStringAccessFallbackTest =
+    tasks.register<Test>("compactStringAccessFallbackTest") {
+        description = "Test JSON string writing when compact String access initialization fails."
+        group = "verification"
+
+        val testSourceSet = project.the<SourceSetContainer>()["test"]
+        testClassesDirs = testSourceSet.output.classesDirs
+        classpath = testSourceSet.runtimeClasspath
+
+        useJUnitPlatform()
+        systemProperty(
+            "software.amazon.smithy.java.codecs.commons.disableCompactStringAccess",
+            "true",
+        )
+        systemProperty("smithy.java.test.compactStringAccessMode", "fallback")
+
+        filter {
+            includeTestsMatching("*JsonWriteUtilsTest.forcedInitializationFailureUsesFallback")
+        }
+    }
+
+val compactStringsDisabledTest =
+    tasks.register<Test>("compactStringsDisabledTest") {
+        description = "Test JSON string writing with HotSpot compact strings disabled."
+        group = "verification"
+
+        val testSourceSet = project.the<SourceSetContainer>()["test"]
+        testClassesDirs = testSourceSet.output.classesDirs
+        classpath = testSourceSet.runtimeClasspath
+
+        useJUnitPlatform()
+        jvmArgs("-XX:-CompactStrings")
+        systemProperty("smithy.java.test.compactStringAccessMode", "compactStringsDisabled")
+
+        filter {
+            includeTestsMatching("*JsonWriteUtilsTest.compactStringsDisabledUsesFallback")
+        }
+    }
+
+tasks.named("check") {
+    dependsOn(compactStringAccessFallbackTest, compactStringsDisabledTest)
+}
+
 tasks.named("compileTestJava") {
     dependsOn("smithyBuild")
 }

--- a/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/smithy/JsonStringWriteBenchmark.java
+++ b/codecs/json-codec/src/jmh/java/software/amazon/smithy/java/json/smithy/JsonStringWriteBenchmark.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+public class JsonStringWriteBenchmark {
+
+    @Param({
+            "ascii_0",
+            "ascii_3",
+            "ascii_4",
+            "ascii_7",
+            "ascii_8",
+            "ascii_16",
+            "ascii_24",
+            "ascii_25",
+            "ascii_128",
+            "latin1_128",
+            "utf16_128",
+            "escaped_128",
+    })
+    public String testCaseId;
+
+    private String value;
+    private byte[] buffer;
+
+    @Setup
+    public void setup() {
+        value = switch (testCaseId) {
+            case "ascii_0" -> "";
+            case "ascii_3" -> ascii(3);
+            case "ascii_4" -> ascii(4);
+            case "ascii_7" -> ascii(7);
+            case "ascii_8" -> ascii(8);
+            case "ascii_16" -> ascii(16);
+            case "ascii_24" -> ascii(24);
+            case "ascii_25" -> ascii(25);
+            case "ascii_128" -> ascii(128);
+            case "latin1_128" -> "\u00e9".repeat(128);
+            case "utf16_128" -> "\u20ac".repeat(128);
+            case "escaped_128" -> ascii(127) + '"';
+            default -> throw new IllegalArgumentException("Unknown test case: " + testCaseId);
+        };
+        buffer = new byte[JsonWriteUtils.maxQuotedStringBytes(value)];
+    }
+
+    @Benchmark
+    public int writeWithSmithyJson() {
+        int end = JsonWriteUtils.writeQuotedString(buffer, 0, value);
+        return end + buffer[end - 1];
+    }
+
+    private static String ascii(int length) {
+        String alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        return alphabet.repeat((length + alphabet.length() - 1) / alphabet.length()).substring(0, length);
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
@@ -32,6 +32,8 @@ final class JsonReadUtils {
     // VarHandle for reading 8 bytes at a time from byte arrays (SWAR technique)
     private static final VarHandle LONG_HANDLE =
             MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle INT_HANDLE =
+            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
 
     private static final long ASCII_ZEROES = 0x3030303030303030L;
     private static final long ASCII_NINES = 0x3939393939393939L;
@@ -331,11 +333,17 @@ final class JsonReadUtils {
         throw new SerializationException("Unterminated string");
     }
 
-    private static long stringStopMask(long word) {
+    static long stringStopMask(long word) {
         // Cross-lane borrows can only affect lanes after the earliest stop.
         long quoteOrControl = (word ^ 0x0202020202020202L) - 0x2121212121212121L;
         long backslash = (word ^ 0x5C5C5C5C5C5C5C5CL) - 0x0101010101010101L;
         return (quoteOrControl | backslash | word) & ASCII_HIGH_BITS;
+    }
+
+    static int stringStopMask(int word) {
+        int quoteOrControl = (word ^ 0x02020202) - 0x21212121;
+        int backslash = (word ^ 0x5C5C5C5C) - 0x01010101;
+        return (quoteOrControl | backslash | word) & 0x80808080;
     }
 
     private static long nonAsciiStringStopMask(long word) {
@@ -351,6 +359,18 @@ final class JsonReadUtils {
 
     static long readWord(byte[] buf, int pos) {
         return (long) LONG_HANDLE.get(buf, pos);
+    }
+
+    static void writeWord(byte[] buf, int pos, long word) {
+        LONG_HANDLE.set(buf, pos, word);
+    }
+
+    static int readHalfWord(byte[] buf, int pos) {
+        return (int) INT_HANDLE.get(buf, pos);
+    }
+
+    static void writeHalfWord(byte[] buf, int pos, int word) {
+        INT_HANDLE.set(buf, pos, word);
     }
 
     private static SerializationException unescapedControlCharacter(byte b) {

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonWriteUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonWriteUtils.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.json.smithy;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Arrays;
+import software.amazon.smithy.java.codecs.commons.CompactStringAccess;
 import software.amazon.smithy.java.codecs.commons.NumberCodec;
 import software.amazon.smithy.java.codecs.commons.TimestampCodec;
 import software.amazon.smithy.java.io.ByteBufferUtils;
@@ -84,16 +85,21 @@ final class JsonWriteUtils {
      * Requires {@code value.length() + 2} bytes; on rejection, retry from the original position.
      */
     static int tryWriteQuotedAscii(byte[] buf, int pos, String value) {
+        byte[] latin1 = CompactStringAccess.latin1Bytes(value);
+        return latin1 != null
+                ? writeQuotedAscii(buf, pos, latin1)
+                : tryWriteQuotedAsciiChars(buf, pos, value);
+    }
+
+    private static int tryWriteQuotedAsciiChars(byte[] buf, int pos, String value) {
         int len = value.length();
         int p = pos;
         buf[p++] = '"';
 
         // The JIT auto-vectorizes this loop on JDK 21.
         //
-        // Note: we cannot use String.getBytes(int,int,byte[],int) + SWAR here because
-        // that method truncates chars >= 0x100 to their low byte, which can produce
-        // valid-looking ASCII bytes (e.g. U+0123 -> 0x23 '#') indistinguishable from
-        // real ASCII via any byte-level check.
+        // String.getBytes(int,int,byte[],int) truncates chars above 0xff, so it cannot
+        // safely replace this fallback.
         for (int i = 0; i < len; i++) {
             char c = value.charAt(i);
             if (c >= 0x80 || c < 0x20 || c == '"' || c == '\\') {
@@ -104,6 +110,17 @@ final class JsonWriteUtils {
 
         buf[p++] = '"';
         return p;
+    }
+
+    private static int writeQuotedAscii(byte[] buf, int pos, byte[] latin1) {
+        int copied = copyJsonAscii(latin1, buf, pos + 1);
+        if (copied < 0) {
+            return -1;
+        }
+        buf[pos] = '"';
+        int endQuote = pos + 1 + copied;
+        buf[endQuote] = '"';
+        return endQuote + 1;
     }
 
     /**
@@ -133,6 +150,86 @@ final class JsonWriteUtils {
 
         buf[pos++] = '"';
         return pos;
+    }
+
+    private static int copyJsonAscii(byte[] value, byte[] buf, int pos) {
+        int length = value.length;
+        if (length < Long.BYTES) {
+            if (length >= Integer.BYTES) {
+                int tail = length - Integer.BYTES;
+                int head = JsonReadUtils.readHalfWord(value, 0);
+                int last = JsonReadUtils.readHalfWord(value, tail);
+                if ((JsonReadUtils.stringStopMask(head) | JsonReadUtils.stringStopMask(last)) != 0) {
+                    return -1;
+                }
+                JsonReadUtils.writeHalfWord(buf, pos, head);
+                JsonReadUtils.writeHalfWord(buf, pos + tail, last);
+                return length;
+            }
+            for (int index = 0; index < length; index++) {
+                int current = value[index] & 0xff;
+                if (current < 0x20 || current >= 0x80 || current == '"' || current == '\\') {
+                    return -1;
+                }
+                buf[pos + index] = (byte) current;
+            }
+            return length;
+        }
+        int tail = length - Long.BYTES;
+        long head = JsonReadUtils.readWord(value, 0);
+        long last = JsonReadUtils.readWord(value, tail);
+        if (length <= Long.BYTES * 2) {
+            if ((JsonReadUtils.stringStopMask(head) | JsonReadUtils.stringStopMask(last)) != 0) {
+                return -1;
+            }
+            JsonReadUtils.writeWord(buf, pos, head);
+            JsonReadUtils.writeWord(buf, pos + tail, last);
+            return length;
+        }
+        long middle = JsonReadUtils.readWord(value, Long.BYTES);
+        if (length <= Long.BYTES * 3) {
+            if ((JsonReadUtils.stringStopMask(head)
+                    | JsonReadUtils.stringStopMask(middle)
+                    | JsonReadUtils.stringStopMask(last)) != 0) {
+                return -1;
+            }
+            JsonReadUtils.writeWord(buf, pos, head);
+            JsonReadUtils.writeWord(buf, pos + Long.BYTES, middle);
+            JsonReadUtils.writeWord(buf, pos + tail, last);
+            return length;
+        }
+        return copyJsonAsciiLoop(value, buf, pos, length, tail, head, last);
+    }
+
+    private static int copyJsonAsciiLoop(
+            byte[] value,
+            byte[] buf,
+            int pos,
+            int length,
+            int tail,
+            long head,
+            long last
+    ) {
+        long middle = JsonReadUtils.readWord(value, Long.BYTES);
+        if ((JsonReadUtils.stringStopMask(head) | JsonReadUtils.stringStopMask(middle)) != 0) {
+            return -1;
+        }
+        JsonReadUtils.writeWord(buf, pos, head);
+        JsonReadUtils.writeWord(buf, pos + Long.BYTES, middle);
+        int index = Long.BYTES * 2;
+        while (index < tail) {
+            long word = JsonReadUtils.readWord(value, index);
+            if (JsonReadUtils.stringStopMask(word) != 0) {
+                return -1;
+            }
+            JsonReadUtils.writeWord(buf, pos + index, word);
+            index += Long.BYTES;
+        }
+        if (JsonReadUtils.stringStopMask(last) != 0) {
+            return -1;
+        }
+        JsonReadUtils.writeWord(buf, pos + tail, last);
+        return length;
     }
 
     private static int writeStringSlowPath(byte[] buf, int pos, String value, int startIdx, int len) {

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/JsonWriteUtilsTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/JsonWriteUtilsTest.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.java.json.smithy;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -14,14 +15,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.smithy.java.codecs.commons.CompactStringAccess;
 
 public class JsonWriteUtilsTest {
 
     private static final byte FILL = (byte) 0xEE;
+    private static final String TEST_MODE_PROPERTY = "smithy.java.test.compactStringAccessMode";
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "a", "plain ASCII 123", "\u007f"})
+    @MethodSource("asciiBoundaryStrings")
     public void acceptedStringFitsExactReservationAtAnyOffset(String value) {
         for (int pos = 0; pos <= 8; pos++) {
             var buf = new byte[pos + value.length() + 2];
@@ -36,6 +38,52 @@ public class JsonWriteUtilsTest {
                 assertThat(buf[i]).isEqualTo(FILL);
             }
         }
+    }
+
+    @Test
+    public void acceleratedWordMasksAcceptExactlyUnescapedAscii() {
+        assumeTrue(System.getProperty(TEST_MODE_PROPERTY) == null);
+        assumeTrue(CompactStringAccess.latin1Bytes("a") != null);
+
+        byte[] bytes = new byte[Long.BYTES];
+        Arrays.fill(bytes, (byte) 'a');
+        for (int lane = 0; lane < bytes.length; lane++) {
+            for (int current = 0; current <= 0xFF; current++) {
+                bytes[lane] = (byte) current;
+                String value = new String(bytes, StandardCharsets.ISO_8859_1);
+                boolean expected = current >= 0x20
+                        && current < 0x80
+                        && current != '"'
+                        && current != '\\';
+
+                int end = JsonWriteUtils.tryWriteQuotedAscii(new byte[bytes.length + 2], 0, value);
+
+                assertThat(end >= 0)
+                        .as("byte 0x%02X in lane %d", current, lane)
+                        .isEqualTo(expected);
+            }
+            bytes[lane] = 'a';
+        }
+    }
+
+    @Test
+    public void forcedInitializationFailureUsesFallback() {
+        assumeTrue("fallback".equals(System.getProperty(TEST_MODE_PROPERTY)));
+
+        assertThat(CompactStringAccess.isAvailable()).isFalse();
+        assertThat(CompactStringAccess.latin1Bytes("ASCII")).isNull();
+        assertRepresentativeStrings();
+    }
+
+    @Test
+    public void compactStringsDisabledUsesFallback() {
+        assumeTrue("compactStringsDisabled".equals(System.getProperty(TEST_MODE_PROPERTY)));
+
+        assertThat(CompactStringAccess.isAvailable()).isTrue();
+        assertThat(CompactStringAccess.latin1Bytes("")).isNull();
+        assertThat(CompactStringAccess.latin1Bytes("ASCII")).isNull();
+        assertThat(CompactStringAccess.latin1Bytes("caf\u00e9")).isNull();
+        assertRepresentativeStrings();
     }
 
     @Test
@@ -95,6 +143,13 @@ public class JsonWriteUtilsTest {
                 .isEqualTo(expectedJson);
     }
 
+    static List<String> asciiBoundaryStrings() {
+        return List.of(0, 3, 4, 7, 8, 15, 16, 17, 23, 24, 25, 80)
+                .stream()
+                .map(JsonWriteUtilsTest::ascii)
+                .toList();
+    }
+
     private static List<Character> rejectingChars() {
         return List.of(
                 '"',
@@ -124,5 +179,25 @@ public class JsonWriteUtilsTest {
         return List.of(
                 Arguments.of("plain", "\"plain\":"),
                 Arguments.of("\u0001", "\"\\u0001\":"));
+    }
+
+    private static void assertRepresentativeStrings() {
+        assertWritten("", "\"\"");
+        assertWritten("plain ASCII", "\"plain ASCII\"");
+        assertWritten("caf\u00e9", "\"caf\u00e9\"");
+        assertWritten("\u20ac", "\"\u20ac\"");
+        assertWritten("a\"b", "\"a\\\"b\"");
+        assertWritten("\ud83d\ude00", "\"\ud83d\ude00\"");
+    }
+
+    private static void assertWritten(String value, String expected) {
+        byte[] buffer = new byte[JsonWriteUtils.maxQuotedStringBytes(value)];
+        int end = JsonWriteUtils.writeQuotedString(buffer, 0, value);
+        assertThat(new String(buffer, 0, end, StandardCharsets.UTF_8)).isEqualTo(expected);
+    }
+
+    private static String ascii(int length) {
+        String alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        return alphabet.repeat((length + alphabet.length() - 1) / alphabet.length()).substring(0, length);
     }
 }


### PR DESCRIPTION
### What behavior changes?

Compact ASCII strings are now validated and copied from their backing Latin-1 array in one pass. Other strings and unsupported runtimes keep the character-based fallback.

### Why is this change needed?

This removes repeated `charAt` access from the common JSON string write path without requiring JVM flags.

### How was this validated?

Added `CompactStringAccess` and JSON write tests, forced-fallback coverage, and `JsonStringWriteBenchmark`.

### What should reviewers focus on?

The runtime access fallback, word-at-a-time validation, and partial-copy retry behavior.

### Additional Links

Part of stack #1325.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.