### PR TITLE
fix(mcp-server): Handle oneOf documents as operation input/output roots

### DIFF
--- a/mcp/mcp-schemas/model/main.smithy
+++ b/mcp/mcp-schemas/model/main.smithy
@@ -125,6 +125,10 @@ structure JsonObjectSchema {
 
     description: String
 
+    /// Present when the object is a discriminated polymorphic type (see the smithy.mcp#oneOf
+    /// trait): the instance must additionally match exactly one of these variant schemas.
+    oneOf: JsonSchemaList
+
     @jsonName("$schema")
     schema: String = "http://json-schema.org/draft-07/schema#"
 }

--- a/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpService.java
+++ b/mcp/mcp-server/src/main/java/software/amazon/smithy/java/mcp/server/McpService.java
@@ -992,7 +992,21 @@ public final class McpService {
 
         var cached = cache.get(targetId);
         if (cached != null) {
-            return (JsonObjectSchema) withDescription(cached, memberDescription(member));
+            return asJsonObjectSchema(withDescription(cached, memberDescription(member)));
+        }
+
+        // A document carrying the oneOf trait (a discriminated polymorphic type) can be asked
+        // for in an object position — most notably as an operation's input or output, which
+        // model bundles load without validation. Build it through the oneOf path, which caches
+        // a JsonOneOfSchema for other references to reuse, and re-shape the result into the
+        // object-typed schema this position requires. Scoped to documents (the trait's
+        // selector) so any other shape kind carrying the trait keeps its regular rendering,
+        // matching what runtime input/output adaptation recognizes.
+        if (target.type() == ShapeType.DOCUMENT) {
+            var oneOfTrait = target.getTrait(ONE_OF_TRAIT);
+            if (oneOfTrait != null) {
+                return asJsonObjectSchema(createJsonOneOfSchema(oneOfTrait, member, visited, cache));
+            }
         }
 
         if (!visited.add(targetId)) {
@@ -1022,7 +1036,29 @@ public final class McpService {
                 .build();
         cache.put(targetId, result);
 
-        return (JsonObjectSchema) withDescription(result, memberDescription(member));
+        return asJsonObjectSchema(withDescription(result, memberDescription(member)));
+    }
+
+    /**
+     * Re-shapes a schema for a position that requires an object-typed schema, such as a tool's
+     * input or output (the MCP spec requires both to have {@code "type": "object"}). A
+     * discriminated polymorphic type renders as a {@link JsonOneOfSchema}; it is carried over as
+     * an object schema constrained by the same {@code oneOf} variants, which serializes to the
+     * same JSON. Anything else degrades to a permissive object schema rather than failing the
+     * entire tool listing.
+     */
+    private static JsonObjectSchema asJsonObjectSchema(SerializableShape schema) {
+        if (schema instanceof JsonObjectSchema objectSchema) {
+            return objectSchema;
+        }
+        if (schema instanceof JsonOneOfSchema oneOfSchema) {
+            var builder = JsonObjectSchema.builder().oneOf(oneOfSchema.getOneOf());
+            if (oneOfSchema.getDescription() != null) {
+                builder.description(oneOfSchema.getDescription());
+            }
+            return builder.build();
+        }
+        return JsonObjectSchema.builder().build();
     }
 
     private JsonArraySchema createJsonArraySchema(

--- a/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
+++ b/mcp/mcp-server/src/test/java/software/amazon/smithy/java/mcp/server/McpServerTest.java
@@ -1580,6 +1580,87 @@ public class McpServerTest {
             .assemble()
             .unwrap();
 
+    private static final String ONE_OF_ROOT_MODEL_STR =
+            """
+                    $version: "2"
+
+                    namespace smithy.test.oneofroot
+
+                    use smithy.mcp#oneOf
+
+                    @aws.protocols#awsJson1_0
+                    service TestOneOfRootService {
+                        operations: [ProcessShape, GetShape]
+                    }
+
+                    /// References the polymorphic document as a nested member, so the schema
+                    /// cache holds a oneOf schema for it when GetShape's output is built.
+                    operation ProcessShape {
+                        input: ProcessShapeInput
+                        output: ProcessShapeOutput
+                    }
+
+                    /// Returns the polymorphic document directly as the operation output.
+                    operation GetShape {
+                        input: GetShapeInput
+                        output: ShapeWithOneOf
+                    }
+
+                    structure ProcessShapeInput {
+                        shape: ShapeWithOneOf
+                    }
+
+                    structure ProcessShapeOutput {
+                        shape: ShapeWithOneOf
+                    }
+
+                    structure GetShapeInput {
+                        id: String
+                    }
+
+                    /// Same shapes, but operation names sort the nested reference BEFORE the
+                    /// root reference: AProcessShape caches the oneOf schema, then ZGetShape
+                    /// requests the same shape as its output root (the cache-hit order).
+                    @aws.protocols#awsJson1_0
+                    service TestOneOfRootCachedService {
+                        operations: [AProcessShape, ZGetShape]
+                    }
+
+                    operation AProcessShape {
+                        input: ProcessShapeInput
+                        output: ProcessShapeOutput
+                    }
+
+                    operation ZGetShape {
+                        input: GetShapeInput
+                        output: ShapeWithOneOf
+                    }
+
+                    @oneOf(discriminator: "__type", members: [
+                        {name: "circle", target: Circle},
+                        {name: "square", target: Square}
+                    ])
+                    document ShapeWithOneOf
+
+                    structure Circle {
+                        @required
+                        radius: Integer
+                    }
+
+                    structure Square {
+                        @required
+                        side: Integer
+                    }""";
+
+    // Assembled without validation, mirroring ModelBundles: bundled models reach the MCP server
+    // with document-typed operation outputs, which strict validation would reject.
+    private static final Model ONE_OF_ROOT_MODEL = Model.assembler()
+            .addUnparsedModel("test-oneof-root.smithy", ONE_OF_ROOT_MODEL_STR)
+            .discoverModels()
+            .disableValidation()
+            .assemble()
+            .unwrap();
+
     @Test
     void testUnionSchemaGeneratesOneOfWithWrappedMembers() {
         server = McpServer.builder()
@@ -1670,6 +1751,97 @@ public class McpServerTest {
         // Document with @oneOf should have oneOf array generated from trait members
         var oneOf = shapeProperty.get("oneOf").asList();
         assertEquals(2, oneOf.size(), "Document with @oneOf should have 2 oneOf variants");
+    }
+
+    @Test
+    void testOneOfDocumentAsOperationOutputRoot() {
+        // Regression test: a @oneOf document used directly as an operation output used to
+        // either throw ClassCastException (when another operation had already cached its
+        // JsonOneOfSchema) or silently cache an empty object schema that clobbered nested
+        // references, depending on operation processing order.
+        server = McpServer.builder()
+                .name("smithy-mcp-server")
+                .input(input)
+                .output(output)
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test.oneofroot#TestOneOfRootService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(ONE_OF_ROOT_MODEL)
+                                .build())
+                .build();
+
+        server.start();
+
+        initializeWithProtocolVersion(ProtocolVersion.v2025_06_18.INSTANCE);
+        write("tools/list", Document.of(Map.of()));
+        var response = read();
+        var tools = response.getResult().asStringMap().get("tools").asList();
+
+        // The tool whose output IS the polymorphic document: the root schema must be
+        // object-typed (required by the MCP spec) and still carry the oneOf variants.
+        var rootTool = tools.stream()
+                .filter(t -> t.asStringMap().get("name").asString().equals("GetShape"))
+                .findFirst()
+                .orElseThrow()
+                .asStringMap();
+        var outputSchema = rootTool.get("outputSchema").asStringMap();
+        assertEquals("object", outputSchema.get("type").asString());
+        var rootOneOf = outputSchema.get("oneOf").asList();
+        assertEquals(2, rootOneOf.size(), "Polymorphic output root should have 2 oneOf variants");
+
+        // The nested reference must keep its full oneOf schema: rendering the same shape in an
+        // object position must not pollute the schema cache for other references.
+        var nestedTool = tools.stream()
+                .filter(t -> t.asStringMap().get("name").asString().equals("ProcessShape"))
+                .findFirst()
+                .orElseThrow()
+                .asStringMap();
+        var shapeProp = nestedTool.get("inputSchema")
+                .asStringMap()
+                .get("properties")
+                .asStringMap()
+                .get("shape")
+                .asStringMap();
+        assertEquals(2,
+                shapeProp.get("oneOf").asList().size(),
+                "Nested reference to the polymorphic document should keep its oneOf variants");
+    }
+
+    @Test
+    void testOneOfDocumentAsOperationOutputRootWithCachedSchema() {
+        // Operations are processed in sorted order, so AProcessShape caches the document's
+        // JsonOneOfSchema before ZGetShape requests the same shape as its output root. This is
+        // the order that used to throw ClassCastException while building the service.
+        server = McpServer.builder()
+                .name("smithy-mcp-server")
+                .input(input)
+                .output(output)
+                .addService("test-mcp",
+                        ProxyService.builder()
+                                .service(ShapeId.from("smithy.test.oneofroot#TestOneOfRootCachedService"))
+                                .proxyEndpoint("http://localhost")
+                                .model(ONE_OF_ROOT_MODEL)
+                                .build())
+                .build();
+
+        server.start();
+
+        initializeWithProtocolVersion(ProtocolVersion.v2025_06_18.INSTANCE);
+        write("tools/list", Document.of(Map.of()));
+        var response = read();
+        var tools = response.getResult().asStringMap().get("tools").asList();
+
+        var rootTool = tools.stream()
+                .filter(t -> t.asStringMap().get("name").asString().equals("ZGetShape"))
+                .findFirst()
+                .orElseThrow()
+                .asStringMap();
+        var outputSchema = rootTool.get("outputSchema").asStringMap();
+        assertEquals("object", outputSchema.get("type").asString());
+        assertEquals(2,
+                outputSchema.get("oneOf").asList().size(),
+                "Root schema converted from the cached oneOf schema should keep its variants");
     }
 
     @Test


### PR DESCRIPTION
### What behavior changes?

Tool schema generation (`McpSchemaFactory`, formerly `McpService`) no longer fails (or silently degrades) when a shape carrying the `smithy.mcp#oneOf` trait is used directly as an operation input or output.

With a model like:

```smithy
@oneOf(discriminator: "__type", members: [...])
document ShapeWithOneOf

operation GetShape {
    output: ShapeWithOneOf
}

operation ProcessShape {
    input: ProcessShapeInput // contains a member targeting ShapeWithOneOf
}
```

building the MCP service previously had two order-dependent failures, because the per-service schema cache is shared across schema kinds:

- If a nested reference (`ProcessShape`) was processed first, the cache held a `JsonOneOfSchema` for the shape, and `createObjectSchema` for the `GetShape` output root then threw `ClassCastException: JsonOneOfSchema cannot be cast to JsonObjectSchema` — failing construction of the entire service (every tool), not just the offending operation.
- If the root reference was processed first, `createObjectSchema` treated the document as a plain (member-less) shape and cached an **empty** `JsonObjectSchema` under the shape id, which nested references then reused — silently dropping all oneOf variants.

After this change both positions render correctly: the root position produces `{"type": "object", "oneOf": [...]}` (the MCP spec requires tool input/output schemas to be object-typed; the oneOf variants are all objects, so the constraints compose), and nested references keep the cached `JsonOneOfSchema` exactly as before.

### Why is this change needed?

Bundled models (loaded through `ModelBundles`, which assembles with validation disabled) can and do contain document-typed operation outputs: tooling that converts service models for MCP represents polymorphic type hierarchies as `@oneOf` documents, and a service with a polymorphic operation output currently cannot list tools at all. Observed in production as a deterministic `ClassCastException` at `McpSchemaFactory.createObjectSchema` (formerly `McpService.createJsonObjectSchema`) for every such service.

### How was this validated?

- Two new regression tests in `StdioMcpServerTest`. The schema cache is per operation and an operation's input schema is built before its output, so each test uses a single operation (in its own service) to pin one ordering:
  - `testOneOfDocumentAsOperationOutputRootWithCachedSchema` — `GetShape`: nested reference in the input caches the `JsonOneOfSchema`, then the output requests the same shape as its root (the `ClassCastException` order).
  - `testOneOfDocumentAsOperationInputRootBeforeNestedReference` — `PutShape`: the document is the input root, then the output references it as a nested member (the order that silently dropped the variants).
  - The test model is assembled with `disableValidation()` to mirror `ModelBundles`.
- Verified both tests fail on `main` without the fix (with the `ClassCastException` and the missing variants respectively), and that each fails only for its own mechanism when that mechanism is mutated out (blind cast restored / document guard removed).
- `./gradlew :mcp:mcp-server:test` passes.

### What should reviewers focus on?

- `McpSchemaFactory#asJsonObjectSchema`: the re-shaping of a `JsonOneOfSchema` into an object-typed schema, and the new `@oneOf` guard in `createObjectSchema` that routes trait-carrying shapes through `createOneOfSchema` so the cache keeps the full oneOf schema for other references.
- `mcp-schemas/model/main.smithy`: `JsonObjectSchema` gains an optional `oneOf` member so the object-typed root can carry the variants. The converted root preserves the `type: "object"`, `oneOf`, and `description` a `JsonOneOfSchema` would serialize, plus the `$schema` annotation that all object-typed roots already carry.
- The new guard in `createObjectSchema` is scoped to `ShapeType.DOCUMENT` (the trait's selector), so a non-document shape incorrectly carrying the trait in an unvalidated model keeps its existing rendering — matching what runtime input/output adaptation recognizes.

### Scope note

This change fixes schema *generation* (`tools/list`). Invoking a tool whose **input** root is a `@oneOf` document is a separate, pre-existing limitation: `SchemaGuidedDocumentBuilder` rejects document roots during input adaptation. That behavior is unchanged here.

### Additional Links

None.


