### PR TITLE
Add shared runtime codegen serde machinery

### DIFF
--- a/codecs/codec-commons/build.gradle.kts
+++ b/codecs/codec-commons/build.gradle.kts
@@ -14,16 +14,65 @@ description = "Shared utilities for Smithy codec implementations (number formatt
 extra["displayName"] = "Smithy :: Java :: Codec Commons"
 extra["moduleName"] = "software.amazon.smithy.java.codecs.commons"
 
+sourceSets {
+    create("jdk25") {
+        java {
+            srcDir("src/jdk25/java")
+        }
+    }
+    create("jdk21Test") {
+        java {
+            srcDir("src/jdk21Test/java")
+        }
+    }
+}
+
 dependencies {
     api(libs.smithy.utils)
+    implementation(project(":core"))
     compileOnly(libs.fastdoubleparser)
+    testImplementation(sourceSets["jdk25"].output)
     testRuntimeOnly(libs.fastdoubleparser)
+    "jdk25Implementation"(sourceSets.main.get().output)
+    "jdk21TestImplementation"(sourceSets.main.get().output)
+}
+
+tasks.named<JavaCompile>("compileJdk25Java") {
+    javaCompiler =
+        javaToolchains.compilerFor {
+            languageVersion = JavaLanguageVersion.of(25)
+        }
+    options.release.set(25)
+}
+
+tasks.named<Jar>("sourcesJar") {
+    from("src/jdk25/java")
+}
+
+tasks.register<Test>("jdk21Test") {
+    testClassesDirs = sourceSets["jdk21Test"].output.classesDirs
+    classpath = sourceSets["jdk21Test"].runtimeClasspath
+    javaLauncher =
+        javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    useJUnitPlatform()
+}
+
+tasks.named("check") {
+    dependsOn("jdk21Test")
 }
 
 tasks {
     shadowJar {
         archiveClassifier.set("")
         mergeServiceFiles()
+        from(sourceSets["jdk25"].output) {
+            into("META-INF/versions/25")
+        }
+        manifest {
+            attributes["Multi-Release"] = "true"
+        }
         configurations = listOf(project.configurations.compileClasspath.get())
         dependencies {
             include(
@@ -43,6 +92,15 @@ tasks {
 
 configurations {
     shadow.get().extendsFrom(api.get())
+    named("jdk25Implementation") {
+        extendsFrom(configurations.implementation.get())
+    }
+    named("jdk21TestImplementation") {
+        extendsFrom(configurations.testImplementation.get())
+    }
+    named("jdk21TestRuntimeOnly") {
+        extendsFrom(configurations.testRuntimeOnly.get())
+    }
 }
 
 configurePublishing {

--- a/codecs/codec-commons/src/jdk21Test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenJdk21Test.java
+++ b/codecs/codec-commons/src/jdk21Test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenJdk21Test.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.core.serde.RuntimeCodegenMode;
+
+final class RuntimeCodegenJdk21Test {
+    @Test
+    void enabledGateFallsBackWithoutLoadingClassFileBackend() {
+        assertThat(Runtime.version().feature()).isEqualTo(21);
+        System.setProperty("smithy-java.runtime-codegen", "enabled");
+        try {
+            assertThat(RuntimeCodegenFeature.enabled("json")).isFalse();
+            assertThat(RuntimeCodegenFeature.enabled("cbor")).isFalse();
+        } finally {
+            System.clearProperty("smithy-java.runtime-codegen");
+        }
+    }
+
+    @Test
+    void everyRequestedModeResolvesToDisabledOnAnIncapableJvm() {
+        assertThat(RuntimeCodegenFeature.resolve(RuntimeCodegenMode.ENABLED, "json"))
+                .isEqualTo(RuntimeCodegenMode.DISABLED);
+        assertThatThrownBy(() -> RuntimeCodegenFeature.resolve(RuntimeCodegenMode.STRICT, "json"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/codecs/codec-commons/src/jdk25/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/JdkClassFileEmitter.java
+++ b/codecs/codec-commons/src/jdk25/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/JdkClassFileEmitter.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen.classfile;
+
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.CodeBuilder;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.instruction.SwitchCase;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassFileModel.Instruction;
+
+final class JdkClassFileEmitter {
+    private static final Opcode[] OPCODES = createOpcodeTable();
+
+    private JdkClassFileEmitter() {}
+
+    static byte[] emit(ClassFileModel model) {
+        ClassDesc thisClass = classDesc(model.name());
+        return ClassFile.of().build(thisClass, builder -> {
+            builder.withVersion(model.version(), 0);
+            builder.withFlags(model.access());
+            builder.withSuperclass(classDesc(model.superName()));
+            builder.withInterfaceSymbols(model.interfaces().stream().map(JdkClassFileEmitter::classDesc).toList());
+            for (ClassFileModel.FieldModel field : model.fields()) {
+                builder.withField(field.name(), ClassDesc.ofDescriptor(field.descriptor()), field.access());
+            }
+            for (ClassFileModel.MethodModel method : model.methods()) {
+                builder.withMethodBody(
+                        method.name(),
+                        MethodTypeDesc.ofDescriptor(method.descriptor()),
+                        method.access(),
+                        code -> emitCode(code, method));
+            }
+        });
+    }
+
+    private static void emitCode(CodeBuilder code, ClassFileModel.MethodModel method) {
+        Map<Label, java.lang.classfile.Label> labels = new IdentityHashMap<>();
+        for (Instruction instruction : method.instructions()) {
+            Object[] operands = instruction.operands();
+            switch (instruction.kind()) {
+                case INSN -> emitInsn(code, instruction.opcode());
+                case VAR -> emitVar(code, instruction.opcode(), (int) operands[0]);
+                case TYPE -> emitType(code, instruction.opcode(), (String) operands[0]);
+                case FIELD -> code.fieldAccess(
+                        opcode(instruction.opcode()),
+                        classDesc((String) operands[0]),
+                        (String) operands[1],
+                        ClassDesc.ofDescriptor((String) operands[2]));
+                case METHOD -> code.invoke(
+                        opcode(instruction.opcode()),
+                        classDesc((String) operands[0]),
+                        (String) operands[1],
+                        MethodTypeDesc.ofDescriptor((String) operands[2]),
+                        (boolean) operands[3]);
+                case JUMP -> code.branch(
+                        opcode(instruction.opcode()),
+                        label(code, labels, (Label) operands[0]));
+                case LABEL -> code.labelBinding(label(code, labels, (Label) operands[0]));
+                case CONSTANT -> emitConstant(code, operands[0]);
+                case INCREMENT -> code.iinc((int) operands[0], (int) operands[1]);
+                case LOOKUP_SWITCH -> emitLookupSwitch(code, labels, operands);
+            }
+        }
+        for (ClassFileModel.TryCatch tryCatch : method.tryCatches()) {
+            code.exceptionCatch(
+                    label(code, labels, tryCatch.start()),
+                    label(code, labels, tryCatch.end()),
+                    label(code, labels, tryCatch.handler()),
+                    classDesc(tryCatch.type()));
+        }
+    }
+
+    private static void emitInsn(CodeBuilder code, int opcode) {
+        switch (opcode) {
+            case Opcodes.ACONST_NULL -> code.aconst_null();
+            case Opcodes.ICONST_0 -> code.iconst_0();
+            case Opcodes.ICONST_1 -> code.iconst_1();
+            case Opcodes.POP -> code.pop();
+            case Opcodes.DUP -> code.dup();
+            case Opcodes.IRETURN -> code.ireturn();
+            case Opcodes.ARETURN -> code.areturn();
+            case Opcodes.RETURN -> code.return_();
+            case Opcodes.ARRAYLENGTH -> code.arraylength();
+            case Opcodes.ATHROW -> code.athrow();
+            default -> throw unsupported("instruction", opcode);
+        }
+    }
+
+    private static void emitVar(CodeBuilder code, int opcode, int variable) {
+        switch (opcode) {
+            case Opcodes.ILOAD -> code.iload(variable);
+            case Opcodes.LLOAD -> code.lload(variable);
+            case Opcodes.FLOAD -> code.fload(variable);
+            case Opcodes.DLOAD -> code.dload(variable);
+            case Opcodes.ALOAD -> code.aload(variable);
+            case Opcodes.ISTORE -> code.istore(variable);
+            case Opcodes.LSTORE -> code.lstore(variable);
+            case Opcodes.FSTORE -> code.fstore(variable);
+            case Opcodes.DSTORE -> code.dstore(variable);
+            case Opcodes.ASTORE -> code.astore(variable);
+            default -> throw unsupported("variable instruction", opcode);
+        }
+    }
+
+    private static void emitType(CodeBuilder code, int opcode, String type) {
+        switch (opcode) {
+            case Opcodes.NEW -> code.new_(classDesc(type));
+            case Opcodes.CHECKCAST -> code.checkcast(classDesc(type));
+            case Opcodes.INSTANCEOF -> code.instanceOf(classDesc(type));
+            default -> throw unsupported("type instruction", opcode);
+        }
+    }
+
+    private static void emitConstant(CodeBuilder code, Object value) {
+        if (value instanceof String string) {
+            code.ldc(code.constantPool().stringEntry(string));
+        } else if (value instanceof Integer integer) {
+            code.loadConstant(integer);
+        } else if (value instanceof Long longValue) {
+            code.loadConstant(longValue);
+        } else if (value instanceof Float floatValue) {
+            code.loadConstant(floatValue);
+        } else if (value instanceof Double doubleValue) {
+            code.loadConstant(doubleValue);
+        } else if (value instanceof Class<?> type) {
+            code.loadConstant(ClassDesc.ofDescriptor(Type.getDescriptor(type)));
+        } else {
+            throw new IllegalArgumentException("Unsupported generated constant: " + value);
+        }
+    }
+
+    private static void emitLookupSwitch(
+            CodeBuilder code,
+            Map<Label, java.lang.classfile.Label> labels,
+            Object[] operands
+    ) {
+        Label defaultTarget = (Label) operands[0];
+        int[] keys = (int[]) operands[1];
+        Label[] targets = (Label[]) operands[2];
+        List<SwitchCase> cases = new ArrayList<>(keys.length);
+        for (int i = 0; i < keys.length; i++) {
+            cases.add(SwitchCase.of(keys[i], label(code, labels, targets[i])));
+        }
+        code.lookupswitch(label(code, labels, defaultTarget), cases);
+    }
+
+    private static java.lang.classfile.Label label(
+            CodeBuilder code,
+            Map<Label, java.lang.classfile.Label> labels,
+            Label label
+    ) {
+        return labels.computeIfAbsent(label, ignored -> code.newLabel());
+    }
+
+    private static Opcode opcode(int value) {
+        if (value >= 0 && value < OPCODES.length && OPCODES[value] != null) {
+            return OPCODES[value];
+        }
+        throw unsupported("opcode", value);
+    }
+
+    private static Opcode[] createOpcodeTable() {
+        Opcode[] result = new Opcode[256];
+        for (Opcode opcode : Opcode.values()) {
+            int bytecode = opcode.bytecode();
+            if (bytecode >= 0 && bytecode < result.length) {
+                result[bytecode] = opcode;
+            }
+        }
+        return result;
+    }
+
+    private static ClassDesc classDesc(String internalName) {
+        return ClassDesc.ofInternalName(internalName);
+    }
+
+    private static IllegalArgumentException unsupported(String kind, int opcode) {
+        return new IllegalArgumentException("Unsupported generated " + kind + ": " + opcode);
+    }
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/NumberCodec.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/NumberCodec.java
@@ -434,6 +434,7 @@ public final class NumberCodec {
     }
 
     public static int writeBigDecimal(byte[] buf, int pos, BigDecimal value) {
+        // TODO: Bound plain-notation expansion before calling BigDecimal.toPlainString.
         int scale = value.scale();
         if (value.unscaledValue().bitLength() < 64) {
             if (scale == 0) {

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecBackend.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecBackend.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/** Generation-time backend for a runtime codec. */
+@SmithyInternalApi
+public interface RuntimeCodecBackend<T> {
+    /** Stable token used by properties, logs, and generated class names. */
+    String id();
+
+    /** Diagnostic class-name suffix for backend settings. */
+    default String variant() {
+        return "";
+    }
+
+    Class<T> codecType();
+
+    Class<?> lookupHost();
+
+    default Budgets budgets() {
+        return Budgets.unbounded();
+    }
+
+    /** Returns whether the backend requires read-side builder metadata. */
+    default Mode mode() {
+        return Mode.READ_WRITE;
+    }
+
+    /** Returns a stable selector for root members; nested shapes are always complete. */
+    default MemberSelector memberSelector() {
+        return MemberSelector.all();
+    }
+
+    Emission emit(RuntimeCodecPlan plan, String generatedName);
+
+    record Emission(byte[] bytecode, int methodCount) {}
+
+    /** Whether a backend generates both directions or only writes. */
+    enum Mode {
+        WRITE_ONLY,
+        READ_WRITE
+    }
+
+    /** Stable selector for root members. */
+    @FunctionalInterface
+    interface MemberSelector {
+        boolean select(Schema root, Schema member);
+
+        static MemberSelector all() {
+            return All.INSTANCE;
+        }
+    }
+
+    final class All {
+        private static final MemberSelector INSTANCE = (root, member) -> true;
+
+        private All() {}
+    }
+
+    record Budgets(
+            int writerBytecodeLimit,
+            int readerBytecodeLimit,
+            int maxMembersPerWriterMethod,
+            int maxMembersPerReaderBucket) {
+        public Budgets {
+            if (writerBytecodeLimit <= 0
+                    || readerBytecodeLimit <= 0
+                    || maxMembersPerWriterMethod <= 0
+                    || maxMembersPerReaderBucket <= 0) {
+                throw new IllegalArgumentException("Runtime codegen budgets must be positive");
+            }
+        }
+
+        public static Budgets unbounded() {
+            return new Budgets(
+                    Integer.MAX_VALUE,
+                    Integer.MAX_VALUE,
+                    Integer.MAX_VALUE,
+                    Integer.MAX_VALUE);
+        }
+    }
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecPlan.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecPlan.java
@@ -1,0 +1,560 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.schema.SmithyEnum;
+import software.amazon.smithy.java.core.schema.SmithyIntEnum;
+import software.amazon.smithy.java.core.schema.TraitKey;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/** Immutable generation-time plan for a schema graph. */
+@SmithyInternalApi
+public record RuntimeCodecPlan(
+        Schema root,
+        Class<?> rootClass,
+        List<StructPlan> structures,
+        int estimatedBytecode) {
+    private static final int MEMBER_ESTIMATE = 36;
+
+    public RuntimeCodecPlan {
+        structures = List.copyOf(structures);
+    }
+
+    public static RuntimeCodecPlan analyze(Schema root) {
+        return analyze(root, RuntimeCodecBackend.Budgets.unbounded());
+    }
+
+    public static RuntimeCodecPlan analyze(
+            Schema root,
+            RuntimeCodecBackend.Budgets budgets
+    ) {
+        return analyze(
+                root,
+                budgets,
+                RuntimeCodecBackend.Mode.READ_WRITE,
+                RuntimeCodecBackend.MemberSelector.all());
+    }
+
+    public static RuntimeCodecPlan analyze(
+            Schema root,
+            RuntimeCodecBackend.Budgets budgets,
+            RuntimeCodecBackend.Mode mode,
+            RuntimeCodecBackend.MemberSelector selector
+    ) {
+        Schema target = root.isMember() ? root.memberTarget() : root;
+        Class<?> rootClass = requireShapeClass(target);
+        var structures = new ArrayList<StructPlan>();
+        var visited = new HashSet<ShapeId>();
+        analyze(target, structures, visited, new Context(budgets, mode, selector, target));
+        int estimate = structures.stream().mapToInt(StructPlan::estimatedBytecode).sum();
+        RuntimeCodecPlan plan = new RuntimeCodecPlan(target, rootClass, structures, estimate);
+        if (isNarrowed(plan) && plannedGraphReferencesRoot(plan)) {
+            throw new UnsupportedSchemaException(
+                    "Cannot narrow recursive root schema " + target.id());
+        }
+        return plan;
+    }
+
+    private static void analyze(
+            Schema schema,
+            List<StructPlan> structures,
+            Set<ShapeId> visited,
+            Context context
+    ) {
+        schema = schema.isMember() ? schema.memberTarget() : schema;
+        if (!visited.add(schema.id())) {
+            return;
+        }
+
+        ShapeType type = schema.type();
+        if (type != ShapeType.STRUCTURE && type != ShapeType.UNION) {
+            analyzeChildren(schema, structures, visited, context);
+            return;
+        }
+
+        Class<?> shapeClass = requireShapeClass(schema);
+        boolean union = type == ShapeType.UNION || (shapeClass.isInterface() && shapeClass.isSealed());
+        // Write-only backends do not require builder metadata.
+        boolean reads = context.mode() == RuntimeCodecBackend.Mode.READ_WRITE;
+        Class<?> builderClass = null;
+        Method builderFactory = null;
+        if (reads) {
+            ShapeBuilder<?> builder = schema.shapeBuilder();
+            if (builder == null) {
+                throw new UnsupportedSchemaException("No builder for " + schema.id());
+            }
+            builderClass = builder.getClass();
+            requirePubliclyAccessible(builderClass, "Generated Java builder", schema);
+            builderFactory = resolveBuilderFactory(shapeClass);
+        }
+        var members = new ArrayList<MemberPlan>(schema.members().size());
+        var getters = new HashMap<Method, Schema>();
+        var setters = new HashMap<Method, Schema>();
+        int estimate = 24;
+        // Only the root may be narrowed.
+        boolean isRoot = schema == context.rootTarget();
+        for (Schema member : schema.members()) {
+            if (isRoot && !context.selector().select(schema, member)) {
+                continue;
+            }
+            Schema target = member.memberTarget();
+            Method getter = union ? null : resolveGetter(shapeClass, member);
+            Method presence = union ? null : resolvePresence(shapeClass, member);
+            Class<?> unionVariant = union ? resolveUnionVariant(shapeClass, member) : null;
+            Method unionAccessor = unionVariant == null ? null : resolveUnionAccessor(unionVariant, member);
+            Class<?> memberType = unionAccessor == null
+                    ? getter.getReturnType()
+                    : unionAccessor.getReturnType();
+            validateAccessorType(member, memberType);
+            Method setter = reads
+                    ? resolveSetter(
+                            builderClass,
+                            member,
+                            unionAccessor == null ? null : unionAccessor.getName(),
+                            memberType)
+                    : null;
+            rejectAccessorCollision(getters, getter, member, "getter");
+            rejectAccessorCollision(setters, setter, member, "setter");
+            int memberEstimate = estimateMember(target);
+            estimate += memberEstimate;
+            members.add(new MemberPlan(
+                    member,
+                    target,
+                    member.memberName(),
+                    getter,
+                    presence,
+                    setter,
+                    unionVariant,
+                    unionAccessor,
+                    member.hasTrait(TraitKey.REQUIRED_TRAIT),
+                    memberEstimate));
+            analyze(target, structures, visited, context);
+        }
+        RuntimeCodecBackend.Budgets budgets = context.budgets();
+        List<MethodRange> writerChunks = chunkRanges(
+                members,
+                budgets.writerBytecodeLimit(),
+                budgets.maxMembersPerWriterMethod());
+        int readerBuckets = Math.max(
+                divideRoundingUp(estimate, budgets.readerBytecodeLimit()),
+                divideRoundingUp(members.size(), budgets.maxMembersPerReaderBucket()));
+        structures.add(new StructPlan(
+                schema,
+                shapeClass,
+                builderClass,
+                builderFactory,
+                union,
+                members,
+                estimate,
+                writerChunks,
+                readerBuckets));
+    }
+
+    private static void analyzeChildren(
+            Schema schema,
+            List<StructPlan> structures,
+            Set<ShapeId> visited,
+            Context context
+    ) {
+        switch (schema.type()) {
+            case LIST, SET -> analyze(schema.listMember(), structures, visited, context);
+            case MAP -> analyze(schema.mapValueMember(), structures, visited, context);
+            default -> {
+            }
+        }
+    }
+
+    private static boolean isNarrowed(RuntimeCodecPlan plan) {
+        ShapeType type = plan.root().type();
+        return (type == ShapeType.STRUCTURE || type == ShapeType.UNION)
+                && plan.rootStructure().members().size() != plan.root().members().size();
+    }
+
+    private static boolean plannedGraphReferencesRoot(RuntimeCodecPlan plan) {
+        ShapeId rootId = plan.root().id();
+        for (StructPlan structure : plan.structures()) {
+            for (MemberPlan member : structure.members()) {
+                if (references(member.target(), rootId, new HashSet<>())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean references(Schema schema, ShapeId target, Set<ShapeId> visited) {
+        schema = schema.isMember() ? schema.memberTarget() : schema;
+        if (schema.id().equals(target)) {
+            return true;
+        }
+        if (!visited.add(schema.id())) {
+            return false;
+        }
+        return switch (schema.type()) {
+            case LIST, SET -> references(schema.listMember(), target, visited);
+            case MAP -> references(schema.mapValueMember(), target, visited);
+            default -> false;
+        };
+    }
+
+    private record Context(
+            RuntimeCodecBackend.Budgets budgets,
+            RuntimeCodecBackend.Mode mode,
+            RuntimeCodecBackend.MemberSelector selector,
+            Schema rootTarget) {}
+
+    private static List<MethodRange> chunkRanges(
+            List<MemberPlan> members,
+            int bytecodeLimit,
+            int maxMembers
+    ) {
+        var chunks = new ArrayList<MethodRange>();
+        int start = 0;
+        int size = 0;
+        int count = 0;
+        for (int i = 0; i < members.size(); i++) {
+            MemberPlan member = members.get(i);
+            if (count > 0
+                    && (count == maxMembers
+                            || size + member.estimatedBytecode() > bytecodeLimit)) {
+                chunks.add(new MethodRange(start, i, size));
+                start = i;
+                size = 0;
+                count = 0;
+            }
+            size += member.estimatedBytecode();
+            count++;
+        }
+        chunks.add(new MethodRange(start, members.size(), size));
+        return chunks;
+    }
+
+    private static int divideRoundingUp(int value, int divisor) {
+        return value == 0 ? 1 : 1 + (value - 1) / divisor;
+    }
+
+    private static int estimateMember(Schema target) {
+        return switch (target.type()) {
+            case BOOLEAN, BYTE, SHORT, INTEGER, LONG, FLOAT, DOUBLE, INT_ENUM -> 24;
+            case STRING -> 60;
+            case ENUM, BLOB, TIMESTAMP -> 36;
+            case BIG_INTEGER, BIG_DECIMAL, DOCUMENT -> 48;
+            case LIST, SET, MAP -> 72;
+            case STRUCTURE, UNION -> 44;
+            default -> MEMBER_ESTIMATE;
+        };
+    }
+
+    private static Class<?> requireShapeClass(Schema schema) {
+        Class<?> result = schema.shapeClass();
+        if (result == null) {
+            throw new UnsupportedSchemaException("No generated Java class for " + schema.id());
+        }
+        requirePubliclyAccessible(result, "Generated Java class", schema);
+        return result;
+    }
+
+    private static void requirePubliclyAccessible(Class<?> type, String description, Schema schema) {
+        for (Class<?> current = type; current != null; current = current.getEnclosingClass()) {
+            if (!Modifier.isPublic(current.getModifiers())) {
+                throw new UnsupportedSchemaException(
+                        description + " is not publicly accessible for " + schema.id() + ": " + type.getName());
+            }
+        }
+    }
+
+    private static void rejectAccessorCollision(
+            Map<Method, Schema> resolved,
+            Method accessor,
+            Schema member,
+            String kind
+    ) {
+        if (accessor == null) {
+            return;
+        }
+        Schema previous = resolved.putIfAbsent(accessor, member);
+        if (previous != null) {
+            throw new UnsupportedSchemaException(
+                    "Members "
+                            + previous.id()
+                            + " and "
+                            + member.id()
+                            + " resolve to the same "
+                            + kind
+                            + ": "
+                            + accessor);
+        }
+    }
+
+    private static Method resolveGetter(Class<?> shapeClass, Schema member) {
+        boolean isBoolean = member.memberTarget().type() == ShapeType.BOOLEAN;
+        List<String> candidates = new ArrayList<>(6);
+        // Try generated Java naming first, then the raw name for hand-written shapes.
+        addAccessorCandidates(candidates, toJavaName(member.memberName()), isBoolean);
+        addAccessorCandidates(candidates, member.memberName(), isBoolean);
+        for (String candidate : candidates) {
+            try {
+                Method method = shapeClass.getMethod(candidate);
+                if (Modifier.isPublic(method.getModifiers())
+                        && method.getParameterCount() == 0
+                        // Never bind model members to Object or schema API methods.
+                        && method.getDeclaringClass() != Object.class
+                        && method.getReturnType() != Schema.class) {
+                    return method;
+                }
+            } catch (NoSuchMethodException ignored) {}
+        }
+        throw new UnsupportedSchemaException(
+                "No direct getter for " + member.id() + " on " + shapeClass.getName());
+    }
+
+    private static void addAccessorCandidates(List<String> candidates, String name, boolean isBoolean) {
+        String capitalized = Character.toUpperCase(name.charAt(0)) + name.substring(1);
+        if (isBoolean) {
+            addCandidate(candidates, "is" + capitalized);
+        }
+        addCandidate(candidates, "get" + capitalized);
+        addCandidate(candidates, name);
+    }
+
+    private static void addCandidate(List<String> candidates, String candidate) {
+        if (!candidates.contains(candidate)) {
+            candidates.add(candidate);
+        }
+    }
+
+    private static Method resolvePresence(Class<?> shapeClass, Schema member) {
+        // Presence methods use the same generated name as accessors.
+        Method method = findPresence(shapeClass, toJavaName(member.memberName()));
+        return method != null ? method : findPresence(shapeClass, member.memberName());
+    }
+
+    private static Method findPresence(Class<?> shapeClass, String name) {
+        String candidate = "has" + Character.toUpperCase(name.charAt(0)) + name.substring(1);
+        try {
+            Method method = shapeClass.getMethod(candidate);
+            return method.getReturnType() == boolean.class && method.getParameterCount() == 0 ? method : null;
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+
+    private static Method resolveBuilderFactory(Class<?> shapeClass) {
+        try {
+            Method method = shapeClass.getDeclaredMethod("builder");
+            return Modifier.isPublic(method.getModifiers()) ? method : null;
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+
+    private static Class<?> resolveUnionVariant(Class<?> shapeClass, Schema member) {
+        String normalized = normalizeName(member.memberName());
+        for (Class<?> candidate : shapeClass.getPermittedSubclasses()) {
+            if (!candidate.isRecord() || candidate.getRecordComponents().length != 1) {
+                continue;
+            }
+            if (normalizeName(candidate.getRecordComponents()[0].getName()).equals(normalized)) {
+                return candidate;
+            }
+        }
+        throw new UnsupportedSchemaException(
+                "No direct union variant for " + member.id() + " on " + shapeClass.getName());
+    }
+
+    private static Method resolveUnionAccessor(Class<?> variant, Schema member) {
+        if (variant.getRecordComponents().length == 1) {
+            return variant.getRecordComponents()[0].getAccessor();
+        }
+        throw new UnsupportedSchemaException(
+                "No union accessor for " + member.id() + " on " + variant.getName());
+    }
+
+    private static Method resolveSetter(
+            Class<?> builderClass,
+            Schema member,
+            String unionAccessor,
+            Class<?> memberType
+    ) {
+        String expected = unionAccessor == null ? toJavaName(member.memberName()) : unionAccessor;
+        Method match = null;
+        for (Method method : builderClass.getMethods()) {
+            if (!method.getName().equals(expected)
+                    || method.getParameterCount() != 1
+                    || !Modifier.isPublic(method.getModifiers())
+                    || method.getParameterTypes()[0] != memberType) {
+                continue;
+            }
+            if (match == null
+                    || (match.isBridge() && !method.isBridge())
+                    || (match.isSynthetic() && !method.isSynthetic())) {
+                match = method;
+            }
+        }
+        if (match != null) {
+            return match;
+        }
+        throw new UnsupportedSchemaException(
+                "No direct builder setter for "
+                        + member.id()
+                        + " accepting "
+                        + memberType.getName()
+                        + " on "
+                        + builderClass.getName());
+    }
+
+    private static void validateAccessorType(Schema member, Class<?> declaredType) {
+        Schema target = member.memberTarget();
+        boolean compatible = switch (target.type()) {
+            case BOOLEAN -> isPrimitiveOrBoxed(declaredType, boolean.class, Boolean.class);
+            case BYTE -> isPrimitiveOrBoxed(declaredType, byte.class, Byte.class);
+            case SHORT -> isPrimitiveOrBoxed(declaredType, short.class, Short.class);
+            case INTEGER -> isPrimitiveOrBoxed(declaredType, int.class, Integer.class);
+            case LONG -> isPrimitiveOrBoxed(declaredType, long.class, Long.class);
+            case FLOAT -> isPrimitiveOrBoxed(declaredType, float.class, Float.class);
+            case DOUBLE -> isPrimitiveOrBoxed(declaredType, double.class, Double.class);
+            case BIG_INTEGER -> BigInteger.class.isAssignableFrom(declaredType);
+            case BIG_DECIMAL -> BigDecimal.class.isAssignableFrom(declaredType);
+            case STRING -> String.class.isAssignableFrom(declaredType);
+            case ENUM -> SmithyEnum.class.isAssignableFrom(declaredType);
+            case INT_ENUM -> SmithyIntEnum.class.isAssignableFrom(declaredType);
+            case BLOB -> ByteBuffer.class.isAssignableFrom(declaredType);
+            case TIMESTAMP -> Instant.class.isAssignableFrom(declaredType);
+            case DOCUMENT -> Document.class.isAssignableFrom(declaredType);
+            case LIST, SET -> List.class.isAssignableFrom(declaredType);
+            case MAP -> Map.class.isAssignableFrom(declaredType);
+            case STRUCTURE, UNION -> requireShapeClass(target).isAssignableFrom(declaredType);
+            default -> false;
+        };
+        if (!compatible) {
+            throw new UnsupportedSchemaException(
+                    "Accessor for "
+                            + member.id()
+                            + " returns "
+                            + declaredType.getTypeName()
+                            + ", which is incompatible with "
+                            + target.type());
+        }
+    }
+
+    private static boolean isPrimitiveOrBoxed(
+            Class<?> declaredType,
+            Class<?> primitive,
+            Class<?> boxed
+    ) {
+        return declaredType == primitive || declaredType == boxed;
+    }
+
+    // Mirrors generated accessor naming, including acronym folding.
+    private static String toJavaName(String value) {
+        if (value.indexOf('_') < 0 && value.indexOf('-') < 0 && value.indexOf(' ') < 0) {
+            if (Character.isLowerCase(value.charAt(0))) {
+                return value;
+            }
+            if (value.equals(value.toUpperCase(Locale.ROOT))) {
+                return value.toLowerCase(Locale.ROOT);
+            }
+            StringBuilder folded = new StringBuilder(value.length());
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                boolean nextIsUpperCase = i + 1 < value.length() && Character.isUpperCase(value.charAt(i + 1));
+                if (Character.isUpperCase(c) && (nextIsUpperCase || i == 0)) {
+                    folded.append(Character.toLowerCase(c));
+                } else {
+                    folded.append(c);
+                }
+            }
+            return folded.toString();
+        }
+        StringBuilder result = new StringBuilder(value.length());
+        boolean capitalize = false;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '-' || c == '_' || c == ' ') {
+                capitalize = true;
+            } else if (capitalize) {
+                result.append(Character.toUpperCase(c));
+                capitalize = false;
+            } else if (result.isEmpty()) {
+                result.append(Character.toLowerCase(c));
+            } else {
+                result.append(c);
+            }
+        }
+        return result.toString();
+    }
+
+    private static String normalizeName(String value) {
+        StringBuilder result = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (Character.isLetterOrDigit(current)) {
+                result.append(Character.toLowerCase(current));
+            }
+        }
+        if (result.toString().endsWith("member")) {
+            result.setLength(result.length() - "member".length());
+        }
+        return result.toString();
+    }
+
+    public StructPlan rootStructure() {
+        for (StructPlan structure : structures) {
+            if (structure.schema().id().equals(root.id())) {
+                return structure;
+            }
+        }
+        throw new UnsupportedSchemaException("Root is not a structure or union: " + root.id());
+    }
+
+    public record StructPlan(
+            Schema schema,
+            Class<?> shapeClass,
+            Class<?> builderClass,
+            Method builderFactory,
+            boolean union,
+            List<MemberPlan> members,
+            int estimatedBytecode,
+            List<MethodRange> writerChunks,
+            int readerBuckets) {
+        public StructPlan {
+            members = List.copyOf(members);
+            writerChunks = List.copyOf(writerChunks);
+        }
+    }
+
+    public record MethodRange(int startInclusive, int endExclusive, int estimatedBytecode) {}
+
+    public record MemberPlan(
+            Schema schema,
+            Schema target,
+            String memberName,
+            Method getter,
+            Method presence,
+            Method setter,
+            Class<?> unionVariant,
+            Method unionAccessor,
+            boolean required,
+            int estimatedBytecode) {}
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecRegistry.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecRegistry.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/** Concurrent cache and publication point for generated codecs. */
+@SmithyInternalApi
+public final class RuntimeCodecRegistry<T> {
+    private static final AtomicLong CLASS_SEQUENCE = new AtomicLong();
+    private static final System.Logger LOGGER = System.getLogger(RuntimeCodecRegistry.class.getName());
+
+    private final RuntimeCodecBackend<T> backend;
+    private volatile ClassValue<ConcurrentHashMap<CacheKey, CompletableFuture<Result<T>>>> entries =
+            newEntryTable();
+
+    public RuntimeCodecRegistry(RuntimeCodecBackend<T> backend) {
+        this.backend = Objects.requireNonNull(backend, "backend");
+    }
+
+    public T get(Schema schema, Object settingsIdentity) {
+        return get(schema, settingsIdentity, backend.memberSelector());
+    }
+
+    public T get(Schema schema, Object settingsIdentity, RuntimeCodecBackend.MemberSelector selector) {
+        return get(schema, settingsIdentity, selector, RuntimeCodegenFeature.strict(backend.id()));
+    }
+
+    /**
+     * Returns a generated codec, or null when lenient generation declines or fails.
+     *
+     * <p>Settings and selectors are identity-based cache keys. Strictness applies to the lookup,
+     * not the cached generation outcome.
+     */
+    public T get(
+            Schema schema,
+            Object settingsIdentity,
+            RuntimeCodecBackend.MemberSelector selector,
+            boolean strict
+    ) {
+        Objects.requireNonNull(selector, "selector");
+        Schema root = schema.isMember() ? schema.memberTarget() : schema;
+        Class<?> shapeClass = root.shapeClass();
+        if (shapeClass == null) {
+            if (strict) {
+                var unsupported = new UnsupportedSchemaException("No generated Java class for " + root.id());
+                RuntimeCodegenStats.recordUnsupported(backend.id());
+                throw new RuntimeCodegenException(
+                        "Runtime codec generation is unsupported for "
+                                + root.id()
+                                + " using backend "
+                                + backend.id(),
+                        unsupported);
+            }
+            return null;
+        }
+        ConcurrentHashMap<CacheKey, CompletableFuture<Result<T>>> classEntries = entries.get(shapeClass);
+        CacheKey key = new CacheKey(root, settingsIdentity, selector);
+        CompletableFuture<Result<T>> created = new CompletableFuture<>();
+        CompletableFuture<Result<T>> future = classEntries.putIfAbsent(key, created);
+        if (future == null) {
+            future = created;
+            generate(root, selector, key, classEntries, created);
+        }
+        Result<T> result;
+        try {
+            result = future.join();
+        } catch (CompletionException error) {
+            rethrowFatal(error.getCause());
+            throw error;
+        }
+        if (strict && result.unsupported() != null) {
+            throw new RuntimeCodegenException(
+                    "Runtime codec generation is unsupported for "
+                            + root.id()
+                            + " using backend "
+                            + backend.id(),
+                    result.unsupported());
+        }
+        if (strict && result.failure() != null) {
+            throw new RuntimeCodegenException(
+                    "Runtime codec generation failed for "
+                            + root.id()
+                            + " using backend "
+                            + backend.id(),
+                    result.failure());
+        }
+        return result.codec();
+    }
+
+    public void clear() {
+        entries = newEntryTable();
+    }
+
+    private void generate(
+            Schema schema,
+            RuntimeCodecBackend.MemberSelector selector,
+            CacheKey key,
+            ConcurrentHashMap<CacheKey, CompletableFuture<Result<T>>> classEntries,
+            CompletableFuture<Result<T>> future
+    ) {
+        try {
+            RuntimeCodecPlan plan = RuntimeCodecPlan.analyze(
+                    schema,
+                    backend.budgets(),
+                    backend.mode(),
+                    selector);
+            String generatedName = backend.lookupHost().getPackageName().replace('.', '/')
+                    + "/Generated"
+                    + sanitize(backend.id())
+                    + sanitize(backend.variant())
+                    + Long.toUnsignedString(CLASS_SEQUENCE.incrementAndGet(), 36);
+            RuntimeCodecBackend.Emission emission = backend.emit(plan, generatedName);
+            MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                    backend.lookupHost(),
+                    MethodHandles.lookup());
+            MethodHandles.Lookup hiddenLookup = lookup.defineHiddenClass(
+                    emission.bytecode(),
+                    true,
+                    MethodHandles.Lookup.ClassOption.NESTMATE);
+            Class<?> generatedClass = hiddenLookup.lookupClass();
+            Object instance = hiddenLookup.findConstructor(generatedClass, MethodType.methodType(void.class))
+                    .invoke();
+            T codec = backend.codecType().cast(instance);
+            RuntimeCodegenStats.recordGenerated(backend.id());
+            future.complete(new Result<>(codec, null, null));
+        } catch (Throwable error) {
+            Throwable failure = unwrap(error);
+            if (failure instanceof VirtualMachineError virtualMachineError) {
+                classEntries.remove(key, future);
+                future.completeExceptionally(virtualMachineError);
+                throw virtualMachineError;
+            }
+            if (failure instanceof UnsupportedSchemaException) {
+                RuntimeCodegenStats.recordUnsupported(backend.id());
+                if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+                    LOGGER.log(
+                            System.Logger.Level.DEBUG,
+                            "Runtime codec generation is unsupported for "
+                                    + schema.id()
+                                    + " using backend "
+                                    + backend.id(),
+                            failure);
+                }
+                future.complete(new Result<>(null, (UnsupportedSchemaException) failure, null));
+                return;
+            }
+            RuntimeCodegenStats.recordFailed(backend.id());
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "Runtime codec generation failed for "
+                            + schema.id()
+                            + " using backend "
+                            + backend.id()
+                            + "; falling back to dispatch serde",
+                    failure);
+            // Cache the cause so strict and lenient callers can share the generation attempt.
+            future.complete(new Result<>(null, null, failure));
+        }
+    }
+
+    private ClassValue<ConcurrentHashMap<CacheKey, CompletableFuture<Result<T>>>> newEntryTable() {
+        return new ClassValue<>() {
+            @Override
+            protected ConcurrentHashMap<CacheKey, CompletableFuture<Result<T>>> computeValue(Class<?> type) {
+                return new ConcurrentHashMap<>();
+            }
+        };
+    }
+
+    private static Throwable unwrap(Throwable error) {
+        if (error instanceof InvocationTargetException ite && ite.getCause() != null) {
+            return ite.getCause();
+        }
+        return error;
+    }
+
+    private static void rethrowFatal(Throwable failure) {
+        if (failure instanceof VirtualMachineError virtualMachineError) {
+            throw virtualMachineError;
+        }
+    }
+
+    private static String sanitize(String value) {
+        StringBuilder result = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            result.append(Character.isJavaIdentifierPart(c) ? c : '_');
+        }
+        return result.toString();
+    }
+
+    private static final class CacheKey {
+        private final Schema schemaIdentity;
+        private final Object settingsIdentity;
+        private final Object selectorIdentity;
+        private final int hashCode;
+
+        private CacheKey(Schema schemaIdentity, Object settingsIdentity, Object selectorIdentity) {
+            this.schemaIdentity = schemaIdentity;
+            this.settingsIdentity = settingsIdentity;
+            this.selectorIdentity = selectorIdentity;
+            int result = 31 * System.identityHashCode(schemaIdentity)
+                    + System.identityHashCode(settingsIdentity);
+            this.hashCode = 31 * result + System.identityHashCode(selectorIdentity);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof CacheKey that
+                    && schemaIdentity == that.schemaIdentity
+                    && settingsIdentity == that.settingsIdentity
+                    && selectorIdentity == that.selectorIdentity;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+    }
+
+    private record Result<T>(T codec, UnsupportedSchemaException unsupported, Throwable failure) {}
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenBytecode.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenBytecode.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.ACC_PUBLIC;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.ALOAD;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.ASTORE;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.ATHROW;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.DLOAD;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.DSTORE;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.DUP;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.FLOAD;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.FSTORE;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.ICONST_0;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.ICONST_1;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.IF_ACMPNE;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.ILOAD;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.INVOKEINTERFACE;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.INVOKESPECIAL;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.INVOKESTATIC;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.INVOKEVIRTUAL;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.IRETURN;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.ISTORE;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.LLOAD;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.LSTORE;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.NEW;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes.RETURN;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassWriter;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Label;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.MethodVisitor;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Type;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/** Shared bytecode helpers for runtime codec backends. */
+@SmithyInternalApi
+public final class RuntimeCodegenBytecode {
+    private RuntimeCodegenBytecode() {}
+
+    public static void emitDefaultConstructor(ClassWriter writer) {
+        MethodVisitor method = writer.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+        method.visitCode();
+        method.visitVarInsn(ALOAD, 0);
+        method.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+        method.visitInsn(RETURN);
+        method.visitMaxs(0, 0);
+        method.visitEnd();
+    }
+
+    // Generated readers call concrete setters, so only the exact builder class is safe.
+    public static void emitAcceptsBuilder(ClassWriter writer, Class<?> builderClass) {
+        MethodVisitor method = writer.visitMethod(
+                ACC_PUBLIC,
+                "acceptsBuilder",
+                "(Lsoftware/amazon/smithy/java/core/schema/ShapeBuilder;)Z",
+                null,
+                null);
+        method.visitCode();
+        method.visitVarInsn(ALOAD, 1);
+        method.visitMethodInsn(
+                INVOKEVIRTUAL,
+                "java/lang/Object",
+                "getClass",
+                "()Ljava/lang/Class;",
+                false);
+        method.visitLdcInsn(builderClass);
+        Label wrongClass = new Label();
+        method.visitJumpInsn(IF_ACMPNE, wrongClass);
+        method.visitInsn(ICONST_1);
+        method.visitInsn(IRETURN);
+        method.visitLabel(wrongClass);
+        method.visitInsn(ICONST_0);
+        method.visitInsn(IRETURN);
+        method.visitMaxs(0, 0);
+        method.visitEnd();
+    }
+
+    public static void invoke(MethodVisitor method, Method target) {
+        Class<?> owner = target.getDeclaringClass();
+        boolean itf = owner.isInterface();
+        boolean isStatic = Modifier.isStatic(target.getModifiers());
+        method.visitMethodInsn(
+                isStatic ? INVOKESTATIC : (itf ? INVOKEINTERFACE : INVOKEVIRTUAL),
+                Type.getInternalName(owner),
+                target.getName(),
+                Type.getMethodDescriptor(target),
+                itf);
+    }
+
+    public static Method findBuild(Class<?> builderClass, Class<?> shapeClass) {
+        for (Method method : builderClass.getMethods()) {
+            if (method.getName().equals("build")
+                    && method.getParameterCount() == 0
+                    && method.getReturnType() == shapeClass) {
+                return method;
+            }
+        }
+        throw new UnsupportedSchemaException("No direct build method on " + builderClass.getName());
+    }
+
+    public static int fieldHash(String value) {
+        int hash = 0;
+        for (byte b : value.getBytes(StandardCharsets.UTF_8)) {
+            hash = 31 * hash + (b & 0xff);
+        }
+        return hash;
+    }
+
+    public static int storeOpcode(Class<?> type) {
+        if (type == long.class) {
+            return LSTORE;
+        } else if (type == float.class) {
+            return FSTORE;
+        } else if (type == double.class) {
+            return DSTORE;
+        } else if (type.isPrimitive()) {
+            return ISTORE;
+        }
+        return ASTORE;
+    }
+
+    public static int loadOpcode(Class<?> type) {
+        if (type == long.class) {
+            return LLOAD;
+        } else if (type == float.class) {
+            return FLOAD;
+        } else if (type == double.class) {
+            return DLOAD;
+        } else if (type.isPrimitive()) {
+            return ILOAD;
+        }
+        return ALOAD;
+    }
+
+    public static void emitThrow(MethodVisitor method, String message) {
+        method.visitTypeInsn(NEW, "software/amazon/smithy/java/core/serde/SerializationException");
+        method.visitInsn(DUP);
+        method.visitLdcInsn(message);
+        method.visitMethodInsn(
+                INVOKESPECIAL,
+                "software/amazon/smithy/java/core/serde/SerializationException",
+                "<init>",
+                "(Ljava/lang/String;)V",
+                false);
+        method.visitInsn(ATHROW);
+    }
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenException.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/** Raised when strict runtime codegen cannot produce a codec. */
+@SmithyInternalApi
+public final class RuntimeCodegenException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    RuntimeCodegenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenFeature.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenFeature.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import java.util.Locale;
+import software.amazon.smithy.java.core.serde.RuntimeCodegenMode;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/** Resolves runtime codegen mode from caller settings and system properties. */
+@SmithyInternalApi
+public final class RuntimeCodegenFeature {
+    private static final String PROPERTY = "smithy-java.runtime-codegen";
+
+    private RuntimeCodegenFeature() {}
+
+    public static boolean available() {
+        return Runtime.version().feature() >= 25;
+    }
+
+    public static boolean enabled(String backend) {
+        return resolve(null, backend) != RuntimeCodegenMode.DISABLED;
+    }
+
+    public static boolean strict(String backend) {
+        return resolve(null, backend) == RuntimeCodegenMode.STRICT;
+    }
+
+    /** Resolves the effective mode for a backend. */
+    public static RuntimeCodegenMode resolve(RuntimeCodegenMode requested, String backend) {
+        RuntimeCodegenMode configured = configured(backend);
+        if (requested == RuntimeCodegenMode.DISABLED
+                || configured == RuntimeCodegenMode.DISABLED
+                || (requested == null && configured == null)) {
+            return RuntimeCodegenMode.DISABLED;
+        }
+        RuntimeCodegenMode resolved = requested == RuntimeCodegenMode.STRICT || configured == RuntimeCodegenMode.STRICT
+                ? RuntimeCodegenMode.STRICT
+                : RuntimeCodegenMode.ENABLED;
+        if (available()) {
+            return resolved;
+        }
+        if (resolved == RuntimeCodegenMode.STRICT) {
+            throw new IllegalStateException(
+                    "Runtime code generation requires Java 25 or later; strict mode forbids fallback");
+        }
+        return RuntimeCodegenMode.DISABLED;
+    }
+
+    private static RuntimeCodegenMode configured(String backend) {
+        RuntimeCodegenMode scoped = parse(PROPERTY + "." + backend);
+        return scoped != null ? scoped : parse(PROPERTY);
+    }
+
+    private static RuntimeCodegenMode parse(String property) {
+        String value;
+        try {
+            value = System.getProperty(property);
+        } catch (SecurityException ignored) {
+            return null;
+        }
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return RuntimeCodegenMode.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            // Fail invalid operational configuration at first use.
+            throw new IllegalArgumentException(
+                    "Invalid value '" + value + "' for " + property
+                            + "; expected one of disabled, enabled, strict");
+        }
+    }
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenStats.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenStats.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Process-wide counters describing runtime codec generation outcomes, keyed by backend id.
+ *
+ * <p>Generation is attempted once per {@code (shape, settings)} pair, so these counters are only
+ * touched on a cache miss and never from a serialization or deserialization hot path.
+ *
+ * <p>They exist because generation failure is, by contract, invisible: an unsupported shape falls
+ * back to the dispatch serde and the caller still gets a correct answer. That makes a test suite
+ * running with generation enabled indistinguishable from one running entirely on the fallback.
+ * Assert against a {@link #snapshot(String)} to prove generation actually engaged.
+ */
+@SmithyInternalApi
+public final class RuntimeCodegenStats {
+    private static final ConcurrentHashMap<String, Counters> BACKENDS = new ConcurrentHashMap<>();
+
+    private RuntimeCodegenStats() {}
+
+    /** A generated codec was emitted, loaded, and published. */
+    public static void recordGenerated(String backend) {
+        counters(backend).generated.increment();
+    }
+
+    /** The schema graph is outside what the backend supports; the caller falls back by design. */
+    public static void recordUnsupported(String backend) {
+        counters(backend).unsupported.increment();
+    }
+
+    /** Generation broke. Always a bug in the backend, the plan, or the classfile emitter. */
+    public static void recordFailed(String backend) {
+        counters(backend).failed.increment();
+    }
+
+    public static Snapshot snapshot(String backend) {
+        Counters counters = BACKENDS.get(backend);
+        return counters == null ? Snapshot.EMPTY : counters.snapshot();
+    }
+
+    public static Map<String, Snapshot> snapshots() {
+        return BACKENDS.entrySet()
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> entry.getValue().snapshot()));
+    }
+
+    public static void reset() {
+        BACKENDS.clear();
+    }
+
+    private static Counters counters(String backend) {
+        return BACKENDS.computeIfAbsent(backend, ignored -> new Counters());
+    }
+
+    /**
+     * An immutable read of one backend's counters.
+     *
+     * @param generated codecs successfully emitted and published
+     * @param unsupported shapes rejected as unsupported, which fall back by design
+     * @param failed generation attempts that broke, which fall back but indicate a bug
+     */
+    public record Snapshot(long generated, long unsupported, long failed) {
+        private static final Snapshot EMPTY = new Snapshot(0, 0, 0);
+
+        public long attempts() {
+            return generated + unsupported + failed;
+        }
+    }
+
+    private static final class Counters {
+        private final LongAdder generated = new LongAdder();
+        private final LongAdder unsupported = new LongAdder();
+        private final LongAdder failed = new LongAdder();
+
+        private Snapshot snapshot() {
+            return new Snapshot(generated.sum(), unsupported.sum(), failed.sum());
+        }
+    }
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/UnsupportedSchemaException.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/UnsupportedSchemaException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class UnsupportedSchemaException extends RuntimeException {
+    public UnsupportedSchemaException(String message) {
+        super(message);
+    }
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/ClassFileModel.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/ClassFileModel.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen.classfile;
+
+import java.util.List;
+
+record ClassFileModel(
+        int version,
+        int access,
+        String name,
+        String superName,
+        List<String> interfaces,
+        List<FieldModel> fields,
+        List<MethodModel> methods) {
+    record FieldModel(int access, String name, String descriptor) {}
+
+    record MethodModel(
+            int access,
+            String name,
+            String descriptor,
+            List<Instruction> instructions,
+            List<TryCatch> tryCatches) {}
+
+    record TryCatch(Label start, Label end, Label handler, String type) {}
+
+    record Instruction(Kind kind, int opcode, Object[] operands) {
+        enum Kind {
+            INSN,
+            VAR,
+            TYPE,
+            FIELD,
+            METHOD,
+            JUMP,
+            LABEL,
+            CONSTANT,
+            INCREMENT,
+            LOOKUP_SWITCH
+        }
+    }
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/ClassWriter.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/ClassWriter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen.classfile;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassFileModel.FieldModel;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassFileModel.MethodModel;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class ClassWriter {
+    public static final int COMPUTE_FRAMES = 1;
+    public static final int COMPUTE_MAXS = 2;
+
+    private static final String EMITTER =
+            "software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.JdkClassFileEmitter";
+
+    private final List<FieldModel> fields = new ArrayList<>();
+    private final List<MethodEntry> methods = new ArrayList<>();
+    private int version;
+    private int access;
+    private String name;
+    private String superName;
+    private List<String> interfaces;
+
+    public ClassWriter(int flags) {}
+
+    public void visit(
+            int version,
+            int access,
+            String name,
+            String signature,
+            String superName,
+            String[] interfaces
+    ) {
+        this.version = version;
+        this.access = access;
+        this.name = name;
+        this.superName = superName;
+        this.interfaces = List.of(interfaces.clone());
+    }
+
+    public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+        fields.add(new FieldModel(access, name, descriptor));
+        return new FieldVisitor();
+    }
+
+    public MethodVisitor visitMethod(
+            int access,
+            String name,
+            String descriptor,
+            String signature,
+            String[] exceptions
+    ) {
+        MethodVisitor visitor = new MethodVisitor();
+        methods.add(new MethodEntry(access, name, descriptor, visitor));
+        return visitor;
+    }
+
+    public void visitEnd() {}
+
+    public byte[] toByteArray() {
+        if (Runtime.version().feature() < 25) {
+            throw new UnsupportedOperationException("Runtime codec generation requires JDK 25 or newer");
+        }
+        List<MethodModel> methodModels = methods.stream()
+                .map(entry -> new MethodModel(
+                        entry.access,
+                        entry.name,
+                        entry.descriptor,
+                        entry.visitor.instructions(),
+                        entry.visitor.tryCatches()))
+                .toList();
+        ClassFileModel model =
+                new ClassFileModel(version, access, name, superName, interfaces, List.copyOf(fields), methodModels);
+        try {
+            return (byte[]) EmitterHolder.EMIT.invokeExact(model);
+        } catch (Throwable cause) {
+            if (cause instanceof RuntimeException runtime) {
+                throw runtime;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new IllegalStateException("JDK ClassFile emission failed", cause);
+        }
+    }
+
+    private static final class EmitterHolder {
+        private static final MethodHandle EMIT = load();
+
+        private static MethodHandle load() {
+            try {
+                Class<?> emitter = Class.forName(EMITTER, true, ClassWriter.class.getClassLoader());
+                return MethodHandles.lookup()
+                        .findStatic(
+                                emitter,
+                                "emit",
+                                MethodType.methodType(byte[].class, ClassFileModel.class))
+                        .asType(MethodType.methodType(byte[].class, ClassFileModel.class));
+            } catch (ReflectiveOperationException | LinkageError e) {
+                throw new IllegalStateException("JDK ClassFile emitter is unavailable", e);
+            }
+        }
+    }
+
+    private record MethodEntry(int access, String name, String descriptor, MethodVisitor visitor) {}
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/FieldVisitor.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/FieldVisitor.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen.classfile;
+
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class FieldVisitor {
+    public void visitEnd() {}
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/Label.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/Label.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen.classfile;
+
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class Label {}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/MethodVisitor.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/MethodVisitor.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen.classfile;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassFileModel.Instruction;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassFileModel.Instruction.Kind;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassFileModel.TryCatch;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class MethodVisitor {
+    private final List<Instruction> instructions = new ArrayList<>();
+    private final List<TryCatch> tryCatches = new ArrayList<>();
+
+    public void visitCode() {}
+
+    public void visitInsn(int opcode) {
+        add(Kind.INSN, opcode);
+    }
+
+    public void visitVarInsn(int opcode, int variable) {
+        add(Kind.VAR, opcode, variable);
+    }
+
+    public void visitTypeInsn(int opcode, String type) {
+        add(Kind.TYPE, opcode, type);
+    }
+
+    public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
+        add(Kind.FIELD, opcode, owner, name, descriptor);
+    }
+
+    public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+        add(Kind.METHOD, opcode, owner, name, descriptor, isInterface);
+    }
+
+    public void visitJumpInsn(int opcode, Label target) {
+        add(Kind.JUMP, opcode, target);
+    }
+
+    public void visitLabel(Label label) {
+        add(Kind.LABEL, 0, label);
+    }
+
+    public void visitLdcInsn(Object value) {
+        add(Kind.CONSTANT, 0, value);
+    }
+
+    public void visitIincInsn(int variable, int increment) {
+        add(Kind.INCREMENT, 0, variable, increment);
+    }
+
+    public void visitLookupSwitchInsn(Label defaultTarget, int[] keys, Label[] targets) {
+        if (keys.length != targets.length) {
+            throw new IllegalArgumentException("Lookup switch keys and targets must have equal lengths");
+        }
+        int[] sortedKeys = keys.clone();
+        Label[] sortedTargets = targets.clone();
+        for (int i = 1; i < sortedKeys.length; i++) {
+            int key = sortedKeys[i];
+            Label target = sortedTargets[i];
+            int insert = i - 1;
+            while (insert >= 0 && sortedKeys[insert] > key) {
+                sortedKeys[insert + 1] = sortedKeys[insert];
+                sortedTargets[insert + 1] = sortedTargets[insert];
+                insert--;
+            }
+            sortedKeys[insert + 1] = key;
+            sortedTargets[insert + 1] = target;
+        }
+        add(Kind.LOOKUP_SWITCH, 0, defaultTarget, sortedKeys, sortedTargets);
+    }
+
+    public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
+        tryCatches.add(new TryCatch(start, end, handler, type));
+    }
+
+    public void visitMaxs(int maxStack, int maxLocals) {}
+
+    public void visitEnd() {}
+
+    List<Instruction> instructions() {
+        return List.copyOf(instructions);
+    }
+
+    List<TryCatch> tryCatches() {
+        return List.copyOf(tryCatches);
+    }
+
+    private void add(Kind kind, int opcode, Object... operands) {
+        instructions.add(new Instruction(kind, opcode, operands));
+    }
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/Opcodes.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/Opcodes.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen.classfile;
+
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public interface Opcodes {
+    int V17 = 61;
+
+    int ACC_PUBLIC = 0x0001;
+    int ACC_PRIVATE = 0x0002;
+    int ACC_STATIC = 0x0008;
+    int ACC_FINAL = 0x0010;
+    int ACC_SUPER = 0x0020;
+
+    int ACONST_NULL = 1;
+    int ICONST_0 = 3;
+    int ICONST_1 = 4;
+    int ILOAD = 21;
+    int LLOAD = 22;
+    int FLOAD = 23;
+    int DLOAD = 24;
+    int ALOAD = 25;
+    int ISTORE = 54;
+    int LSTORE = 55;
+    int FSTORE = 56;
+    int DSTORE = 57;
+    int ASTORE = 58;
+    int POP = 87;
+    int DUP = 89;
+    int IRETURN = 172;
+    int ARETURN = 176;
+    int RETURN = 177;
+    int GETSTATIC = 178;
+    int PUTSTATIC = 179;
+    int INVOKEVIRTUAL = 182;
+    int INVOKESPECIAL = 183;
+    int INVOKESTATIC = 184;
+    int INVOKEINTERFACE = 185;
+    int NEW = 187;
+    int ARRAYLENGTH = 190;
+    int ATHROW = 191;
+    int CHECKCAST = 192;
+    int INSTANCEOF = 193;
+    int IFEQ = 153;
+    int IFNE = 154;
+    int IF_ICMPEQ = 159;
+    int IF_ICMPGE = 162;
+    int IF_ACMPNE = 166;
+    int GOTO = 167;
+    int IFNULL = 198;
+    int IFNONNULL = 199;
+}

--- a/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/Type.java
+++ b/codecs/codec-commons/src/main/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/Type.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen.classfile;
+
+import java.lang.reflect.Method;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class Type {
+    public static final Type VOID_TYPE = new Type(void.class);
+
+    private final Class<?> type;
+
+    private Type(Class<?> type) {
+        this.type = type;
+    }
+
+    public static String getInternalName(Class<?> type) {
+        return type.getName().replace('.', '/');
+    }
+
+    public static String getDescriptor(Class<?> type) {
+        if (type.isPrimitive()) {
+            if (type == void.class) {
+                return "V";
+            } else if (type == boolean.class) {
+                return "Z";
+            } else if (type == byte.class) {
+                return "B";
+            } else if (type == char.class) {
+                return "C";
+            } else if (type == short.class) {
+                return "S";
+            } else if (type == int.class) {
+                return "I";
+            } else if (type == long.class) {
+                return "J";
+            } else if (type == float.class) {
+                return "F";
+            } else {
+                return "D";
+            }
+        }
+        return type.isArray() ? type.getName().replace('.', '/') : "L" + getInternalName(type) + ";";
+    }
+
+    public static String getMethodDescriptor(Method method) {
+        Type[] parameters = new Type[method.getParameterCount()];
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int i = 0; i < parameters.length; i++) {
+            parameters[i] = getType(parameterTypes[i]);
+        }
+        return getMethodDescriptor(getType(method.getReturnType()), parameters);
+    }
+
+    public static String getMethodDescriptor(Type returnType, Type... parameterTypes) {
+        StringBuilder result = new StringBuilder("(");
+        for (Type parameter : parameterTypes) {
+            result.append(getDescriptor(parameter.type));
+        }
+        return result.append(')').append(getDescriptor(returnType.type)).toString();
+    }
+
+    public static Type getType(Class<?> type) {
+        return new Type(type);
+    }
+
+    public static boolean isPrimitive(Class<?> type) {
+        return type.isPrimitive();
+    }
+}

--- a/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecPlanTest.java
+++ b/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecPlanTest.java
@@ -1,0 +1,958 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class RuntimeCodecPlanTest {
+
+    private static final Schema NESTED = Schema.structureBuilder(ShapeId.from("example#Nested"))
+            .shapeClass(Nested.class)
+            .builderSupplier(Nested.Builder::new)
+            .putMember("a", PreludeSchemas.STRING)
+            .putMember("b", PreludeSchemas.STRING)
+            .build();
+
+    private static final Schema ROOT = Schema.structureBuilder(ShapeId.from("example#Root"))
+            .shapeClass(Root.class)
+            .builderSupplier(Root.Builder::new)
+            .putMember("kept", PreludeSchemas.STRING)
+            .putMember("dropped", NESTED)
+            .putMember("nested", NESTED)
+            .build();
+
+    private static final Schema NO_SETTER = Schema.structureBuilder(ShapeId.from("example#NoSetter"))
+            .shapeClass(NoSetter.class)
+            .builderSupplier(NoSetter.Builder::new)
+            .putMember("value", PreludeSchemas.STRING)
+            .build();
+
+    private static final Schema TAGS = Schema.listBuilder(ShapeId.from("example#Tags"))
+            .putMember("member", PreludeSchemas.STRING)
+            .build();
+
+    private static final Schema ACRONYMS = Schema.structureBuilder(ShapeId.from("example#Acronyms"))
+            .shapeClass(Acronyms.class)
+            .builderSupplier(Acronyms.Builder::new)
+            .putMember("ACL", PreludeSchemas.STRING)
+            .putMember("SSEKMSKeyId", PreludeSchemas.STRING)
+            .putMember("GrantReadACP", PreludeSchemas.STRING)
+            .putMember("ETag", PreludeSchemas.STRING)
+            .putMember("BucketKeyEnabled", PreludeSchemas.BOOLEAN)
+            .putMember("Tags", TAGS)
+            .build();
+
+    private static final Schema SHADOWS_SCHEMA = Schema.structureBuilder(ShapeId.from("example#ShadowsSchema"))
+            .shapeClass(ShadowsSchema.class)
+            .builderSupplier(ShadowsSchema.Builder::new)
+            .putMember("schema", PreludeSchemas.STRING)
+            .build();
+
+    private static final Schema SHADOWS_OBJECT = Schema.structureBuilder(ShapeId.from("example#ShadowsObject"))
+            .shapeClass(ShadowsObject.class)
+            .builderSupplier(ShadowsObject.Builder::new)
+            .putMember("hashCode", PreludeSchemas.STRING)
+            .build();
+
+    private static final Schema RECURSIVE = recursiveSchema();
+
+    private static final Schema WRONG_ACCESSOR = Schema.structureBuilder(ShapeId.from("example#WrongAccessor"))
+            .shapeClass(WrongAccessor.class)
+            .builderSupplier(WrongAccessor.Builder::new)
+            .putMember("value", PreludeSchemas.STRING)
+            .build();
+
+    private static final Schema PACKAGE_PRIVATE_SHAPE =
+            Schema.structureBuilder(ShapeId.from("example#PackagePrivateShape"))
+                    .shapeClass(PackagePrivateShape.class)
+                    .builderSupplier(PackagePrivateShape.Builder::new)
+                    .putMember("value", PreludeSchemas.STRING)
+                    .build();
+
+    private static final Schema PACKAGE_PRIVATE_BUILDER =
+            Schema.structureBuilder(ShapeId.from("example#PackagePrivateBuilder"))
+                    .shapeClass(PackagePrivateBuilder.class)
+                    .builderSupplier(PackagePrivateBuilder.Builder::new)
+                    .putMember("value", PreludeSchemas.STRING)
+                    .build();
+
+    private static final Schema PUBLIC_SHAPE_IN_PACKAGE_PRIVATE_OUTER =
+            Schema.structureBuilder(ShapeId.from("example#PublicShapeInPackagePrivateOuter"))
+                    .shapeClass(PackagePrivateOuter.PublicShape.class)
+                    .builderSupplier(PackagePrivateOuter.PublicShape.Builder::new)
+                    .putMember("value", PreludeSchemas.STRING)
+                    .build();
+
+    private static final Schema COLLIDING_ACCESSORS =
+            Schema.structureBuilder(ShapeId.from("example#CollidingAccessors"))
+                    .shapeClass(CollidingAccessors.class)
+                    .builderSupplier(CollidingAccessors.Builder::new)
+                    .putMember("GrantReadACP", PreludeSchemas.STRING)
+                    .putMember("grantReadacP", PreludeSchemas.STRING)
+                    .build();
+
+    private static Schema recursiveSchema() {
+        var builder = Schema.structureBuilder(ShapeId.from("example#Recursive"))
+                .shapeClass(Recursive.class)
+                .builderSupplier(Recursive.Builder::new)
+                .putMember("value", PreludeSchemas.STRING);
+        return builder.putMember("next", builder).build();
+    }
+
+    private static List<String> memberNames(RuntimeCodecPlan.StructPlan plan) {
+        return plan.members().stream().map(RuntimeCodecPlan.MemberPlan::memberName).toList();
+    }
+
+    @Test
+    void selectsAllRootMembersByDefault() {
+        var plan = RuntimeCodecPlan.analyze(ROOT);
+
+        assertEquals(List.of("kept", "dropped", "nested"), memberNames(plan.rootStructure()));
+    }
+
+    @Test
+    void memberSelectorNarrowsTheRoot() {
+        var plan = RuntimeCodecPlan.analyze(
+                ROOT,
+                RuntimeCodecBackend.Budgets.unbounded(),
+                RuntimeCodecBackend.Mode.READ_WRITE,
+                (root, member) -> !member.memberName().equals("dropped"));
+
+        assertEquals(List.of("kept", "nested"), memberNames(plan.rootStructure()));
+    }
+
+    @Test
+    void memberSelectorDoesNotNarrowNestedShapes() {
+        var plan = RuntimeCodecPlan.analyze(
+                ROOT,
+                RuntimeCodecBackend.Budgets.unbounded(),
+                RuntimeCodecBackend.Mode.READ_WRITE,
+                (root, member) -> !member.memberName().equals("a"));
+
+        var nested = plan.structures()
+                .stream()
+                .filter(s -> s.schema().id().equals(NESTED.id()))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(List.of("a", "b"), memberNames(nested));
+    }
+
+    @Test
+    void excludingAMemberAlsoSkipsItsUnreachableTarget() {
+        var keepsNested = RuntimeCodecPlan.analyze(
+                ROOT,
+                RuntimeCodecBackend.Budgets.unbounded(),
+                RuntimeCodecBackend.Mode.READ_WRITE,
+                (root, member) -> !member.memberName().equals("dropped"));
+        assertTrue(keepsNested.structures().stream().anyMatch(s -> s.schema().id().equals(NESTED.id())));
+
+        var dropsNested = RuntimeCodecPlan.analyze(
+                ROOT,
+                RuntimeCodecBackend.Budgets.unbounded(),
+                RuntimeCodecBackend.Mode.READ_WRITE,
+                (root, member) -> member.memberName().equals("kept"));
+
+        assertEquals(List.of("kept"), memberNames(dropsNested.rootStructure()));
+        assertTrue(dropsNested.structures().stream().noneMatch(s -> s.schema().id().equals(NESTED.id())));
+    }
+
+    @Test
+    void readWriteModeRejectsAShapeWithNoResolvableSetter() {
+        assertThrows(UnsupportedSchemaException.class, () -> RuntimeCodecPlan.analyze(NO_SETTER));
+    }
+
+    @Test
+    void writeOnlyModeSkipsSetterAndBuilderResolution() {
+        var plan = RuntimeCodecPlan.analyze(
+                NO_SETTER,
+                RuntimeCodecBackend.Budgets.unbounded(),
+                RuntimeCodecBackend.Mode.WRITE_ONLY,
+                RuntimeCodecBackend.MemberSelector.all());
+
+        var structure = plan.rootStructure();
+        assertNull(structure.builderClass());
+        assertNull(structure.builderFactory());
+        assertNull(structure.members().getFirst().setter());
+        assertNotNull(structure.members().getFirst().getter());
+        assertEquals("getValue", structure.members().getFirst().getter().getName());
+    }
+
+    @Test
+    void resolvesAccessorsThatFoldAcronyms() {
+        var plan = RuntimeCodecPlan.analyze(ACRONYMS);
+        var members = plan.rootStructure().members();
+
+        assertEquals(
+                List.of("getAcl", "getSsekmsKeyId", "getGrantReadacP", "getETag", "isBucketKeyEnabled", "getTags"),
+                members.stream().map(m -> m.getter().getName()).toList());
+        assertEquals(
+                List.of("acl", "ssekmsKeyId", "grantReadacP", "eTag", "bucketKeyEnabled", "tags"),
+                members.stream().map(m -> m.setter().getName()).toList());
+        assertEquals("hasTags", members.get(5).presence().getName());
+        assertNull(members.getFirst().presence());
+    }
+
+    @Test
+    void doesNotResolveAMemberToAFrameworkOrObjectMethod() {
+        assertThrows(UnsupportedSchemaException.class, () -> RuntimeCodecPlan.analyze(SHADOWS_SCHEMA));
+        assertThrows(UnsupportedSchemaException.class, () -> RuntimeCodecPlan.analyze(SHADOWS_OBJECT));
+    }
+
+    @Test
+    void rejectsNarrowedRecursiveRoot() {
+        assertThrows(
+                UnsupportedSchemaException.class,
+                () -> RuntimeCodecPlan.analyze(
+                        RECURSIVE,
+                        RuntimeCodecBackend.Budgets.unbounded(),
+                        RuntimeCodecBackend.Mode.READ_WRITE,
+                        (root, member) -> member.memberName().equals("next")));
+
+        var nonRecursiveSubset = RuntimeCodecPlan.analyze(
+                RECURSIVE,
+                RuntimeCodecBackend.Budgets.unbounded(),
+                RuntimeCodecBackend.Mode.READ_WRITE,
+                (root, member) -> member.memberName().equals("value"));
+        assertEquals(List.of("value"), memberNames(nonRecursiveSubset.rootStructure()));
+    }
+
+    @Test
+    void rejectsAccessorTypeThatDoesNotMatchSchema() {
+        assertThrows(UnsupportedSchemaException.class, () -> RuntimeCodecPlan.analyze(WRONG_ACCESSOR));
+    }
+
+    @Test
+    void rejectsPackagePrivateShapeClass() {
+        assertThrows(UnsupportedSchemaException.class, () -> RuntimeCodecPlan.analyze(PACKAGE_PRIVATE_SHAPE));
+    }
+
+    @Test
+    void rejectsPackagePrivateBuilderClass() {
+        assertThrows(UnsupportedSchemaException.class, () -> RuntimeCodecPlan.analyze(PACKAGE_PRIVATE_BUILDER));
+    }
+
+    @Test
+    void rejectsPublicShapeNestedInPackagePrivateClass() {
+        assertThrows(
+                UnsupportedSchemaException.class,
+                () -> RuntimeCodecPlan.analyze(PUBLIC_SHAPE_IN_PACKAGE_PRIVATE_OUTER));
+    }
+
+    @Test
+    void rejectsMembersThatResolveToTheSameAccessor() {
+        assertThrows(UnsupportedSchemaException.class, () -> RuntimeCodecPlan.analyze(COLLIDING_ACCESSORS));
+    }
+
+    @Test
+    void chunksAtExactMemberBoundaries() {
+        var plan = RuntimeCodecPlan.analyze(
+                ACRONYMS,
+                new RuntimeCodecBackend.Budgets(
+                        Integer.MAX_VALUE,
+                        Integer.MAX_VALUE,
+                        2,
+                        2));
+        var structure = plan.rootStructure();
+
+        assertEquals(
+                List.of(
+                        new RuntimeCodecPlan.MethodRange(0, 2, 120),
+                        new RuntimeCodecPlan.MethodRange(2, 4, 120),
+                        new RuntimeCodecPlan.MethodRange(4, 6, 96)),
+                structure.writerChunks());
+        assertEquals(3, structure.readerBuckets());
+    }
+
+    public static final class Root implements SerializableStruct {
+        private final String kept;
+        private final Nested dropped;
+        private final Nested nested;
+
+        Root(Builder builder) {
+            this.kept = builder.kept;
+            this.dropped = builder.dropped;
+            this.nested = builder.nested;
+        }
+
+        public String getKept() {
+            return kept;
+        }
+
+        public Nested getDropped() {
+            return dropped;
+        }
+
+        public Nested getNested() {
+            return nested;
+        }
+
+        @Override
+        public Schema schema() {
+            return ROOT;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeString(ROOT.member("kept"), kept);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) kept;
+        }
+
+        public static final class Builder implements ShapeBuilder<Root> {
+            private String kept;
+            private Nested dropped;
+            private Nested nested;
+
+            public Builder kept(String kept) {
+                this.kept = kept;
+                return this;
+            }
+
+            public Builder dropped(Nested dropped) {
+                this.dropped = dropped;
+                return this;
+            }
+
+            public Builder nested(Nested nested) {
+                this.nested = nested;
+                return this;
+            }
+
+            @Override
+            public Root build() {
+                return new Root(this);
+            }
+
+            @Override
+            public ShapeBuilder<Root> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return ROOT;
+            }
+        }
+    }
+
+    public static final class Nested implements SerializableStruct {
+        private final String a;
+        private final String b;
+
+        Nested(Builder builder) {
+            this.a = builder.a;
+            this.b = builder.b;
+        }
+
+        public String getA() {
+            return a;
+        }
+
+        public String getB() {
+            return b;
+        }
+
+        @Override
+        public Schema schema() {
+            return NESTED;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeString(NESTED.member("a"), a);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) a;
+        }
+
+        public static final class Builder implements ShapeBuilder<Nested> {
+            private String a;
+            private String b;
+
+            public Builder a(String a) {
+                this.a = a;
+                return this;
+            }
+
+            public Builder b(String b) {
+                this.b = b;
+                return this;
+            }
+
+            @Override
+            public Nested build() {
+                return new Nested(this);
+            }
+
+            @Override
+            public ShapeBuilder<Nested> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return NESTED;
+            }
+        }
+    }
+
+    public static final class Acronyms implements SerializableStruct {
+        private final String acl;
+        private final String ssekmsKeyId;
+        private final String grantReadacP;
+        private final String eTag;
+        private final Boolean bucketKeyEnabled;
+        private final List<String> tags;
+
+        Acronyms(Builder builder) {
+            this.acl = builder.acl;
+            this.ssekmsKeyId = builder.ssekmsKeyId;
+            this.grantReadacP = builder.grantReadacP;
+            this.eTag = builder.eTag;
+            this.bucketKeyEnabled = builder.bucketKeyEnabled;
+            this.tags = builder.tags;
+        }
+
+        public String getAcl() {
+            return acl;
+        }
+
+        public String getSsekmsKeyId() {
+            return ssekmsKeyId;
+        }
+
+        public String getGrantReadacP() {
+            return grantReadacP;
+        }
+
+        public String getETag() {
+            return eTag;
+        }
+
+        public Boolean isBucketKeyEnabled() {
+            return bucketKeyEnabled;
+        }
+
+        public List<String> getTags() {
+            return tags;
+        }
+
+        public boolean hasTags() {
+            return tags != null;
+        }
+
+        @Override
+        public Schema schema() {
+            return ACRONYMS;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeString(ACRONYMS.member("ACL"), acl);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) acl;
+        }
+
+        public static final class Builder implements ShapeBuilder<Acronyms> {
+            private String acl;
+            private String ssekmsKeyId;
+            private String grantReadacP;
+            private String eTag;
+            private Boolean bucketKeyEnabled;
+            private List<String> tags;
+
+            public Builder acl(String acl) {
+                this.acl = acl;
+                return this;
+            }
+
+            public Builder ssekmsKeyId(String ssekmsKeyId) {
+                this.ssekmsKeyId = ssekmsKeyId;
+                return this;
+            }
+
+            public Builder grantReadacP(String grantReadacP) {
+                this.grantReadacP = grantReadacP;
+                return this;
+            }
+
+            public Builder eTag(String eTag) {
+                this.eTag = eTag;
+                return this;
+            }
+
+            public Builder bucketKeyEnabled(Boolean bucketKeyEnabled) {
+                this.bucketKeyEnabled = bucketKeyEnabled;
+                return this;
+            }
+
+            public Builder tags(List<String> tags) {
+                this.tags = tags;
+                return this;
+            }
+
+            @Override
+            public Acronyms build() {
+                return new Acronyms(this);
+            }
+
+            @Override
+            public ShapeBuilder<Acronyms> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return ACRONYMS;
+            }
+        }
+    }
+
+    public static final class ShadowsSchema implements SerializableStruct {
+        @Override
+        public Schema schema() {
+            return SHADOWS_SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return null;
+        }
+
+        public static final class Builder implements ShapeBuilder<ShadowsSchema> {
+            @Override
+            public ShadowsSchema build() {
+                return new ShadowsSchema();
+            }
+
+            @Override
+            public ShapeBuilder<ShadowsSchema> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return SHADOWS_SCHEMA;
+            }
+        }
+    }
+
+    public static final class ShadowsObject implements SerializableStruct {
+        @Override
+        public Schema schema() {
+            return SHADOWS_OBJECT;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return null;
+        }
+
+        public static final class Builder implements ShapeBuilder<ShadowsObject> {
+            @Override
+            public ShadowsObject build() {
+                return new ShadowsObject();
+            }
+
+            @Override
+            public ShapeBuilder<ShadowsObject> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return SHADOWS_OBJECT;
+            }
+        }
+    }
+
+    public static final class Recursive implements SerializableStruct {
+        private final String value;
+        private final Recursive next;
+
+        Recursive(Builder builder) {
+            this.value = builder.value;
+            this.next = builder.next;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public Recursive getNext() {
+            return next;
+        }
+
+        @Override
+        public Schema schema() {
+            return RECURSIVE;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return null;
+        }
+
+        public static final class Builder implements ShapeBuilder<Recursive> {
+            private String value;
+            private Recursive next;
+
+            public Builder value(String value) {
+                this.value = value;
+                return this;
+            }
+
+            public Builder next(Recursive next) {
+                this.next = next;
+                return this;
+            }
+
+            @Override
+            public Recursive build() {
+                return new Recursive(this);
+            }
+
+            @Override
+            public ShapeBuilder<Recursive> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return RECURSIVE;
+            }
+        }
+    }
+
+    public static final class WrongAccessor implements SerializableStruct {
+        private final CharSequence value;
+
+        WrongAccessor(Builder builder) {
+            this.value = builder.value;
+        }
+
+        public CharSequence getValue() {
+            return value;
+        }
+
+        @Override
+        public Schema schema() {
+            return WRONG_ACCESSOR;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return null;
+        }
+
+        public static final class Builder implements ShapeBuilder<WrongAccessor> {
+            private CharSequence value;
+
+            public Builder value(CharSequence value) {
+                this.value = value;
+                return this;
+            }
+
+            @Override
+            public WrongAccessor build() {
+                return new WrongAccessor(this);
+            }
+
+            @Override
+            public ShapeBuilder<WrongAccessor> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return WRONG_ACCESSOR;
+            }
+        }
+    }
+
+    static final class PackagePrivateShape implements SerializableStruct {
+        private final String value;
+
+        PackagePrivateShape(Builder builder) {
+            this.value = builder.value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public Schema schema() {
+            return PACKAGE_PRIVATE_SHAPE;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return null;
+        }
+
+        public static final class Builder implements ShapeBuilder<PackagePrivateShape> {
+            private String value;
+
+            public Builder value(String value) {
+                this.value = value;
+                return this;
+            }
+
+            @Override
+            public PackagePrivateShape build() {
+                return new PackagePrivateShape(this);
+            }
+
+            @Override
+            public ShapeBuilder<PackagePrivateShape> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return PACKAGE_PRIVATE_SHAPE;
+            }
+        }
+    }
+
+    public static final class PackagePrivateBuilder implements SerializableStruct {
+        private final String value;
+
+        PackagePrivateBuilder(Builder builder) {
+            this.value = builder.value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public Schema schema() {
+            return PACKAGE_PRIVATE_BUILDER;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return null;
+        }
+
+        static final class Builder implements ShapeBuilder<PackagePrivateBuilder> {
+            private String value;
+
+            public Builder value(String value) {
+                this.value = value;
+                return this;
+            }
+
+            @Override
+            public PackagePrivateBuilder build() {
+                return new PackagePrivateBuilder(this);
+            }
+
+            @Override
+            public ShapeBuilder<PackagePrivateBuilder> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return PACKAGE_PRIVATE_BUILDER;
+            }
+        }
+    }
+
+    static final class PackagePrivateOuter {
+        public static final class PublicShape implements SerializableStruct {
+            private final String value;
+
+            PublicShape(Builder builder) {
+                this.value = builder.value;
+            }
+
+            public String getValue() {
+                return value;
+            }
+
+            @Override
+            public Schema schema() {
+                return PUBLIC_SHAPE_IN_PACKAGE_PRIVATE_OUTER;
+            }
+
+            @Override
+            public void serializeMembers(ShapeSerializer serializer) {}
+
+            @Override
+            public <T> T getMemberValue(Schema member) {
+                return null;
+            }
+
+            public static final class Builder implements ShapeBuilder<PublicShape> {
+                private String value;
+
+                public Builder value(String value) {
+                    this.value = value;
+                    return this;
+                }
+
+                @Override
+                public PublicShape build() {
+                    return new PublicShape(this);
+                }
+
+                @Override
+                public ShapeBuilder<PublicShape> deserialize(ShapeDeserializer decoder) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Schema schema() {
+                    return PUBLIC_SHAPE_IN_PACKAGE_PRIVATE_OUTER;
+                }
+            }
+        }
+    }
+
+    public static final class CollidingAccessors implements SerializableStruct {
+        private final String value;
+
+        CollidingAccessors(Builder builder) {
+            this.value = builder.value;
+        }
+
+        public String getGrantReadacP() {
+            return value;
+        }
+
+        @Override
+        public Schema schema() {
+            return COLLIDING_ACCESSORS;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return null;
+        }
+
+        public static final class Builder implements ShapeBuilder<CollidingAccessors> {
+            private String value;
+
+            public Builder grantReadacP(String value) {
+                this.value = value;
+                return this;
+            }
+
+            @Override
+            public CollidingAccessors build() {
+                return new CollidingAccessors(this);
+            }
+
+            @Override
+            public ShapeBuilder<CollidingAccessors> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return COLLIDING_ACCESSORS;
+            }
+        }
+    }
+
+    public static final class NoSetter implements SerializableStruct {
+        private final String value;
+
+        NoSetter(Builder builder) {
+            this.value = builder.value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public Schema schema() {
+            return NO_SETTER;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeString(NO_SETTER.member("value"), value);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) value;
+        }
+
+        public static final class Builder implements ShapeBuilder<NoSetter> {
+            private final String value = null;
+
+            @Override
+            public NoSetter build() {
+                return new NoSetter(this);
+            }
+
+            @Override
+            public ShapeBuilder<NoSetter> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return NO_SETTER;
+            }
+        }
+    }
+}

--- a/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecRegistryTest.java
+++ b/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodecRegistryTest.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassWriter;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.MethodVisitor;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Type;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class RuntimeCodecRegistryTest {
+    private static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("example#TestShape"))
+            .shapeClass(TestShape.class)
+            .builderSupplier(Builder::new)
+            .putMember("value", PreludeSchemas.STRING)
+            .build();
+
+    @Test
+    void plansDirectAccessAndDefinesHiddenClass() {
+        var backend = new TestBackend(false);
+        var registry = new RuntimeCodecRegistry<>(backend);
+
+        TestCodec codec = registry.get(SCHEMA, "settings");
+
+        assertNotNull(codec);
+        assertEquals("generated", codec.value());
+        assertTrue(codec.acceptsBuilder(new Builder()));
+        assertFalse(codec.acceptsBuilder(new OtherBuilder()));
+        assertEquals(1, backend.emissions.get());
+    }
+
+    @Test
+    void resolvesSetterByMemberTypeWhenBuilderMethodIsOverloaded() {
+        RuntimeCodecPlan plan = RuntimeCodecPlan.analyze(SCHEMA);
+
+        assertSame(
+                String.class,
+                plan.rootStructure().members().getFirst().setter().getParameterTypes()[0]);
+    }
+
+    @Test
+    void deduplicatesConcurrentGenerationAndPublication() throws Exception {
+        var backend = new TestBackend(false);
+        var registry = new RuntimeCodecRegistry<>(backend);
+        var start = new CountDownLatch(1);
+        try (var executor = Executors.newFixedThreadPool(8)) {
+            List<Future<TestCodec>> futures = new ArrayList<>();
+            for (int i = 0; i < 32; i++) {
+                futures.add(executor.submit(() -> {
+                    start.await();
+                    return registry.get(SCHEMA, "settings");
+                }));
+            }
+            start.countDown();
+            TestCodec first = futures.getFirst().get();
+            for (var future : futures) {
+                assertSame(first, future.get());
+            }
+        }
+
+        assertEquals(1, backend.emissions.get());
+    }
+
+    @Test
+    void cachesGenerationFailure() {
+        var backend = new TestBackend(new UnsupportedSchemaException("expected"));
+        var registry = new RuntimeCodecRegistry<>(backend);
+
+        assertNull(registry.get(SCHEMA, "settings"));
+        assertNull(registry.get(SCHEMA, "settings"));
+
+        assertEquals(1, backend.emissions.get());
+    }
+
+    @Test
+    void cachesUnexpectedGenerationFailuresAsFallbacks() {
+        var backend = new TestBackend(new IllegalStateException("generation bug"));
+        var registry = new RuntimeCodecRegistry<>(backend);
+
+        assertNull(registry.get(SCHEMA, "settings"));
+        assertNull(registry.get(SCHEMA, "settings"));
+
+        assertEquals(1, backend.emissions.get());
+    }
+
+    @Test
+    void retainsMoreThanPreviousDefaultLimit() {
+        var backend = new TestBackend(false);
+        var registry = new RuntimeCodecRegistry<>(backend);
+        List<Object> settings = new ArrayList<>();
+
+        for (int i = 0; i < 300; i++) {
+            Object identity = new Object();
+            settings.add(identity);
+            assertNotNull(registry.get(SCHEMA, identity));
+        }
+
+        assertEquals(300, backend.emissions.get());
+        assertNotNull(registry.get(SCHEMA, settings.getFirst()));
+        assertEquals(300, backend.emissions.get());
+    }
+
+    @Test
+    void settingsCacheKeyUsesIdentity() {
+        var backend = new TestBackend(false);
+        var registry = new RuntimeCodecRegistry<>(backend);
+
+        assertNotNull(registry.get(SCHEMA, new String("settings")));
+        assertNotNull(registry.get(SCHEMA, new String("settings")));
+
+        assertEquals(2, backend.emissions.get());
+    }
+
+    @Test
+    void clearReplacesClassScopedEntries() {
+        var backend = new TestBackend(false);
+        var registry = new RuntimeCodecRegistry<>(backend);
+
+        assertNotNull(registry.get(SCHEMA, "settings"));
+        registry.clear();
+        assertNotNull(registry.get(SCHEMA, "settings"));
+
+        assertEquals(2, backend.emissions.get());
+    }
+
+    @Test
+    void fatalVmErrorsAreNotConvertedToFallbacks() {
+        var failure = new OutOfMemoryError("expected");
+        var backend = new TestBackend(failure);
+        var registry = new RuntimeCodecRegistry<>(backend);
+
+        assertSame(failure, assertThrows(OutOfMemoryError.class, () -> registry.get(SCHEMA, "settings")));
+        assertSame(failure, assertThrows(OutOfMemoryError.class, () -> registry.get(SCHEMA, "settings")));
+        assertEquals(2, backend.emissions.get());
+    }
+
+    @Test
+    void countsGenerationOutcomesPerBackend() {
+        RuntimeCodegenStats.reset();
+
+        assertNotNull(new RuntimeCodecRegistry<>(new TestBackend((Throwable) null, "stats")).get(SCHEMA, "settings"));
+        assertNull(new RuntimeCodecRegistry<>(new TestBackend(new UnsupportedSchemaException("nope"), "stats"))
+                .get(SCHEMA, "settings"));
+        assertNull(new RuntimeCodecRegistry<>(new TestBackend(new IllegalStateException("bug"), "stats"))
+                .get(SCHEMA, "settings"));
+
+        var snapshot = RuntimeCodegenStats.snapshot("stats");
+        assertEquals(1, snapshot.generated());
+        assertEquals(1, snapshot.unsupported());
+        assertEquals(1, snapshot.failed());
+        assertEquals(3, snapshot.attempts());
+    }
+
+    @Test
+    void countersStayZeroForAnUnknownBackend() {
+        RuntimeCodegenStats.reset();
+
+        assertEquals(0, RuntimeCodegenStats.snapshot("never-used").attempts());
+    }
+
+    @Test
+    void strictModeRethrowsGenerationBugsRatherThanFallingBack() {
+        var bug = new IllegalStateException("generation bug");
+        var backend = new TestBackend(bug, "strict-bug");
+        var registry = new RuntimeCodecRegistry<>(backend);
+        System.setProperty("smithy-java.runtime-codegen.strict-bug", "strict");
+        try {
+            var thrown = assertThrows(RuntimeCodegenException.class, () -> registry.get(SCHEMA, "settings"));
+            assertSame(bug, thrown.getCause());
+
+            var again = assertThrows(RuntimeCodegenException.class, () -> registry.get(SCHEMA, "settings"));
+            assertSame(bug, again.getCause());
+            assertEquals(1, backend.emissions.get());
+        } finally {
+            System.clearProperty("smithy-java.runtime-codegen.strict-bug");
+        }
+    }
+
+    @Test
+    void strictModeRejectsUnsupportedSchemas() {
+        var unsupported = new UnsupportedSchemaException("unsupported by design");
+        var backend = new TestBackend(unsupported, "strict-unsupported");
+        var registry = new RuntimeCodecRegistry<>(backend);
+        System.setProperty("smithy-java.runtime-codegen", "strict");
+        try {
+            var thrown = assertThrows(RuntimeCodegenException.class, () -> registry.get(SCHEMA, "settings"));
+            assertSame(unsupported, thrown.getCause());
+
+            var again = assertThrows(RuntimeCodegenException.class, () -> registry.get(SCHEMA, "settings"));
+            assertSame(unsupported, again.getCause());
+            assertEquals(1, backend.emissions.get());
+        } finally {
+            System.clearProperty("smithy-java.runtime-codegen");
+        }
+    }
+
+    @Test
+    void strictnessBelongsToTheCallNotTheCacheEntry() {
+        var bug = new IllegalStateException("generation bug");
+        var backend = new TestBackend(bug, "per-call-strict");
+        var registry = new RuntimeCodecRegistry<>(backend);
+        var all = RuntimeCodecBackend.MemberSelector.all();
+
+        assertNull(registry.get(SCHEMA, "settings", all, false));
+        var thrown = assertThrows(
+                RuntimeCodegenException.class,
+                () -> registry.get(SCHEMA, "settings", all, true));
+        assertSame(bug, thrown.getCause());
+        assertNull(registry.get(SCHEMA, "settings", all, false));
+        assertEquals(1, backend.emissions.get());
+    }
+
+    @Test
+    void strictCallsRejectUnsupportedSchemas() {
+        var unsupported = new UnsupportedSchemaException("unsupported by design");
+        var backend = new TestBackend(unsupported, "per-call-strict2");
+        var registry = new RuntimeCodecRegistry<>(backend);
+
+        var thrown = assertThrows(
+                RuntimeCodegenException.class,
+                () -> registry.get(SCHEMA, "settings", RuntimeCodecBackend.MemberSelector.all(), true));
+        assertSame(unsupported, thrown.getCause());
+        assertNull(registry.get(SCHEMA, "settings", RuntimeCodecBackend.MemberSelector.all(), false));
+        assertEquals(1, backend.emissions.get());
+    }
+
+    @Test
+    void strictCallsRejectSchemasWithoutGeneratedClasses() {
+        var schema = Schema.structureBuilder(ShapeId.from("example#DynamicShape"))
+                .putMember("value", PreludeSchemas.STRING)
+                .build();
+        var registry = new RuntimeCodecRegistry<>(new TestBackend((Throwable) null, "dynamic"));
+
+        assertNull(registry.get(schema, "settings", RuntimeCodecBackend.MemberSelector.all(), false));
+        var thrown = assertThrows(
+                RuntimeCodegenException.class,
+                () -> registry.get(schema, "settings", RuntimeCodecBackend.MemberSelector.all(), true));
+        assertTrue(thrown.getCause() instanceof UnsupportedSchemaException);
+    }
+
+    @Test
+    void selectorIsASeparateCacheAxis() {
+        var backend = new TestBackend(false);
+        var registry = new RuntimeCodecRegistry<>(backend);
+        RuntimeCodecBackend.MemberSelector narrowed = (root, member) -> true;
+
+        assertNotNull(registry.get(SCHEMA, "settings"));
+        assertNotNull(registry.get(SCHEMA, "settings", narrowed));
+        assertEquals(2, backend.emissions.get());
+
+        assertNotNull(registry.get(SCHEMA, "settings"));
+        assertNotNull(registry.get(SCHEMA, "settings", narrowed));
+        assertEquals(2, backend.emissions.get());
+    }
+
+    @Test
+    void defaultSelectorIsStableAcrossCallsSoTheCacheStillHits() {
+        var backend = new TestBackend(false);
+        var registry = new RuntimeCodecRegistry<>(backend);
+
+        assertSame(RuntimeCodecBackend.MemberSelector.all(), RuntimeCodecBackend.MemberSelector.all());
+        assertNotNull(registry.get(SCHEMA, "settings"));
+        assertNotNull(registry.get(SCHEMA, "settings"));
+        assertNotNull(registry.get(SCHEMA, "settings", RuntimeCodecBackend.MemberSelector.all()));
+
+        assertEquals(1, backend.emissions.get());
+    }
+
+    private interface TestCodec {
+        String value();
+
+        boolean acceptsBuilder(ShapeBuilder<?> builder);
+    }
+
+    private static final class TestBackend implements RuntimeCodecBackend<TestCodec> {
+        private final AtomicInteger emissions = new AtomicInteger();
+        private final Throwable failure;
+        private final String id;
+
+        TestBackend(boolean fail) {
+            this(fail ? new UnsupportedSchemaException("expected") : null);
+        }
+
+        TestBackend(Throwable failure) {
+            this(failure, "test");
+        }
+
+        TestBackend(Throwable failure, String id) {
+            this.failure = failure;
+            this.id = id;
+        }
+
+        @Override
+        public String id() {
+            return id;
+        }
+
+        @Override
+        public Class<TestCodec> codecType() {
+            return TestCodec.class;
+        }
+
+        @Override
+        public Class<?> lookupHost() {
+            return RuntimeCodecRegistryTest.class;
+        }
+
+        @Override
+        public Emission emit(RuntimeCodecPlan plan, String generatedName) {
+            emissions.incrementAndGet();
+            assertEquals("getValue", plan.rootStructure().members().getFirst().getter().getName());
+            assertEquals("value", plan.rootStructure().members().getFirst().setter().getName());
+            if (failure instanceof Error error) {
+                throw error;
+            }
+            if (failure instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+
+            var writer = new ClassWriter(0);
+            writer.visit(
+                    Opcodes.V17,
+                    Opcodes.ACC_FINAL | Opcodes.ACC_SUPER,
+                    generatedName,
+                    null,
+                    "java/lang/Object",
+                    new String[] {Type.getInternalName(TestCodec.class)});
+            MethodVisitor constructor = writer.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+            constructor.visitCode();
+            constructor.visitVarInsn(Opcodes.ALOAD, 0);
+            constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            constructor.visitInsn(Opcodes.RETURN);
+            constructor.visitMaxs(1, 1);
+            constructor.visitEnd();
+            RuntimeCodegenBytecode.emitAcceptsBuilder(writer, plan.rootStructure().builderClass());
+
+            MethodVisitor value = writer.visitMethod(
+                    Opcodes.ACC_PUBLIC,
+                    "value",
+                    "()Ljava/lang/String;",
+                    null,
+                    null);
+            value.visitCode();
+            value.visitLdcInsn("generated");
+            value.visitInsn(Opcodes.ARETURN);
+            value.visitMaxs(1, 1);
+            value.visitEnd();
+            writer.visitEnd();
+            return new Emission(writer.toByteArray(), 3);
+        }
+    }
+
+    public static final class TestShape implements SerializableStruct {
+        private final String value;
+
+        TestShape(Builder builder) {
+            value = builder.value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeString(SCHEMA.member("value"), value);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) value;
+        }
+    }
+
+    public static final class Builder implements ShapeBuilder<TestShape> {
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder value(Object value) {
+            this.value = String.valueOf(value);
+            return this;
+        }
+
+        @Override
+        public TestShape build() {
+            return new TestShape(this);
+        }
+
+        @Override
+        public ShapeBuilder<TestShape> deserialize(ShapeDeserializer decoder) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+    }
+
+    private static final class OtherBuilder implements ShapeBuilder<TestShape> {
+        @Override
+        public TestShape build() {
+            return new TestShape(new Builder());
+        }
+
+        @Override
+        public ShapeBuilder<TestShape> deserialize(ShapeDeserializer decoder) {
+            return this;
+        }
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+    }
+}

--- a/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenFeatureTest.java
+++ b/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/RuntimeCodegenFeatureTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static software.amazon.smithy.java.core.serde.RuntimeCodegenMode.DISABLED;
+import static software.amazon.smithy.java.core.serde.RuntimeCodegenMode.ENABLED;
+import static software.amazon.smithy.java.core.serde.RuntimeCodegenMode.STRICT;
+
+import org.junit.jupiter.api.Test;
+
+final class RuntimeCodegenFeatureTest {
+    private static final String PROPERTY = "smithy-java.runtime-codegen";
+
+    @Test
+    void unsetModeFollowsTheGlobalProperty() {
+        assertEquals(DISABLED, RuntimeCodegenFeature.resolve(null, "resolve-a"));
+
+        withProperty(PROPERTY,
+                "enabled",
+                () -> assertEquals(ENABLED, RuntimeCodegenFeature.resolve(null, "resolve-a")));
+        withProperty(PROPERTY, "strict", () -> assertEquals(STRICT, RuntimeCodegenFeature.resolve(null, "resolve-a")));
+    }
+
+    @Test
+    void backendPropertyOverridesTheGlobalProperty() {
+        withProperty(PROPERTY, "enabled", () -> {
+            withProperty(PROPERTY + ".resolve-b", "strict", () -> {
+                assertEquals(STRICT, RuntimeCodegenFeature.resolve(null, "resolve-b"));
+                assertEquals(ENABLED, RuntimeCodegenFeature.resolve(null, "resolve-other"));
+            });
+            withProperty(PROPERTY + ".resolve-b",
+                    "disabled",
+                    () -> assertEquals(DISABLED, RuntimeCodegenFeature.resolve(null, "resolve-b")));
+        });
+    }
+
+    @Test
+    void explicitModeCombinesWithThePropertyBySeverity() {
+        assertEquals(ENABLED, RuntimeCodegenFeature.resolve(ENABLED, "resolve-c"));
+        assertEquals(STRICT, RuntimeCodegenFeature.resolve(STRICT, "resolve-c"));
+        assertEquals(DISABLED, RuntimeCodegenFeature.resolve(DISABLED, "resolve-c"));
+
+        withProperty(PROPERTY, "strict", () -> {
+            assertEquals(STRICT, RuntimeCodegenFeature.resolve(ENABLED, "resolve-c"));
+            assertEquals(DISABLED, RuntimeCodegenFeature.resolve(DISABLED, "resolve-c"));
+        });
+        withProperty(PROPERTY,
+                "enabled",
+                () -> assertEquals(STRICT, RuntimeCodegenFeature.resolve(STRICT, "resolve-c")));
+    }
+
+    @Test
+    void disabledPropertyIsAKillSwitchOverExplicitOptIn() {
+        withProperty(PROPERTY + ".resolve-d", "disabled", () -> {
+            assertEquals(DISABLED, RuntimeCodegenFeature.resolve(ENABLED, "resolve-d"));
+            assertEquals(DISABLED, RuntimeCodegenFeature.resolve(STRICT, "resolve-d"));
+            assertEquals(ENABLED, RuntimeCodegenFeature.resolve(ENABLED, "resolve-other"));
+        });
+        withProperty(PROPERTY,
+                "disabled",
+                () -> assertEquals(DISABLED, RuntimeCodegenFeature.resolve(STRICT, "resolve-d")));
+    }
+
+    @Test
+    void rejectsAModeThatIsNotAModeName() {
+        withProperty(PROPERTY, "json,cbor", () -> {
+            var thrown = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> RuntimeCodegenFeature.resolve(null, "resolve-e"));
+            assertTrue(thrown.getMessage().contains(PROPERTY));
+        });
+    }
+
+    private static void withProperty(String property, String value, Runnable body) {
+        System.setProperty(property, value);
+        try {
+            body.run();
+        } finally {
+            System.clearProperty(property);
+        }
+    }
+}

--- a/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/MethodVisitorTest.java
+++ b/codecs/codec-commons/src/test/java/software/amazon/smithy/java/codecs/commons/internal/codegen/classfile/MethodVisitorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.codecs.commons.internal.codegen.classfile;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+final class MethodVisitorTest {
+    @Test
+    void recordsLookupSwitchCasesInAscendingOrder() {
+        var visitor = new MethodVisitor();
+        var defaultTarget = new Label();
+        var first = new Label();
+        var second = new Label();
+        var third = new Label();
+        int[] keys = {20, -10, 5};
+        Label[] targets = {third, first, second};
+
+        visitor.visitLookupSwitchInsn(defaultTarget, keys, targets);
+
+        Object[] operands = visitor.instructions().getFirst().operands();
+        assertSame(defaultTarget, operands[0]);
+        assertArrayEquals(new int[] {-10, 5, 20}, (int[]) operands[1]);
+        assertArrayEquals(new Label[] {first, second, third}, (Label[]) operands[2]);
+        assertArrayEquals(new int[] {20, -10, 5}, keys);
+        assertArrayEquals(new Label[] {third, first, second}, targets);
+    }
+}

--- a/core/src/main/java/software/amazon/smithy/java/core/serde/RuntimeCodegenMode.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/RuntimeCodegenMode.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.core.serde;
+
+/** Controls runtime code generation and fallback behavior. */
+public enum RuntimeCodegenMode {
+    /** Always use interpreted serde. */
+    DISABLED,
+
+    /** Generate when possible and fall back when unavailable. */
+    ENABLED,
+
+    /** Generate or fail instead of falling back. */
+    STRICT
+}


### PR DESCRIPTION
### What behavior changes?
Adds opt-in runtime codec generation on JDK 25 with disabled, enabled, and strict modes; default interpreted serde behavior remains unchanged.

### Why is this change needed?
Provides shared schema planning, caching, hidden-class publication, and Java 21-compatible bytecode recording for protocol-specific generated codecs.

### How was this validated?
Covered by plan, registry, feature-resolution, and bytecode visitor tests, plus the Java 21 compatibility suite and JDK 25 compilation.

### What should reviewers focus on?
Review `RuntimeCodecPlan` accessor resolution, `RuntimeCodecRegistry` identity-based caching and strict outcomes, and the multi-release classfile bridge.

### Additional Links
Base of the runtime-codegen stack; followed by #1358.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.