### PR TITLE
Fix XML isNull() misclassifying structure list members as null

### DIFF
--- a/codecs/xml-codec/model/test.smithy
+++ b/codecs/xml-codec/model/test.smithy
@@ -272,3 +272,35 @@ structure AllListsStruct {
     blobs: BlobList
     timestamps: TimestampList
 }
+
+structure DenseListStruct {
+    structs: StructItemList
+    strings: PlainStringList
+}
+
+structure SparseListStruct {
+    structs: SparseStructItemList
+    strings: SparsePlainStringList
+}
+
+structure StructItem {
+    id: String
+}
+
+list StructItemList {
+    member: StructItem
+}
+
+@sparse
+list SparseStructItemList {
+    member: StructItem
+}
+
+list PlainStringList {
+    member: String
+}
+
+@sparse
+list SparsePlainStringList {
+    member: String
+}

--- a/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlDeserializer.java
+++ b/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlDeserializer.java
@@ -575,7 +575,12 @@ final class XmlDeserializer implements ShapeDeserializer, XmlErrorCodeParser {
         @Override
         public boolean isNull() {
             try {
-                return reader.getText().isEmpty();
+                // An element is null only when it is genuinely empty: no text content AND no child
+                // elements. getText() returns "" both for a truly empty element (<x/> or <x></x>)
+                // and for an element whose content is entirely child elements, e.g. a structure
+                // (<x><child>..</child></x>). To tell them apart, require that consuming the text left
+                // us on this element's own end tag rather than on a nested child node.
+                return reader.getText().isEmpty() && reader.atEndElement();
             } catch (XMLStreamException e) {
                 throw error("Failed to determine if value is null", e);
             }

--- a/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlReader.java
+++ b/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/XmlReader.java
@@ -77,6 +77,11 @@ sealed abstract class XmlReader implements AutoCloseable {
         return textReader.toString();
     }
 
+    final boolean atEndElement() throws XMLStreamException {
+        nextIfNeeded();
+        return getEventType() == XMLStreamConstants.END_ELEMENT;
+    }
+
     private static boolean readNextString(int event) {
         return switch (event) {
             case XMLStreamReader.CHARACTERS, XMLStreamConstants.CDATA -> true;

--- a/codecs/xml-codec/src/test/java/software/amazon/smithy/java/xml/GeneratedModelSerdeTest.java
+++ b/codecs/xml-codec/src/test/java/software/amazon/smithy/java/xml/GeneratedModelSerdeTest.java
@@ -24,6 +24,7 @@ import smithy.java.xml.test.model.AllListsStruct;
 import smithy.java.xml.test.model.BlobStruct;
 import smithy.java.xml.test.model.Color;
 import smithy.java.xml.test.model.ComplexStruct;
+import smithy.java.xml.test.model.DenseListStruct;
 import smithy.java.xml.test.model.FlattenedListStruct;
 import smithy.java.xml.test.model.FlattenedMapStruct;
 import smithy.java.xml.test.model.InnerStruct;
@@ -32,7 +33,9 @@ import smithy.java.xml.test.model.NestedStruct;
 import smithy.java.xml.test.model.NumericStruct;
 import smithy.java.xml.test.model.RecursiveStruct;
 import smithy.java.xml.test.model.SimpleStruct;
+import smithy.java.xml.test.model.SparseListStruct;
 import smithy.java.xml.test.model.StringStruct;
+import smithy.java.xml.test.model.StructItem;
 import smithy.java.xml.test.model.TimestampStruct;
 import smithy.java.xml.test.model.XmlAttributeStruct;
 import smithy.java.xml.test.model.XmlNameStruct;
@@ -737,6 +740,69 @@ public class GeneratedModelSerdeTest extends ProviderTestBase {
         var nativeResult = deserialize(NATIVE, xml, ComplexStruct.builder());
         assertThat(nativeResult.getTags()).isEqualTo(staxResult.getTags());
         assertThat(nativeResult.getTags()).containsExactly(null, "hello", null);
+    }
+
+    @PerProvider
+    void denseStructListDeserializes(boolean useNative) {
+        String xml = "<DenseListStruct><structs><member><id>abcd</id></member></structs></DenseListStruct>";
+        var result = deserialize(useNative, xml, DenseListStruct.builder());
+        assertThat(result.getStructs()).hasSize(1);
+        assertThat(result.getStructs().get(0).getId()).isEqualTo("abcd");
+    }
+
+    @PerProvider
+    void prettyPrintedStructListDeserializes(boolean useNative) {
+        String xml = """
+                <DenseListStruct>
+                  <structs>
+                    <member>
+                      <id>abcd</id>
+                    </member>
+                  </structs>
+                </DenseListStruct>
+                """;
+        var result = deserialize(useNative, xml, DenseListStruct.builder());
+        assertThat(result.getStructs()).hasSize(1);
+        assertThat(result.getStructs().get(0).getId()).isEqualTo("abcd");
+    }
+
+    // Both empty forms, <member/> and <member></member>, are null and rejected by a dense list.
+    @PerProvider
+    void denseStructListNullMemberThrows(boolean useNative) {
+        String singleTag = "<DenseListStruct><structs><member/></structs></DenseListStruct>";
+        assertThatThrownBy(() -> deserialize(useNative, singleTag, DenseListStruct.builder()))
+                .isInstanceOf(SerializationException.class);
+        String separateTag = "<DenseListStruct><structs><member></member></structs></DenseListStruct>";
+        assertThatThrownBy(() -> deserialize(useNative, separateTag, DenseListStruct.builder()))
+                .isInstanceOf(SerializationException.class);
+    }
+
+    @PerProvider
+    void sparseStructListNullMemberIsNull(boolean useNative) {
+        String xml = "<SparseListStruct><structs><member/></structs></SparseListStruct>";
+        var result = deserialize(useNative, xml, SparseListStruct.builder());
+        assertThat(result.getStructs()).containsExactly((StructItem) null);
+    }
+
+    @PerProvider
+    void densePopulatedStringListDeserializes(boolean useNative) {
+        String xml = "<DenseListStruct><strings><member>a</member><member>x</member></strings></DenseListStruct>";
+        var result = deserialize(useNative, xml, DenseListStruct.builder());
+        assertThat(result.getStrings()).containsExactly("a", "x");
+    }
+
+    @PerProvider
+    void denseStringListEmptyMemberThrows(boolean useNative) {
+        String xml = "<DenseListStruct><strings><member></member><member>x</member></strings></DenseListStruct>";
+        assertThatThrownBy(() -> deserialize(useNative, xml, DenseListStruct.builder()))
+                .isInstanceOf(SerializationException.class);
+    }
+
+    @PerProvider
+    void sparseStringListEmptyMemberIsNull(boolean useNative) {
+        String xml = "<SparseListStruct><strings><member></member><member>x</member></strings></SparseListStruct>";
+        var result = deserialize(useNative, xml, SparseListStruct.builder());
+        assertThat(result.getStrings()).containsExactly(null, "x");
     }
 
     @PerProvider


### PR DESCRIPTION
### What behavior changes?
The XML deserializer misjudged the nullability of a list element whose value is a structure when the XML was compact (no whitespace between the element and its firstchild). 
For example, the following raises `SerializationException("Null value found in dense list")`: the `<member>` element has no direct text all its data is in child elements. `reader.getText().isEmpty()` evaluates to `true` inside `isNull()` in `XmlDeserializer`, and the member is wrongly treated as null.

```xml
<DenseListStruct><structs><member><id>abcd</id></member></structs></DenseListStruct>
```
This PR fixes it by additionally checking that the reader is at the element's END_ELEMENT, so only a genuinely empty element is treated as null.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
