### PR TITLE
Return -32601 for unknown MCP methods instead of an empty response

### DIFF
--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpService.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpService.java
@@ -77,6 +77,7 @@ public final class McpService {
 
     private static final InternalLogger LOG = InternalLogger.getLogger(McpService.class);
     private static final Context.Key<Boolean> ASYNC_DISPATCH = Context.key("mcp.asyncDispatch");
+    private static final int METHOD_NOT_FOUND_ERROR_CODE = -32601;
 
     private static final JsonCodec CODEC = JsonCodec.builder()
             .settings(JsonSettings.builder()
@@ -131,8 +132,8 @@ public final class McpService {
      *   <li><b>Synchronous (return value):</b> For most requests, the response is returned directly.</li>
      *   <li><b>Asynchronous (callback):</b> For proxy tool calls, returns {@code null} and the callback
      *       is invoked when the proxy responds.</li>
-     *   <li><b>Neither:</b> For notifications and unknown methods, returns {@code null} and the callback
-     *       is never invoked.</li>
+     *   <li><b>Neither:</b> For notifications, returns {@code null} and the callback is never
+     *       invoked. Requests with unknown methods receive a -32601 (Method not found) error.</li>
      * </ul>
      *
      * @param req The JSON-RPC request to handle
@@ -172,7 +173,7 @@ public final class McpService {
                         case "tools/list" -> handleToolsList(currentReq, protocolVersion);
                         case "tools/call" ->
                             handleToolsCall(currentReq, asyncResponseCallback, protocolVersion, hook);
-                        default -> null;
+                        default -> methodNotFound(currentReq);
                     };
                 }
             };
@@ -211,7 +212,7 @@ public final class McpService {
                         case "tools/list" -> handleToolsList(req, protocolVersion);
                         case "tools/call" ->
                             handleToolsCallDirect(req, asyncResponseCallback, protocolVersion);
-                        default -> null; // Notifications or unknown methods
+                        default -> methodNotFound(req);
                     };
                 }
             };
@@ -790,6 +791,25 @@ public final class McpService {
         var error = JsonRpcErrorResponse.builder()
                 .code(500)
                 .message(s)
+                .build();
+        return JsonRpcResponse.builder()
+                .id(req.getId())
+                .error(error)
+                .jsonrpc("2.0")
+                .build();
+    }
+
+    /**
+     * Per JSON-RPC 2.0, a request with an unknown method must receive a -32601 (Method not found)
+     * error, while notifications (requests without an id) must never receive a response.
+     */
+    private static JsonRpcResponse methodNotFound(JsonRpcRequest req) {
+        if (req.getId() == null) {
+            return null;
+        }
+        var error = JsonRpcErrorResponse.builder()
+                .code(METHOD_NOT_FOUND_ERROR_CODE)
+                .message("Method not found: " + req.getMethod())
                 .build();
         return JsonRpcResponse.builder()
                 .id(req.getId())

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
@@ -755,6 +755,77 @@ public class McpServerTest {
     }
 
     @Test
+    void testUnknownMethodReturnsMethodNotFound() {
+        server = McpServer.builder()
+                .name("smithy-mcp-server")
+                .input(input)
+                .output(output)
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
+                .build();
+
+        server.start();
+
+        write("nonexistent/method", Document.of(Map.of()), Document.of(42));
+        var response = read();
+        assertEquals("2.0", response.getJsonrpc());
+        assertEquals(42, response.getId().asNumber().intValue());
+        assertNull(response.getResult());
+        assertNotNull(response.getError());
+        assertEquals(-32601, response.getError().getCode());
+        assertTrue(response.getError().getMessage().contains("nonexistent/method"));
+
+        // String ids must be echoed back with their original type
+        write("server/discover", Document.of(Map.of()), Document.of("discover-1"));
+        response = read();
+        assertEquals("discover-1", response.getId().asString());
+        assertNull(response.getResult());
+        assertEquals(-32601, response.getError().getCode());
+
+        // Known methods are unaffected
+        write("ping", Document.of(Map.of()), Document.of(43));
+        response = read();
+        assertEquals(43, response.getId().asNumber().intValue());
+        assertNull(response.getError());
+        assertNotNull(response.getResult());
+    }
+
+    @Test
+    void testUnknownNotificationIsSilentlyDropped() {
+        server = McpServer.builder()
+                .name("smithy-mcp-server")
+                .input(input)
+                .output(output)
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test#TestService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(MODEL)
+                                .build())
+                .build();
+
+        server.start();
+
+        // Unknown notifications (no id) must not receive a Method not found error
+        writeNotification("notifications/does-not-exist", Document.of(Map.of()));
+        output.assertNoOutput();
+
+        // Known notifications remain silently dropped
+        writeNotification("notifications/initialized", Document.of(Map.of()));
+        output.assertNoOutput();
+
+        // The next response on the wire belongs to the follow-up request, not a late error
+        write("tools/list", Document.of(Map.of()), Document.of(7));
+        var response = read();
+        assertEquals(7, response.getId().asNumber().intValue());
+        assertNotNull(response.getResult());
+    }
+
+    @Test
     void testPromptsList() {
         server = McpServer.builder()
                 .name("smithy-mcp-server")


### PR DESCRIPTION
### What behavior changes?

A request with an unknown JSON-RPC method that carries an `id` now receives a proper error response:

```json
{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found: nonexistent/method"},"id":4}
```

Previously both dispatch switches in `McpService` returned `null` for unknown methods, so the request got no response at all (over HTTP transports that surfaces as a 200 with an empty body). Notifications — known or unknown, identified by the absence of an `id` — are still silently dropped, and all known methods are unchanged.

### Why is this change needed?

JSON-RPC 2.0 requires that every request carrying an `id` receive a response. Beyond spec correctness, this is groundwork for MCP protocol revision 2026-07-28 (#1337, PR 1 of the ladder proposed there): the Python SDK ≥ 2.0.0 probes servers with `server/discover` and falls back to the legacy `initialize` handshake when the probe fails. Today that fallback only works because the client synthesizes a parse error from the empty body — with this change it triggers off a clean, deterministic `-32601`, which is one of the documented legacy-server signals. The description of #1304 records this same empty-response symptom for `initialize` with an unrecognized version.

### How was this validated?

- New unit tests in `McpServerTest`: unknown method with an integer id and with a string id (the id is echoed with its original type — it is modeled as a `Document`), unknown and known notifications produce no output, `ping`/`tools/list` unaffected. Module `test` and `check` (spotless, spotbugs, integration suite) green.
- End-to-end against our internal MCP gateway (which embeds this engine) with Python SDK `mcp==1.28.1` (full legacy flow unchanged) and `mcp==2.0.0` (`mode=auto` still connects, now falling back via the clean error; verified on the wire).

### What should reviewers focus on?

- The `methodNotFound(JsonRpcRequest)` helper in `McpService` and its two call sites (both dispatch paths).
- One pre-existing quirk left untouched: `validate()` requires an `id` on any method not prefixed `notifications/`, so an id-less request with an unknown non-notification method is rejected as a validation error rather than treated as a notification per strict JSON-RPC. Flagged in #1337.

### Additional Links

- #1337 (MCP 2026-07-28 support proposal; this is step 1)
- #1304 (prior fix that documents the empty-response symptom)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
