### PR TITLE
Optimize exact-array base64 encoding

### DIFF
--- a/io/src/main/java/software/amazon/smithy/java/io/ByteBufferUtils.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/ByteBufferUtils.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public final class ByteBufferUtils {
+    private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
 
     private ByteBufferUtils() {}
 
@@ -22,7 +23,9 @@ public final class ByteBufferUtils {
     }
 
     public static byte[] base64EncodeToBytes(ByteBuffer buffer) {
-        return Base64.getEncoder().encode(buffer.duplicate()).array();
+        return isExact(buffer)
+                ? BASE64_ENCODER.encode(buffer.array())
+                : BASE64_ENCODER.encode(buffer.duplicate()).array();
     }
 
     public static String getUTF8String(ByteBuffer buffer) {

--- a/io/src/test/java/software/amazon/smithy/java/io/ByteBufferUtilsTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/ByteBufferUtilsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+public class ByteBufferUtilsTest {
+
+    @Test
+    public void base64EncodingPreservesBufferPosition() {
+        byte[] data = "prefix-hello-suffix".getBytes(StandardCharsets.UTF_8);
+        byte[] expected = Base64.getEncoder()
+                .encode("hello".getBytes(StandardCharsets.UTF_8));
+
+        assertEncoding(expected, ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+        assertEncoding(expected, ByteBuffer.wrap(data, 7, 5));
+        assertEncoding(expected, ByteBuffer.wrap(data, 7, 5).asReadOnlyBuffer());
+
+        ByteBuffer direct = ByteBuffer.allocateDirect(data.length);
+        direct.put(data).position(7).limit(12);
+        assertEncoding(expected, direct);
+    }
+
+    private static void assertEncoding(byte[] expected, ByteBuffer buffer) {
+        int position = buffer.position();
+        assertThat(ByteBufferUtils.base64EncodeToBytes(buffer)).isEqualTo(expected);
+        assertThat(buffer.position()).isEqualTo(position);
+    }
+}


### PR DESCRIPTION
### What behavior changes?
Base64 encoding of exact ByteBuffer is faster.

### Why is this change needed?
Performance.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
