### PR TITLE
Write XML strings from compact Latin-1 storage

### DIFF
--- a/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlWriteUtils.java
+++ b/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlWriteUtils.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.java.xml;
 
+import software.amazon.smithy.java.codecs.commons.CompactStringAccess;
+
 /**
  * Low-level utilities for writing XML content directly to byte arrays with proper escaping.
  */
@@ -19,6 +21,13 @@ final class XmlWriteUtils {
     private static final byte[] APOS_ESC = {'&', 'a', 'p', 'o', 's', ';'};
 
     static int writeEscapedText(byte[] buf, int pos, String value) {
+        byte[] latin1 = CompactStringAccess.latin1Bytes(value);
+        return latin1 != null
+                ? writeEscapedLatin1(buf, pos, latin1, false)
+                : writeEscapedTextChars(buf, pos, value);
+    }
+
+    private static int writeEscapedTextChars(byte[] buf, int pos, String value) {
         int len = value.length();
         for (int i = 0; i < len; i++) {
             char c = value.charAt(i);
@@ -64,6 +73,13 @@ final class XmlWriteUtils {
     }
 
     static int writeEscapedAttribute(byte[] buf, int pos, String value) {
+        byte[] latin1 = CompactStringAccess.latin1Bytes(value);
+        return latin1 != null
+                ? writeEscapedLatin1(buf, pos, latin1, true)
+                : writeEscapedAttributeChars(buf, pos, value);
+    }
+
+    private static int writeEscapedAttributeChars(byte[] buf, int pos, String value) {
         int len = value.length();
         for (int i = 0; i < len; i++) {
             char c = value.charAt(i);
@@ -112,6 +128,45 @@ final class XmlWriteUtils {
             }
         }
         return pos;
+    }
+
+    private static int writeEscapedLatin1(byte[] buf, int pos, byte[] value, boolean attribute) {
+        int copyStart = 0;
+        for (int i = 0; i < value.length; i++) {
+            byte current = value[i];
+            byte[] escape = null;
+            if (current == '&') {
+                escape = AMP_ESC;
+            } else if (current == '<') {
+                escape = LT_ESC;
+            } else if (current == '>') {
+                escape = GT_ESC;
+            } else if (attribute && current == '"') {
+                escape = QUOT_ESC;
+            } else if (attribute && current == '\'') {
+                escape = APOS_ESC;
+            }
+
+            if (escape != null) {
+                pos = copyAscii(value, copyStart, i, buf, pos);
+                System.arraycopy(escape, 0, buf, pos, escape.length);
+                pos += escape.length;
+                copyStart = i + 1;
+            } else if (current < 0) {
+                pos = copyAscii(value, copyStart, i, buf, pos);
+                int c = current & 0xff;
+                buf[pos++] = (byte) (0xC0 | (c >> 6));
+                buf[pos++] = (byte) (0x80 | (c & 0x3F));
+                copyStart = i + 1;
+            }
+        }
+        return copyAscii(value, copyStart, value.length, buf, pos);
+    }
+
+    private static int copyAscii(byte[] value, int start, int end, byte[] buf, int pos) {
+        int length = end - start;
+        System.arraycopy(value, start, buf, pos, length);
+        return pos + length;
     }
 
     static int maxEscapedTextBytes(String value) {

--- a/codecs/xml-codec/src/test/java/software/amazon/smithy/java/xml/GeneratedModelSerdeTest.java
+++ b/codecs/xml-codec/src/test/java/software/amazon/smithy/java/xml/GeneratedModelSerdeTest.java
@@ -207,6 +207,7 @@ public class GeneratedModelSerdeTest extends ProviderTestBase {
                 "",
                 "abcdefghijklmnopqrstuvwxyz0123456789",
                 "quote:\" backslash:\\ tab:\t newline:\n",
+                "café",
                 "é中ü",
                 "😀🎉",
                 "hello\tworld\né😀\"quoted\"")) {
@@ -362,6 +363,17 @@ public class GeneratedModelSerdeTest extends ProviderTestBase {
         var original = XmlAttributeStruct.builder()
                 .version("1.0")
                 .identifier("abc-123")
+                .content("hello world")
+                .build();
+        assertThat(roundtrip(ser, de, original, XmlAttributeStruct.builder())).isEqualTo(original);
+    }
+
+    @ParameterizedTest
+    @MethodSource("crossProviders")
+    void xmlAttributeSpecialCharactersRoundtrip(boolean ser, boolean de) {
+        var original = XmlAttributeStruct.builder()
+                .version("café & \"quoted\"")
+                .identifier("l'été < 2027")
                 .content("hello world")
                 .build();
         assertThat(roundtrip(ser, de, original, XmlAttributeStruct.builder())).isEqualTo(original);


### PR DESCRIPTION
### What behavior changes?

XML now reads compact text and attribute values from their Latin-1 backing array. Plain ASCII spans are bulk-copied, with escapes and UTF-8 expansion handled as needed.

### Why is this change needed?

This removes repeated `charAt` access from the common XML write path.

### How was this validated?

Added Latin-1 text and escaped-attribute round trips, then ran XML tests with compact access enabled and forcibly disabled, plus Spotless checks.

### What should reviewers focus on?

ASCII span copying, XML escapes, Latin-1 expansion, and the existing UTF-16 fallback.

### Additional Links

Part of stack #1325.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.