### PR TITLE
Serialize structure members in schema order, not declaration order

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/StructureSerializerGenerator.java
@@ -55,7 +55,7 @@ record StructureSerializerGenerator(
     private void writeMemberSerialization(JavaWriter writer) {
         boolean isError = shape.hasTrait(ErrorTrait.class);
 
-        for (var member : shape.members()) {
+        for (var member : CodegenUtils.getSortedMembers(shape)) {
             var memberName = symbolProvider.toMemberName(member);
             // if the shape is an error we need to use the `getMessage()` method for message field.
             if (isError && memberName.equalsIgnoreCase("message")) {

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/jspecify/expected/CollectionStruct.java
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/jspecify/expected/CollectionStruct.java
@@ -200,22 +200,22 @@ public final class CollectionStruct implements SerializableStruct {
 
     @Override
     public void serializeMembers(ShapeSerializer serializer) {
+        serializer.writeList($SCHEMA_SPARSE_LIST, sparseList, sparseList.size(), SharedSerde.SparseStringListSerializer.INSTANCE);
+        serializer.writeMap($SCHEMA_SPARSE_MAP, sparseMap, sparseMap.size(), SharedSerde.SparseStringMapSerializer.INSTANCE);
+        serializer.writeList($SCHEMA_SPARSE_LIST_OF_SPARSE_MAP, sparseListOfSparseMap, sparseListOfSparseMap.size(), SharedSerde.SparseListOfSparseMapSerializer.INSTANCE);
+        serializer.writeList($SCHEMA_NON_SPARSE_LIST_OF_NON_SPARSE_MAP, nonSparseListOfNonSparseMap, nonSparseListOfNonSparseMap.size(), SharedSerde.NonSparseListOfNonSparseMapSerializer.INSTANCE);
         if (nonSparseList != null) {
             serializer.writeList($SCHEMA_NON_SPARSE_LIST, nonSparseList, nonSparseList.size(), SharedSerde.NonSparseStringListSerializer.INSTANCE);
         }
-        serializer.writeList($SCHEMA_SPARSE_LIST, sparseList, sparseList.size(), SharedSerde.SparseStringListSerializer.INSTANCE);
         if (nonSparseMap != null) {
             serializer.writeMap($SCHEMA_NON_SPARSE_MAP, nonSparseMap, nonSparseMap.size(), SharedSerde.NonSparseStringMapSerializer.INSTANCE);
         }
-        serializer.writeMap($SCHEMA_SPARSE_MAP, sparseMap, sparseMap.size(), SharedSerde.SparseStringMapSerializer.INSTANCE);
         if (nonSparseListOfSparseMap != null) {
             serializer.writeList($SCHEMA_NON_SPARSE_LIST_OF_SPARSE_MAP, nonSparseListOfSparseMap, nonSparseListOfSparseMap.size(), SharedSerde.NonSparseListOfSparseMapSerializer.INSTANCE);
         }
-        serializer.writeList($SCHEMA_SPARSE_LIST_OF_SPARSE_MAP, sparseListOfSparseMap, sparseListOfSparseMap.size(), SharedSerde.SparseListOfSparseMapSerializer.INSTANCE);
         if (sparseMapOfNonSparseList != null) {
             serializer.writeMap($SCHEMA_SPARSE_MAP_OF_NON_SPARSE_LIST, sparseMapOfNonSparseList, sparseMapOfNonSparseList.size(), SharedSerde.SparseMapOfNonSparseListSerializer.INSTANCE);
         }
-        serializer.writeList($SCHEMA_NON_SPARSE_LIST_OF_NON_SPARSE_MAP, nonSparseListOfNonSparseMap, nonSparseListOfNonSparseMap.size(), SharedSerde.NonSparseListOfNonSparseMapSerializer.INSTANCE);
     }
 
     @Override

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/jspecify/expected/JSpecifyStruct.java
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/jspecify/expected/JSpecifyStruct.java
@@ -103,10 +103,10 @@ public final class JSpecifyStruct implements SerializableStruct {
     @Override
     public void serializeMembers(ShapeSerializer serializer) {
         serializer.writeString($SCHEMA_REQUIRED_STRING, requiredString);
+        serializer.writeBoolean($SCHEMA_REQUIRED_PRIMITIVE, requiredPrimitive);
         if (optionalString != null) {
             serializer.writeString($SCHEMA_OPTIONAL_STRING, optionalString);
         }
-        serializer.writeBoolean($SCHEMA_REQUIRED_PRIMITIVE, requiredPrimitive);
         if (sparseList != null) {
             serializer.writeList($SCHEMA_SPARSE_LIST, sparseList, sparseList.size(), SharedSerde.SparseStringListSerializer.INSTANCE);
         }


### PR DESCRIPTION
### What behavior changes?
Serialize structure members in schema order, not declaration order

### Why is this change needed?

So that adding changing the order of fields in the model doesn't change the order of serialization.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
