### PR TITLE
Optimize HTTP header value normalization

### DIFF
--- a/http/http-api/build.gradle.kts
+++ b/http/http-api/build.gradle.kts
@@ -10,4 +10,5 @@ extra["moduleName"] = "software.amazon.smithy.java.http.api"
 
 dependencies {
     api(project(":io"))
+    implementation(project(":codecs:codec-commons", configuration = "shadow"))
 }

--- a/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HeaderUtils.java
+++ b/http/http-api/src/main/java/software/amazon/smithy/java/http/api/HeaderUtils.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.java.http.api;
 
+import software.amazon.smithy.java.codecs.commons.CompactStringAccess;
+
 /**
  * HTTP header utilities.
  */
@@ -89,6 +91,38 @@ public final class HeaderUtils {
      * @throws IllegalArgumentException if the value contains invalid characters
      */
     public static String normalizeValue(String value) {
+        byte[] latin1 = CompactStringAccess.latin1Bytes(value);
+        return latin1 == null ? normalizeUtf16Value(value) : normalizeLatin1Value(value, latin1);
+    }
+
+    private static String normalizeLatin1Value(String value, byte[] latin1) {
+        int length = latin1.length;
+        if (length == 0) {
+            return value;
+        }
+
+        for (byte b : latin1) {
+            int c = b & 0xff;
+            if ((c < 0x20 && c != '\t') || c == 0x7f) {
+                throw invalidHeaderValueChar(value);
+            }
+        }
+
+        int start = 0;
+        while (start < length && (latin1[start] == ' ' || latin1[start] == '\t')) {
+            start++;
+        }
+        if (start == length) {
+            return "";
+        }
+        int end = length - 1;
+        while (end > start && (latin1[end] == ' ' || latin1[end] == '\t')) {
+            end--;
+        }
+        return start == 0 && end == length - 1 ? value : value.substring(start, end + 1);
+    }
+
+    private static String normalizeUtf16Value(String value) {
         int len = value.length();
         if (len == 0) {
             return value;

--- a/http/http-api/src/test/java/software/amazon/smithy/java/http/api/HeaderUtilsTest.java
+++ b/http/http-api/src/test/java/software/amazon/smithy/java/http/api/HeaderUtilsTest.java
@@ -97,5 +97,11 @@ public class HeaderUtilsTest {
     void normalizeValue_allowsObsText() {
         // obs-text (0x80-0xFF) is allowed
         assertEquals("foo\u0080bar", HeaderUtils.normalizeValue("foo\u0080bar"));
+        assertEquals("caf\u00e9", HeaderUtils.normalizeValue("caf\u00e9"));
+    }
+
+    @Test
+    void normalizeValue_rejectsCharactersOutsideLatin1() {
+        assertThrows(IllegalArgumentException.class, () -> HeaderUtils.normalizeValue("not-http-\u20ac"));
     }
 }


### PR DESCRIPTION
### What behavior changes?
Improves performance if header values only contain Latin1 byes.

### Why is this change needed?
Improves performance if header values only contain Latin1 byes.

### How was this validated?
List tests added, benchmarks run, or manual verification performed.

### What should reviewers focus on?
Point reviewers to the files or sections that contain the interesting logic.

### Additional Links
Related issues, design docs, or prior art.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
