### PR TITLE
Generate JSON codecs at runtime

### DIFF
--- a/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
+++ b/aws/aws-service-bundler/src/test/java/software/amazon/smithy/java/aws/servicebundle/bundler/AwsServiceBundlerTest.java
@@ -82,9 +82,11 @@ public class AwsServiceBundlerTest {
     }
 
     @Test
-    public void cw() {
-        assertThat(AwsServiceBundler.builder().serviceName("cloudwatch").build().bundle())
-                .isNotNull();
+    public void cloudWatchModelIsRegistered() {
+        assertThat(AwsServiceBundler.GH_URIS_BY_SERVICE)
+                .containsEntry(
+                        "cloudwatch",
+                        "cloudwatch/service/2010-08-01/cloudwatch-2010-08-01.json");
     }
 
     @Test

--- a/aws/client/aws-client-awsjson/build.gradle.kts
+++ b/aws/client/aws-client-awsjson/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
 protocolTestRuns {
     run("native") { systemProperty("smithy-java.json-provider", "smithy") }
     run("jackson") { systemProperty("smithy-java.json-provider", "jackson") }
+    run("codegen") {
+        systemProperty("smithy-java.json-provider", "smithy")
+        systemProperty("smithy-java.runtime-codegen", "enabled")
+    }
 }
 
 val generator = "software.amazon.smithy.java.protocoltests.generators.ProtocolTestGenerator"

--- a/aws/client/aws-client-restjson/build.gradle.kts
+++ b/aws/client/aws-client-restjson/build.gradle.kts
@@ -22,6 +22,10 @@ dependencies {
 protocolTestRuns {
     run("native") { systemProperty("smithy-java.json-provider", "smithy") }
     run("jackson") { systemProperty("smithy-java.json-provider", "jackson") }
+    run("codegen") {
+        systemProperty("smithy-java.json-provider", "smithy")
+        systemProperty("smithy-java.runtime-codegen", "enabled")
+    }
 }
 
 val generator = "software.amazon.smithy.java.protocoltests.generators.ProtocolTestGenerator"

--- a/aws/server/aws-server-restjson/build.gradle.kts
+++ b/aws/server/aws-server-restjson/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
 protocolTestRuns {
     run("native") { systemProperty("smithy-java.json-provider", "smithy") }
     run("jackson") { systemProperty("smithy-java.json-provider", "jackson") }
+    run("codegen") {
+        systemProperty("smithy-java.json-provider", "smithy")
+        systemProperty("smithy-java.runtime-codegen", "enabled")
+    }
 }
 
 val generator = "software.amazon.smithy.java.protocoltests.generators.ProtocolTestGenerator"

--- a/benchmarks/serde-benchmarks/build.gradle.kts
+++ b/benchmarks/serde-benchmarks/build.gradle.kts
@@ -69,6 +69,10 @@ dependencies {
     // model instead of codegen, selected via -Dsmithy-java.benchmark.client=dynamic.
     jmh(project(":client:dynamic-client"))
     jmh(project(":dynamic-schemas"))
+
+    testImplementation(sourceSets["jmh"].output)
+    testImplementation(sourceSets["jmh"].compileClasspath)
+    testRuntimeOnly(sourceSets["jmh"].runtimeClasspath)
 }
 
 // Smithy benchmark model files (tagged @httpRequestTests / @httpResponseTests
@@ -101,6 +105,22 @@ abstract class GenerateSmithyManifest : DefaultTask() {
         entries.sort()
 
         smithyDir.resolve("manifest").writeText(entries.joinToString("\n", postfix = "\n"))
+    }
+}
+
+abstract class WriteJmhClasspath : DefaultTask() {
+    @get:Classpath
+    abstract val classpath: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        outputFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(classpath.asPath)
+        }
     }
 }
 
@@ -167,9 +187,20 @@ tasks.named("compileJmhJava") {
     dependsOn("smithyBuild")
 }
 
+tasks.register<WriteJmhClasspath>("writeJmhClasspath") {
+    group = "benchmarks"
+    description = "Write the JMH runtime classpath for external JDK launches."
+    dependsOn("jmhCompileGeneratedClasses")
+    classpath.from(sourceSets["jmh"].runtimeClasspath)
+    classpath.from(layout.buildDirectory.dir("jmh-generated-classes"))
+    classpath.from(layout.buildDirectory.dir("jmh-generated-resources"))
+    outputFile.set(layout.buildDirectory.file("runtime-codegen/jmh-classpath.txt"))
+}
+
 // Test case:  -Pjmh.testCaseId=rpcv2Cbor_PutItemRequest_BinaryData_S
 val fast = providers.gradleProperty("jmh.fast").isPresent
 jmh {
+    includeTests.set(false)
     benchmarkMode.set(listOf("sample"))
     profilers.add("software.amazon.smithy.java.benchmarks.OpsPerCpuSecondProfiler")
     if (!fast) {
@@ -190,6 +221,11 @@ jmh {
         prop.add(id)
         benchmarkParameters.put("testCaseId", prop)
     }
+    providers.gradleProperty("jmh.implementation").orNull?.let { impl ->
+        val prop = objects.listProperty(String::class.java)
+        impl.split(',').forEach { prop.add(it.trim()) }
+        benchmarkParameters.put("implementation", prop)
+    }
     resultFormat = "json"
     resultsFile = layout.buildDirectory.file("results/jmh/results.json")
 }
@@ -204,6 +240,7 @@ tasks.jmhJar {
     }
     mergeServiceFiles()
     append("META-INF/smithy/manifest")
+    configurations = listOf(project.configurations["jmhRuntimeClasspath"])
 }
 
 // Run the cross-language result converter. Reads the JMH JSON written by the

--- a/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/AwsJson1_0DeserializeBenchmark.java
+++ b/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/AwsJson1_0DeserializeBenchmark.java
@@ -32,6 +32,9 @@ public class AwsJson1_0DeserializeBenchmark {
     private static final byte[] EMPTY_JSON_BODY = "{}".getBytes(StandardCharsets.UTF_8);
     private static final String CONTENT_TYPE = "application/x-amz-json-1.0";
 
+    @Param("generic")
+    public String implementation;
+
     @Param({
             "awsJson1_0_GetItemOutput_Baseline",
             "awsJson1_0_GetItemOutput_S",
@@ -53,6 +56,12 @@ public class AwsJson1_0DeserializeBenchmark {
 
     @Setup
     public void setup() {
+        boolean generated = "generated".equals(implementation);
+        if (generated && Runtime.version().feature() < 25) {
+            throw new IllegalStateException("Runtime codegen unavailable on " + Runtime.version());
+        }
+        System.setProperty("smithy-java.runtime-codegen", generated ? "enabled" : "disabled");
+        System.setProperty("smithy-java.json-provider", "smithy");
         protocol = new AwsJson1Protocol(SERVICE_ID);
         state = DeserializeState
                 .forTestCase(testCaseId, GENERATED_PACKAGE, SERVICE_ID, EMPTY_JSON_BODY, CONTENT_TYPE, false);
@@ -60,10 +69,17 @@ public class AwsJson1_0DeserializeBenchmark {
 
     @Benchmark
     public void deserialize(Blackhole bh) {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        ApiOperation<SerializableStruct, SerializableStruct> op =
-                (ApiOperation) state.operation;
         bh.consume(
-                protocol.deserializeResponse(op, state.context, state.typeRegistry, state.request, state.response));
+                protocol.deserializeResponse(
+                        operation(),
+                        state.context,
+                        state.typeRegistry,
+                        state.request,
+                        state.response));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ApiOperation<SerializableStruct, SerializableStruct> operation() {
+        return (ApiOperation) state.operation;
     }
 }

--- a/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/AwsJson1_0SerializeBenchmark.java
+++ b/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/AwsJson1_0SerializeBenchmark.java
@@ -31,6 +31,9 @@ public class AwsJson1_0SerializeBenchmark {
     private static final ShapeId SERVICE_ID =
             ShapeId.from("com.amazonaws.sdk.benchmark#AwsJsonRpc10DataPlane");
 
+    @Param("generic")
+    public String implementation;
+
     @Param({
             "awsJson1_0_GetItemInput_Baseline",
             "awsJson1_0_HealthcheckRequest_Example",
@@ -57,15 +60,23 @@ public class AwsJson1_0SerializeBenchmark {
 
     @Setup
     public void setup() {
+        boolean generated = "generated".equals(implementation);
+        if (generated && Runtime.version().feature() < 25) {
+            throw new IllegalStateException("Runtime codegen unavailable on " + Runtime.version());
+        }
+        System.setProperty("smithy-java.runtime-codegen", generated ? "enabled" : "disabled");
+        System.setProperty("smithy-java.json-provider", "smithy");
         protocol = new AwsJson1Protocol(SERVICE_ID);
         state = SerializeState.forTestCase(testCaseId, GENERATED_PACKAGE, SERVICE_ID);
     }
 
     @Benchmark
     public void serialize(Blackhole bh) {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        ApiOperation<SerializableStruct, SerializableStruct> op =
-                (ApiOperation) state.operation;
-        bh.consume(protocol.createRequest(op, state.input, state.context, state.endpoint));
+        bh.consume(protocol.createRequest(operation(), state.input, state.context, state.endpoint));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ApiOperation<SerializableStruct, SerializableStruct> operation() {
+        return (ApiOperation) state.operation;
     }
 }

--- a/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/JmhResultConverter.java
+++ b/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/JmhResultConverter.java
@@ -25,10 +25,7 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import software.amazon.smithy.java.benchmarks.OpsPerCpuSecondProfiler;
 import software.amazon.smithy.java.core.Version;
-import software.amazon.smithy.model.node.ArrayNode;
-import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.NumberNode;
-import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.*;
 
 /**
  * Converts a JMH JSON result file (produced by {@code jmh -rf json -rff
@@ -176,11 +173,20 @@ public final class JmhResultConverter {
                 continue;
             }
             var result = element.expectObjectNode();
-            String id = result.getObjectMember("params")
-                    .flatMap(p -> p.getStringMember("testCaseId"))
-                    .map(s -> s.getValue())
+            var params = result.getObjectMember("params").orElse(Node.objectNode());
+            String testCaseId = params.getStringMember("testCaseId")
+                    .map(StringNode::getValue)
                     .orElse(null);
-            if (id == null || !seen.add(id)) {
+            if (testCaseId == null) {
+                continue;
+            }
+            String implementation = params.getStringMember("implementation")
+                    .map(StringNode::getValue)
+                    .orElse(null);
+            String id = implementation == null || implementation.equals("generic")
+                    ? testCaseId
+                    : testCaseId + "+" + implementation;
+            if (!seen.add(id)) {
                 continue;
             }
 

--- a/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/RestJson1DeserializeBenchmark.java
+++ b/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/RestJson1DeserializeBenchmark.java
@@ -32,6 +32,9 @@ public class RestJson1DeserializeBenchmark {
     private static final byte[] EMPTY_JSON_BODY = "{}".getBytes(StandardCharsets.UTF_8);
     private static final String CONTENT_TYPE = "application/json";
 
+    @Param("generic")
+    public String implementation;
+
     @Param({
             "restJson1_WideTypesResponse_S",
             "restJson1_WideTypesResponse_M",
@@ -50,6 +53,12 @@ public class RestJson1DeserializeBenchmark {
 
     @Setup
     public void setup() {
+        boolean generated = "generated".equals(implementation);
+        if (generated && Runtime.version().feature() < 25) {
+            throw new IllegalStateException("Runtime codegen unavailable on " + Runtime.version());
+        }
+        System.setProperty("smithy-java.runtime-codegen", generated ? "enabled" : "disabled");
+        System.setProperty("smithy-java.json-provider", "smithy");
         protocol = new RestJsonClientProtocol(SERVICE_ID);
         state = DeserializeState
                 .forTestCase(testCaseId, GENERATED_PACKAGE, SERVICE_ID, EMPTY_JSON_BODY, CONTENT_TYPE, false);
@@ -57,10 +66,17 @@ public class RestJson1DeserializeBenchmark {
 
     @Benchmark
     public void deserialize(Blackhole bh) {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        ApiOperation<SerializableStruct, SerializableStruct> op =
-                (ApiOperation) state.operation;
         bh.consume(
-                protocol.deserializeResponse(op, state.context, state.typeRegistry, state.request, state.response));
+                protocol.deserializeResponse(
+                        operation(),
+                        state.context,
+                        state.typeRegistry,
+                        state.request,
+                        state.response));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ApiOperation<SerializableStruct, SerializableStruct> operation() {
+        return (ApiOperation) state.operation;
     }
 }

--- a/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/RestJson1SerializeBenchmark.java
+++ b/benchmarks/serde-benchmarks/src/jmh/java/software/amazon/smithy/java/benchmarks/serde/RestJson1SerializeBenchmark.java
@@ -29,6 +29,9 @@ public class RestJson1SerializeBenchmark {
     private static final ShapeId SERVICE_ID =
             ShapeId.from("com.amazonaws.sdk.benchmark#AwsRestJsonDataPlane");
 
+    @Param("generic")
+    public String implementation;
+
     @Param({
             "restJson1_WideTypesRequest_S",
             "restJson1_WideTypesRequest_M",
@@ -38,6 +41,9 @@ public class RestJson1SerializeBenchmark {
             "restJson1_PutObject_S",
             "restJson1_PutObject_M",
             "restJson1_PutObject_L",
+            "awsQuery_PutMetricDataRequest_S",
+            "awsQuery_PutMetricDataRequest_M",
+            "awsQuery_PutMetricDataRequest_L",
     })
     public String testCaseId;
 
@@ -46,15 +52,23 @@ public class RestJson1SerializeBenchmark {
 
     @Setup
     public void setup() {
+        boolean generated = "generated".equals(implementation);
+        if (generated && Runtime.version().feature() < 25) {
+            throw new IllegalStateException("Runtime codegen unavailable on " + Runtime.version());
+        }
+        System.setProperty("smithy-java.runtime-codegen", generated ? "enabled" : "disabled");
+        System.setProperty("smithy-java.json-provider", "smithy");
         protocol = new RestJsonClientProtocol(SERVICE_ID);
         state = SerializeState.forTestCase(testCaseId, GENERATED_PACKAGE, SERVICE_ID);
     }
 
     @Benchmark
     public void serialize(Blackhole bh) {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        ApiOperation<SerializableStruct, SerializableStruct> op =
-                (ApiOperation) state.operation;
-        bh.consume(protocol.createRequest(op, state.input, state.context, state.endpoint));
+        bh.consume(protocol.createRequest(operation(), state.input, state.context, state.endpoint));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ApiOperation<SerializableStruct, SerializableStruct> operation() {
+        return (ApiOperation) state.operation;
     }
 }

--- a/benchmarks/serde-benchmarks/src/test/java/software/amazon/smithy/java/benchmarks/serde/RuntimeCodegenStrictCoverageTest.java
+++ b/benchmarks/serde-benchmarks/src/test/java/software/amazon/smithy/java/benchmarks/serde/RuntimeCodegenStrictCoverageTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.benchmarks.serde;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openjdk.jmh.annotations.Param;
+import software.amazon.smithy.java.aws.client.awsjson.AwsJson1Protocol;
+import software.amazon.smithy.java.aws.client.restjson.RestJsonClientProtocol;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+class RuntimeCodegenStrictCoverageTest {
+
+    private static final String REST_JSON_PACKAGE =
+            "software.amazon.smithy.java.benchmarks.serde.generated.restjson.model";
+    private static final ShapeId REST_JSON_SERVICE =
+            ShapeId.from("com.amazonaws.sdk.benchmark#AwsRestJsonDataPlane");
+    private static final String AWS_JSON_PACKAGE =
+            "software.amazon.smithy.java.benchmarks.serde.generated.awsjson10.model";
+    private static final ShapeId AWS_JSON_SERVICE =
+            ShapeId.from("com.amazonaws.sdk.benchmark#AwsJsonRpc10DataPlane");
+    private static final byte[] EMPTY_JSON_BODY = "{}".getBytes(StandardCharsets.UTF_8);
+    private static final String REST_JSON_CONTENT_TYPE = "application/json";
+    private static final String AWS_JSON_CONTENT_TYPE = "application/x-amz-json-1.0";
+
+    private static String previousCodegen;
+    private static String previousProvider;
+
+    @BeforeAll
+    static void enableStrictCodegen() {
+        previousCodegen = System.setProperty("smithy-java.runtime-codegen", "strict");
+        previousProvider = System.setProperty("smithy-java.json-provider", "smithy");
+    }
+
+    @AfterAll
+    static void restoreProperties() {
+        restore("smithy-java.runtime-codegen", previousCodegen);
+        restore("smithy-java.json-provider", previousProvider);
+    }
+
+    static List<String> restJsonSerializeCases() throws Exception {
+        return benchmarkCases(RestJson1SerializeBenchmark.class);
+    }
+
+    static List<String> restJsonDeserializeCases() throws Exception {
+        return benchmarkCases(RestJson1DeserializeBenchmark.class);
+    }
+
+    static List<String> awsJsonSerializeCases() throws Exception {
+        return benchmarkCases(AwsJson1_0SerializeBenchmark.class);
+    }
+
+    static List<String> awsJsonDeserializeCases() throws Exception {
+        return benchmarkCases(AwsJson1_0DeserializeBenchmark.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("restJsonSerializeCases")
+    void restJsonSerialize(String testCaseId) {
+        var protocol = new RestJsonClientProtocol(REST_JSON_SERVICE);
+        var state = SerializeState.forTestCase(testCaseId, REST_JSON_PACKAGE, REST_JSON_SERVICE);
+        assertNotNull(protocol.createRequest(operation(state.operation), state.input, state.context, state.endpoint));
+    }
+
+    @ParameterizedTest
+    @MethodSource("restJsonDeserializeCases")
+    void restJsonDeserialize(String testCaseId) throws Exception {
+        var protocol = new RestJsonClientProtocol(REST_JSON_SERVICE);
+        var state = DeserializeState.forTestCase(
+                testCaseId,
+                REST_JSON_PACKAGE,
+                REST_JSON_SERVICE,
+                EMPTY_JSON_BODY,
+                REST_JSON_CONTENT_TYPE,
+                false);
+        assertNotNull(protocol.deserializeResponse(
+                operation(state.operation),
+                state.context,
+                state.typeRegistry,
+                state.request,
+                state.response));
+    }
+
+    @ParameterizedTest
+    @MethodSource("awsJsonSerializeCases")
+    void awsJsonSerialize(String testCaseId) {
+        var protocol = new AwsJson1Protocol(AWS_JSON_SERVICE);
+        var state = SerializeState.forTestCase(testCaseId, AWS_JSON_PACKAGE, AWS_JSON_SERVICE);
+        assertNotNull(protocol.createRequest(operation(state.operation), state.input, state.context, state.endpoint));
+    }
+
+    @ParameterizedTest
+    @MethodSource("awsJsonDeserializeCases")
+    void awsJsonDeserialize(String testCaseId) throws Exception {
+        var protocol = new AwsJson1Protocol(AWS_JSON_SERVICE);
+        var state = DeserializeState.forTestCase(
+                testCaseId,
+                AWS_JSON_PACKAGE,
+                AWS_JSON_SERVICE,
+                EMPTY_JSON_BODY,
+                AWS_JSON_CONTENT_TYPE,
+                false);
+        assertNotNull(protocol.deserializeResponse(
+                operation(state.operation),
+                state.context,
+                state.typeRegistry,
+                state.request,
+                state.response));
+    }
+
+    private static List<String> benchmarkCases(Class<?> benchmark) throws Exception {
+        Param param = benchmark.getField("testCaseId").getAnnotation(Param.class);
+        return List.of(param.value());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static ApiOperation<SerializableStruct, SerializableStruct> operation(Object operation) {
+        return (ApiOperation) operation;
+    }
+
+    private static void restore(String property, String previous) {
+        if (previous == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, previous);
+        }
+    }
+}

--- a/codecs/json-codec/README.md
+++ b/codecs/json-codec/README.md
@@ -6,3 +6,18 @@ JSON Protocol implementation can use this package to provide basic serde capabil
 
 **Note:** This codec can discover custom `JsonSerdeProvider` service implementations via SPI. 
 By default, [Jackson](https://github.com/FasterXML/jackson) is used to provide JSON serde.
+
+On JDK 25 or newer, runtime-generated codecs can be enabled explicitly:
+
+```java
+JsonCodec codec = JsonCodec.builder()
+        .runtimeCodegen(true)
+        .build();
+```
+
+Unsupported models fall back to the native Smithy JSON provider. Explicit runtime-codegen
+activation cannot be combined with a custom provider.
+
+The `smithy-java.runtime-codegen` system property sets process-wide mode (`disabled`, `enabled`,
+or `strict`), and `smithy-java.runtime-codegen.json` overrides it for JSON. `strict` rejects
+fallbacks.

--- a/codecs/json-codec/build.gradle.kts
+++ b/codecs/json-codec/build.gradle.kts
@@ -110,14 +110,53 @@ val compactStringsDisabledTest =
         }
     }
 
-tasks.named("check") {
-    dependsOn(compactStringAccessFallbackTest, compactStringsDisabledTest)
-}
-
 tasks.named("compileTestJava") {
     dependsOn("smithyBuild")
 }
 
 tasks.named("processTestResources") {
     dependsOn("smithyBuild")
+}
+
+val jdk25CodegenTest =
+    tasks.register<Test>("jdk25CodegenTest") {
+        description = "Run the JSON test suite with strict runtime code generation."
+        group = "verification"
+
+        testClassesDirs = sourceSets.test.get().output.classesDirs
+        classpath = sourceSets.test.get().runtimeClasspath
+        javaLauncher =
+            javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(25)
+        }
+        systemProperty("smithy-java.runtime-codegen.json", "strict")
+        systemProperty("smithy-java.json-provider", "smithy")
+        useJUnitPlatform()
+    }
+
+val runtimeCodegenPropertyValidationTest =
+    tasks.register<Test>("runtimeCodegenPropertyValidationTest") {
+        description = "Validate runtime-codegen property activation with the default JSON provider."
+        group = "verification"
+
+        testClassesDirs = sourceSets.test.get().output.classesDirs
+        classpath = sourceSets.test.get().runtimeClasspath
+        javaLauncher =
+            javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        systemProperty("smithy-java.runtime-codegen.json", "enabled")
+        filter {
+            includeTestsMatching("*RuntimeCodegenPropertyValidationTest")
+        }
+        useJUnitPlatform()
+    }
+
+tasks.named("check") {
+    dependsOn(
+        compactStringAccessFallbackTest,
+        compactStringsDisabledTest,
+        jdk25CodegenTest,
+        runtimeCodegenPropertyValidationTest,
+    )
 }

--- a/codecs/json-codec/model/bench.smithy
+++ b/codecs/json-codec/model/bench.smithy
@@ -74,6 +74,16 @@ structure ComplexStruct {
 
     colorList: ColorList
 
+    wireLength: WireLengthEnum
+
+    wireLengthList: WireLengthEnumList
+
+    priority: Priority
+
+    priorityList: PriorityList
+
+    priorityMap: PriorityMap
+
     sparseStrings: SparseStringList
 
     sparseMap: SparseStringMap
@@ -111,6 +121,45 @@ enum Color {
     GREEN
     BLUE
     YELLOW
+}
+
+enum WireLengthEnum {
+    ONE = "a"
+    SEVEN = "abcdefg"
+    EIGHT = "abcdefgh"
+    NINE = "abcdefghi"
+    SIXTEEN = "abcdefghijklmnop"
+    SEVENTEEN = "abcdefghijklmnopq"
+    LONG = "abcdefghijklmnopqrstuvwxyz0123456789"
+    SHARED_PREFIX_EIGHT = "abcdefgx"
+    SHARED_PREFIX_NINE = "abcdefghx"
+    SHARED_PREFIX_LONG = "abcdefghijklmnopqx"
+    QUOTE = "a\"b"
+    BACKSLASH = "a\\b"
+    NON_ASCII_SHORT = "ü"
+    NON_ASCII = "café-ünïcøde"
+}
+
+list WireLengthEnumList {
+    member: WireLengthEnum
+}
+
+intEnum Priority {
+    MIN = -2147483648
+    NEGATIVE = -7
+    ZERO = 0
+    ONE = 1
+    HUNDRED = 100
+    MAX = 2147483647
+}
+
+list PriorityList {
+    member: Priority
+}
+
+map PriorityMap {
+    key: String
+    value: Priority
 }
 
 list StringList {
@@ -192,7 +241,21 @@ structure JsonNameStruct {
     @jsonName("DisplayName")
     displayName: String
 
+    @jsonName("é")
+    unicodeName: String
+
     normalField: String
+}
+
+structure HashCollisionStruct {
+    aa: String
+    bB: String
+}
+
+structure RequiredDefaultStruct {
+    @required
+    @default("text")
+    type: String
 }
 
 /// Structure that nests itself for depth testing
@@ -204,6 +267,14 @@ structure RecursiveStruct {
 /// Structure for blob testing
 structure BlobStruct {
     data: Blob
+}
+
+@error("client")
+structure BenchError {
+    @required
+    message: String
+
+    code: Integer
 }
 
 list DoubleList {

--- a/codecs/json-codec/src/fuzz/java/software/amazon/smithy/java/json/DifferentialRuntimeCodegenJsonFuzzTest.java
+++ b/codecs/json-codec/src/fuzz/java/software/amazon/smithy/java/json/DifferentialRuntimeCodegenJsonFuzzTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import com.code_intelligence.jazzer.junit.DictionaryFile;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenException;
+import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.schema.ShapeUtils;
+import software.amazon.smithy.java.core.serde.SerializationException;
+import software.amazon.smithy.java.io.ByteBufferUtils;
+import software.amazon.smithy.java.json.smithy.SmithyJsonSerdeProvider;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.smithy.fuzz.test.model.GeneratedSchemaIndex;
+
+class DifferentialRuntimeCodegenJsonFuzzTest {
+
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
+    private static final int MAX_CANONICAL_EXPONENT = 10_000;
+
+    private static final JsonCodec INTERPRETED =
+            JsonCodec.builder().overrideSerdeProvider(new SmithyJsonSerdeProvider()).build();
+    private static final JsonCodec CODEGEN;
+
+    static {
+        // Avoid leaking strict mode to other fuzz tests.
+        System.setProperty("smithy-java.runtime-codegen.json", "strict");
+        try {
+            CODEGEN = JsonCodec.builder()
+                    .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                    .runtimeCodegen(true)
+                    .build();
+        } finally {
+            System.clearProperty("smithy-java.runtime-codegen.json");
+        }
+    }
+
+    @DictionaryFile(resourcePath = "/dictionary/codec-fuzz.dict")
+    @MethodSource("seed")
+    @FuzzTest
+    void fuzzDifferential(byte[] input) {
+        Assertions.assertTimeoutPreemptively(DEFAULT_TIMEOUT,
+                () -> runTestsOn(input),
+                () -> "Timeout with input: " + Base64.getEncoder().encodeToString(input));
+    }
+
+    private void runTestsOn(byte[] input) {
+        boolean skipCanonicalSerialization = hasExcessiveJsonExponent(input);
+        for (var shapeBuilderSupplier : getShapeBuilders()) {
+            var refResult = tryDeserialize(INTERPRETED, shapeBuilderSupplier.get(), input);
+            var genResult = tryDeserialize(CODEGEN, shapeBuilderSupplier.get(), input);
+
+            if (refResult.error != null && genResult.error != null) {
+                continue;
+            }
+
+            if (refResult.error == null && genResult.error != null) {
+                Assertions.fail(String.format(
+                        "Interpreted codec succeeded but codegen codec failed.%n"
+                                + "Input (base64): %s%n"
+                                + "Interpreted output: %s%n"
+                                + "Codegen error: %s",
+                        Base64.getEncoder().encodeToString(input),
+                        safeSerializeToString(refResult.shape, skipCanonicalSerialization),
+                        genResult.error));
+            }
+
+            if (refResult.error != null) {
+                Assertions.fail(String.format(
+                        "Codegen codec succeeded but interpreted codec failed.%n"
+                                + "Input (base64): %s%n"
+                                + "Codegen output: %s%n"
+                                + "Interpreted error: %s",
+                        Base64.getEncoder().encodeToString(input),
+                        safeSerializeToString(genResult.shape, skipCanonicalSerialization),
+                        refResult.error));
+            }
+
+            // TODO: Remove when NumberCodec.writeBigDecimal bounds plain-notation expansion.
+            if (skipCanonicalSerialization) {
+                continue;
+            }
+
+            byte[] refBytes = trySerialize(INTERPRETED, refResult.shape);
+            byte[] genBytes = trySerialize(INTERPRETED, genResult.shape);
+            if ((refBytes == null) != (genBytes == null)) {
+                Assertions.fail(String.format(
+                        "Serialization of the deserialized shape failed on one side only.%n"
+                                + "Input (base64): %s%nInterpreted: %s%nCodegen: %s",
+                        Base64.getEncoder().encodeToString(input),
+                        asString(refBytes),
+                        asString(genBytes)));
+            }
+            if (refBytes != null && !Arrays.equals(refBytes, genBytes)) {
+                Assertions.fail(String.format(
+                        "Deserialized values diverge.%n"
+                                + "Input (base64): %s%n"
+                                + "Interpreted: %s%n"
+                                + "Codegen:     %s",
+                        Base64.getEncoder().encodeToString(input),
+                        asString(refBytes),
+                        asString(genBytes)));
+            }
+
+            byte[] genSerialized;
+            try {
+                genSerialized = ByteBufferUtils.getBytes(CODEGEN.serialize(refResult.shape));
+            } catch (RuntimeCodegenException e) {
+                // Strict-mode failures are not input-dependent serialization failures.
+                throw e;
+            } catch (Exception e) {
+                genSerialized = null;
+            }
+            if ((refBytes == null) != (genSerialized == null)
+                    || (refBytes != null && !Arrays.equals(refBytes, genSerialized))) {
+                Assertions.fail(String.format(
+                        "Serializer divergence for the same shape.%n"
+                                + "Input (base64): %s%n"
+                                + "Interpreted: %s%n"
+                                + "Codegen:     %s",
+                        Base64.getEncoder().encodeToString(input),
+                        asString(refBytes),
+                        asString(genSerialized)));
+            }
+        }
+    }
+
+    private static String asString(byte[] bytes) {
+        return bytes == null ? "<serialization failed>" : new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private static byte[] trySerialize(JsonCodec codec, SerializableShape shape) {
+        try {
+            return ByteBufferUtils.getBytes(codec.serialize(shape));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String safeSerializeToString(SerializableShape shape, boolean skipCanonicalSerialization) {
+        return skipCanonicalSerialization
+                ? "<canonical serialization omitted: excessive exponent>"
+                : asString(trySerialize(INTERPRETED, shape));
+    }
+
+    private static boolean hasExcessiveJsonExponent(byte[] input) {
+        boolean inString = false;
+        boolean escaped = false;
+        for (int i = 0; i < input.length; i++) {
+            int current = input[i] & 0xff;
+            if (inString) {
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == '"') {
+                    inString = false;
+                }
+                continue;
+            }
+            if (current == '"') {
+                inString = true;
+                continue;
+            }
+            if ((current != 'e' && current != 'E')
+                    || i == 0
+                    || ((input[i - 1] < '0' || input[i - 1] > '9') && input[i - 1] != '.')) {
+                continue;
+            }
+
+            int offset = i + 1;
+            if (offset < input.length && (input[offset] == '+' || input[offset] == '-')) {
+                offset++;
+            }
+            int magnitude = 0;
+            int digits = 0;
+            while (offset < input.length && input[offset] >= '0' && input[offset] <= '9') {
+                digits++;
+                int digit = input[offset++] - '0';
+                if (magnitude > (MAX_CANONICAL_EXPONENT - digit) / 10) {
+                    return true;
+                }
+                magnitude = magnitude * 10 + digit;
+            }
+            if (digits > 0 && magnitude > MAX_CANONICAL_EXPONENT) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private record DeserializeResult(SerializableShape shape, Exception error) {}
+
+    @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION")
+    private static DeserializeResult tryDeserialize(JsonCodec codec, ShapeBuilder<?> builder, byte[] input) {
+        try {
+            return new DeserializeResult(codec.deserializeShape(input, builder), null);
+        } catch (SerializationException
+                | IllegalArgumentException
+                | IllegalStateException
+                | UnsupportedOperationException
+                | IndexOutOfBoundsException
+                | NullPointerException e) {
+            return new DeserializeResult(null, e);
+        }
+    }
+
+    private static Stream<byte[]> seed() {
+        return getShapeBuilders().stream()
+                .flatMap(b -> Stream.generate(() -> b).limit(10))
+                .map(Supplier::get)
+                .map(DifferentialRuntimeCodegenJsonFuzzTest::tryGenerateSeed)
+                .filter(Objects::nonNull);
+    }
+
+    private static byte[] tryGenerateSeed(ShapeBuilder<?> builder) {
+        try {
+            return trySerialize(INTERPRETED, ShapeUtils.generateRandom(builder));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static List<Supplier<ShapeBuilder<? extends SerializableShape>>> getShapeBuilders() {
+        var schemaIndex = new GeneratedSchemaIndex();
+        List<Supplier<ShapeBuilder<?>>> shapeBuilders = new ArrayList<>();
+        schemaIndex.visit(s -> {
+            if (s.type() == ShapeType.STRUCTURE || s.type() == ShapeType.UNION) {
+                shapeBuilders.add(s::shapeBuilder);
+            }
+        });
+        return shapeBuilders;
+    }
+}

--- a/codecs/json-codec/src/fuzz/java/software/amazon/smithy/java/json/UnknownUnionMemberCodegenReproTest.java
+++ b/codecs/json-codec/src/fuzz/java/software/amazon/smithy/java/json/UnknownUnionMemberCodegenReproTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.io.ByteBufferUtils;
+import software.amazon.smithy.java.json.smithy.SmithyJsonSerdeProvider;
+import software.smithy.fuzz.test.model.UnionValue;
+
+class UnknownUnionMemberCodegenReproTest {
+
+    @Test
+    void unknownUnionMemberSerializesSameAsInterpreted() {
+        var interpreted = JsonCodec.builder().overrideSerdeProvider(new SmithyJsonSerdeProvider()).build();
+        var codegen = JsonCodec.builder()
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .runtimeCodegen(true)
+                .build();
+
+        byte[] input = "{\"value\":{\"notARealMember\":-864441130}}".getBytes(StandardCharsets.UTF_8);
+        var shape = interpreted.deserializeShape(input, UnionValue.builder());
+
+        String viaInterpreted = new String(
+                ByteBufferUtils.getBytes(interpreted.serialize(shape)),
+                StandardCharsets.UTF_8);
+        String viaCodegen = new String(
+                ByteBufferUtils.getBytes(codegen.serialize(shape)),
+                StandardCharsets.UTF_8);
+
+        Assertions.assertEquals("{\"value\":{}}", viaInterpreted);
+        Assertions.assertEquals(viaInterpreted, viaCodegen);
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/CodegenJsonSerdeProvider.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/CodegenJsonSerdeProvider.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.json.smithy.SmithyGeneratedJsonSerde;
+
+final class CodegenJsonSerdeProvider implements JsonSerdeProvider {
+    private final JsonSerdeProvider delegate;
+    private final SmithyGeneratedJsonSerde generated = new SmithyGeneratedJsonSerde();
+
+    CodegenJsonSerdeProvider(JsonSerdeProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    JsonSerdeProvider delegate() {
+        return delegate;
+    }
+
+    @Override
+    public int getPriority() {
+        return delegate.getPriority();
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public ByteBuffer serialize(SerializableShape shape, JsonSettings settings) {
+        if (shape instanceof SerializableStruct struct) {
+            ByteBuffer result = generated.serialize(struct, settings);
+            if (result != null) {
+                return result;
+            }
+        } else if (settings.strictRuntimeCodegen()) {
+            throw new IllegalStateException(
+                    "Strict JSON runtime codegen requires a structure or union root, found "
+                            + shape.getClass().getName());
+        }
+        return delegate.serialize(shape, settings);
+    }
+
+    ByteBuffer serializeMemberSubset(
+            SerializableStruct struct,
+            MemberSubsetCodec.MemberSubset subset,
+            JsonSettings settings
+    ) {
+        return generated.serialize(struct, settings, subset);
+    }
+
+    boolean deserializeMemberSubset(
+            Schema schema,
+            ShapeBuilder<?> builder,
+            ByteBuffer source,
+            MemberSubsetCodec.MemberSubset subset,
+            JsonSettings settings
+    ) {
+        return generated.deserialize(schema, builder, source, settings, subset);
+    }
+
+    boolean deserializeInto(
+            Schema schema,
+            ShapeBuilder<?> builder,
+            ByteBuffer source,
+            JsonSettings settings
+    ) {
+        return generated.deserialize(schema, builder, source, settings, null);
+    }
+
+    @Override
+    public ShapeDeserializer newDeserializer(byte[] source, JsonSettings settings) {
+        rejectStrictRootlessDeserializer(settings);
+        return delegate.newDeserializer(source, settings);
+    }
+
+    @Override
+    public ShapeDeserializer newDeserializer(ByteBuffer source, JsonSettings settings) {
+        rejectStrictRootlessDeserializer(settings);
+        return delegate.newDeserializer(source, settings);
+    }
+
+    @Override
+    public ShapeSerializer newSerializer(OutputStream sink, JsonSettings settings) {
+        return new CodegenShapeSerializer(sink, delegate, generated, settings);
+    }
+
+    <T extends SerializableShape> T deserialize(
+            byte[] source,
+            ShapeBuilder<T> builder,
+            JsonSettings settings
+    ) {
+        T result = generated.deserialize(source, builder, settings);
+        if (result != null) {
+            return result;
+        }
+        return genericDeserialize(source, builder, settings);
+    }
+
+    <T extends SerializableShape> T deserialize(
+            ByteBuffer source,
+            ShapeBuilder<T> builder,
+            JsonSettings settings
+    ) {
+        T result = generated.deserialize(source, builder, settings);
+        if (result != null) {
+            return result;
+        }
+        return genericDeserialize(source, builder, settings);
+    }
+
+    private <T extends SerializableShape> T genericDeserialize(
+            byte[] source,
+            ShapeBuilder<T> builder,
+            JsonSettings settings
+    ) {
+        try (ShapeDeserializer deserializer = delegate.newDeserializer(source, settings)) {
+            return builder.deserialize(deserializer).errorCorrection().build();
+        }
+    }
+
+    private <T extends SerializableShape> T genericDeserialize(
+            ByteBuffer source,
+            ShapeBuilder<T> builder,
+            JsonSettings settings
+    ) {
+        try (ShapeDeserializer deserializer = delegate.newDeserializer(source, settings)) {
+            return builder.deserialize(deserializer).errorCorrection().build();
+        }
+    }
+
+    private static void rejectStrictRootlessDeserializer(JsonSettings settings) {
+        if (settings.strictRuntimeCodegen()) {
+            throw new IllegalStateException(
+                    "Strict JSON runtime codegen requires deserializeShape with a concrete builder; "
+                            + "createDeserializer would use dispatch serde");
+        }
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/CodegenShapeSerializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/CodegenShapeSerializer.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.function.BiConsumer;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.serde.MapSerializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.core.serde.event.EventStream;
+import software.amazon.smithy.java.io.datastream.DataStream;
+import software.amazon.smithy.java.json.smithy.SmithyGeneratedJsonSerde;
+
+final class CodegenShapeSerializer implements ShapeSerializer {
+    private final OutputStream sink;
+    private final JsonSerdeProvider delegateProvider;
+    private final SmithyGeneratedJsonSerde generated;
+    private final JsonSettings settings;
+    private ShapeSerializer delegate;
+
+    CodegenShapeSerializer(
+            OutputStream sink,
+            JsonSerdeProvider delegateProvider,
+            SmithyGeneratedJsonSerde generated,
+            JsonSettings settings
+    ) {
+        this.sink = sink;
+        this.delegateProvider = delegateProvider;
+        this.generated = generated;
+        this.settings = settings;
+    }
+
+    @Override
+    public void writeStruct(Schema schema, SerializableStruct struct) {
+        if (!generated.serializeTo(struct, sink, settings)) {
+            delegate().writeStruct(schema, struct);
+        }
+    }
+
+    @Override
+    public <T> void writeList(Schema schema, T state, int size, BiConsumer<T, ShapeSerializer> consumer) {
+        delegate().writeList(schema, state, size, consumer);
+    }
+
+    @Override
+    public <T> void writeMap(Schema schema, T state, int size, BiConsumer<T, MapSerializer> consumer) {
+        delegate().writeMap(schema, state, size, consumer);
+    }
+
+    @Override
+    public void writeBoolean(Schema schema, boolean value) {
+        delegate().writeBoolean(schema, value);
+    }
+
+    @Override
+    public void writeByte(Schema schema, byte value) {
+        delegate().writeByte(schema, value);
+    }
+
+    @Override
+    public void writeShort(Schema schema, short value) {
+        delegate().writeShort(schema, value);
+    }
+
+    @Override
+    public void writeInteger(Schema schema, int value) {
+        delegate().writeInteger(schema, value);
+    }
+
+    @Override
+    public void writeLong(Schema schema, long value) {
+        delegate().writeLong(schema, value);
+    }
+
+    @Override
+    public void writeFloat(Schema schema, float value) {
+        delegate().writeFloat(schema, value);
+    }
+
+    @Override
+    public void writeDouble(Schema schema, double value) {
+        delegate().writeDouble(schema, value);
+    }
+
+    @Override
+    public void writeBigInteger(Schema schema, BigInteger value) {
+        delegate().writeBigInteger(schema, value);
+    }
+
+    @Override
+    public void writeBigDecimal(Schema schema, BigDecimal value) {
+        delegate().writeBigDecimal(schema, value);
+    }
+
+    @Override
+    public void writeString(Schema schema, String value) {
+        delegate().writeString(schema, value);
+    }
+
+    @Override
+    public void writeBlob(Schema schema, ByteBuffer value) {
+        delegate().writeBlob(schema, value);
+    }
+
+    @Override
+    public void writeDataStream(Schema schema, DataStream value) {
+        delegate().writeDataStream(schema, value);
+    }
+
+    @Override
+    public void writeEventStream(Schema schema, EventStream<? extends SerializableStruct> value) {
+        delegate().writeEventStream(schema, value);
+    }
+
+    @Override
+    public void writeTimestamp(Schema schema, Instant value) {
+        delegate().writeTimestamp(schema, value);
+    }
+
+    @Override
+    public void writeDocument(Schema schema, Document value) {
+        delegate().writeDocument(schema, value);
+    }
+
+    @Override
+    public void writeNull(Schema schema) {
+        delegate().writeNull(schema);
+    }
+
+    @Override
+    public void flush() {
+        if (delegate != null) {
+            delegate.flush();
+        }
+    }
+
+    @Override
+    public void close() {
+        if (delegate != null) {
+            delegate.close();
+        }
+    }
+
+    private ShapeSerializer delegate() {
+        if (settings.strictRuntimeCodegen()) {
+            throw new IllegalStateException(
+                    "Strict JSON runtime codegen cannot fall back to the streaming dispatch serializer");
+        }
+        if (delegate == null) {
+            delegate = delegateProvider.newSerializer(sink, settings);
+        }
+        return delegate;
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonCodec.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonCodec.java
@@ -7,9 +7,12 @@ package software.amazon.smithy.java.json;
 
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.TimestampFormatter;
@@ -27,7 +30,7 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait;
  *
  * <p>Blobs are base64 encoded as strings.
  */
-public final class JsonCodec implements Codec {
+public final class JsonCodec implements Codec, MemberSubsetCodec {
 
     private final JsonSettings settings;
 
@@ -54,7 +57,38 @@ public final class JsonCodec implements Codec {
     }
 
     @Override
+    public ByteBuffer serialize(SerializableStruct struct, MemberSubset subset) {
+        return settings.provider() instanceof CodegenJsonSerdeProvider generated
+                ? generated.serializeMemberSubset(struct, subset, settings)
+                : null;
+    }
+
+    @Override
+    public boolean deserialize(
+            Schema schema,
+            ShapeBuilder<?> builder,
+            ByteBuffer source,
+            MemberSubset subset
+    ) {
+        return settings.provider() instanceof CodegenJsonSerdeProvider generated
+                && generated.deserializeMemberSubset(schema, builder, source, subset, settings);
+    }
+
+    @Override
+    public boolean deserialize(
+            Schema schema,
+            ShapeBuilder<?> builder,
+            ByteBuffer source
+    ) {
+        return settings.provider() instanceof CodegenJsonSerdeProvider generated
+                && generated.deserializeInto(schema, builder, source, settings);
+    }
+
+    @Override
     public <T extends SerializableShape> T deserializeShape(byte[] source, ShapeBuilder<T> builder) {
+        if (settings.provider() instanceof CodegenJsonSerdeProvider generated) {
+            return generated.deserialize(source, builder, settings);
+        }
         var deserializer = createDeserializer(source);
         T result;
         try {
@@ -69,6 +103,9 @@ public final class JsonCodec implements Codec {
 
     @Override
     public <T extends SerializableShape> T deserializeShape(ByteBuffer source, ShapeBuilder<T> builder) {
+        if (settings.provider() instanceof CodegenJsonSerdeProvider generated) {
+            return generated.deserialize(source, builder, settings);
+        }
         var deserializer = createDeserializer(source);
         T result;
         try {
@@ -218,6 +255,12 @@ public final class JsonCodec implements Codec {
          */
         public Builder useStringForArbitraryPrecision(boolean useStringForArbitraryPrecision) {
             settingsBuilder.useStringForArbitraryPrecision(useStringForArbitraryPrecision);
+            return this;
+        }
+
+        /** Enables runtime-generated codecs when supported by the current JVM. */
+        public Builder runtimeCodegen(boolean runtimeCodegen) {
+            settingsBuilder.runtimeCodegen(runtimeCodegen);
             return this;
         }
 

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSettings.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/JsonSettings.java
@@ -7,7 +7,10 @@ package software.amazon.smithy.java.json;
 
 import java.util.Objects;
 import java.util.ServiceLoader;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenFeature;
+import software.amazon.smithy.java.core.serde.RuntimeCodegenMode;
 import software.amazon.smithy.java.core.serde.TimestampFormatter;
+import software.amazon.smithy.java.json.smithy.SmithyJsonSerdeProvider;
 
 /**
  * Settings used by a {@link JsonCodec}.
@@ -46,6 +49,7 @@ public final class JsonSettings {
     private final boolean serializeTypeInDocuments;
     private final boolean prettyPrint;
     private final boolean useStringForArbitraryPrecision;
+    private final RuntimeCodegenMode runtimeCodegenMode;
 
     private JsonSettings(Builder builder) {
         this.timestampResolver = builder.useTimestampFormat
@@ -56,7 +60,29 @@ public final class JsonSettings {
                 : JsonFieldMapper.UseMemberName.INSTANCE;
         this.forbidUnknownUnionMembers = builder.forbidUnknownUnionMembers;
         this.defaultNamespace = builder.defaultNamespace;
-        this.provider = builder.provider;
+        JsonSerdeProvider provider = builder.provider instanceof CodegenJsonSerdeProvider codegen
+                ? codegen.delegate()
+                : builder.provider;
+        RuntimeCodegenMode requested = builder.runtimeCodegenMode;
+        RuntimeCodegenMode resolved = RuntimeCodegenFeature.resolve(requested, "json");
+        if (resolved != RuntimeCodegenMode.DISABLED
+                && builder.runtimeCodegenMode == null
+                && builder.providerOverridden
+                && !(provider instanceof SmithyJsonSerdeProvider)) {
+            if (resolved == RuntimeCodegenMode.STRICT) {
+                throw new IllegalStateException(
+                        "Strict JSON runtime codegen cannot fall back to a custom serde provider");
+            }
+            resolved = RuntimeCodegenMode.DISABLED;
+        }
+        this.runtimeCodegenMode = resolved;
+        boolean runtimeCodegen = resolved != RuntimeCodegenMode.DISABLED;
+        if (runtimeCodegen && !(provider instanceof SmithyJsonSerdeProvider)) {
+            throw new IllegalStateException(
+                    "JSON runtime code generation decorates only the native Smithy provider; "
+                            + "select it with -Dsmithy-java.json-provider=smithy or remove the custom provider");
+        }
+        this.provider = runtimeCodegen ? new CodegenJsonSerdeProvider(provider) : provider;
         this.serializeTypeInDocuments = builder.serializeTypeInDocuments;
         this.prettyPrint = builder.prettyPrint;
         this.useStringForArbitraryPrecision = builder.useStringForArbitraryPrecision;
@@ -138,6 +164,16 @@ public final class JsonSettings {
         return useStringForArbitraryPrecision;
     }
 
+    /** Returns whether runtime code generation is active. */
+    public boolean runtimeCodegen() {
+        return runtimeCodegenMode != RuntimeCodegenMode.DISABLED;
+    }
+
+    /** Returns whether runtime code generation rejects fallbacks. */
+    public boolean strictRuntimeCodegen() {
+        return runtimeCodegenMode == RuntimeCodegenMode.STRICT;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -150,7 +186,8 @@ public final class JsonSettings {
                 && serializeTypeInDocuments == that.serializeTypeInDocuments
                 && prettyPrint == that.prettyPrint
                 && useStringForArbitraryPrecision == that.useStringForArbitraryPrecision
-                && timestampResolver.getClass() == that.timestampResolver.getClass()
+                && runtimeCodegenMode == that.runtimeCodegenMode
+                && timestampResolver.equals(that.timestampResolver)
                 && fieldMapper.getClass() == that.fieldMapper.getClass()
                 && Objects.equals(defaultNamespace, that.defaultNamespace);
     }
@@ -161,7 +198,8 @@ public final class JsonSettings {
         h = 31 * h + Boolean.hashCode(serializeTypeInDocuments);
         h = 31 * h + Boolean.hashCode(prettyPrint);
         h = 31 * h + Boolean.hashCode(useStringForArbitraryPrecision);
-        h = 31 * h + timestampResolver.getClass().hashCode();
+        h = 31 * h + runtimeCodegenMode.hashCode();
+        h = 31 * h + timestampResolver.hashCode();
         h = 31 * h + fieldMapper.getClass().hashCode();
         h = 31 * h + Objects.hashCode(defaultNamespace);
         return h;
@@ -175,6 +213,7 @@ public final class JsonSettings {
         builder.forbidUnknownUnionMembers(forbidUnknownUnionMembers);
         builder.defaultNamespace(defaultNamespace);
         builder.overrideSerdeProvider(provider);
+        builder.defaultTimestampFormat(timestampResolver.defaultFormat());
         if (timestampResolver instanceof TimestampResolver.UseTimestampFormatTrait) {
             builder.useTimestampFormat(true);
         }
@@ -184,6 +223,7 @@ public final class JsonSettings {
         builder.serializeTypeInDocuments(serializeTypeInDocuments);
         builder.prettyPrint(prettyPrint);
         builder.useStringForArbitraryPrecision(useStringForArbitraryPrecision);
+        builder.runtimeCodegenMode(runtimeCodegenMode);
     }
 
     /**
@@ -210,6 +250,8 @@ public final class JsonSettings {
         private boolean serializeTypeInDocuments = true;
         private boolean prettyPrint = false;
         private boolean useStringForArbitraryPrecision = false;
+        private RuntimeCodegenMode runtimeCodegenMode;
+        private boolean providerOverridden;
 
         private Builder() {}
 
@@ -324,6 +366,19 @@ public final class JsonSettings {
             return this;
         }
 
+        /** Enables runtime-generated codecs when supported by the current JVM. */
+        public Builder runtimeCodegen(boolean runtimeCodegen) {
+            this.runtimeCodegenMode = runtimeCodegen
+                    ? RuntimeCodegenMode.ENABLED
+                    : RuntimeCodegenMode.DISABLED;
+            return this;
+        }
+
+        private Builder runtimeCodegenMode(RuntimeCodegenMode runtimeCodegenMode) {
+            this.runtimeCodegenMode = runtimeCodegenMode;
+            return this;
+        }
+
         /**
          * Uses a custom JSON serde provider.
          *
@@ -332,6 +387,7 @@ public final class JsonSettings {
          */
         Builder overrideSerdeProvider(JsonSerdeProvider provider) {
             this.provider = Objects.requireNonNull(provider);
+            this.providerOverridden = true;
             return this;
         }
     }

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/GeneratedJsonCodec.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/GeneratedJsonCodec.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.json.JsonSettings;
+
+interface GeneratedJsonCodec {
+    void write(SerializableShape value, JsonCodegenWriter writer);
+
+    boolean acceptsBuilder(ShapeBuilder<?> builder);
+
+    void readInto(
+            byte[] source,
+            int offset,
+            int end,
+            ShapeBuilder<?> builder,
+            JsonSettings settings
+    );
+
+    default SerializableShape read(byte[] source, ShapeBuilder<?> builder, JsonSettings settings) {
+        readInto(source, 0, source.length, builder, settings);
+        return builder.errorCorrection().build();
+    }
+
+    int scan(byte[] source, JsonSettings settings);
+
+    default void writeMapValue(int mapId, Object value, JsonCodegenWriter writer) {
+        throw new UnsupportedOperationException("Codec has no map members");
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonCodegenWriter.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonCodegenWriter.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.Arrays;
+import software.amazon.smithy.java.codecs.commons.CompactStringAccess;
+import software.amazon.smithy.java.codecs.commons.NumberCodec;
+import software.amazon.smithy.java.codecs.commons.StripedPool;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.serde.SerializationException;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.io.ByteBufferUtils;
+import software.amazon.smithy.java.json.JsonSettings;
+
+final class JsonCodegenWriter {
+    private static final int DEFAULT_CAPACITY = 8192;
+    private static final int MAX_CACHEABLE_CAPACITY = DEFAULT_CAPACITY * 16;
+    private static final int MAX_DEPTH = 64;
+    private static final StripedPool<JsonCodegenWriter, JsonSettings> POOL = new WriterPool();
+
+    private byte[] bytes = new byte[DEFAULT_CAPACITY];
+    private int position;
+    private int depth;
+    private final boolean[] needsComma = new boolean[MAX_DEPTH];
+    private JsonSettings settings;
+    private OutputStream sink;
+
+    private JsonCodegenWriter(JsonSettings settings) {
+        this.settings = settings;
+    }
+
+    static JsonCodegenWriter acquire(JsonSettings settings) {
+        return POOL.acquire(settings);
+    }
+
+    static void release(JsonCodegenWriter writer) {
+        POOL.release(writer);
+    }
+
+    void sink(OutputStream sink) {
+        this.sink = sink;
+    }
+
+    ByteBuffer detach() {
+        return ByteBuffer.wrap(Arrays.copyOf(bytes, position));
+    }
+
+    int size() {
+        return position;
+    }
+
+    void flush() {
+        if (sink == null || position == 0) {
+            return;
+        }
+        try {
+            sink.write(bytes, 0, position);
+            position = 0;
+            sink.flush();
+        } catch (Exception e) {
+            throw new SerializationException(e);
+        }
+    }
+
+    void beginObject() {
+        ensure(1);
+        bytes[position++] = '{';
+        push();
+    }
+
+    void endObject() {
+        pop();
+        ensure(1);
+        bytes[position++] = '}';
+    }
+
+    void beginArray() {
+        ensure(1);
+        bytes[position++] = '[';
+        push();
+    }
+
+    void endArray() {
+        pop();
+        ensure(1);
+        bytes[position++] = ']';
+    }
+
+    void field(byte[] token) {
+        separator();
+        ensure(token.length);
+        position = copyToken(token, position);
+    }
+
+    void field(byte[] token, int index) {
+        ensure(token.length + 1);
+        if (index != 0) {
+            bytes[position++] = ',';
+        }
+        position = copyToken(token, position);
+    }
+
+    // Overlapping word stores avoid arraycopy overhead without writing past the token.
+    private int copyToken(byte[] token, int pos) {
+        int length = token.length;
+        if (length <= Long.BYTES * 2) {
+            if (length >= Long.BYTES) {
+                int tail = length - Long.BYTES;
+                JsonReadUtils.writeLongLittleEndian(bytes, pos, JsonReadUtils.readLongLittleEndian(token, 0));
+                JsonReadUtils.writeLongLittleEndian(
+                        bytes,
+                        pos + tail,
+                        JsonReadUtils.readLongLittleEndian(token, tail));
+                return pos + length;
+            }
+            if (length >= Integer.BYTES) {
+                int tail = length - Integer.BYTES;
+                JsonReadUtils.writeIntLittleEndian(bytes, pos, JsonReadUtils.readIntLittleEndian(token, 0));
+                JsonReadUtils.writeIntLittleEndian(
+                        bytes,
+                        pos + tail,
+                        JsonReadUtils.readIntLittleEndian(token, tail));
+                return pos + length;
+            }
+        }
+        System.arraycopy(token, 0, bytes, pos, length);
+        return pos + length;
+    }
+
+    void fieldString(byte[] token, int index, String value) {
+        byte[] latin1 = CompactStringAccess.latin1Bytes(value);
+        ensure(token.length + 1
+                + (latin1 != null
+                        ? latin1.length + 2
+                        : JsonWriteUtils.maxQuotedStringBytes(value)));
+        if (index != 0) {
+            bytes[position++] = ',';
+        }
+        position = copyToken(token, position);
+        if (latin1 != null) {
+            int next = JsonWriteUtils.writeQuotedAscii(bytes, position, latin1);
+            if (next >= 0) {
+                position = next;
+                return;
+            }
+            ensure(JsonWriteUtils.maxQuotedStringBytes(value));
+        }
+        position = JsonWriteUtils.writeQuotedStringGeneral(bytes, position, value);
+    }
+
+    void element() {
+        separator();
+    }
+
+    void element(int index) {
+        if (index != 0) {
+            ensure(1);
+            bytes[position++] = ',';
+        }
+    }
+
+    void dynamicField(String name) {
+        separator();
+        writeString(name);
+        ensure(1);
+        bytes[position++] = ':';
+    }
+
+    void dynamicField(String name, int index) {
+        if (index != 0) {
+            ensure(1);
+            bytes[position++] = ',';
+        }
+        writeString(name);
+        ensure(1);
+        bytes[position++] = ':';
+    }
+
+    void writeNull() {
+        ensure(4);
+        bytes[position++] = 'n';
+        bytes[position++] = 'u';
+        bytes[position++] = 'l';
+        bytes[position++] = 'l';
+    }
+
+    void writeBoolean(boolean value) {
+        ensure(5);
+        position = NumberCodec.writeBoolean(bytes, position, value);
+    }
+
+    void writeByte(byte value) {
+        ensure(4);
+        position = JsonWriteUtils.writeInt(bytes, position, value);
+    }
+
+    void writeShort(short value) {
+        ensure(6);
+        position = JsonWriteUtils.writeInt(bytes, position, value);
+    }
+
+    void writeInteger(int value) {
+        ensure(11);
+        position = JsonWriteUtils.writeInt(bytes, position, value);
+    }
+
+    void writeLong(long value) {
+        ensure(20);
+        position = JsonWriteUtils.writeLong(bytes, position, value);
+    }
+
+    void writeFloat(float value) {
+        ensure(24);
+        position = NumberCodec.writeFloatFullQuoted(bytes, position, value);
+    }
+
+    void writeDouble(double value) {
+        ensure(24);
+        position = NumberCodec.writeDoubleFullQuoted(bytes, position, value);
+    }
+
+    void writeBigInteger(BigInteger value) {
+        ensure(value.bitLength() / 3 + 4);
+        if (settings.useStringForArbitraryPrecision()) {
+            bytes[position++] = '"';
+            position = NumberCodec.writeBigInteger(bytes, position, value);
+            bytes[position++] = '"';
+        } else {
+            position = NumberCodec.writeBigInteger(bytes, position, value);
+        }
+    }
+
+    void writeBigDecimal(BigDecimal value) {
+        ensure(NumberCodec.maxBigDecimalLength(value) + 2);
+        if (settings.useStringForArbitraryPrecision()) {
+            bytes[position++] = '"';
+            position = NumberCodec.writeBigDecimal(bytes, position, value);
+            bytes[position++] = '"';
+        } else {
+            position = NumberCodec.writeBigDecimal(bytes, position, value);
+        }
+    }
+
+    void writeString(String value) {
+        byte[] latin1 = CompactStringAccess.latin1Bytes(value);
+        if (latin1 != null) {
+            ensure(latin1.length + 2);
+            int next = JsonWriteUtils.writeQuotedAscii(bytes, position, latin1);
+            if (next >= 0) {
+                position = next;
+                return;
+            }
+        }
+        ensure(JsonWriteUtils.maxQuotedStringBytes(value));
+        position = JsonWriteUtils.writeQuotedStringGeneral(bytes, position, value);
+    }
+
+    private byte[] base64Scratch;
+
+    void writeBlob(ByteBuffer value) {
+        int remaining = value.remaining();
+        ensure(ByteBufferUtils.base64EncodedSize(remaining) + 2);
+        if (remaining >= 32) {
+            byte[] b = bytes;
+            int p = position;
+            b[p++] = '"';
+            p += ByteBufferUtils.base64EncodeTo(value, b, p, base64Scratch(remaining));
+            b[p++] = '"';
+            position = p;
+            return;
+        }
+        position = JsonWriteUtils.writeBase64String(bytes, position, value);
+    }
+
+    private byte[] base64Scratch(int dataLen) {
+        int capacity = ByteBufferUtils.base64EncodedSize(dataLen);
+        byte[] scratch = base64Scratch;
+        if (scratch == null || scratch.length < capacity) {
+            scratch = base64Scratch = new byte[capacity];
+        }
+        return scratch;
+    }
+
+    void writeTimestamp(Instant value, int format) {
+        switch (format) {
+            case 1 -> {
+                ensure(42);
+                position = JsonWriteUtils.writeIso8601Timestamp(bytes, position, value);
+            }
+            case 2 -> {
+                ensure(35);
+                position = JsonWriteUtils.writeHttpDate(bytes, position, value);
+            }
+            default -> {
+                ensure(30);
+                position = JsonWriteUtils.writeEpochSeconds(
+                        bytes,
+                        position,
+                        value.getEpochSecond(),
+                        value.getNano());
+            }
+        }
+    }
+
+    void writeDocument(Document document) {
+        if (document == null) {
+            writeNull();
+            return;
+        }
+        SmithyJsonSerializer serializer = SmithyJsonSerializer.acquire(settings);
+        boolean failed = true;
+        try {
+            serializer.writeDocument(PreludeSchemas.DOCUMENT, document);
+            ByteBuffer encoded = serializer.extractResult();
+            ensure(encoded.remaining());
+            int length = encoded.remaining();
+            encoded.get(bytes, position, length);
+            position += length;
+            failed = false;
+        } finally {
+            SmithyJsonSerializer.release(serializer, failed);
+        }
+    }
+
+    private void push() {
+        if (++depth >= MAX_DEPTH) {
+            throw new SerializationException("Maximum nesting depth exceeded: " + MAX_DEPTH);
+        }
+        needsComma[depth] = false;
+    }
+
+    private void pop() {
+        needsComma[depth] = false;
+        depth--;
+    }
+
+    private void separator() {
+        ensure(1);
+        if (needsComma[depth]) {
+            bytes[position++] = ',';
+        } else {
+            needsComma[depth] = true;
+        }
+    }
+
+    private void ensure(int needed) {
+        if (position + needed > bytes.length) {
+            grow(needed);
+        }
+    }
+
+    private void grow(int needed) {
+        bytes = Arrays.copyOf(bytes, Math.max(bytes.length * 2, position + needed));
+    }
+
+    private static final class WriterPool extends StripedPool<JsonCodegenWriter, JsonSettings> {
+        @Override
+        protected JsonCodegenWriter create(JsonSettings settings) {
+            return new JsonCodegenWriter(settings);
+        }
+
+        @Override
+        protected void cleanup(JsonCodegenWriter writer) {
+            writer.sink = null;
+            writer.position = 0;
+            writer.depth = 0;
+        }
+
+        @Override
+        protected boolean canPool(JsonCodegenWriter writer) {
+            return writer.bytes != null;
+        }
+
+        @Override
+        protected void prepareForPool(JsonCodegenWriter writer) {
+            if (writer.bytes.length > MAX_CACHEABLE_CAPACITY) {
+                writer.bytes = new byte[DEFAULT_CAPACITY];
+            }
+            if (writer.base64Scratch != null && writer.base64Scratch.length > MAX_CACHEABLE_CAPACITY) {
+                writer.base64Scratch = null;
+            }
+        }
+
+        @Override
+        protected boolean reset(JsonCodegenWriter writer, JsonSettings settings) {
+            writer.settings = settings;
+            return true;
+        }
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonReadUtils.java
@@ -41,6 +41,22 @@ final class JsonReadUtils {
 
     private static final int MAX_SAFE_LONG_DIGITS = 18;
 
+    static long readLongLittleEndian(byte[] buf, int pos) {
+        return (long) LONG_HANDLE.get(buf, pos);
+    }
+
+    static void writeLongLittleEndian(byte[] buf, int pos, long value) {
+        LONG_HANDLE.set(buf, pos, value);
+    }
+
+    static int readIntLittleEndian(byte[] buf, int pos) {
+        return (int) INT_HANDLE.get(buf, pos);
+    }
+
+    static void writeIntLittleEndian(byte[] buf, int pos, int value) {
+        INT_HANDLE.set(buf, pos, value);
+    }
+
     // Hex digit lookup table: -1 means invalid hex digit
     private static final int[] HEX_VALUES = new int[128];
 

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonRuntimeCodegenBackend.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonRuntimeCodegenBackend.java
@@ -1,0 +1,2624 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenBytecode.emitAcceptsBuilder;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenBytecode.emitDefaultConstructor;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenBytecode.emitThrow;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenBytecode.fieldHash;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenBytecode.findBuild;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenBytecode.invoke;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodecBackend;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodecPlan;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.UnsupportedSchemaException;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassWriter;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Label;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.MethodVisitor;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Type;
+import software.amazon.smithy.java.core.error.ModeledException;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.schema.SmithyEnum;
+import software.amazon.smithy.java.core.schema.SmithyIntEnum;
+import software.amazon.smithy.java.core.schema.TraitKey;
+import software.amazon.smithy.java.core.serde.TimestampFormatter;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.json.JsonFieldMapper;
+import software.amazon.smithy.java.json.JsonSettings;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
+
+final class JsonRuntimeCodegenBackend implements RuntimeCodecBackend<GeneratedJsonCodec>, Opcodes {
+    private static final String CODEC = Type.getInternalName(GeneratedJsonCodec.class);
+    private static final String WRITER = Type.getInternalName(JsonCodegenWriter.class);
+    private static final String MAP_CONSUMER = Type.getInternalName(MapWriteConsumer.class);
+    private static final String READER = Type.getInternalName(SmithyJsonDeserializer.class);
+    private static final String SETTINGS = Type.getInternalName(JsonSettings.class);
+    private static final String SERIALIZABLE_SHAPE = Type.getInternalName(SerializableShape.class);
+    private static final String SHAPE_BUILDER = Type.getInternalName(ShapeBuilder.class);
+    private static final String DOCUMENT = Type.getInternalName(Document.class);
+    private static final String SMITHY_ENUM = Type.getInternalName(SmithyEnum.class);
+    private static final String SMITHY_INT_ENUM = Type.getInternalName(SmithyIntEnum.class);
+    private static final String BYTE_BUFFER = Type.getInternalName(ByteBuffer.class);
+
+    private static final String TYPE_DISCRIMINATOR = "__type";
+
+    private static final String MISSING_UNION_MEMBER = "Union object must contain one member";
+
+    private final boolean useJsonName;
+    private final boolean forbidUnknownUnionMembers;
+    private final JsonSettings settings;
+
+    JsonRuntimeCodegenBackend(JsonSettings settings) {
+        this.settings = settings;
+        this.useJsonName = settings.fieldMapper() instanceof JsonFieldMapper.UseJsonNameTrait;
+        this.forbidUnknownUnionMembers = settings.forbidUnknownUnionMembers();
+    }
+
+    @Override
+    public String id() {
+        return "json";
+    }
+
+    @Override
+    public String variant() {
+        return useJsonName ? "Names" : "Members";
+    }
+
+    @Override
+    public Class<GeneratedJsonCodec> codecType() {
+        return GeneratedJsonCodec.class;
+    }
+
+    @Override
+    public Class<?> lookupHost() {
+        return GeneratedJsonCodec.class;
+    }
+
+    @Override
+    public Budgets budgets() {
+        return new Budgets(220, 300, 8, 8);
+    }
+
+    @Override
+    public Emission emit(RuntimeCodecPlan plan, String generatedName) {
+        validate(plan);
+        var generator = new Generator(plan, generatedName, settings, useJsonName, forbidUnknownUnionMembers);
+        return generator.generate();
+    }
+
+    private static void validate(RuntimeCodecPlan plan) {
+        for (RuntimeCodecPlan.StructPlan structure : plan.structures()) {
+            if (structure.builderFactory() == null && structure.schema() != plan.root()) {
+                if (!structure.union()) {
+                    throw new UnsupportedSchemaException("No public builder factory for " + structure.schema().id());
+                }
+            }
+            rejectModeledException(structure);
+            requireAccessible(structure.shapeClass(), structure.schema());
+            if (structure.builderClass() != null) {
+                requireAccessible(structure.builderClass(), structure.schema());
+            }
+            for (RuntimeCodecPlan.MemberPlan member : structure.members()) {
+                validateAggregate(member.target(), new HashSet<>());
+                switch (member.target().type()) {
+                    case BOOLEAN, BYTE, SHORT, INTEGER, LONG, FLOAT, DOUBLE, BIG_INTEGER, BIG_DECIMAL,
+                            STRING, ENUM, INT_ENUM, BLOB, TIMESTAMP, DOCUMENT, LIST, SET, MAP, STRUCTURE,
+                            UNION ->
+                        {
+                        }
+                    default -> throw new UnsupportedSchemaException(
+                            "JSON runtime codegen does not yet lower " + member.target().type()
+                                    + " at " + member.schema().id());
+                }
+            }
+        }
+    }
+
+    private static void validateAggregate(Schema schema, Set<ShapeId> visited) {
+        Schema target = schema.isMember() ? schema.memberTarget() : schema;
+        if (!visited.add(target.id())) {
+            return;
+        }
+        switch (target.type()) {
+            case LIST, SET -> validateAggregate(target.listMember(), visited);
+            case MAP -> {
+                if (target.mapKeyMember().memberTarget().type() != ShapeType.STRING) {
+                    throw new UnsupportedSchemaException(
+                            "JSON runtime codegen requires string map keys at " + target.id());
+                }
+                validateAggregate(target.mapValueMember(), visited);
+            }
+            default -> {
+            }
+        }
+    }
+
+    // Generated setters cannot mark ModeledException instances as deserialized.
+    private static void rejectModeledException(RuntimeCodecPlan.StructPlan structure) {
+        Class<?> shapeClass = structure.shapeClass();
+        if (shapeClass != null && ModeledException.class.isAssignableFrom(shapeClass)) {
+            throw new UnsupportedSchemaException(
+                    "JSON runtime codegen does not support modeled exceptions: " + structure.schema().id());
+        }
+    }
+
+    // Reject inaccessible classes during generation rather than failing later with IllegalAccessError.
+    private static void requireAccessible(Class<?> type, Schema schema) {
+        for (Class<?> current = type; current != null; current = current.getEnclosingClass()) {
+            if (!Modifier.isPublic(current.getModifiers())) {
+                throw new UnsupportedSchemaException(
+                        "Cannot reach " + type.getName() + " for " + schema.id() + " from generated code");
+            }
+        }
+    }
+
+    private static final class Generator {
+        private final RuntimeCodecPlan plan;
+        private final String className;
+        private final JsonSettings settings;
+        private final boolean useJsonName;
+        private final boolean forbidUnknownUnionMembers;
+        private final ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+        private final IdentityHashMap<RuntimeCodecPlan.StructPlan, Integer> structureIds = new IdentityHashMap<>();
+        private final IdentityHashMap<RuntimeCodecPlan.MemberPlan, Integer> memberIds = new IdentityHashMap<>();
+        private final List<RuntimeCodecPlan.MemberPlan> orderedMembers = new ArrayList<>();
+        private final Map<ShapeId, RuntimeCodecPlan.StructPlan> structuresBySchema = new LinkedHashMap<>();
+        private final Map<ShapeId, Integer> aggregateIds = new LinkedHashMap<>();
+        private final List<Schema> orderedAggregates = new ArrayList<>();
+        private final Map<Class<?>, Integer> enumIds = new LinkedHashMap<>();
+        private final Map<Class<?>, Integer> intEnumIds = new LinkedHashMap<>();
+        private int methodCount;
+
+        Generator(
+                RuntimeCodecPlan plan,
+                String className,
+                JsonSettings settings,
+                boolean useJsonName,
+                boolean forbidUnknownUnionMembers
+        ) {
+            this.plan = plan;
+            this.className = className;
+            this.settings = settings;
+            this.useJsonName = useJsonName;
+            this.forbidUnknownUnionMembers = forbidUnknownUnionMembers;
+            for (int i = 0; i < plan.structures().size(); i++) {
+                RuntimeCodecPlan.StructPlan structure = plan.structures().get(i);
+                structureIds.put(structure, i);
+                structuresBySchema.put(structure.schema().id(), structure);
+                for (RuntimeCodecPlan.MemberPlan member : structure.members()) {
+                    memberIds.put(member, memberIds.size());
+                    orderedMembers.add(member);
+                    collectTarget(member.target());
+                }
+            }
+        }
+
+        private void collectTarget(Schema schema) {
+            schema = schema.isMember() ? schema.memberTarget() : schema;
+            switch (schema.type()) {
+                case LIST, SET -> {
+                    ShapeId key = schema.id();
+                    if (!aggregateIds.containsKey(key)) {
+                        aggregateIds.put(key, aggregateIds.size());
+                        orderedAggregates.add(schema);
+                        collectTarget(schema.listMember());
+                    }
+                }
+                case MAP -> {
+                    ShapeId key = schema.id();
+                    if (!aggregateIds.containsKey(key)) {
+                        aggregateIds.put(key, aggregateIds.size());
+                        orderedAggregates.add(schema);
+                        collectTarget(schema.mapValueMember());
+                    }
+                }
+                case ENUM -> enumIds.computeIfAbsent(schema.shapeClass(), ignored -> enumIds.size());
+                case INT_ENUM -> intEnumIds.computeIfAbsent(schema.shapeClass(), ignored -> intEnumIds.size());
+                default -> {
+                }
+            }
+        }
+
+        Emission generate() {
+            writer.visit(V17, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Object", new String[] {CODEC});
+            emitFields();
+            emitConstructor();
+            emitClassInitializer();
+            emitEnumReaders();
+            emitIntEnumReaders();
+            emitAggregateMethods();
+            emitWriteMapValueDispatch();
+            RuntimeCodecPlan.StructPlan root = plan.rootStructure();
+            for (RuntimeCodecPlan.StructPlan structure : plan.structures()) {
+                emitWriter(structure);
+                boolean hasReaderBody = false;
+                if (structure == root) {
+                    emitReader(structure);
+                    hasReaderBody = true;
+                }
+                if (structure.union()) {
+                    emitUnionValueReader(structure);
+                } else if (structure.builderFactory() != null && needsStructureValueReader(structure, root)) {
+                    emitStructureValueReader(structure);
+                    hasReaderBody = true;
+                }
+                if (hasReaderBody) {
+                    emitReaderBuckets(structure);
+                }
+            }
+            emitWriteEntry();
+            emitAcceptsBuilder(writer, plan.rootStructure().builderClass());
+            methodCount++;
+            emitReadEntry();
+            emitScanEntry();
+            writer.visitEnd();
+            return new Emission(writer.toByteArray(), methodCount);
+        }
+
+        private boolean needsStructureValueReader(
+                RuntimeCodecPlan.StructPlan structure,
+                RuntimeCodecPlan.StructPlan root
+        ) {
+            if (structure != root) {
+                return true;
+            }
+            ShapeId target = structure.schema().id();
+            for (RuntimeCodecPlan.StructPlan candidate : plan.structures()) {
+                for (RuntimeCodecPlan.MemberPlan member : candidate.members()) {
+                    if (containsStructure(member.target(), target)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private boolean containsStructure(Schema schema, ShapeId target) {
+            Schema value = schema.isMember() ? schema.memberTarget() : schema;
+            if (value.id().equals(target)) {
+                return true;
+            }
+            return switch (value.type()) {
+                case LIST, SET -> containsStructure(value.listMember(), target);
+                case MAP -> containsStructure(value.mapValueMember(), target);
+                default -> false;
+            };
+        }
+
+        private void emitFields() {
+            for (RuntimeCodecPlan.MemberPlan member : orderedMembers) {
+                int id = memberIds.get(member);
+                writer.visitField(ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "N" + id, "[B", null, null).visitEnd();
+                writer.visitField(ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "W" + id, "[B", null, null).visitEnd();
+            }
+        }
+
+        private void emitConstructor() {
+            emitDefaultConstructor(writer);
+            methodCount++;
+        }
+
+        private void emitClassInitializer() {
+            MethodVisitor method = writer.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
+            method.visitCode();
+            for (RuntimeCodecPlan.MemberPlan member : orderedMembers) {
+                int id = memberIds.get(member);
+                emitUtf8(method, wireName(member));
+                method.visitFieldInsn(PUTSTATIC, className, "N" + id, "[B");
+                var extension = member.schema().getExtension(SmithyJsonSchemaExtensions.KEY);
+                byte[] fieldToken = useJsonName
+                        ? extension.jsonNameBytes()
+                        : extension.memberNameBytes();
+                emitUtf8(method, new String(fieldToken, StandardCharsets.UTF_8));
+                method.visitFieldInsn(PUTSTATIC, className, "W" + id, "[B");
+            }
+            method.visitInsn(RETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitEnumReaders() {
+            for (Map.Entry<Class<?>, Integer> entry : enumIds.entrySet()) {
+                Class<?> enumClass = entry.getKey();
+                Method unknown;
+                try {
+                    unknown = enumClass.getMethod("unknown", String.class);
+                } catch (NoSuchMethodException e) {
+                    throw new UnsupportedSchemaException("Generated enum lacks unknown method: "
+                            + enumClass.getName());
+                }
+                List<EnumConstant> constants = enumConstants(enumClass);
+                MethodVisitor method = writer.visitMethod(
+                        ACC_PRIVATE,
+                        enumReaderName(enumClass),
+                        "(L" + READER + ";)L" + Type.getInternalName(enumClass) + ";",
+                        null,
+                        null);
+                method.visitCode();
+                method.visitVarInsn(ALOAD, 1);
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        "generatedReadStringKey",
+                        "()I",
+                        false);
+                method.visitVarInsn(ISTORE, 2);
+                Map<Integer, List<EnumConstant>> groups = new LinkedHashMap<>();
+                for (EnumConstant constant : constants) {
+                    groups.computeIfAbsent(enumSwitchKey(constant.value()), ignored -> new ArrayList<>())
+                            .add(constant);
+                }
+                List<Integer> hashes = groups.keySet().stream().sorted().toList();
+                int[] keys = hashes.stream().mapToInt(Integer::intValue).toArray();
+                Label unknownValue = new Label();
+                Label[] labels = hashes.stream().map(ignored -> new Label()).toArray(Label[]::new);
+                method.visitVarInsn(ILOAD, 2);
+                method.visitLookupSwitchInsn(unknownValue, keys, labels);
+                for (int i = 0; i < hashes.size(); i++) {
+                    method.visitLabel(labels[i]);
+                    for (EnumConstant constant : groups.get(hashes.get(i))) {
+                        Label next = new Label();
+                        emitEnumValueEquals(method, constant.value());
+                        method.visitJumpInsn(IFEQ, next);
+                        method.visitFieldInsn(
+                                GETSTATIC,
+                                Type.getInternalName(enumClass),
+                                constant.field().getName(),
+                                "L" + Type.getInternalName(enumClass) + ";");
+                        method.visitInsn(ARETURN);
+                        method.visitLabel(next);
+                    }
+                    method.visitJumpInsn(GOTO, unknownValue);
+                }
+                method.visitLabel(unknownValue);
+                method.visitVarInsn(ALOAD, 1);
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        "generatedFieldName",
+                        "()Ljava/lang/String;",
+                        false);
+                invoke(method, unknown);
+                method.visitInsn(ARETURN);
+                method.visitMaxs(0, 0);
+                method.visitEnd();
+                methodCount++;
+            }
+        }
+
+        private void emitIntEnumReaders() {
+            for (Map.Entry<Class<?>, Integer> entry : intEnumIds.entrySet()) {
+                Class<?> enumClass = entry.getKey();
+                Method unknown;
+                try {
+                    unknown = enumClass.getMethod("unknown", int.class);
+                } catch (NoSuchMethodException e) {
+                    throw new UnsupportedSchemaException("Generated intEnum lacks unknown method: "
+                            + enumClass.getName());
+                }
+                List<IntEnumConstant> constants = intEnumConstants(enumClass);
+                MethodVisitor method = writer.visitMethod(
+                        ACC_PRIVATE,
+                        intEnumReaderName(enumClass),
+                        "(L" + READER + ";)L" + Type.getInternalName(enumClass) + ";",
+                        null,
+                        null);
+                method.visitCode();
+                method.visitVarInsn(ALOAD, 1);
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        "generatedReadInteger",
+                        "()I",
+                        false);
+                method.visitVarInsn(ISTORE, 2);
+                Label unknownValue = new Label();
+                if (!constants.isEmpty()) {
+                    int[] keys = constants.stream().mapToInt(IntEnumConstant::value).toArray();
+                    Label[] labels = constants.stream().map(ignored -> new Label()).toArray(Label[]::new);
+                    method.visitVarInsn(ILOAD, 2);
+                    method.visitLookupSwitchInsn(unknownValue, keys, labels);
+                    for (int i = 0; i < constants.size(); i++) {
+                        method.visitLabel(labels[i]);
+                        method.visitFieldInsn(
+                                GETSTATIC,
+                                Type.getInternalName(enumClass),
+                                constants.get(i).field().getName(),
+                                "L" + Type.getInternalName(enumClass) + ";");
+                        method.visitInsn(ARETURN);
+                    }
+                }
+                method.visitLabel(unknownValue);
+                method.visitVarInsn(ILOAD, 2);
+                invoke(method, unknown);
+                method.visitInsn(ARETURN);
+                method.visitMaxs(0, 0);
+                method.visitEnd();
+                methodCount++;
+            }
+        }
+
+        private List<IntEnumConstant> intEnumConstants(Class<?> enumClass) {
+            List<IntEnumConstant> result = new ArrayList<>();
+            Set<Integer> seen = new HashSet<>();
+            for (var field : enumClass.getFields()) {
+                if (Modifier.isStatic(field.getModifiers()) && field.getType() == enumClass) {
+                    int value;
+                    try {
+                        value = ((SmithyIntEnum) field.get(null)).getValue();
+                    } catch (IllegalAccessException e) {
+                        throw new UnsupportedSchemaException("Cannot access intEnum constant "
+                                + enumClass.getName() + "." + field.getName());
+                    }
+                    // Duplicate switch keys would make the generated class fail verification.
+                    if (seen.add(value)) {
+                        result.add(new IntEnumConstant(field, value));
+                    }
+                }
+            }
+            result.sort(Comparator.comparingInt(IntEnumConstant::value));
+            return result;
+        }
+
+        private List<EnumConstant> enumConstants(Class<?> enumClass) {
+            List<EnumConstant> result = new ArrayList<>();
+            for (var field : enumClass.getFields()) {
+                if (Modifier.isStatic(field.getModifiers()) && field.getType() == enumClass) {
+                    try {
+                        result.add(new EnumConstant(field, ((SmithyEnum) field.get(null)).getValue()));
+                    } catch (IllegalAccessException e) {
+                        throw new UnsupportedSchemaException("Cannot access enum constant "
+                                + enumClass.getName() + "." + field.getName());
+                    }
+                }
+            }
+            result.sort(Comparator.comparing(constant -> constant.field().getName()));
+            return result;
+        }
+
+        private void emitEnumValueEquals(MethodVisitor method, String value) {
+            byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+            method.visitVarInsn(ALOAD, 1);
+            if (bytes.length <= Long.BYTES) {
+                method.visitLdcInsn(packLittleEndian(bytes, 0, bytes.length));
+                method.visitLdcInsn(lowByteMask(bytes.length));
+                method.visitLdcInsn(bytes.length);
+                method.visitLdcInsn(value);
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        "generatedStringEquals8",
+                        "(JJILjava/lang/String;)Z",
+                        false);
+            } else if (bytes.length <= Long.BYTES * 2) {
+                method.visitLdcInsn(packLittleEndian(bytes, 0, Long.BYTES));
+                method.visitLdcInsn(packLittleEndian(bytes, Long.BYTES, bytes.length - Long.BYTES));
+                method.visitLdcInsn(lowByteMask(bytes.length - Long.BYTES));
+                method.visitLdcInsn(bytes.length);
+                method.visitLdcInsn(value);
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        "generatedStringEquals16",
+                        "(JJJILjava/lang/String;)Z",
+                        false);
+            } else {
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        "generatedFieldName",
+                        "()Ljava/lang/String;",
+                        false);
+                method.visitLdcInsn(value);
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        "java/lang/String",
+                        "equals",
+                        "(Ljava/lang/Object;)Z",
+                        false);
+            }
+        }
+
+        private static int enumSwitchKey(String value) {
+            byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+            int prefix = Math.min(bytes.length, Long.BYTES);
+            return SmithyJsonDeserializer.stringKey(packLittleEndian(bytes, 0, prefix), bytes.length);
+        }
+
+        private record EnumConstant(Field field, String value) {}
+
+        private record IntEnumConstant(Field field, int value) {}
+
+        private void emitAggregateMethods() {
+            for (var schema : orderedAggregates) {
+                if (schema.type() == ShapeType.MAP) {
+                    emitMapWriter(schema);
+                    emitMapReader(schema);
+                } else {
+                    emitListWriter(schema);
+                    emitListReader(schema);
+                }
+            }
+        }
+
+        private void emitListWriter(Schema schema) {
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    aggregateWriterName(schema),
+                    "(Ljava/util/List;L" + WRITER + ";)V",
+                    null,
+                    null);
+            method.visitCode();
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "beginArray", "()V", false);
+            method.visitInsn(ICONST_0);
+            method.visitVarInsn(ISTORE, 3);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEINTERFACE, "java/util/List", "size", "()I", true);
+            method.visitVarInsn(ISTORE, 4);
+            Label loop = new Label();
+            Label done = new Label();
+            method.visitLabel(loop);
+            method.visitVarInsn(ILOAD, 3);
+            method.visitVarInsn(ILOAD, 4);
+            method.visitJumpInsn(IF_ICMPGE, done);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitVarInsn(ILOAD, 3);
+            method.visitMethodInsn(
+                    INVOKEINTERFACE,
+                    "java/util/List",
+                    "get",
+                    "(I)Ljava/lang/Object;",
+                    true);
+            method.visitVarInsn(ASTORE, 5);
+            method.visitVarInsn(ALOAD, 2);
+            method.visitVarInsn(ILOAD, 3);
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "element", "(I)V", false);
+            Label nonNull = new Label();
+            Label next = new Label();
+            method.visitVarInsn(ALOAD, 5);
+            method.visitJumpInsn(IFNONNULL, nonNull);
+            if (schema.hasTrait(TraitKey.SPARSE_TRAIT)) {
+                method.visitVarInsn(ALOAD, 2);
+                method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeNull", "()V", false);
+            } else {
+                emitThrow(method, "Null value found in dense list");
+            }
+            method.visitJumpInsn(GOTO, next);
+            method.visitLabel(nonNull);
+            emitWriteTarget(method, schema.listMember(), 5, 2);
+            method.visitLabel(next);
+            method.visitIincInsn(3, 1);
+            method.visitJumpInsn(GOTO, loop);
+            method.visitLabel(done);
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "endArray", "()V", false);
+            method.visitInsn(RETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitListReader(Schema schema) {
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    aggregateReaderName(schema),
+                    "(L" + READER + ";)Ljava/util/List;",
+                    null,
+                    null);
+            method.visitCode();
+            method.visitInsn(ACONST_NULL);
+            method.visitVarInsn(ASTORE, 2);
+            method.visitInsn(ICONST_0);
+            method.visitVarInsn(ISTORE, 3);
+            for (int local = 5; local <= 8; local++) {
+                method.visitInsn(ACONST_NULL);
+                method.visitVarInsn(ASTORE, local);
+            }
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedBeginArray", "()Z", false);
+            Label done = new Label();
+            Label loop = new Label();
+            method.visitJumpInsn(IFEQ, done);
+            method.visitLabel(loop);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedTryReadNull", "()Z", false);
+            Label value = new Label();
+            Label decoded = new Label();
+            method.visitJumpInsn(IFEQ, value);
+            if (schema.hasTrait(TraitKey.SPARSE_TRAIT)) {
+                method.visitInsn(ACONST_NULL);
+            } else {
+                emitThrow(method, "Null value found in dense list");
+            }
+            method.visitJumpInsn(GOTO, decoded);
+            method.visitLabel(value);
+            emitReadTarget(method, schema.listMember(), 1);
+            method.visitLabel(decoded);
+            method.visitVarInsn(ASTORE, 4);
+
+            Label append = new Label();
+            Label added = new Label();
+            method.visitVarInsn(ALOAD, 2);
+            method.visitJumpInsn(IFNONNULL, append);
+            Label spill = new Label();
+            Label[] slots = {new Label(), new Label(), new Label(), new Label()};
+            method.visitVarInsn(ILOAD, 3);
+            method.visitLookupSwitchInsn(spill, new int[] {0, 1, 2, 3}, slots);
+            for (int i = 0; i < slots.length; i++) {
+                method.visitLabel(slots[i]);
+                method.visitVarInsn(ALOAD, 4);
+                method.visitVarInsn(ASTORE, 5 + i);
+                method.visitJumpInsn(GOTO, added);
+            }
+            method.visitLabel(spill);
+            emitNewArrayList(method, 8);
+            method.visitVarInsn(ASTORE, 2);
+            for (int local = 5; local <= 8; local++) {
+                emitArrayListAdd(method, 2, local);
+            }
+            emitArrayListAdd(method, 2, 4);
+            method.visitJumpInsn(GOTO, added);
+
+            method.visitLabel(append);
+            emitArrayListAdd(method, 2, 4);
+            method.visitLabel(added);
+            method.visitIincInsn(3, 1);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedArrayHasNext", "()Z", false);
+            method.visitJumpInsn(IFNE, loop);
+            method.visitLabel(done);
+
+            Label result = new Label();
+            method.visitVarInsn(ALOAD, 2);
+            method.visitJumpInsn(IFNONNULL, result);
+            method.visitTypeInsn(NEW, "java/util/ArrayList");
+            method.visitInsn(DUP);
+            method.visitVarInsn(ILOAD, 3);
+            method.visitMethodInsn(
+                    INVOKESPECIAL,
+                    "java/util/ArrayList",
+                    "<init>",
+                    "(I)V",
+                    false);
+            method.visitVarInsn(ASTORE, 2);
+            Label impossible = new Label();
+            Label[] sizes = {new Label(), new Label(), new Label(), new Label(), new Label()};
+            method.visitVarInsn(ILOAD, 3);
+            method.visitLookupSwitchInsn(impossible, new int[] {0, 1, 2, 3, 4}, sizes);
+            for (int size = 0; size < sizes.length; size++) {
+                method.visitLabel(sizes[size]);
+                for (int local = 5; local < 5 + size; local++) {
+                    emitArrayListAdd(method, 2, local);
+                }
+                method.visitJumpInsn(GOTO, result);
+            }
+            method.visitLabel(impossible);
+            emitThrow(method, "Invalid staged list size");
+            method.visitLabel(result);
+            method.visitVarInsn(ALOAD, 2);
+            method.visitInsn(ARETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private static void emitNewArrayList(MethodVisitor method, int capacity) {
+            method.visitTypeInsn(NEW, "java/util/ArrayList");
+            method.visitInsn(DUP);
+            method.visitLdcInsn(capacity);
+            method.visitMethodInsn(
+                    INVOKESPECIAL,
+                    "java/util/ArrayList",
+                    "<init>",
+                    "(I)V",
+                    false);
+        }
+
+        private static void emitArrayListAdd(
+                MethodVisitor method,
+                int listLocal,
+                int valueLocal
+        ) {
+            method.visitVarInsn(ALOAD, listLocal);
+            method.visitVarInsn(ALOAD, valueLocal);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    "java/util/ArrayList",
+                    "add",
+                    "(Ljava/lang/Object;)Z",
+                    false);
+            method.visitInsn(POP);
+        }
+
+        private void emitMapWriter(Schema schema) {
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    aggregateWriterName(schema),
+                    "(Ljava/util/Map;L" + WRITER + ";)V",
+                    null,
+                    null);
+            method.visitCode();
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "beginObject", "()V", false);
+            Schema target = schema.isMember() ? schema.memberTarget() : schema;
+            method.visitVarInsn(ALOAD, 1);
+            method.visitTypeInsn(NEW, MAP_CONSUMER);
+            method.visitInsn(DUP);
+            method.visitVarInsn(ALOAD, 0);
+            method.visitVarInsn(ALOAD, 2);
+            method.visitLdcInsn(aggregateIds.get(target.id()));
+            method.visitInsn(schema.hasTrait(TraitKey.SPARSE_TRAIT) ? ICONST_1 : ICONST_0);
+            method.visitMethodInsn(
+                    INVOKESPECIAL,
+                    MAP_CONSUMER,
+                    "<init>",
+                    "(L" + CODEC + ";L" + WRITER + ";IZ)V",
+                    false);
+            method.visitMethodInsn(
+                    INVOKEINTERFACE,
+                    "java/util/Map",
+                    "forEach",
+                    "(Ljava/util/function/BiConsumer;)V",
+                    true);
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "endObject", "()V", false);
+            method.visitInsn(RETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitWriteMapValueDispatch() {
+            List<Schema> maps = new ArrayList<>();
+            for (Schema aggregate : orderedAggregates) {
+                if (aggregate.type() == ShapeType.MAP) {
+                    maps.add(aggregate);
+                }
+            }
+            if (maps.isEmpty()) {
+                return;
+            }
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PUBLIC,
+                    "writeMapValue",
+                    "(ILjava/lang/Object;L" + WRITER + ";)V",
+                    null,
+                    null);
+            method.visitCode();
+            int[] keys = new int[maps.size()];
+            Label[] labels = new Label[maps.size()];
+            for (int i = 0; i < maps.size(); i++) {
+                keys[i] = aggregateIds.get(maps.get(i).id());
+                labels[i] = new Label();
+            }
+            Label unknown = new Label();
+            method.visitVarInsn(ILOAD, 1);
+            method.visitLookupSwitchInsn(unknown, keys, labels);
+            for (int i = 0; i < maps.size(); i++) {
+                method.visitLabel(labels[i]);
+                emitWriteTarget(method, maps.get(i).mapValueMember(), 2, 3);
+                method.visitInsn(RETURN);
+            }
+            method.visitLabel(unknown);
+            emitThrow(method, "Unknown map aggregate id");
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitMapReader(Schema schema) {
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    aggregateReaderName(schema),
+                    "(L" + READER + ";)Ljava/util/Map;",
+                    null,
+                    null);
+            method.visitCode();
+            method.visitTypeInsn(NEW, "java/util/LinkedHashMap");
+            method.visitInsn(DUP);
+            method.visitMethodInsn(INVOKESPECIAL, "java/util/LinkedHashMap", "<init>", "()V", false);
+            method.visitVarInsn(ASTORE, 2);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedBeginObject", "()Z", false);
+            Label done = new Label();
+            Label loop = new Label();
+            method.visitJumpInsn(IFEQ, done);
+            method.visitLabel(loop);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    READER,
+                    "generatedReadMapKey",
+                    "()Ljava/lang/String;",
+                    false);
+            method.visitVarInsn(ASTORE, 3);
+            method.visitVarInsn(ALOAD, 2);
+            method.visitVarInsn(ALOAD, 3);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedTryReadNull", "()Z", false);
+            Label value = new Label();
+            Label put = new Label();
+            method.visitJumpInsn(IFEQ, value);
+            if (schema.hasTrait(TraitKey.SPARSE_TRAIT)) {
+                method.visitInsn(ACONST_NULL);
+            } else {
+                emitThrow(method, "Null value found in dense map");
+            }
+            method.visitJumpInsn(GOTO, put);
+            method.visitLabel(value);
+            emitReadTarget(method, schema.mapValueMember(), 1);
+            method.visitLabel(put);
+            method.visitMethodInsn(
+                    INVOKEINTERFACE,
+                    "java/util/Map",
+                    "put",
+                    "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                    true);
+            method.visitInsn(POP);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedObjectHasNext", "()Z", false);
+            method.visitJumpInsn(IFNE, loop);
+            method.visitLabel(done);
+            method.visitVarInsn(ALOAD, 2);
+            method.visitInsn(ARETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private static void emitUtf8(MethodVisitor method, String value) {
+            method.visitLdcInsn(value);
+            method.visitFieldInsn(
+                    GETSTATIC,
+                    Type.getInternalName(StandardCharsets.class),
+                    "UTF_8",
+                    "Ljava/nio/charset/Charset;");
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    "java/lang/String",
+                    "getBytes",
+                    "(Ljava/nio/charset/Charset;)[B",
+                    false);
+        }
+
+        private void emitWriteEntry() {
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PUBLIC,
+                    "write",
+                    "(L" + SERIALIZABLE_SHAPE + ";L" + WRITER + ";)V",
+                    null,
+                    null);
+            method.visitCode();
+            RuntimeCodecPlan.StructPlan root = plan.rootStructure();
+            if (root.union()) {
+                Label supported = new Label();
+                method.visitVarInsn(ALOAD, 1);
+                method.visitTypeInsn(INSTANCEOF, Type.getInternalName(findUnknownUnionClass(root.shapeClass())));
+                method.visitJumpInsn(IFEQ, supported);
+                emitThrow(method, "Unsupported or unknown union variant for " + root.schema().id());
+                method.visitLabel(supported);
+            }
+            method.visitVarInsn(ALOAD, 0);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitTypeInsn(CHECKCAST, Type.getInternalName(root.shapeClass()));
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(
+                    INVOKESPECIAL,
+                    className,
+                    writerName(root),
+                    writerDescriptor(root),
+                    false);
+            method.visitInsn(RETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitReadEntry() {
+            RuntimeCodecPlan.StructPlan root = plan.rootStructure();
+            String builderName = Type.getInternalName(root.builderClass());
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PUBLIC,
+                    "readInto",
+                    "([BIIL" + SHAPE_BUILDER + ";L" + SETTINGS + ";)V",
+                    null,
+                    null);
+            method.visitCode();
+            method.visitTypeInsn(NEW, READER);
+            method.visitInsn(DUP);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitVarInsn(ILOAD, 2);
+            method.visitVarInsn(ILOAD, 3);
+            method.visitVarInsn(ALOAD, 5);
+            method.visitMethodInsn(
+                    INVOKESPECIAL,
+                    READER,
+                    "<init>",
+                    "([BIIL" + SETTINGS + ";)V",
+                    false);
+            method.visitVarInsn(ASTORE, 6);
+
+            Label start = new Label();
+            Label end = new Label();
+            Label handler = new Label();
+            method.visitTryCatchBlock(start, end, handler, "java/lang/Throwable");
+            method.visitLabel(start);
+            Label empty = new Label();
+            method.visitVarInsn(ALOAD, 6);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedAtEnd", "()Z", false);
+            method.visitJumpInsn(IFNE, empty);
+            method.visitVarInsn(ALOAD, 0);
+            method.visitVarInsn(ALOAD, 6);
+            method.visitVarInsn(ALOAD, 4);
+            method.visitTypeInsn(CHECKCAST, builderName);
+            method.visitMethodInsn(
+                    INVOKESPECIAL,
+                    className,
+                    readerName(root),
+                    readerDescriptor(root),
+                    false);
+            method.visitLabel(empty);
+            method.visitVarInsn(ALOAD, 6);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "close", "()V", false);
+            method.visitLabel(end);
+            method.visitInsn(RETURN);
+            method.visitLabel(handler);
+            method.visitVarInsn(ASTORE, 7);
+            method.visitVarInsn(ALOAD, 6);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedAbort", "()V", false);
+            method.visitVarInsn(ALOAD, 7);
+            method.visitInsn(ATHROW);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitScanEntry() {
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PUBLIC,
+                    "scan",
+                    "([BL" + SETTINGS + ";)I",
+                    null,
+                    null);
+            method.visitCode();
+            method.visitTypeInsn(NEW, READER);
+            method.visitInsn(DUP);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitInsn(ICONST_0);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitInsn(ARRAYLENGTH);
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(
+                    INVOKESPECIAL,
+                    READER,
+                    "<init>",
+                    "([BIIL" + SETTINGS + ";)V",
+                    false);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedScan", "()I", false);
+            method.visitInsn(IRETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitWriter(RuntimeCodecPlan.StructPlan structure) {
+            if (structure.union()) {
+                emitUnionWriter(structure);
+                return;
+            }
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    writerName(structure),
+                    writerDescriptor(structure),
+                    null,
+                    null);
+            method.visitCode();
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "beginObject", "()V", false);
+            method.visitInsn(ICONST_0);
+            method.visitVarInsn(ISTORE, 3);
+            List<RuntimeCodecPlan.MemberPlan> members = structure.members();
+            List<RuntimeCodecPlan.MethodRange> chunks = structure.writerChunks();
+            for (int chunk = 0; chunk < chunks.size(); chunk++) {
+                method.visitVarInsn(ALOAD, 0);
+                method.visitVarInsn(ALOAD, 1);
+                method.visitVarInsn(ALOAD, 2);
+                method.visitVarInsn(ILOAD, 3);
+                method.visitMethodInsn(
+                        INVOKESPECIAL,
+                        className,
+                        writerChunkName(structure, chunk),
+                        writerChunkDescriptor(structure),
+                        false);
+                method.visitVarInsn(ISTORE, 3);
+            }
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "endObject", "()V", false);
+            method.visitInsn(RETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+
+            for (int chunk = 0; chunk < chunks.size(); chunk++) {
+                RuntimeCodecPlan.MethodRange range = chunks.get(chunk);
+                MethodVisitor chunkMethod = writer.visitMethod(
+                        ACC_PRIVATE,
+                        writerChunkName(structure, chunk),
+                        writerChunkDescriptor(structure),
+                        null,
+                        null);
+                chunkMethod.visitCode();
+                for (int i = range.startInclusive(); i < range.endExclusive(); i++) {
+                    emitWriteMember(chunkMethod, members.get(i), 3, 4);
+                }
+                chunkMethod.visitVarInsn(ILOAD, 3);
+                chunkMethod.visitInsn(IRETURN);
+                chunkMethod.visitMaxs(0, 0);
+                chunkMethod.visitEnd();
+                methodCount++;
+            }
+        }
+
+        private void emitUnionWriter(RuntimeCodecPlan.StructPlan structure) {
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    writerName(structure),
+                    writerDescriptor(structure),
+                    null,
+                    null);
+            method.visitCode();
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "beginObject", "()V", false);
+            for (RuntimeCodecPlan.MemberPlan member : structure.members()) {
+                Label next = new Label();
+                method.visitVarInsn(ALOAD, 1);
+                method.visitTypeInsn(INSTANCEOF, Type.getInternalName(member.unionVariant()));
+                method.visitJumpInsn(IFEQ, next);
+                emitField(method, member, -1);
+                Method accessor = member.unionAccessor();
+                Class<?> valueType = accessor.getReturnType();
+                if (valueType.isPrimitive()) {
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitTypeInsn(CHECKCAST, Type.getInternalName(member.unionVariant()));
+                    invoke(method, accessor);
+                    emitWriteTargetOnStack(method, member.schema(), valueType);
+                } else {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitTypeInsn(CHECKCAST, Type.getInternalName(member.unionVariant()));
+                    invoke(method, accessor);
+                    method.visitVarInsn(ASTORE, 3);
+                    emitWriteTarget(method, member.schema(), 3, 2);
+                }
+                method.visitVarInsn(ALOAD, 2);
+                method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "endObject", "()V", false);
+                method.visitInsn(RETURN);
+                method.visitLabel(next);
+            }
+            method.visitVarInsn(ALOAD, 2);
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "endObject", "()V", false);
+            method.visitInsn(RETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitWriteMember(
+                MethodVisitor method,
+                RuntimeCodecPlan.MemberPlan member,
+                int indexLocal,
+                int valueLocal
+        ) {
+            Label skip = new Label();
+            Method presence = member.presence();
+            if (presence != null) {
+                method.visitVarInsn(ALOAD, 1);
+                invoke(method, presence);
+                method.visitJumpInsn(IFEQ, skip);
+            }
+
+            Class<?> returnType = member.getter().getReturnType();
+            if (!returnType.isPrimitive()) {
+                method.visitVarInsn(ALOAD, 1);
+                invoke(method, member.getter());
+                method.visitVarInsn(ASTORE, valueLocal);
+                method.visitVarInsn(ALOAD, valueLocal);
+                method.visitJumpInsn(IFNULL, skip);
+                if (member.target().type() == ShapeType.STRING) {
+                    emitStringField(method, member, indexLocal, valueLocal);
+                    method.visitLabel(skip);
+                    return;
+                }
+                emitField(method, member, indexLocal);
+                if (member.target().type() == ShapeType.STRUCTURE
+                        || member.target().type() == ShapeType.UNION) {
+                    RuntimeCodecPlan.StructPlan nested = structuresBySchema.get(member.target().id());
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, valueLocal);
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            writerName(nested),
+                            writerDescriptor(nested),
+                            false);
+                } else if (member.target().type() == ShapeType.LIST
+                        || member.target().type() == ShapeType.SET) {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, valueLocal);
+                    method.visitTypeInsn(CHECKCAST, "java/util/List");
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            aggregateWriterName(member.target()),
+                            "(Ljava/util/List;L" + WRITER + ";)V",
+                            false);
+                } else if (member.target().type() == ShapeType.MAP) {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, valueLocal);
+                    method.visitTypeInsn(CHECKCAST, "java/util/Map");
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            aggregateWriterName(member.target()),
+                            "(Ljava/util/Map;L" + WRITER + ";)V",
+                            false);
+                } else {
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitVarInsn(ALOAD, valueLocal);
+                    emitWriteValue(method, member, returnType);
+                }
+                method.visitLabel(skip);
+                return;
+            }
+            emitField(method, member, indexLocal);
+            method.visitVarInsn(ALOAD, 2);
+            method.visitVarInsn(ALOAD, 1);
+            invoke(method, member.getter());
+            emitWriteValue(method, member, returnType);
+            method.visitLabel(skip);
+        }
+
+        private void emitStringField(
+                MethodVisitor method,
+                RuntimeCodecPlan.MemberPlan member,
+                int indexLocal,
+                int valueLocal
+        ) {
+            method.visitVarInsn(ALOAD, 2);
+            method.visitFieldInsn(GETSTATIC, className, "W" + memberIds.get(member), "[B");
+            method.visitVarInsn(ILOAD, indexLocal);
+            method.visitVarInsn(ALOAD, valueLocal);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    WRITER,
+                    "fieldString",
+                    "([BILjava/lang/String;)V",
+                    false);
+            method.visitIincInsn(indexLocal, 1);
+        }
+
+        private void emitField(
+                MethodVisitor method,
+                RuntimeCodecPlan.MemberPlan member,
+                int indexLocal
+        ) {
+            method.visitVarInsn(ALOAD, 2);
+            method.visitFieldInsn(GETSTATIC, className, "W" + memberIds.get(member), "[B");
+            if (indexLocal < 0) {
+                method.visitInsn(ICONST_0);
+            } else {
+                method.visitVarInsn(ILOAD, indexLocal);
+            }
+            method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "field", "([BI)V", false);
+            if (indexLocal >= 0) {
+                method.visitIincInsn(indexLocal, 1);
+            }
+        }
+
+        private void emitWriteValue(
+                MethodVisitor method,
+                RuntimeCodecPlan.MemberPlan member,
+                Class<?> javaType
+        ) {
+            ShapeType type = member.target().type();
+            String descriptor;
+            switch (type) {
+                case BOOLEAN -> {
+                    unbox(method, javaType, Boolean.class, "booleanValue", "()Z");
+                    descriptor = "(Z)V";
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeBoolean", descriptor, false);
+                }
+                case BYTE -> {
+                    unbox(method, javaType, Byte.class, "byteValue", "()B");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeByte", "(B)V", false);
+                }
+                case SHORT -> {
+                    unbox(method, javaType, Short.class, "shortValue", "()S");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeShort", "(S)V", false);
+                }
+                case INTEGER -> {
+                    unbox(method, javaType, Integer.class, "intValue", "()I");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeInteger", "(I)V", false);
+                }
+                case LONG -> {
+                    unbox(method, javaType, Long.class, "longValue", "()J");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeLong", "(J)V", false);
+                }
+                case FLOAT -> {
+                    unbox(method, javaType, Float.class, "floatValue", "()F");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeFloat", "(F)V", false);
+                }
+                case DOUBLE -> {
+                    unbox(method, javaType, Double.class, "doubleValue", "()D");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeDouble", "(D)V", false);
+                }
+                case BIG_INTEGER -> method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        WRITER,
+                        "writeBigInteger",
+                        "(Ljava/math/BigInteger;)V",
+                        false);
+                case BIG_DECIMAL -> method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        WRITER,
+                        "writeBigDecimal",
+                        "(Ljava/math/BigDecimal;)V",
+                        false);
+                case STRING -> method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        WRITER,
+                        "writeString",
+                        "(Ljava/lang/String;)V",
+                        false);
+                case BLOB -> method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        WRITER,
+                        "writeBlob",
+                        "(L" + BYTE_BUFFER + ";)V",
+                        false);
+                case TIMESTAMP -> {
+                    method.visitLdcInsn(timestampFormat(member));
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            WRITER,
+                            "writeTimestamp",
+                            "(L" + Type.getInternalName(Instant.class) + ";I)V",
+                            false);
+                }
+                case DOCUMENT -> method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        WRITER,
+                        "writeDocument",
+                        "(L" + DOCUMENT + ";)V",
+                        false);
+                case ENUM -> {
+                    method.visitTypeInsn(CHECKCAST, SMITHY_ENUM);
+                    method.visitMethodInsn(
+                            INVOKEINTERFACE,
+                            SMITHY_ENUM,
+                            "getValue",
+                            "()Ljava/lang/String;",
+                            true);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            WRITER,
+                            "writeString",
+                            "(Ljava/lang/String;)V",
+                            false);
+                }
+                case INT_ENUM -> {
+                    method.visitTypeInsn(CHECKCAST, SMITHY_INT_ENUM);
+                    method.visitMethodInsn(INVOKEINTERFACE, SMITHY_INT_ENUM, "getValue", "()I", true);
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeInteger", "(I)V", false);
+                }
+                case LIST, SET, MAP, UNION -> throw new AssertionError("Aggregate writes are emitted by the caller");
+                case STRUCTURE -> throw new AssertionError("Structure writes are emitted by the caller");
+                // Unsupported types decline generation rather than reporting an emitter failure.
+                default -> throw new UnsupportedSchemaException(
+                        "JSON runtime codegen cannot write " + type + " at " + member.schema().id());
+            }
+        }
+
+        private static void unbox(
+                MethodVisitor method,
+                Class<?> actual,
+                Class<?> boxed,
+                String name,
+                String descriptor
+        ) {
+            if (!actual.isPrimitive()) {
+                method.visitTypeInsn(CHECKCAST, Type.getInternalName(boxed));
+                method.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(boxed), name, descriptor, false);
+            }
+        }
+
+        private void emitWriteTarget(
+                MethodVisitor method,
+                Schema schema,
+                int valueLocal,
+                int writerLocal
+        ) {
+            var target = schema.isMember() ? schema.memberTarget() : schema;
+            switch (target.type()) {
+                case STRUCTURE, UNION -> {
+                    RuntimeCodecPlan.StructPlan nested = structuresBySchema.get(target.id());
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, valueLocal);
+                    method.visitTypeInsn(CHECKCAST, Type.getInternalName(nested.shapeClass()));
+                    method.visitVarInsn(ALOAD, writerLocal);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            writerName(nested),
+                            writerDescriptor(nested),
+                            false);
+                }
+                case LIST, SET -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, valueLocal);
+                    method.visitTypeInsn(CHECKCAST, "java/util/List");
+                    method.visitVarInsn(ALOAD, writerLocal);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            aggregateWriterName(target),
+                            "(Ljava/util/List;L" + WRITER + ";)V",
+                            false);
+                }
+                case MAP -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, valueLocal);
+                    method.visitTypeInsn(CHECKCAST, "java/util/Map");
+                    method.visitVarInsn(ALOAD, writerLocal);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            aggregateWriterName(target),
+                            "(Ljava/util/Map;L" + WRITER + ";)V",
+                            false);
+                }
+                default -> {
+                    method.visitVarInsn(ALOAD, writerLocal);
+                    method.visitVarInsn(ALOAD, valueLocal);
+                    emitWriteTargetOnStack(method, schema, Object.class);
+                }
+            }
+        }
+
+        private void emitWriteTargetOnStack(
+                MethodVisitor method,
+                Schema schema,
+                Class<?> javaType
+        ) {
+            var target = schema.isMember() ? schema.memberTarget() : schema;
+            switch (target.type()) {
+                case BOOLEAN -> {
+                    castAndUnbox(method, javaType, Boolean.class, "booleanValue", "()Z");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeBoolean", "(Z)V", false);
+                }
+                case BYTE -> {
+                    castAndUnbox(method, javaType, Byte.class, "byteValue", "()B");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeByte", "(B)V", false);
+                }
+                case SHORT -> {
+                    castAndUnbox(method, javaType, Short.class, "shortValue", "()S");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeShort", "(S)V", false);
+                }
+                case INTEGER -> {
+                    castAndUnbox(method, javaType, Integer.class, "intValue", "()I");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeInteger", "(I)V", false);
+                }
+                case LONG -> {
+                    castAndUnbox(method, javaType, Long.class, "longValue", "()J");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeLong", "(J)V", false);
+                }
+                case FLOAT -> {
+                    castAndUnbox(method, javaType, Float.class, "floatValue", "()F");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeFloat", "(F)V", false);
+                }
+                case DOUBLE -> {
+                    castAndUnbox(method, javaType, Double.class, "doubleValue", "()D");
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeDouble", "(D)V", false);
+                }
+                case BIG_INTEGER -> {
+                    method.visitTypeInsn(CHECKCAST, "java/math/BigInteger");
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            WRITER,
+                            "writeBigInteger",
+                            "(Ljava/math/BigInteger;)V",
+                            false);
+                }
+                case BIG_DECIMAL -> {
+                    method.visitTypeInsn(CHECKCAST, "java/math/BigDecimal");
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            WRITER,
+                            "writeBigDecimal",
+                            "(Ljava/math/BigDecimal;)V",
+                            false);
+                }
+                case STRING -> {
+                    method.visitTypeInsn(CHECKCAST, "java/lang/String");
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            WRITER,
+                            "writeString",
+                            "(Ljava/lang/String;)V",
+                            false);
+                }
+                case ENUM -> {
+                    method.visitTypeInsn(CHECKCAST, SMITHY_ENUM);
+                    method.visitMethodInsn(
+                            INVOKEINTERFACE,
+                            SMITHY_ENUM,
+                            "getValue",
+                            "()Ljava/lang/String;",
+                            true);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            WRITER,
+                            "writeString",
+                            "(Ljava/lang/String;)V",
+                            false);
+                }
+                case BLOB -> {
+                    method.visitTypeInsn(CHECKCAST, BYTE_BUFFER);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            WRITER,
+                            "writeBlob",
+                            "(L" + BYTE_BUFFER + ";)V",
+                            false);
+                }
+                case TIMESTAMP -> {
+                    method.visitTypeInsn(CHECKCAST, Type.getInternalName(Instant.class));
+                    method.visitLdcInsn(timestampFormat(schema));
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            WRITER,
+                            "writeTimestamp",
+                            "(L" + Type.getInternalName(Instant.class) + ";I)V",
+                            false);
+                }
+                case DOCUMENT -> {
+                    method.visitTypeInsn(CHECKCAST, DOCUMENT);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            WRITER,
+                            "writeDocument",
+                            "(L" + DOCUMENT + ";)V",
+                            false);
+                }
+                case INT_ENUM -> {
+                    method.visitTypeInsn(CHECKCAST, SMITHY_INT_ENUM);
+                    method.visitMethodInsn(INVOKEINTERFACE, SMITHY_INT_ENUM, "getValue", "()I", true);
+                    method.visitMethodInsn(INVOKEVIRTUAL, WRITER, "writeInteger", "(I)V", false);
+                }
+                // Unsupported types decline generation rather than reporting an emitter failure.
+                default -> throw new UnsupportedSchemaException(
+                        "JSON runtime codegen cannot write " + target.type() + " at " + schema.id());
+            }
+        }
+
+        private static void castAndUnbox(
+                MethodVisitor method,
+                Class<?> actual,
+                Class<?> boxed,
+                String name,
+                String descriptor
+        ) {
+            if (!actual.isPrimitive()) {
+                method.visitTypeInsn(CHECKCAST, Type.getInternalName(boxed));
+                method.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(boxed), name, descriptor, false);
+            }
+        }
+
+        private void emitReader(RuntimeCodecPlan.StructPlan structure) {
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    readerName(structure),
+                    readerDescriptor(structure),
+                    null,
+                    null);
+            method.visitCode();
+            emitReaderBody(method, structure);
+            method.visitInsn(RETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitReaderBuckets(RuntimeCodecPlan.StructPlan structure) {
+            int buckets = readerBucketCount(structure);
+            if (buckets > 1) {
+                for (int bucket = 0; bucket < buckets; bucket++) {
+                    emitReaderBucket(structure, bucket, buckets);
+                }
+            }
+        }
+
+        private void emitReaderBody(MethodVisitor method, RuntimeCodecPlan.StructPlan structure) {
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedBeginObject", "()Z", false);
+            Label done = new Label();
+            method.visitJumpInsn(IFEQ, done);
+            Label loop = new Label();
+            if (canFuseOrderedObjectFraming(structure)) {
+                Label fallback = new Label();
+                RuntimeCodecPlan.MemberPlan first = structure.members().getFirst();
+                emitTryReadField(method, first, false);
+                method.visitJumpInsn(IFEQ, fallback);
+                emitReadMember(method, first);
+                for (int i = 1; i < structure.members().size(); i++) {
+                    RuntimeCodecPlan.MemberPlan member = structure.members().get(i);
+                    Label next = new Label();
+                    emitTryReadField(method, member, true);
+                    method.visitJumpInsn(IFEQ, next);
+                    emitReadMember(method, member);
+                    method.visitLabel(next);
+                }
+                method.visitVarInsn(ALOAD, 1);
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        "generatedObjectHasNext",
+                        "()Z",
+                        false);
+                method.visitJumpInsn(IFEQ, done);
+                method.visitLabel(fallback);
+            } else {
+                for (RuntimeCodecPlan.MemberPlan member : structure.members()) {
+                    Label next = new Label();
+                    emitTryReadField(method, member, false);
+                    method.visitJumpInsn(IFEQ, next);
+                    emitReadMember(method, member);
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedObjectHasNext",
+                            "()Z",
+                            false);
+                    method.visitJumpInsn(IFEQ, done);
+                    method.visitLabel(next);
+                }
+            }
+            method.visitLabel(loop);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedReadFieldHash", "()I", false);
+            method.visitVarInsn(ISTORE, 3);
+            int buckets = readerBucketCount(structure);
+            if (buckets == 1) {
+                emitReadDispatch(method, structure);
+            } else {
+                Label dispatched = new Label();
+                Label unknown = new Label();
+                Map<Integer, Integer> hashBuckets = new LinkedHashMap<>();
+                for (RuntimeCodecPlan.MemberPlan member : structure.members()) {
+                    int hash = fieldHash(wireName(member));
+                    hashBuckets.put(hash, Math.floorMod(hash, buckets));
+                }
+                List<Integer> hashes = hashBuckets.keySet().stream().sorted().toList();
+                int[] switchKeys = hashes.stream().mapToInt(Integer::intValue).toArray();
+                Label[] bucketLabels = new Label[buckets];
+                for (int bucket = 0; bucket < buckets; bucket++) {
+                    bucketLabels[bucket] = new Label();
+                }
+                Label[] switchLabels = new Label[hashes.size()];
+                for (int i = 0; i < hashes.size(); i++) {
+                    switchLabels[i] = bucketLabels[hashBuckets.get(hashes.get(i))];
+                }
+                method.visitVarInsn(ILOAD, 3);
+                method.visitLookupSwitchInsn(unknown, switchKeys, switchLabels);
+                for (int bucket = 0; bucket < buckets; bucket++) {
+                    method.visitLabel(bucketLabels[bucket]);
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitVarInsn(ILOAD, 3);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            readerBucketName(structure, bucket),
+                            readerBucketDescriptor(structure),
+                            false);
+                    method.visitJumpInsn(IFEQ, unknown);
+                    method.visitJumpInsn(GOTO, dispatched);
+                }
+                method.visitLabel(unknown);
+                emitUnknownField(method, structure);
+                method.visitLabel(dispatched);
+            }
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedObjectHasNext", "()Z", false);
+            method.visitJumpInsn(IFNE, loop);
+            method.visitLabel(done);
+        }
+
+        private void emitStructureValueReader(RuntimeCodecPlan.StructPlan structure) {
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    structureValueReaderName(structure),
+                    structureValueReaderDescriptor(structure),
+                    null,
+                    null);
+            method.visitCode();
+            invoke(method, structure.builderFactory());
+            method.visitVarInsn(ASTORE, 2);
+            emitReaderBody(method, structure);
+            method.visitVarInsn(ALOAD, 2);
+            invoke(method, findBuild(structure.builderClass(), structure.shapeClass()));
+            method.visitInsn(ARETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private boolean canFuseOrderedObjectFraming(RuntimeCodecPlan.StructPlan structure) {
+            return !structure.union()
+                    && !structure.members().isEmpty()
+                    && structure.members().getFirst().required();
+        }
+
+        // Scan the full object so null/discriminator fields are skipped and duplicate members fail.
+        private void emitUnionValueReader(RuntimeCodecPlan.StructPlan structure) {
+            String unionName = Type.getInternalName(structure.shapeClass());
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    unionValueReaderName(structure),
+                    "(L" + READER + ";)L" + unionName + ";",
+                    null,
+                    null);
+            method.visitCode();
+            method.visitInsn(ACONST_NULL);
+            method.visitVarInsn(ASTORE, 3);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedBeginObject", "()Z", false);
+            Label dispatch = new Label();
+            method.visitJumpInsn(IFNE, dispatch);
+            emitThrow(method, MISSING_UNION_MEMBER);
+
+            Label advance = new Label();
+            Label multiple = new Label();
+
+            method.visitLabel(dispatch);
+            for (RuntimeCodecPlan.MemberPlan member : structure.members()) {
+                Label next = new Label();
+                emitTryReadField(method, member);
+                method.visitJumpInsn(IFEQ, next);
+                emitUnionValue(method, member, advance, multiple);
+                method.visitLabel(next);
+            }
+
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedReadFieldHash", "()I", false);
+            method.visitVarInsn(ISTORE, 2);
+
+            Map<Integer, List<RuntimeCodecPlan.MemberPlan>> groups = new LinkedHashMap<>();
+            for (RuntimeCodecPlan.MemberPlan member : structure.members()) {
+                groups.computeIfAbsent(fieldHash(wireName(member)), ignored -> new ArrayList<>())
+                        .add(member);
+            }
+            List<Integer> keys = groups.keySet().stream().sorted().toList();
+            int[] switchKeys = keys.stream().mapToInt(Integer::intValue).toArray();
+            Label unknown = new Label();
+            Label[] labels = keys.stream().map(ignored -> new Label()).toArray(Label[]::new);
+            method.visitVarInsn(ILOAD, 2);
+            method.visitLookupSwitchInsn(unknown, switchKeys, labels);
+            for (int i = 0; i < keys.size(); i++) {
+                method.visitLabel(labels[i]);
+                for (RuntimeCodecPlan.MemberPlan member : groups.get(keys.get(i))) {
+                    Label next = new Label();
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitFieldInsn(GETSTATIC, className, "N" + memberIds.get(member), "[B");
+                    method.visitLdcInsn(wireName(member));
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedFieldEquals",
+                            "([BLjava/lang/String;)Z",
+                            false);
+                    method.visitJumpInsn(IFEQ, next);
+                    emitUnionValue(method, member, advance, multiple);
+                    method.visitLabel(next);
+                }
+                method.visitJumpInsn(GOTO, unknown);
+            }
+
+            method.visitLabel(unknown);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    READER,
+                    "generatedFieldName",
+                    "()Ljava/lang/String;",
+                    false);
+            method.visitVarInsn(ASTORE, 4);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedSkipValue", "()V", false);
+            emitTypeDiscriminatorEquals(method, 4);
+            method.visitJumpInsn(IFNE, advance);
+            if (forbidUnknownUnionMembers) {
+                emitThrow(method, "Unknown union member");
+            } else {
+                method.visitVarInsn(ALOAD, 3);
+                method.visitJumpInsn(IFNONNULL, multiple);
+                Class<?> unknownClass = findUnknownUnionClass(structure.shapeClass());
+                method.visitTypeInsn(NEW, Type.getInternalName(unknownClass));
+                method.visitInsn(DUP);
+                method.visitVarInsn(ALOAD, 4);
+                method.visitMethodInsn(
+                        INVOKESPECIAL,
+                        Type.getInternalName(unknownClass),
+                        "<init>",
+                        "(Ljava/lang/String;)V",
+                        false);
+                method.visitVarInsn(ASTORE, 3);
+                method.visitJumpInsn(GOTO, advance);
+            }
+
+            method.visitLabel(multiple);
+            emitThrow(method, "Union object contains multiple members");
+
+            method.visitLabel(advance);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedObjectHasNext", "()Z", false);
+            method.visitJumpInsn(IFNE, dispatch);
+            method.visitVarInsn(ALOAD, 3);
+            Label found = new Label();
+            method.visitJumpInsn(IFNONNULL, found);
+            emitThrow(method, MISSING_UNION_MEMBER);
+            method.visitLabel(found);
+            method.visitVarInsn(ALOAD, 3);
+            // The merged frame type is the variants' common superclass, so the verifier needs this cast.
+            method.visitTypeInsn(CHECKCAST, unionName);
+            method.visitInsn(ARETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitUnionValue(
+                MethodVisitor method,
+                RuntimeCodecPlan.MemberPlan member,
+                Label advance,
+                Label multiple
+        ) {
+            // Null-valued fields do not select a union member.
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedTryReadNull", "()Z", false);
+            method.visitJumpInsn(IFNE, advance);
+            method.visitVarInsn(ALOAD, 3);
+            method.visitJumpInsn(IFNONNULL, multiple);
+            String variant = Type.getInternalName(member.unionVariant());
+            method.visitTypeInsn(NEW, variant);
+            method.visitInsn(DUP);
+            emitReadTarget(method, member.schema(), 1);
+            Class<?> parameter = member.unionAccessor().getReturnType();
+            unboxIfPrimitive(method, parameter);
+            method.visitMethodInsn(
+                    INVOKESPECIAL,
+                    variant,
+                    "<init>",
+                    Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(parameter)),
+                    false);
+            method.visitVarInsn(ASTORE, 3);
+            method.visitJumpInsn(GOTO, advance);
+        }
+
+        private static void emitTypeDiscriminatorEquals(MethodVisitor method, int nameLocal) {
+            method.visitLdcInsn(TYPE_DISCRIMINATOR);
+            method.visitVarInsn(ALOAD, nameLocal);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    "java/lang/String",
+                    "equals",
+                    "(Ljava/lang/Object;)Z",
+                    false);
+        }
+
+        private static Class<?> findUnknownUnionClass(Class<?> unionClass) {
+            for (Class<?> nested : unionClass.getDeclaredClasses()) {
+                if (nested.getSimpleName().equals("$Unknown")) {
+                    return nested;
+                }
+            }
+            throw new UnsupportedSchemaException("No unknown union variant on " + unionClass.getName());
+        }
+
+        private static Method findUnknownMemberHook(Class<?> builderClass) {
+            try {
+                return builderClass.getMethod("$unknownMember", String.class);
+            } catch (NoSuchMethodException e) {
+                throw new UnsupportedSchemaException(
+                        "No unknown member hook on union builder " + builderClass.getName());
+            }
+        }
+
+        private static void unboxIfPrimitive(MethodVisitor method, Class<?> type) {
+            if (!type.isPrimitive()) {
+                return;
+            }
+            if (type == boolean.class) {
+                method.visitTypeInsn(CHECKCAST, "java/lang/Boolean");
+                method.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Boolean", "booleanValue", "()Z", false);
+            } else if (type == byte.class) {
+                method.visitTypeInsn(CHECKCAST, "java/lang/Byte");
+                method.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Byte", "byteValue", "()B", false);
+            } else if (type == short.class) {
+                method.visitTypeInsn(CHECKCAST, "java/lang/Short");
+                method.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Short", "shortValue", "()S", false);
+            } else if (type == int.class) {
+                method.visitTypeInsn(CHECKCAST, "java/lang/Integer");
+                method.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Integer", "intValue", "()I", false);
+            } else if (type == long.class) {
+                method.visitTypeInsn(CHECKCAST, "java/lang/Long");
+                method.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Long", "longValue", "()J", false);
+            } else if (type == float.class) {
+                method.visitTypeInsn(CHECKCAST, "java/lang/Float");
+                method.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Float", "floatValue", "()F", false);
+            } else if (type == double.class) {
+                method.visitTypeInsn(CHECKCAST, "java/lang/Double");
+                method.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Double", "doubleValue", "()D", false);
+            }
+        }
+
+        private void emitReadDispatch(MethodVisitor method, RuntimeCodecPlan.StructPlan structure) {
+            Map<Integer, List<RuntimeCodecPlan.MemberPlan>> groups = new LinkedHashMap<>();
+            for (RuntimeCodecPlan.MemberPlan member : structure.members()) {
+                groups.computeIfAbsent(fieldHash(wireName(member)), ignored -> new ArrayList<>())
+                        .add(member);
+            }
+            List<Integer> keys = groups.keySet().stream().sorted(Comparator.naturalOrder()).toList();
+            int[] switchKeys = keys.stream().mapToInt(Integer::intValue).toArray();
+            Label unknown = new Label();
+            Label after = new Label();
+            Label[] labels = keys.stream().map(ignored -> new Label()).toArray(Label[]::new);
+            method.visitVarInsn(ILOAD, 3);
+            method.visitLookupSwitchInsn(unknown, switchKeys, labels);
+            for (int i = 0; i < keys.size(); i++) {
+                method.visitLabel(labels[i]);
+                List<RuntimeCodecPlan.MemberPlan> collisions = groups.get(keys.get(i));
+                for (RuntimeCodecPlan.MemberPlan member : collisions) {
+                    Label next = new Label();
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitFieldInsn(GETSTATIC, className, "N" + memberIds.get(member), "[B");
+                    method.visitLdcInsn(wireName(member));
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedFieldEquals",
+                            "([BLjava/lang/String;)Z",
+                            false);
+                    method.visitJumpInsn(IFEQ, next);
+                    emitReadMember(method, member);
+                    method.visitJumpInsn(GOTO, after);
+                    method.visitLabel(next);
+                }
+                method.visitJumpInsn(GOTO, unknown);
+            }
+            method.visitLabel(unknown);
+            emitUnknownField(method, structure);
+            method.visitLabel(after);
+        }
+
+        // Unknown union fields must reach the builder hook; structures simply skip them.
+        private void emitUnknownField(MethodVisitor method, RuntimeCodecPlan.StructPlan structure) {
+            if (!structure.union()) {
+                method.visitVarInsn(ALOAD, 1);
+                method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedSkipValue", "()V", false);
+                return;
+            }
+            Method unknownMember = findUnknownMemberHook(structure.builderClass());
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    READER,
+                    "generatedFieldName",
+                    "()Ljava/lang/String;",
+                    false);
+            method.visitVarInsn(ASTORE, 4);
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedSkipValue", "()V", false);
+            Label done = new Label();
+            emitTypeDiscriminatorEquals(method, 4);
+            method.visitJumpInsn(IFNE, done);
+            if (forbidUnknownUnionMembers) {
+                emitThrow(method, "Unknown union member");
+            } else {
+                method.visitVarInsn(ALOAD, 2);
+                method.visitVarInsn(ALOAD, 4);
+                invoke(method, unknownMember);
+                if (unknownMember.getReturnType() != void.class) {
+                    method.visitInsn(POP);
+                }
+            }
+            method.visitLabel(done);
+        }
+
+        private void emitTryReadField(MethodVisitor method, RuntimeCodecPlan.MemberPlan member) {
+            emitTryReadField(method, member, false);
+        }
+
+        private void emitTryReadField(
+                MethodVisitor method,
+                RuntimeCodecPlan.MemberPlan member,
+                boolean afterValue
+        ) {
+            byte[] token = fieldToken(member);
+            method.visitVarInsn(ALOAD, 1);
+            if (token.length <= Long.BYTES) {
+                long mask = lowByteMask(token.length);
+                method.visitLdcInsn(packLittleEndian(token, 0, token.length) & mask);
+                method.visitLdcInsn(mask);
+                method.visitLdcInsn(token.length);
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        afterValue ? "generatedTryReadNextField8" : "generatedTryReadField8",
+                        "(JJI)Z",
+                        false);
+            } else if (token.length <= Long.BYTES * 2) {
+                int suffixLength = token.length - Long.BYTES;
+                long suffixMask = lowByteMask(suffixLength);
+                method.visitLdcInsn(packLittleEndian(token, 0, Long.BYTES));
+                method.visitLdcInsn(packLittleEndian(token, Long.BYTES, suffixLength) & suffixMask);
+                method.visitLdcInsn(suffixMask);
+                method.visitLdcInsn(token.length);
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        afterValue ? "generatedTryReadNextField16" : "generatedTryReadField16",
+                        "(JJJI)Z",
+                        false);
+            } else {
+                method.visitFieldInsn(GETSTATIC, className, "W" + memberIds.get(member), "[B");
+                method.visitMethodInsn(
+                        INVOKEVIRTUAL,
+                        READER,
+                        afterValue ? "generatedTryReadNextField" : "generatedTryReadField",
+                        "([B)Z",
+                        false);
+            }
+        }
+
+        private byte[] fieldToken(RuntimeCodecPlan.MemberPlan member) {
+            var extension = member.schema().getExtension(SmithyJsonSchemaExtensions.KEY);
+            return useJsonName ? extension.jsonNameBytes() : extension.memberNameBytes();
+        }
+
+        private static long packLittleEndian(byte[] value, int offset, int length) {
+            long packed = 0;
+            for (int i = 0; i < length; i++) {
+                packed |= (long) (value[offset + i] & 0xFF) << (i << 3);
+            }
+            return packed;
+        }
+
+        private static long lowByteMask(int length) {
+            return length == Long.BYTES ? -1L : (1L << (length << 3)) - 1;
+        }
+
+        private void emitReaderBucket(
+                RuntimeCodecPlan.StructPlan structure,
+                int bucket,
+                int bucketCount
+        ) {
+            List<RuntimeCodecPlan.MemberPlan> members = structure.members()
+                    .stream()
+                    .filter(member -> Math.floorMod(fieldHash(wireName(member)), bucketCount) == bucket)
+                    .toList();
+            MethodVisitor method = writer.visitMethod(
+                    ACC_PRIVATE,
+                    readerBucketName(structure, bucket),
+                    readerBucketDescriptor(structure),
+                    null,
+                    null);
+            method.visitCode();
+            Map<Integer, List<RuntimeCodecPlan.MemberPlan>> groups = new LinkedHashMap<>();
+            for (RuntimeCodecPlan.MemberPlan member : members) {
+                groups.computeIfAbsent(fieldHash(wireName(member)), ignored -> new ArrayList<>())
+                        .add(member);
+            }
+            List<Integer> keys = groups.keySet().stream().sorted(Comparator.naturalOrder()).toList();
+            int[] switchKeys = keys.stream().mapToInt(Integer::intValue).toArray();
+            Label unknown = new Label();
+            Label[] labels = keys.stream().map(ignored -> new Label()).toArray(Label[]::new);
+            method.visitVarInsn(ILOAD, 3);
+            method.visitLookupSwitchInsn(unknown, switchKeys, labels);
+            for (int i = 0; i < keys.size(); i++) {
+                method.visitLabel(labels[i]);
+                for (RuntimeCodecPlan.MemberPlan member : groups.get(keys.get(i))) {
+                    Label next = new Label();
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitFieldInsn(GETSTATIC, className, "N" + memberIds.get(member), "[B");
+                    method.visitLdcInsn(wireName(member));
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedFieldEquals",
+                            "([BLjava/lang/String;)Z",
+                            false);
+                    method.visitJumpInsn(IFEQ, next);
+                    emitReadMember(method, member);
+                    method.visitInsn(ICONST_1);
+                    method.visitInsn(IRETURN);
+                    method.visitLabel(next);
+                }
+                method.visitJumpInsn(GOTO, unknown);
+            }
+            method.visitLabel(unknown);
+            method.visitInsn(ICONST_0);
+            method.visitInsn(IRETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitReadMember(MethodVisitor method, RuntimeCodecPlan.MemberPlan member) {
+            Class<?> parameter = member.setter().getParameterTypes()[0];
+            Label skip = new Label();
+            // Null leaves errorCorrection() to supply defaults, including for primitive setters.
+            method.visitVarInsn(ALOAD, 1);
+            method.visitMethodInsn(INVOKEVIRTUAL, READER, "generatedTryReadNull", "()Z", false);
+            method.visitJumpInsn(IFNE, skip);
+            method.visitVarInsn(ALOAD, 2);
+            emitReadValue(method, member, parameter);
+            invoke(method, member.setter());
+            if (member.setter().getReturnType() != void.class) {
+                method.visitInsn(POP);
+            }
+            method.visitLabel(skip);
+        }
+
+        private void emitReadValue(
+                MethodVisitor method,
+                RuntimeCodecPlan.MemberPlan member,
+                Class<?> parameter
+        ) {
+            ShapeType type = member.target().type();
+            switch (type) {
+                case BOOLEAN -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadBoolean",
+                            "()Z",
+                            false);
+                    box(method, parameter, Boolean.class, "(Z)Ljava/lang/Boolean;");
+                }
+                case BYTE -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadByte",
+                            "()B",
+                            false);
+                    box(method, parameter, Byte.class, "(B)Ljava/lang/Byte;");
+                }
+                case SHORT -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadShort",
+                            "()S",
+                            false);
+                    box(method, parameter, Short.class, "(S)Ljava/lang/Short;");
+                }
+                case INTEGER -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadInteger",
+                            "()I",
+                            false);
+                    box(method, parameter, Integer.class, "(I)Ljava/lang/Integer;");
+                }
+                case LONG -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadLong",
+                            "()J",
+                            false);
+                    box(method, parameter, Long.class, "(J)Ljava/lang/Long;");
+                }
+                case FLOAT -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadFloat",
+                            "()F",
+                            false);
+                    box(method, parameter, Float.class, "(F)Ljava/lang/Float;");
+                }
+                case DOUBLE -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadDouble",
+                            "()D",
+                            false);
+                    box(method, parameter, Double.class, "(D)Ljava/lang/Double;");
+                }
+                case BIG_INTEGER -> readObject(method, "readBigInteger", "Ljava/math/BigInteger;");
+                case BIG_DECIMAL -> readObject(method, "readBigDecimal", "Ljava/math/BigDecimal;");
+                case STRING -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadString",
+                            "()Ljava/lang/String;",
+                            false);
+                }
+                case ENUM -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            enumReaderName(member.target().shapeClass()),
+                            "(L" + READER + ";)L" + Type.getInternalName(member.target().shapeClass()) + ";",
+                            false);
+                }
+                case INT_ENUM -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            intEnumReaderName(member.target().shapeClass()),
+                            "(L" + READER + ";)L" + Type.getInternalName(member.target().shapeClass()) + ";",
+                            false);
+                }
+                case BLOB -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadBlob",
+                            "()L" + BYTE_BUFFER + ";",
+                            false);
+                }
+                case TIMESTAMP -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            timestampReader(member.schema()),
+                            "()L" + Type.getInternalName(Instant.class) + ";",
+                            false);
+                }
+                case DOCUMENT -> {
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "readDocument",
+                            "()L" + DOCUMENT + ";",
+                            false);
+                }
+                case STRUCTURE -> emitReadStructure(method, member);
+                case UNION -> {
+                    RuntimeCodecPlan.StructPlan nested = structuresBySchema.get(member.target().id());
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            unionValueReaderName(nested),
+                            "(L" + READER + ";)L" + Type.getInternalName(nested.shapeClass()) + ";",
+                            false);
+                }
+                case LIST, SET -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            aggregateReaderName(member.target()),
+                            "(L" + READER + ";)Ljava/util/List;",
+                            false);
+                }
+                case MAP -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, 1);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            aggregateReaderName(member.target()),
+                            "(L" + READER + ";)Ljava/util/Map;",
+                            false);
+                }
+                default -> throw new UnsupportedSchemaException(
+                        "JSON runtime codegen cannot read " + type + " at " + member.schema().id());
+            }
+        }
+
+        private void emitReadTarget(
+                MethodVisitor method,
+                Schema schema,
+                int readerLocal
+        ) {
+            var target = schema.isMember() ? schema.memberTarget() : schema;
+            switch (target.type()) {
+                case BOOLEAN -> {
+                    readGeneratedPrimitive(method, readerLocal, "generatedReadBoolean", "Z");
+                    method.visitMethodInsn(
+                            INVOKESTATIC,
+                            "java/lang/Boolean",
+                            "valueOf",
+                            "(Z)Ljava/lang/Boolean;",
+                            false);
+                }
+                case BYTE -> {
+                    readGeneratedPrimitive(method, readerLocal, "generatedReadByte", "B");
+                    method.visitMethodInsn(
+                            INVOKESTATIC,
+                            "java/lang/Byte",
+                            "valueOf",
+                            "(B)Ljava/lang/Byte;",
+                            false);
+                }
+                case SHORT -> {
+                    readGeneratedPrimitive(method, readerLocal, "generatedReadShort", "S");
+                    method.visitMethodInsn(
+                            INVOKESTATIC,
+                            "java/lang/Short",
+                            "valueOf",
+                            "(S)Ljava/lang/Short;",
+                            false);
+                }
+                case INTEGER -> {
+                    readGeneratedPrimitive(method, readerLocal, "generatedReadInteger", "I");
+                    method.visitMethodInsn(
+                            INVOKESTATIC,
+                            "java/lang/Integer",
+                            "valueOf",
+                            "(I)Ljava/lang/Integer;",
+                            false);
+                }
+                case LONG -> {
+                    readGeneratedPrimitive(method, readerLocal, "generatedReadLong", "J");
+                    method.visitMethodInsn(
+                            INVOKESTATIC,
+                            "java/lang/Long",
+                            "valueOf",
+                            "(J)Ljava/lang/Long;",
+                            false);
+                }
+                case FLOAT -> {
+                    readGeneratedPrimitive(method, readerLocal, "generatedReadFloat", "F");
+                    method.visitMethodInsn(
+                            INVOKESTATIC,
+                            "java/lang/Float",
+                            "valueOf",
+                            "(F)Ljava/lang/Float;",
+                            false);
+                }
+                case DOUBLE -> {
+                    readGeneratedPrimitive(method, readerLocal, "generatedReadDouble", "D");
+                    method.visitMethodInsn(
+                            INVOKESTATIC,
+                            "java/lang/Double",
+                            "valueOf",
+                            "(D)Ljava/lang/Double;",
+                            false);
+                }
+                case BIG_INTEGER -> readObject(method, readerLocal, "readBigInteger", "Ljava/math/BigInteger;");
+                case BIG_DECIMAL -> readObject(method, readerLocal, "readBigDecimal", "Ljava/math/BigDecimal;");
+                case STRING -> {
+                    method.visitVarInsn(ALOAD, readerLocal);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadString",
+                            "()Ljava/lang/String;",
+                            false);
+                }
+                case ENUM -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, readerLocal);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            enumReaderName(target.shapeClass()),
+                            "(L" + READER + ";)L" + Type.getInternalName(target.shapeClass()) + ";",
+                            false);
+                }
+                case INT_ENUM -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, readerLocal);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            intEnumReaderName(target.shapeClass()),
+                            "(L" + READER + ";)L" + Type.getInternalName(target.shapeClass()) + ";",
+                            false);
+                }
+                case BLOB -> {
+                    method.visitVarInsn(ALOAD, readerLocal);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "generatedReadBlob",
+                            "()L" + BYTE_BUFFER + ";",
+                            false);
+                }
+                case TIMESTAMP -> {
+                    method.visitVarInsn(ALOAD, readerLocal);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            timestampReader(schema),
+                            "()L" + Type.getInternalName(Instant.class) + ";",
+                            false);
+                }
+                case DOCUMENT -> {
+                    method.visitVarInsn(ALOAD, readerLocal);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            READER,
+                            "readDocument",
+                            "()L" + DOCUMENT + ";",
+                            false);
+                }
+                case LIST, SET -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, readerLocal);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            aggregateReaderName(target),
+                            "(L" + READER + ";)Ljava/util/List;",
+                            false);
+                }
+                case MAP -> {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, readerLocal);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            aggregateReaderName(target),
+                            "(L" + READER + ";)Ljava/util/Map;",
+                            false);
+                }
+                case STRUCTURE -> emitReadStructureValue(method, target, readerLocal);
+                case UNION -> {
+                    RuntimeCodecPlan.StructPlan nested = structuresBySchema.get(target.id());
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, readerLocal);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            unionValueReaderName(nested),
+                            "(L" + READER + ";)L" + Type.getInternalName(nested.shapeClass()) + ";",
+                            false);
+                }
+                default -> throw new UnsupportedSchemaException(
+                        "JSON runtime codegen cannot read " + target.type() + " at " + schema.id());
+            }
+        }
+
+        private void readGeneratedPrimitive(
+                MethodVisitor method,
+                int readerLocal,
+                String name,
+                String returnDescriptor
+        ) {
+            method.visitVarInsn(ALOAD, readerLocal);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    READER,
+                    name,
+                    "()" + returnDescriptor,
+                    false);
+        }
+
+        private void readObject(
+                MethodVisitor method,
+                int readerLocal,
+                String name,
+                String returnDescriptor
+        ) {
+            method.visitVarInsn(ALOAD, readerLocal);
+            method.visitInsn(ACONST_NULL);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    READER,
+                    name,
+                    "(Lsoftware/amazon/smithy/java/core/schema/Schema;)" + returnDescriptor,
+                    false);
+        }
+
+        private void readObject(MethodVisitor method, String name, String returnDescriptor) {
+            method.visitVarInsn(ALOAD, 1);
+            method.visitInsn(ACONST_NULL);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    READER,
+                    name,
+                    "(Lsoftware/amazon/smithy/java/core/schema/Schema;)" + returnDescriptor,
+                    false);
+        }
+
+        private void emitReadStructure(MethodVisitor method, RuntimeCodecPlan.MemberPlan member) {
+            emitReadStructureValue(method, member.target(), 1);
+        }
+
+        private void emitReadStructureValue(
+                MethodVisitor method,
+                Schema schema,
+                int readerLocal
+        ) {
+            Schema target = schema.isMember() ? schema.memberTarget() : schema;
+            RuntimeCodecPlan.StructPlan nested = structuresBySchema.get(target.id());
+            method.visitVarInsn(ALOAD, 0);
+            method.visitVarInsn(ALOAD, readerLocal);
+            if (nested.union()) {
+                method.visitMethodInsn(
+                        INVOKESPECIAL,
+                        className,
+                        unionValueReaderName(nested),
+                        "(L" + READER + ";)L" + Type.getInternalName(nested.shapeClass()) + ";",
+                        false);
+                return;
+            }
+            method.visitMethodInsn(
+                    INVOKESPECIAL,
+                    className,
+                    structureValueReaderName(nested),
+                    structureValueReaderDescriptor(nested),
+                    false);
+        }
+
+        private static void box(
+                MethodVisitor method,
+                Class<?> parameter,
+                Class<?> boxed,
+                String descriptor
+        ) {
+            if (!parameter.isPrimitive()) {
+                method.visitMethodInsn(
+                        INVOKESTATIC,
+                        Type.getInternalName(boxed),
+                        "valueOf",
+                        descriptor,
+                        false);
+            }
+        }
+
+        private String writerName(RuntimeCodecPlan.StructPlan structure) {
+            return "writeS" + structureIds.get(structure);
+        }
+
+        private String writerChunkName(RuntimeCodecPlan.StructPlan structure, int chunk) {
+            return writerName(structure) + "C" + chunk;
+        }
+
+        private static String writerDescriptor(RuntimeCodecPlan.StructPlan structure) {
+            return "(L" + Type.getInternalName(structure.shapeClass()) + ";L" + WRITER + ";)V";
+        }
+
+        private static String writerChunkDescriptor(RuntimeCodecPlan.StructPlan structure) {
+            return "(L" + Type.getInternalName(structure.shapeClass()) + ";L" + WRITER + ";I)I";
+        }
+
+        private String readerName(RuntimeCodecPlan.StructPlan structure) {
+            return "readS" + structureIds.get(structure);
+        }
+
+        private String readerBucketName(RuntimeCodecPlan.StructPlan structure, int bucket) {
+            return readerName(structure) + "B" + bucket;
+        }
+
+        private String unionValueReaderName(RuntimeCodecPlan.StructPlan structure) {
+            return "readU" + structureIds.get(structure);
+        }
+
+        private String structureValueReaderName(RuntimeCodecPlan.StructPlan structure) {
+            return "readV" + structureIds.get(structure);
+        }
+
+        private String aggregateWriterName(Schema schema) {
+            Schema target = schema.isMember() ? schema.memberTarget() : schema;
+            return "writeA" + aggregateIds.get(target.id());
+        }
+
+        private String aggregateReaderName(Schema schema) {
+            Schema target = schema.isMember() ? schema.memberTarget() : schema;
+            return "readA" + aggregateIds.get(target.id());
+        }
+
+        private String enumReaderName(Class<?> enumClass) {
+            return "readE" + enumIds.get(enumClass);
+        }
+
+        private String intEnumReaderName(Class<?> enumClass) {
+            return "readI" + intEnumIds.get(enumClass);
+        }
+
+        private static String readerDescriptor(RuntimeCodecPlan.StructPlan structure) {
+            return "(L" + READER + ";L" + Type.getInternalName(structure.builderClass()) + ";)V";
+        }
+
+        private static String readerBucketDescriptor(RuntimeCodecPlan.StructPlan structure) {
+            return "(L" + READER + ";L" + Type.getInternalName(structure.builderClass()) + ";I)Z";
+        }
+
+        private static String structureValueReaderDescriptor(RuntimeCodecPlan.StructPlan structure) {
+            return "(L" + READER + ";)L" + Type.getInternalName(structure.shapeClass()) + ";";
+        }
+
+        private String wireName(RuntimeCodecPlan.MemberPlan member) {
+            if (useJsonName) {
+                var trait = member.schema().getTrait(TraitKey.JSON_NAME_TRAIT);
+                if (trait != null) {
+                    return trait.getValue();
+                }
+            }
+            return member.memberName();
+        }
+
+        private static int readerBucketCount(RuntimeCodecPlan.StructPlan structure) {
+            return structure.readerBuckets();
+        }
+
+        private int timestampFormat(RuntimeCodecPlan.MemberPlan member) {
+            return timestampFormat(member.schema());
+        }
+
+        private String timestampReader(Schema schema) {
+            return switch (timestampFormat(schema)) {
+                case 1 -> "generatedReadDateTimeTimestamp";
+                case 2 -> "generatedReadHttpDateTimestamp";
+                default -> "generatedReadEpochTimestamp";
+            };
+        }
+
+        private int timestampFormat(Schema schema) {
+            TimestampFormatter formatter = settings.timestampResolver().resolve(schema);
+            return switch (formatter.format()) {
+                case DATE_TIME -> 1;
+                case HTTP_DATE -> 2;
+                default -> 0;
+            };
+        }
+
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonWriteUtils.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/JsonWriteUtils.java
@@ -112,7 +112,7 @@ final class JsonWriteUtils {
         return p;
     }
 
-    private static int writeQuotedAscii(byte[] buf, int pos, byte[] latin1) {
+    static int writeQuotedAscii(byte[] buf, int pos, byte[] latin1) {
         int copied = copyJsonAscii(latin1, buf, pos + 1);
         if (copied < 0) {
             return -1;
@@ -326,13 +326,6 @@ final class JsonWriteUtils {
      */
     static int maxQuotedStringBytes(String value) {
         return value.length() * 6 + 2;
-    }
-
-    /**
-     * Returns the maximum number of bytes needed for a base64-encoded string.
-     */
-    static int maxBase64Bytes(int dataLen) {
-        return ((dataLen + 2) / 3) * 4 + 2;
     }
 
     /// Computes the UTF-8 byte representation of a JSON field name prefix. The result includes the opening quote, the

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/MapWriteConsumer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/MapWriteConsumer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import java.util.function.BiConsumer;
+import software.amazon.smithy.java.core.serde.SerializationException;
+
+final class MapWriteConsumer implements BiConsumer<Object, Object> {
+
+    private final GeneratedJsonCodec codec;
+    private final JsonCodegenWriter writer;
+    private final int mapId;
+    private final boolean sparse;
+
+    MapWriteConsumer(GeneratedJsonCodec codec, JsonCodegenWriter writer, int mapId, boolean sparse) {
+        this.codec = codec;
+        this.writer = writer;
+        this.mapId = mapId;
+        this.sparse = sparse;
+    }
+
+    @Override
+    public void accept(Object key, Object value) {
+        writer.dynamicField((String) key);
+        if (value == null) {
+            if (sparse) {
+                writer.writeNull();
+            } else {
+                throw new SerializationException("Null value found in dense map");
+            }
+        } else {
+            codec.writeMapValue(mapId, value, writer);
+        }
+    }
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyGeneratedJsonSerde.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyGeneratedJsonSerde.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import java.io.OutputStream;
+import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.IdentityHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodecBackend;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodecRegistry;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
+import software.amazon.smithy.java.json.JsonSettings;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class SmithyGeneratedJsonSerde {
+    private static final int MAX_SETTINGS = 16;
+    private static final int MAX_SUBSETS = 16;
+
+    // Keep selector identities stable for the registry cache, with a bound for caller-supplied keys.
+    private final ConcurrentHashMap<
+            MemberSubsetCodec.MemberSubset,
+            RuntimeCodecBackend.MemberSelector> selectors = new ConcurrentHashMap<>();
+
+    private final IdentityHashMap<JsonSettings, RuntimeCodecRegistry<GeneratedJsonCodec>> registries =
+            new IdentityHashMap<>();
+    private final ArrayDeque<JsonSettings> settingsOrder = new ArrayDeque<>();
+    private volatile CachedRegistry lastRegistry;
+    private volatile LastCodec lastCodec;
+
+    public ByteBuffer serialize(SerializableStruct value, JsonSettings settings) {
+        return serialize(value, settings, null);
+    }
+
+    public ByteBuffer serialize(
+            SerializableStruct value,
+            JsonSettings settings,
+            MemberSubsetCodec.MemberSubset subset
+    ) {
+        if (settings.prettyPrint()) {
+            rejectStrictFallback(settings, "pretty-printed JSON is not supported");
+            return null;
+        }
+        if (!generatable(value)) {
+            rejectStrictFallback(settings, "the value is not the generated class for " + value.schema().id());
+            return null;
+        }
+        GeneratedJsonCodec codec = codec(value.schema(), settings, subset);
+        if (codec == null) {
+            rejectStrictFallback(settings, "no generated codec is available for " + value.schema().id());
+            return null;
+        }
+        JsonCodegenWriter writer = JsonCodegenWriter.acquire(settings);
+        try {
+            codec.write(value, writer);
+            return writer.detach();
+        } finally {
+            JsonCodegenWriter.release(writer);
+        }
+    }
+
+    public boolean serializeTo(
+            SerializableStruct value,
+            OutputStream sink,
+            JsonSettings settings
+    ) {
+        if (settings.prettyPrint()) {
+            rejectStrictFallback(settings, "pretty-printed JSON is not supported");
+            return false;
+        }
+        if (!generatable(value)) {
+            rejectStrictFallback(settings, "the value is not the generated class for " + value.schema().id());
+            return false;
+        }
+        GeneratedJsonCodec codec = codec(value.schema(), settings);
+        if (codec == null) {
+            rejectStrictFallback(settings, "no generated codec is available for " + value.schema().id());
+            return false;
+        }
+        JsonCodegenWriter writer = JsonCodegenWriter.acquire(settings);
+        try {
+            writer.sink(sink);
+            codec.write(value, writer);
+            writer.flush();
+            return true;
+        } finally {
+            JsonCodegenWriter.release(writer);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends SerializableShape> T deserialize(
+            byte[] source,
+            ShapeBuilder<T> builder,
+            JsonSettings settings
+    ) {
+        if (settings.prettyPrint()) {
+            rejectStrictFallback(settings, "pretty-printed JSON is not supported");
+            return null;
+        }
+        GeneratedJsonCodec codec = codec(builder.schema(), settings);
+        if (codec == null) {
+            rejectStrictFallback(settings, "no generated codec is available for " + builder.schema().id());
+            return null;
+        }
+        if (!codec.acceptsBuilder(builder)) {
+            rejectStrictFallback(
+                    settings,
+                    "the builder is not the generated builder for " + builder.schema().id());
+            return null;
+        }
+        if (isEmptyObject(source, 0, source.length)) {
+            return (T) builder.errorCorrection().build();
+        }
+        return (T) codec.read(source, builder, settings);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends SerializableShape> T deserialize(
+            ByteBuffer source,
+            ShapeBuilder<T> builder,
+            JsonSettings settings
+    ) {
+        if (settings.prettyPrint()) {
+            rejectStrictFallback(settings, "pretty-printed JSON is not supported");
+            return null;
+        }
+        GeneratedJsonCodec codec = codec(builder.schema(), settings);
+        if (codec == null) {
+            rejectStrictFallback(settings, "no generated codec is available for " + builder.schema().id());
+            return null;
+        }
+        if (!codec.acceptsBuilder(builder)) {
+            rejectStrictFallback(
+                    settings,
+                    "the builder is not the generated builder for " + builder.schema().id());
+            return null;
+        }
+        readInto(codec, source, builder, settings);
+        return (T) builder.errorCorrection().build();
+    }
+
+    public boolean deserialize(
+            Schema schema,
+            ShapeBuilder<?> builder,
+            ByteBuffer source,
+            JsonSettings settings,
+            MemberSubsetCodec.MemberSubset subset
+    ) {
+        if (settings.prettyPrint()) {
+            rejectStrictFallback(settings, "pretty-printed JSON is not supported");
+            return false;
+        }
+        GeneratedJsonCodec codec = codec(schema, settings, subset);
+        if (codec == null) {
+            rejectStrictFallback(settings, "no generated codec is available for " + schema.id());
+            return false;
+        }
+        if (!codec.acceptsBuilder(builder)) {
+            rejectStrictFallback(
+                    settings,
+                    "the builder is not the generated builder for " + builder.schema().id());
+            return false;
+        }
+        readInto(codec, source, builder, settings);
+        return true;
+    }
+
+    private static void readInto(
+            GeneratedJsonCodec codec,
+            ByteBuffer source,
+            ShapeBuilder<?> builder,
+            JsonSettings settings
+    ) {
+        if (source.hasArray()) {
+            int offset = source.arrayOffset() + source.position();
+            int end = offset + source.remaining();
+            byte[] bytes = source.array();
+            if (!isEmptyObject(bytes, offset, end)) {
+                codec.readInto(bytes, offset, end, builder, settings);
+            }
+            return;
+        }
+        ByteBuffer duplicate = source.duplicate();
+        byte[] result = new byte[duplicate.remaining()];
+        duplicate.get(result);
+        if (!isEmptyObject(result, 0, result.length)) {
+            codec.readInto(result, 0, result.length, builder, settings);
+        }
+    }
+
+    private static boolean isEmptyObject(byte[] source, int offset, int end) {
+        return end - offset == 2 && source[offset] == '{' && source[offset + 1] == '}';
+    }
+
+    public int scan(byte[] source, Schema schema, JsonSettings settings) {
+        GeneratedJsonCodec codec = codec(schema, settings);
+        if (codec == null) {
+            rejectStrictFallback(settings, "no generated codec is available for " + schema.id());
+            return -1;
+        }
+        return codec.scan(source, settings);
+    }
+
+    public synchronized void clear() {
+        for (RuntimeCodecRegistry<GeneratedJsonCodec> registry : registries.values()) {
+            registry.clear();
+        }
+        registries.clear();
+        settingsOrder.clear();
+        selectors.clear();
+        lastRegistry = null;
+        lastCodec = null;
+    }
+
+    // Generated writers cast to the schema's concrete class; schema-compatible proxies must fall back.
+    private static boolean generatable(SerializableStruct value) {
+        Schema schema = value.schema();
+        Class<?> shapeClass = (schema.isMember() ? schema.memberTarget() : schema).shapeClass();
+        return shapeClass != null && value.getClass() == shapeClass;
+    }
+
+    private static void rejectStrictFallback(JsonSettings settings, String reason) {
+        if (settings.strictRuntimeCodegen()) {
+            throw new IllegalStateException("Strict JSON runtime codegen cannot fall back: " + reason);
+        }
+    }
+
+    private GeneratedJsonCodec codec(
+            Schema schema,
+            JsonSettings settings
+    ) {
+        return codec(schema, settings, null);
+    }
+
+    private GeneratedJsonCodec codec(
+            Schema schema,
+            JsonSettings settings,
+            MemberSubsetCodec.MemberSubset subset
+    ) {
+        Schema root = schema.isMember() ? schema.memberTarget() : schema;
+        LastCodec cached = lastCodec;
+        if (cached != null && cached.schema.get() == root
+                && cached.settings == settings
+                && cached.subset == subset) {
+            GeneratedJsonCodec codec = cached.codec.get();
+            if (codec != null) {
+                return codec;
+            }
+        }
+        RuntimeCodecBackend.MemberSelector selector;
+        if (subset == null) {
+            selector = RuntimeCodecBackend.MemberSelector.all();
+        } else {
+            selector = selectorFor(subset);
+            if (selector == null) {
+                return null;
+            }
+        }
+        GeneratedJsonCodec codec = registry(settings).get(root, settings, selector);
+        lastCodec = new LastCodec(new WeakReference<>(root), settings, subset, new WeakReference<>(codec));
+        return codec;
+    }
+
+    private RuntimeCodecBackend.MemberSelector selectorFor(MemberSubsetCodec.MemberSubset subset) {
+        RuntimeCodecBackend.MemberSelector selector = selectors.get(subset);
+        if (selector != null) {
+            return selector;
+        }
+        return selectors.size() < MAX_SUBSETS
+                ? selectors.computeIfAbsent(subset, s -> s::includes)
+                : null;
+    }
+
+    private RuntimeCodecRegistry<GeneratedJsonCodec> registry(JsonSettings settings) {
+        CachedRegistry cached = lastRegistry;
+        if (cached != null && cached.settings == settings) {
+            return cached.registry;
+        }
+        synchronized (this) {
+            RuntimeCodecRegistry<GeneratedJsonCodec> result = registries.get(settings);
+            if (result == null) {
+                result = new RuntimeCodecRegistry<>(new JsonRuntimeCodegenBackend(settings));
+                registries.put(settings, result);
+                settingsOrder.addLast(settings);
+                if (registries.size() > MAX_SETTINGS) {
+                    JsonSettings evicted = settingsOrder.removeFirst();
+                    RuntimeCodecRegistry<GeneratedJsonCodec> evictedRegistry = registries.remove(evicted);
+                    if (evictedRegistry != null) {
+                        evictedRegistry.clear();
+                    }
+                }
+            }
+            lastRegistry = new CachedRegistry(settings, result);
+            return result;
+        }
+    }
+
+    private record CachedRegistry(
+            JsonSettings settings,
+            RuntimeCodecRegistry<GeneratedJsonCodec> registry) {}
+
+    private record LastCodec(
+            WeakReference<Schema> schema,
+            JsonSettings settings,
+            MemberSubsetCodec.MemberSubset subset,
+            WeakReference<GeneratedJsonCodec> codec) {}
+}

--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonDeserializer.java
@@ -44,6 +44,9 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
     private final JsonSettings settings;
     private final boolean useJsonName;
     private int depth;
+    private int generatedFieldStart;
+    private int generatedFieldEnd;
+    private String generatedFieldName;
 
     // Mutable result fields, avoids allocating arrays on every parse call.
     // Safe because the deserializer is single-threaded (one instance per operation).
@@ -135,6 +138,10 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
         // Pool full — let GC collect.
     }
 
+    void generatedAbort() {
+        releaseCache();
+    }
+
     /**
      * Decodes an unescaped string, deduplicating short (&lt;= 8 byte) strings through a
      * per-document cache. The packed bytes form an exact identity (see field docs), so a
@@ -214,6 +221,14 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
     @Override
     public boolean readBoolean(Schema schema) {
         skipWhitespace();
+        return readBooleanValue();
+    }
+
+    boolean generatedReadBoolean() {
+        return readBooleanValue();
+    }
+
+    private boolean readBooleanValue() {
         if (pos + 4 <= end && buf[pos] == 't') {
             if (buf[pos + 1] == 'r' && buf[pos + 2] == 'u' && buf[pos + 3] == 'e') {
                 pos += 4;
@@ -235,6 +250,14 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
     @Override
     public byte readByte(Schema schema) {
         skipWhitespace();
+        return readByteValue();
+    }
+
+    byte generatedReadByte() {
+        return readByteValue();
+    }
+
+    private byte readByteValue() {
         JsonReadUtils.parseLong(buf, pos, end, this);
         pos = parsedEndPos;
         if (parsedLong < Byte.MIN_VALUE || parsedLong > Byte.MAX_VALUE) {
@@ -246,6 +269,14 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
     @Override
     public short readShort(Schema schema) {
         skipWhitespace();
+        return readShortValue();
+    }
+
+    short generatedReadShort() {
+        return readShortValue();
+    }
+
+    private short readShortValue() {
         JsonReadUtils.parseLong(buf, pos, end, this);
         pos = parsedEndPos;
         if (parsedLong < Short.MIN_VALUE || parsedLong > Short.MAX_VALUE) {
@@ -257,6 +288,14 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
     @Override
     public int readInteger(Schema schema) {
         skipWhitespace();
+        return readIntegerValue();
+    }
+
+    int generatedReadInteger() {
+        return readIntegerValue();
+    }
+
+    private int readIntegerValue() {
         JsonReadUtils.parseLong(buf, pos, end, this);
         pos = parsedEndPos;
         if (parsedLong < Integer.MIN_VALUE || parsedLong > Integer.MAX_VALUE) {
@@ -268,6 +307,14 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
     @Override
     public long readLong(Schema schema) {
         skipWhitespace();
+        return readLongValue();
+    }
+
+    long generatedReadLong() {
+        return readLongValue();
+    }
+
+    private long readLongValue() {
         JsonReadUtils.parseLong(buf, pos, end, this);
         pos = parsedEndPos;
         return parsedLong;
@@ -276,6 +323,14 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
     @Override
     public float readFloat(Schema schema) {
         skipWhitespace();
+        return readFloatValue();
+    }
+
+    float generatedReadFloat() {
+        return readFloatValue();
+    }
+
+    private float readFloatValue() {
         if (pos < end && buf[pos] == '"') {
             String s = readStringValue();
             return switch (s) {
@@ -293,6 +348,14 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
     @Override
     public double readDouble(Schema schema) {
         skipWhitespace();
+        return readDoubleValue();
+    }
+
+    double generatedReadDouble() {
+        return readDoubleValue();
+    }
+
+    private double readDoubleValue() {
         if (pos < end && buf[pos] == '"') {
             String s = readStringValue();
             return switch (s) {
@@ -380,6 +443,14 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
     @Override
     public ByteBuffer readBlob(Schema schema) {
         skipWhitespace();
+        return readBlobValue();
+    }
+
+    ByteBuffer generatedReadBlob() {
+        return readBlobValue();
+    }
+
+    private ByteBuffer readBlobValue() {
         ByteBuffer decoded = JsonReadUtils.decodeBase64String(buf, pos, end, this);
         pos = parsedEndPos;
         return decoded;
@@ -387,72 +458,55 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
 
     @Override
     public Instant readTimestamp(Schema schema) {
-        skipWhitespace();
         var format = settings.timestampResolver().resolve(schema);
-        if (format == TimestampFormatter.Prelude.EPOCH_SECONDS
-                && pos < end
-                && (buf[pos] == '-' || (buf[pos] >= '0' && buf[pos] <= '9'))) {
-            long tenDigitSecond = JsonReadUtils.tryParseTenDigitEpochSecond(buf, pos, end);
-            if (tenDigitSecond >= 0) {
+        skipWhitespace();
+        return readTimestampValue(format);
+    }
+
+    Instant generatedReadEpochTimestamp() {
+        if (pos < end && (buf[pos] == '-' || (buf[pos] >= '0' && buf[pos] <= '9'))) {
+            long fastSecond = JsonReadUtils.tryParseTenDigitEpochSecond(buf, pos, end);
+            if (fastSecond >= 0) {
                 pos += 10;
-                return Instant.ofEpochSecond(tenDigitSecond);
+                return instantFromEpochSecond(fastSecond);
             }
-            // Fast path for epoch-seconds: try integer parsing first.
-            // Most epoch-seconds timestamps are whole numbers, so parseLong avoids
-            // the expensive FastDoubleParser path entirely.
             int startPos = pos;
-            JsonReadUtils.parseLong(buf, pos, end, this);
+            JsonReadUtils.parseLong(buf, startPos, end, this);
             int endPos = parsedEndPos;
-            if (endPos < end && buf[endPos] == '.') {
-                // Fractional epoch-seconds: parse with full nanosecond precision
-                // instead of going through double (which truncates to ~15 significant digits).
-                int fracPos = endPos + 1;
-                int fracStart = fracPos;
-                while (fracPos < end && buf[fracPos] >= '0' && buf[fracPos] <= '9') {
-                    fracPos++;
-                }
-                int fracLen = fracPos - fracStart;
-                // Skip the precision fast path if an exponent follows — the precision
-                // fast path doesn't apply scientific notation and would leave pos before
-                // the 'e'/'E', corrupting subsequent parsing.
-                boolean hasExponent = fracPos < end && (buf[fracPos] == 'e' || buf[fracPos] == 'E');
-                if (fracLen > 0 && !hasExponent) {
-                    int nano = 0;
-                    for (int i = 0; i < 9; i++) {
-                        nano *= 10;
-                        if (i < fracLen) {
-                            nano += buf[fracStart + i] - '0';
-                        }
-                    }
-                    pos = fracPos;
-                    long epochSecond = parsedLong;
-                    boolean negative = buf[startPos] == '-';
-                    if (negative && nano > 0) {
-                        // -0.5 means parsedLong=0 but the value is -0.5 = Instant(-1, 500_000_000)
-                        // -1.5 means parsedLong=-1 but the value is -1.5 = Instant(-2, 500_000_000)
-                        epochSecond -= 1;
-                        nano = 1_000_000_000 - nano;
-                    }
-                    try {
-                        return Instant.ofEpochSecond(epochSecond, nano);
-                    } catch (DateTimeException e) {
-                        throw new SerializationException("Epoch seconds out of range: " + parsedLong, e);
-                    }
-                }
-                // No digits after dot, or exponent present -- fall through to double parsing
-            } else if (endPos >= end || (buf[endPos] != 'e' && buf[endPos] != 'E')) {
-                // Pure integer -- no fractional part
+            if (endPos >= end || (buf[endPos] != '.' && buf[endPos] != 'e' && buf[endPos] != 'E')) {
                 pos = endPos;
-                try {
-                    return Instant.ofEpochSecond(parsedLong);
-                } catch (DateTimeException e) {
-                    throw new SerializationException("Epoch seconds out of range: " + parsedLong, e);
-                }
+                return instantFromEpochSecond(parsedLong);
             }
-            // Has exponent or unparseable fraction -- fall through to double parsing
-            JsonReadUtils.parseDouble(buf, pos, end, this);
-            pos = parsedEndPos;
-            return format.readFromNumber(parsedDouble);
+            return readFractionalEpochTimestamp(startPos, endPos);
+        }
+        return readTimestampFallback(TimestampFormatter.Prelude.EPOCH_SECONDS);
+    }
+
+    Instant generatedReadDateTimeTimestamp() {
+        if (pos < end && buf[pos] == '"') {
+            Instant result = JsonReadUtils.parseIso8601(buf, pos, end, this);
+            if (result != null) {
+                pos = parsedEndPos;
+                return result;
+            }
+        }
+        return readTimestampFallback(TimestampFormatter.Prelude.DATE_TIME);
+    }
+
+    Instant generatedReadHttpDateTimestamp() {
+        if (pos < end && buf[pos] == '"') {
+            Instant result = JsonReadUtils.parseHttpDate(buf, pos, end, this);
+            if (result != null) {
+                pos = parsedEndPos;
+                return result;
+            }
+        }
+        return readTimestampFallback(TimestampFormatter.Prelude.HTTP_DATE);
+    }
+
+    private Instant readTimestampValue(TimestampFormatter format) {
+        if (format == TimestampFormatter.Prelude.EPOCH_SECONDS) {
+            return generatedReadEpochTimestamp();
         }
         if (pos < end && buf[pos] == '"') {
             // Fast path: parse ISO-8601 and HTTP-date directly from bytes,
@@ -470,7 +524,57 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
                     return result;
                 }
             }
-            // Fallback: parse as String and use DateTimeFormatter
+        }
+        return readTimestampFallback(format);
+    }
+
+    private Instant readFractionalEpochTimestamp(int startPos, int integerEnd) {
+        if (buf[integerEnd] == '.') {
+            // Avoid losing nanosecond precision through double.
+            int fracPos = integerEnd + 1;
+            int fracStart = fracPos;
+            while (fracPos < end && buf[fracPos] >= '0' && buf[fracPos] <= '9') {
+                fracPos++;
+            }
+            int fracLen = fracPos - fracStart;
+            boolean hasExponent = fracPos < end && (buf[fracPos] == 'e' || buf[fracPos] == 'E');
+            if (fracLen > 0 && !hasExponent) {
+                int nano = 0;
+                for (int i = 0; i < 9; i++) {
+                    nano *= 10;
+                    if (i < fracLen) {
+                        nano += buf[fracStart + i] - '0';
+                    }
+                }
+                pos = fracPos;
+                long epochSecond = parsedLong;
+                if (buf[startPos] == '-' && nano > 0) {
+                    epochSecond -= 1;
+                    nano = 1_000_000_000 - nano;
+                }
+                try {
+                    return Instant.ofEpochSecond(epochSecond, nano);
+                } catch (DateTimeException e) {
+                    throw new SerializationException("Epoch seconds out of range: " + parsedLong, e);
+                }
+            }
+        }
+        pos = startPos;
+        JsonReadUtils.parseDouble(buf, startPos, end, this);
+        pos = parsedEndPos;
+        return TimestampFormatter.Prelude.EPOCH_SECONDS.readFromNumber(parsedDouble);
+    }
+
+    private Instant instantFromEpochSecond(long epochSecond) {
+        try {
+            return Instant.ofEpochSecond(epochSecond);
+        } catch (DateTimeException e) {
+            throw new SerializationException("Epoch seconds out of range: " + epochSecond, e);
+        }
+    }
+
+    private Instant readTimestampFallback(TimestampFormatter format) {
+        if (pos < end && buf[pos] == '"') {
             String s = readStringValue();
             try {
                 return format.readFromString(s, true);
@@ -1016,6 +1120,512 @@ final class SmithyJsonDeserializer implements ShapeDeserializer {
                 }
             }
         }
+    }
+
+    boolean generatedBeginObject() {
+        if (pos >= end || buf[pos] != '{') {
+            throw new SerializationException(
+                    "Expected '{', found: " + JsonReadUtils.describePos(buf, pos, end));
+        }
+        pos++;
+        if (++depth > MAX_DEPTH) {
+            throw new SerializationException("Maximum nesting depth exceeded: " + MAX_DEPTH);
+        }
+        skipWhitespace();
+        if (pos < end && buf[pos] == '}') {
+            pos++;
+            depth--;
+            return false;
+        }
+        return true;
+    }
+
+    boolean generatedAtEnd() {
+        pos = JsonReadUtils.skipWhitespace(buf, pos, end);
+        return pos >= end;
+    }
+
+    int generatedReadFieldHash() {
+        skipWhitespace();
+        if (pos >= end || buf[pos] != '"') {
+            throw new SerializationException(
+                    "Expected field name, found: " + JsonReadUtils.describePos(buf, pos, end));
+        }
+        int start = ++pos;
+        int hash = 0;
+        while (pos < end && buf[pos] != '"') {
+            byte value = buf[pos];
+            if (value == '\\' || (value & 0xff) < 0x20) {
+                int fieldStart = start - 1;
+                JsonReadUtils.parseString(buf, fieldStart, end, this);
+                String decoded = parsedString;
+                generatedFieldName = decoded;
+                generatedFieldStart = -1;
+                generatedFieldEnd = -1;
+                pos = parsedEndPos;
+                skipWhitespace();
+                expect(':');
+                skipWhitespace();
+                return utf8Hash(decoded);
+            }
+            hash = 31 * hash + (value & 0xff);
+            pos++;
+        }
+        if (pos >= end) {
+            throw new SerializationException("Unterminated field name");
+        }
+        generatedFieldStart = start;
+        generatedFieldEnd = pos++;
+        generatedFieldName = null;
+        skipWhitespace();
+        expect(':');
+        skipWhitespace();
+        return hash;
+    }
+
+    // Generated switch arms recheck the bytes, so key collisions are safe.
+    int generatedReadStringKey() {
+        int p = pos;
+        if (p >= end || buf[p] != '"') {
+            throw new SerializationException(
+                    "Expected string, found: " + JsonReadUtils.describePos(buf, p, end));
+        }
+        int start = ++p;
+        if (p <= end - Long.BYTES) {
+            long word = JsonReadUtils.readLongLittleEndian(buf, p);
+            long stopMask = JsonReadUtils.stringStopMask(word);
+            if (stopMask != 0) {
+                int length = Long.numberOfTrailingZeros(stopMask) >>> 3;
+                int stop = p + length;
+                if (buf[stop] != '"') {
+                    return generatedStringKeySlow(start - 1);
+                }
+                generatedFieldStart = start;
+                generatedFieldEnd = stop;
+                generatedFieldName = null;
+                pos = stop + 1;
+                return stringKey(word & ((1L << (length << 3)) - 1), length);
+            }
+            p += Long.BYTES;
+        }
+        return generatedReadStringKeyLong(start, p);
+    }
+
+    private int generatedReadStringKeyLong(int start, int scan) {
+        int p = scan;
+        while (p <= end - Long.BYTES) {
+            long stopMask = JsonReadUtils.stringStopMask(JsonReadUtils.readLongLittleEndian(buf, p));
+            if (stopMask == 0) {
+                p += Long.BYTES;
+                continue;
+            }
+            int stop = p + (Long.numberOfTrailingZeros(stopMask) >>> 3);
+            if (buf[stop] != '"') {
+                return generatedStringKeySlow(start - 1);
+            }
+            return generatedStringKeyFound(start, stop);
+        }
+        while (p < end) {
+            byte value = buf[p];
+            if (value == '"') {
+                return generatedStringKeyFound(start, p);
+            }
+            if (value == '\\' || value < 0 || (value & 0xff) < 0x20) {
+                return generatedStringKeySlow(start - 1);
+            }
+            p++;
+        }
+        throw new SerializationException("Unterminated string");
+    }
+
+    private int generatedStringKeyFound(int start, int stop) {
+        generatedFieldStart = start;
+        generatedFieldEnd = stop;
+        generatedFieldName = null;
+        pos = stop + 1;
+        int length = stop - start;
+        long word;
+        if (length >= Long.BYTES) {
+            word = JsonReadUtils.readLongLittleEndian(buf, start);
+        } else {
+            word = start <= end - Long.BYTES
+                    ? JsonReadUtils.readLongLittleEndian(buf, start) & ((1L << (length << 3)) - 1)
+                    : readPackedToken(start, length);
+        }
+        return stringKey(word, length);
+    }
+
+    private int generatedStringKeySlow(int quotePos) {
+        JsonReadUtils.parseString(buf, quotePos, end, this);
+        generatedFieldName = parsedString;
+        generatedFieldStart = -1;
+        generatedFieldEnd = -1;
+        pos = parsedEndPos;
+        return stringKeyUtf8(generatedFieldName);
+    }
+
+    private static int utf8Hash(String value) {
+        int hash = 0;
+        for (int i = 0; i < value.length();) {
+            int codePoint = value.codePointAt(i);
+            i += Character.charCount(codePoint);
+            if (codePoint <= 0x7f) {
+                hash = 31 * hash + codePoint;
+            } else if (codePoint <= 0x7ff) {
+                hash = 31 * hash + (0xc0 | codePoint >>> 6);
+                hash = 31 * hash + (0x80 | codePoint & 0x3f);
+            } else if (codePoint <= 0xffff) {
+                hash = 31 * hash + (0xe0 | codePoint >>> 12);
+                hash = 31 * hash + (0x80 | codePoint >>> 6 & 0x3f);
+                hash = 31 * hash + (0x80 | codePoint & 0x3f);
+            } else {
+                hash = 31 * hash + (0xf0 | codePoint >>> 18);
+                hash = 31 * hash + (0x80 | codePoint >>> 12 & 0x3f);
+                hash = 31 * hash + (0x80 | codePoint >>> 6 & 0x3f);
+                hash = 31 * hash + (0x80 | codePoint & 0x3f);
+            }
+        }
+        return hash;
+    }
+
+    private static int stringKeyUtf8(String value) {
+        long word = 0;
+        int length = 0;
+        for (int i = 0; i < value.length();) {
+            int codePoint = value.codePointAt(i);
+            i += Character.charCount(codePoint);
+            if (codePoint <= 0x7f) {
+                word = appendKeyByte(word, length++, codePoint);
+            } else if (codePoint <= 0x7ff) {
+                word = appendKeyByte(word, length++, 0xc0 | codePoint >>> 6);
+                word = appendKeyByte(word, length++, 0x80 | codePoint & 0x3f);
+            } else if (codePoint <= 0xffff) {
+                word = appendKeyByte(word, length++, 0xe0 | codePoint >>> 12);
+                word = appendKeyByte(word, length++, 0x80 | codePoint >>> 6 & 0x3f);
+                word = appendKeyByte(word, length++, 0x80 | codePoint & 0x3f);
+            } else {
+                word = appendKeyByte(word, length++, 0xf0 | codePoint >>> 18);
+                word = appendKeyByte(word, length++, 0x80 | codePoint >>> 12 & 0x3f);
+                word = appendKeyByte(word, length++, 0x80 | codePoint >>> 6 & 0x3f);
+                word = appendKeyByte(word, length++, 0x80 | codePoint & 0x3f);
+            }
+        }
+        return stringKey(word, length);
+    }
+
+    private static long appendKeyByte(long word, int index, int value) {
+        return index < Long.BYTES ? word | (long) value << (index << 3) : word;
+    }
+
+    // Must match JsonRuntimeCodegenBackend.enumSwitchKey.
+    static int stringKey(long packedPrefix, int length) {
+        return (int) ((packedPrefix * 0x9E3779B97F4A7C15L) >>> 32) ^ length;
+    }
+
+    boolean generatedTryReadField(byte[] token) {
+        int start = pos;
+        int length = token.length;
+        if (start > end - length) {
+            return false;
+        }
+        for (int i = 0; i < length; i++) {
+            if (buf[start + i] != token[i]) {
+                return false;
+            }
+        }
+        pos = JsonReadUtils.skipWhitespace(buf, start + length, end);
+        return true;
+    }
+
+    boolean generatedTryReadNextField(byte[] token) {
+        int start = pos;
+        if (start >= end || buf[start] != ',') {
+            return false;
+        }
+        start = JsonReadUtils.skipWhitespace(buf, start + 1, end);
+        int length = token.length;
+        if (start > end - length) {
+            return false;
+        }
+        for (int i = 0; i < length; i++) {
+            if (buf[start + i] != token[i]) {
+                return false;
+            }
+        }
+        pos = JsonReadUtils.skipWhitespace(buf, start + length, end);
+        return true;
+    }
+
+    boolean generatedTryReadField8(long expected, long mask, int length) {
+        int start = pos;
+        if (start > end - length) {
+            return false;
+        }
+        long actual;
+        if (start <= end - Long.BYTES) {
+            actual = JsonReadUtils.readLongLittleEndian(buf, start) & mask;
+        } else {
+            actual = readPackedToken(start, length);
+        }
+        if (actual != expected) {
+            return false;
+        }
+        pos = JsonReadUtils.skipWhitespace(buf, start + length, end);
+        return true;
+    }
+
+    boolean generatedTryReadNextField8(long expected, long mask, int length) {
+        int start = pos;
+        if (start >= end || buf[start] != ',') {
+            return false;
+        }
+        start = JsonReadUtils.skipWhitespace(buf, start + 1, end);
+        if (start > end - length) {
+            return false;
+        }
+        long actual;
+        if (start <= end - Long.BYTES) {
+            actual = JsonReadUtils.readLongLittleEndian(buf, start) & mask;
+        } else {
+            actual = readPackedToken(start, length);
+        }
+        if (actual != expected) {
+            return false;
+        }
+        pos = JsonReadUtils.skipWhitespace(buf, start + length, end);
+        return true;
+    }
+
+    boolean generatedTryReadField16(long prefix, long suffix, long suffixMask, int length) {
+        int start = pos;
+        if (start > end - length || JsonReadUtils.readLongLittleEndian(buf, start) != prefix) {
+            return false;
+        }
+        int suffixStart = start + Long.BYTES;
+        long actualSuffix;
+        if (suffixStart <= end - Long.BYTES) {
+            actualSuffix = JsonReadUtils.readLongLittleEndian(buf, suffixStart) & suffixMask;
+        } else {
+            actualSuffix = readPackedToken(suffixStart, length - Long.BYTES);
+        }
+        if (actualSuffix != suffix) {
+            return false;
+        }
+        pos = JsonReadUtils.skipWhitespace(buf, start + length, end);
+        return true;
+    }
+
+    boolean generatedTryReadNextField16(long prefix, long suffix, long suffixMask, int length) {
+        int start = pos;
+        if (start >= end || buf[start] != ',') {
+            return false;
+        }
+        start = JsonReadUtils.skipWhitespace(buf, start + 1, end);
+        if (start > end - length || JsonReadUtils.readLongLittleEndian(buf, start) != prefix) {
+            return false;
+        }
+        int suffixStart = start + Long.BYTES;
+        long actualSuffix;
+        if (suffixStart <= end - Long.BYTES) {
+            actualSuffix = JsonReadUtils.readLongLittleEndian(buf, suffixStart) & suffixMask;
+        } else {
+            actualSuffix = readPackedToken(suffixStart, length - Long.BYTES);
+        }
+        if (actualSuffix != suffix) {
+            return false;
+        }
+        pos = JsonReadUtils.skipWhitespace(buf, start + length, end);
+        return true;
+    }
+
+    private long readPackedToken(int start, int length) {
+        long value = 0;
+        for (int i = 0; i < length; i++) {
+            value |= (long) (buf[start + i] & 0xFF) << (i << 3);
+        }
+        return value;
+    }
+
+    boolean generatedFieldEquals(byte[] expected, String decoded) {
+        if (generatedFieldName != null) {
+            return generatedFieldName.equals(decoded);
+        }
+        int start = generatedFieldStart;
+        int length = generatedFieldEnd - start;
+        return start >= 0
+                && length == expected.length
+                && Arrays.equals(buf, start, generatedFieldEnd, expected, 0, expected.length);
+    }
+
+    boolean generatedStringEquals8(long expected, long mask, int length, String decoded) {
+        if (generatedFieldName != null) {
+            return generatedFieldName.equals(decoded);
+        }
+        int start = generatedFieldStart;
+        if (generatedFieldEnd - start != length) {
+            return false;
+        }
+        long actual = start <= end - Long.BYTES
+                ? JsonReadUtils.readLongLittleEndian(buf, start) & mask
+                : readPackedToken(start, length);
+        return actual == expected;
+    }
+
+    boolean generatedStringEquals16(
+            long prefix,
+            long suffix,
+            long suffixMask,
+            int length,
+            String decoded
+    ) {
+        if (generatedFieldName != null) {
+            return generatedFieldName.equals(decoded);
+        }
+        int start = generatedFieldStart;
+        if (generatedFieldEnd - start != length
+                || JsonReadUtils.readLongLittleEndian(buf, start) != prefix) {
+            return false;
+        }
+        int suffixStart = start + Long.BYTES;
+        long actualSuffix = suffixStart <= end - Long.BYTES
+                ? JsonReadUtils.readLongLittleEndian(buf, suffixStart) & suffixMask
+                : readPackedToken(suffixStart, length - Long.BYTES);
+        return actualSuffix == suffix;
+    }
+
+    String generatedFieldName() {
+        if (generatedFieldName != null) {
+            return generatedFieldName;
+        }
+        generatedFieldName = decodeUtf8Cached(
+                buf,
+                generatedFieldStart,
+                generatedFieldEnd - generatedFieldStart);
+        return generatedFieldName;
+    }
+
+    String generatedReadMapKey() {
+        int p = JsonReadUtils.skipWhitespace(buf, pos, end);
+        if (p >= end || buf[p] != '"') {
+            pos = p;
+            throw new SerializationException(
+                    "Expected map key, found: " + JsonReadUtils.describePos(buf, p, end));
+        }
+        int quote = p++;
+        int start = p;
+        while (p <= end - Long.BYTES) {
+            long stops = JsonReadUtils.stringStopMask(JsonReadUtils.readLongLittleEndian(buf, p));
+            if (stops == 0) {
+                p += Long.BYTES;
+                continue;
+            }
+            int stop = p + (Long.numberOfTrailingZeros(stops) >>> 3);
+            if (buf[stop] == '"') {
+                String key = decodeAsciiCached(buf, start, stop - start);
+                generatedFinishMapKey(stop + 1);
+                return key;
+            }
+            return generatedReadMapKeySlow(quote);
+        }
+        while (p < end) {
+            byte value = buf[p];
+            if (value == '"') {
+                String key = decodeAsciiCached(buf, start, p - start);
+                generatedFinishMapKey(p + 1);
+                return key;
+            }
+            if (value == '\\' || value < 0 || (value & 0xff) < 0x20) {
+                return generatedReadMapKeySlow(quote);
+            }
+            p++;
+        }
+        throw new SerializationException("Unterminated map key");
+    }
+
+    private String generatedReadMapKeySlow(int quote) {
+        JsonReadUtils.parseString(buf, quote, end, this);
+        String key = parsedString;
+        generatedFinishMapKey(parsedEndPos);
+        return key;
+    }
+
+    private void generatedFinishMapKey(int next) {
+        next = JsonReadUtils.skipWhitespace(buf, next, end);
+        if (next >= end || buf[next] != ':') {
+            pos = next;
+            throw new SerializationException(
+                    "Expected ':', found: " + JsonReadUtils.describePos(buf, next, end));
+        }
+        pos = JsonReadUtils.skipWhitespace(buf, next + 1, end);
+    }
+
+    boolean generatedObjectHasNext() {
+        skipWhitespace();
+        if (pos < end && buf[pos] == '}') {
+            pos++;
+            depth--;
+            return false;
+        }
+        expect(',');
+        skipWhitespace();
+        return true;
+    }
+
+    boolean generatedBeginArray() {
+        if (pos >= end || buf[pos] != '[') {
+            throw new SerializationException(
+                    "Expected '[', found: " + JsonReadUtils.describePos(buf, pos, end));
+        }
+        pos++;
+        if (++depth > MAX_DEPTH) {
+            throw new SerializationException("Maximum nesting depth exceeded: " + MAX_DEPTH);
+        }
+        skipWhitespace();
+        if (pos < end && buf[pos] == ']') {
+            pos++;
+            depth--;
+            return false;
+        }
+        return true;
+    }
+
+    boolean generatedArrayHasNext() {
+        skipWhitespace();
+        if (pos < end && buf[pos] == ']') {
+            pos++;
+            depth--;
+            return false;
+        }
+        expect(',');
+        skipWhitespace();
+        return true;
+    }
+
+    boolean generatedTryReadNull() {
+        if (pos + 4 <= end
+                && buf[pos] == 'n'
+                && buf[pos + 1] == 'u'
+                && buf[pos + 2] == 'l'
+                && buf[pos + 3] == 'l') {
+            pos += 4;
+            return true;
+        }
+        return false;
+    }
+
+    String generatedReadString() {
+        return readStringValue();
+    }
+
+    void generatedSkipValue() {
+        skipValue();
+    }
+
+    int generatedScan() {
+        int start = pos;
+        skipValue();
+        close();
+        return pos - start;
     }
 
     private void skipString() {

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/EnumKeyedMapModel.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/EnumKeyedMapModel.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.util.Map;
+import java.util.Set;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.schema.SmithyEnum;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class EnumKeyedMapModel {
+    private static final Schema KEY = Schema.createEnum(
+            ShapeId.from("smithy.java.json.test#EnumMapKey"),
+            Set.of("A"),
+            Key.class);
+    private static final Schema MAP = Schema.mapBuilder(ShapeId.from("smithy.java.json.test#EnumKeyedMap"))
+            .putMember("key", KEY)
+            .putMember("value", PreludeSchemas.STRING)
+            .build();
+    private static final Schema VALUE = Schema.structureBuilder(ShapeId.from("smithy.java.json.test#EnumMapValue"))
+            .shapeClass(Value.class)
+            .builderSupplier(Value.Builder::new)
+            .putMember("values", MAP)
+            .build();
+
+    private EnumKeyedMapModel() {}
+
+    public record Key(String value) implements SmithyEnum {
+        @Override
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public record Value(Map<Key, String> values) implements SerializableStruct {
+        @Override
+        public Schema schema() {
+            return VALUE;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) values;
+        }
+
+        public static final class Builder implements ShapeBuilder<Value> {
+            private Map<Key, String> values;
+
+            public Builder values(Map<Key, String> values) {
+                this.values = values;
+                return this;
+            }
+
+            @Override
+            public Value build() {
+                return new Value(values);
+            }
+
+            @Override
+            public ShapeBuilder<Value> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return VALUE;
+            }
+        }
+    }
+}

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/GeneratedModelSerdeTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/GeneratedModelSerdeTest.java
@@ -658,11 +658,13 @@ public class GeneratedModelSerdeTest extends ProviderTestBase {
     void nonStructDocumentRoundtrip(JsonSerdeProvider ser, JsonSerdeProvider de, Document original) {
         try (var serCodec = JsonCodec.builder()
                 .overrideSerdeProvider(ser)
+                .runtimeCodegen(false)
                 .useJsonName(true)
                 .useTimestampFormat(true)
                 .build();
                 var deCodec = JsonCodec.builder()
                         .overrideSerdeProvider(de)
+                        .runtimeCodegen(false)
                         .useJsonName(true)
                         .useTimestampFormat(true)
                         .build()) {
@@ -745,7 +747,7 @@ public class GeneratedModelSerdeTest extends ProviderTestBase {
 
     static Stream<Arguments> invalidInputs() {
         List<Arguments> arguments = new ArrayList<>();
-        for (var provider : List.of(JACKSON, SMITHY)) {
+        for (var provider : providerInstances()) {
             arguments.add(Arguments.of(provider,
                     "eyJ2YWx1ZSI6e2JpdWUiOntiaW50VmE6e2JpbnRWYXJpnm50VmE6e2JpbnRWYXJpnpF0IjotMjA3fQ==",
                     true));

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonDeserializerTest.java
@@ -161,7 +161,7 @@ public class JsonDeserializerTest extends ProviderTestBase {
                 "9223372036854775807",
                 "9223372036854775808",
                 "123456789012345678901234567890");
-        for (var provider : List.of(SMITHY, JACKSON)) {
+        for (var provider : providerInstances()) {
             for (var value : values) {
                 result.add(Arguments.of(provider, value));
             }
@@ -1495,7 +1495,7 @@ public class JsonDeserializerTest extends ProviderTestBase {
 
     public static List<Arguments> epochSecondsWithExponentSource() {
         List<Arguments> args = new ArrayList<>();
-        for (var provider : List.of(JACKSON, SMITHY)) {
+        for (var provider : providerInstances()) {
             // Fraction + exponent: 1.5e3 == 1500s. The buggy path returned Instant(1, 500_000_000).
             args.add(Arguments.of(provider, "1.5e3", Instant.ofEpochSecond(1500)));
             // Uppercase exponent.

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/JsonSerializerTest.java
@@ -334,7 +334,8 @@ public class JsonSerializerTest extends ProviderTestBase {
     @Test
     public void testPrettyPrinting() throws Exception {
         // Pretty printing delegates to Jackson regardless of provider, so test once
-        try (var codec = JsonCodec.builder().prettyPrint(true).build(); var output = new ByteArrayOutputStream()) {
+        try (var codec = JsonCodec.builder().runtimeCodegen(false).prettyPrint(true).build();
+                var output = new ByteArrayOutputStream()) {
             try (var serializer = codec.createSerializer(output)) {
                 serializer.writeStruct(
                         JsonTestData.BIRD,
@@ -740,6 +741,7 @@ public class JsonSerializerTest extends ProviderTestBase {
                     try (var codec = JsonCodec.builder()
                             .overrideSerdeProvider(
                                     new SmithyJsonSerdeProvider())
+                            .runtimeCodegen(false)
                             .build();
                             var output = new ByteArrayOutputStream()) {
                         try (var serializer = codec.createSerializer(output)) {

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/ParsingTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/ParsingTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenFeature;
 import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.core.serde.document.DocumentEqualsFlags;
@@ -34,7 +35,10 @@ public class ParsingTest {
     public void parserTestCases(JsonSerdeProvider provider, Path file) throws IOException {
         var filename = file.getFileName().toString();
         var contents = Files.readAllBytes(file);
-        var codec = JsonCodec.builder().overrideSerdeProvider(provider).build();
+        var codec = JsonCodec.builder()
+                .overrideSerdeProvider(provider)
+                .runtimeCodegen(false)
+                .build();
 
         if (filename.startsWith("y_")) {
             try (var deser = codec.createDeserializer(contents)) {
@@ -69,7 +73,9 @@ public class ParsingTest {
 
         List<Arguments> arguments = new ArrayList<>();
         for (var path : loadJsonFiles()) {
-            arguments.add(Arguments.arguments(jacksonProvider, path));
+            if (!RuntimeCodegenFeature.strict("json")) {
+                arguments.add(Arguments.arguments(jacksonProvider, path));
+            }
             arguments.add(Arguments.arguments(smithyProvider, path));
         }
 

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/ProviderTestBase.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/ProviderTestBase.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.java.json;
 import java.util.List;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.provider.Arguments;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenFeature;
 import software.amazon.smithy.java.json.jackson.JacksonJsonSerdeProvider;
 import software.amazon.smithy.java.json.smithy.SmithyJsonSerdeProvider;
 
@@ -22,13 +23,22 @@ abstract class ProviderTestBase {
     static final JacksonJsonSerdeProvider JACKSON = new JacksonJsonSerdeProvider();
     static final SmithyJsonSerdeProvider SMITHY = new SmithyJsonSerdeProvider();
 
+    static List<JsonSerdeProvider> providerInstances() {
+        return RuntimeCodegenFeature.strict("json")
+                ? List.of(SMITHY)
+                : List.of(JACKSON, SMITHY);
+    }
+
     static List<Arguments> providers() {
-        return List.of(
-                Arguments.of(Named.of("jackson", JACKSON)),
-                Arguments.of(Named.of("smithy", SMITHY)));
+        return providerInstances().stream()
+                .map(provider -> Arguments.of(Named.of(provider.getName(), provider)))
+                .toList();
     }
 
     static List<Arguments> crossProviders() {
+        if (RuntimeCodegenFeature.strict("json")) {
+            return List.of(Arguments.of(Named.of("smithy->smithy", SMITHY), SMITHY));
+        }
         return List.of(
                 Arguments.of(Named.of("jackson->jackson", JACKSON), JACKSON),
                 Arguments.of(Named.of("smithy->smithy", SMITHY), SMITHY),
@@ -40,13 +50,15 @@ abstract class ProviderTestBase {
      * Creates a codec with default settings using the given provider.
      */
     static JsonCodec codec(JsonSerdeProvider provider) {
-        return JsonCodec.builder().overrideSerdeProvider(provider).build();
+        return codecBuilder(provider).build();
     }
 
     /**
      * Creates a codec with custom settings using the given provider.
      */
     static JsonCodec.Builder codecBuilder(JsonSerdeProvider provider) {
-        return JsonCodec.builder().overrideSerdeProvider(provider);
+        return JsonCodec.builder()
+                .overrideSerdeProvider(provider)
+                .runtimeCodegen(false);
     }
 }

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/RuntimeCodegenPropertyValidationTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/RuntimeCodegenPropertyValidationTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenFeature;
+
+final class RuntimeCodegenPropertyValidationTest {
+    @Test
+    void propertyRequiresNativeSmithyProvider() {
+        assumeTrue(RuntimeCodegenFeature.enabled("json"));
+        assumeTrue(System.getProperty("smithy-java.json-provider") == null);
+
+        assertThatThrownBy(() -> JsonCodec.builder().build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("-Dsmithy-java.json-provider=smithy");
+    }
+}

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/RuntimeJsonCodegenTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/RuntimeJsonCodegenTest.java
@@ -1,0 +1,1214 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenFeature;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableShape;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
+import software.amazon.smithy.java.core.serde.SerializationException;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.TimestampFormatter;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.json.bench.model.BenchError;
+import software.amazon.smithy.java.json.bench.model.BenchUnion;
+import software.amazon.smithy.java.json.bench.model.BlobStruct;
+import software.amazon.smithy.java.json.bench.model.Color;
+import software.amazon.smithy.java.json.bench.model.ComplexStruct;
+import software.amazon.smithy.java.json.bench.model.HashCollisionStruct;
+import software.amazon.smithy.java.json.bench.model.InnerStruct;
+import software.amazon.smithy.java.json.bench.model.JsonNameStruct;
+import software.amazon.smithy.java.json.bench.model.NestedStruct;
+import software.amazon.smithy.java.json.bench.model.NumericStruct;
+import software.amazon.smithy.java.json.bench.model.Priority;
+import software.amazon.smithy.java.json.bench.model.RecursiveStruct;
+import software.amazon.smithy.java.json.bench.model.RequiredDefaultStruct;
+import software.amazon.smithy.java.json.bench.model.SimpleStruct;
+import software.amazon.smithy.java.json.bench.model.StringStruct;
+import software.amazon.smithy.java.json.bench.model.TimestampStruct;
+import software.amazon.smithy.java.json.bench.model.WireLengthEnum;
+import software.amazon.smithy.java.json.jackson.JacksonJsonSerdeProvider;
+import software.amazon.smithy.java.json.smithy.SmithyGeneratedJsonSerde;
+import software.amazon.smithy.java.json.smithy.SmithyJsonSerdeProvider;
+
+final class RuntimeJsonCodegenTest {
+    private static final JsonSettings SETTINGS = JsonSettings.builder()
+            .useTimestampFormat(true)
+            .build();
+    private static final JsonSettings FALLBACK_SETTINGS = JsonSettings.builder()
+            .useTimestampFormat(true)
+            .runtimeCodegen(false)
+            .build();
+
+    @Test
+    void directlySerializesAndDeserializesScalarStructure() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var value = SimpleStruct.builder()
+                .name("test-\u00e9")
+                .age(42)
+                .active(true)
+                .score(98.6)
+                .createdAt(Instant.parse("2025-01-15T10:30:00Z"))
+                .build();
+
+        ByteBuffer result = serde.serialize(value, SETTINGS);
+        assertThat(result).isNotNull();
+        byte[] bytes = new byte[result.remaining()];
+        result.get(bytes);
+        assertThat(serde.deserialize(bytes, SimpleStruct.builder(), SETTINGS)).isEqualTo(value);
+        assertThat(serde.scan(bytes, SimpleStruct.builder().schema(), SETTINGS)).isEqualTo(bytes.length);
+        assertThat(new String(bytes, StandardCharsets.UTF_8))
+                .isEqualTo("{\"name\":\"test-\u00e9\",\"age\":42,\"active\":true,"
+                        + "\"score\":98.6,\"createdAt\":1736937000}");
+    }
+
+    @Test
+    void streamingSerializerUsesGeneratedAndFallbackStructPaths() {
+        var value = SimpleStruct.builder().name("value").age(7).build();
+        var proxy = new SimpleSubsetProxy(value, (struct, member) -> true);
+        try (var generated = JsonCodec.builder()
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .runtimeCodegen(true)
+                .build();
+                var dispatch = JsonCodec.builder()
+                        .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                        .runtimeCodegen(false)
+                        .build()) {
+            assertThat(stream(generated, value)).containsExactly(stream(dispatch, value));
+            withProperty("smithy-java.runtime-codegen.json", "enabled", () -> {
+                try (var fallback = JsonCodec.builder()
+                        .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                        .runtimeCodegen(true)
+                        .build()) {
+                    assertThat(stream(fallback, proxy)).containsExactly(stream(dispatch, proxy));
+                }
+            });
+        }
+    }
+
+    @Test
+    void strictStreamingSerializerRejectsProxyFallback() {
+        assumeTrue(RuntimeCodegenFeature.available());
+        var value = SimpleStruct.builder().name("value").age(7).build();
+        var proxy = new SimpleSubsetProxy(value, (struct, member) -> true);
+
+        withProperty("smithy-java.runtime-codegen.json", "strict", () -> {
+            try (var codec = JsonCodec.builder()
+                    .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                    .build()) {
+                assertThatThrownBy(() -> stream(codec, proxy))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("cannot fall back");
+            }
+        });
+    }
+
+    @Test
+    void strictRejectsRootlessDispatchDeserializer() {
+        assumeTrue(RuntimeCodegenFeature.available());
+        withProperty("smithy-java.runtime-codegen.json", "strict", () -> {
+            try (var codec = JsonCodec.builder()
+                    .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                    .build()) {
+                assertThatThrownBy(() -> codec.createDeserializer(new byte[] {'{', '}'}))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("createDeserializer would use dispatch serde");
+            }
+        });
+    }
+
+    @Test
+    void deserializesSlicedHeapAndDirectByteBuffers() {
+        byte[] payload = "{\"name\":\"value\",\"age\":7}".getBytes(StandardCharsets.UTF_8);
+        byte[] padded = new byte[payload.length + 4];
+        System.arraycopy(payload, 0, padded, 2, payload.length);
+        ByteBuffer sliced = ByteBuffer.wrap(padded, 2, payload.length).slice();
+        ByteBuffer direct = ByteBuffer.allocateDirect(payload.length);
+        direct.put(payload).flip();
+
+        try (var codec = JsonCodec.builder()
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .runtimeCodegen(true)
+                .build()) {
+            SimpleStruct expected = codec.deserializeShape(payload, SimpleStruct.builder());
+            assertThat(codec.deserializeShape(sliced, SimpleStruct.builder())).isEqualTo(expected);
+            assertThat(codec.deserializeShape(direct, SimpleStruct.builder())).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void acceptsReorderedAndUnknownFieldsAndNullOptionals() {
+        var serde = new SmithyGeneratedJsonSerde();
+        byte[] payload = """
+                {"unknown":{"nested":[1,2]},"score":null,"age":7,"name":"value","active":false}
+                """.getBytes(StandardCharsets.UTF_8);
+
+        SimpleStruct result = serde.deserialize(payload, SimpleStruct.builder(), SETTINGS);
+
+        assertThat(result.getName()).isEqualTo("value");
+        assertThat(result.getAge()).isEqualTo(7);
+        assertThat(result.isActive()).isFalse();
+        assertThat(result.getScore()).isNull();
+    }
+
+    @Test
+    void nullRequiredReferencesUseGenericErrorCorrection() {
+        var generated = new SmithyGeneratedJsonSerde();
+        var dispatch = new SmithyJsonSerdeProvider();
+        byte[] payload = """
+                {"name":null,"age":7}
+                """.getBytes(StandardCharsets.UTF_8);
+
+        SimpleStruct generatedResult = generated.deserialize(payload, SimpleStruct.builder(), SETTINGS);
+        SimpleStruct dispatchResult;
+        try (var codec = JsonCodec.builder()
+                .overrideSerdeProvider(dispatch)
+                .runtimeCodegen(false)
+                .build()) {
+            dispatchResult = codec.deserializeShape(payload, SimpleStruct.builder());
+        }
+
+        assertThat(generatedResult.getName()).isEmpty();
+        assertThat(generatedResult).isEqualTo(dispatchResult);
+    }
+
+    @Test
+    void nullRequiredMemberWithDefaultUsesDefault() {
+        var generated = new SmithyGeneratedJsonSerde();
+        var dispatch = new SmithyJsonSerdeProvider();
+        byte[] payload = "{\"type\":null}".getBytes(StandardCharsets.UTF_8);
+
+        RequiredDefaultStruct generatedResult =
+                generated.deserialize(payload, RequiredDefaultStruct.builder(), SETTINGS);
+        RequiredDefaultStruct dispatchResult;
+        try (var codec = JsonCodec.builder()
+                .overrideSerdeProvider(dispatch)
+                .runtimeCodegen(false)
+                .build()) {
+            dispatchResult = codec.deserializeShape(payload, RequiredDefaultStruct.builder());
+        }
+
+        assertThat(generatedResult.getType()).isEqualTo("text");
+        assertThat(generatedResult).isEqualTo(dispatchResult);
+    }
+
+    @Test
+    void acceptsWhitespaceAroundPackedFieldTokens() {
+        var serde = new SmithyGeneratedJsonSerde();
+        byte[] payload = """
+                { "name" : "value", "age": 7 , "active" :false, "createdAt": 1736937000 }
+                """.getBytes(StandardCharsets.UTF_8);
+
+        SimpleStruct result = serde.deserialize(payload, SimpleStruct.builder(), SETTINGS);
+
+        assertThat(result.getName()).isEqualTo("value");
+        assertThat(result.getAge()).isEqualTo(7);
+        assertThat(result.isActive()).isFalse();
+        assertThat(result.getCreatedAt()).isEqualTo(Instant.parse("2025-01-15T10:30:00Z"));
+    }
+
+    @Test
+    void readsAndWritesNonAsciiJsonName() {
+        var serde = new SmithyGeneratedJsonSerde();
+        JsonSettings settings = JsonSettings.builder()
+                .useJsonName(true)
+                .build();
+        var value = JsonNameStruct.builder().unicodeName("value").build();
+        String serialized = StandardCharsets.UTF_8.decode(serde.serialize(value, settings)).toString();
+        byte[] escaped = """
+                {"\\u00e9":"value"}
+                """.getBytes(StandardCharsets.UTF_8);
+        byte[] raw = """
+                {"é":"value"}
+                """.getBytes(StandardCharsets.UTF_8);
+
+        assertThat(serialized).contains("\"é\":\"value\"");
+        assertThat(serde.deserialize(escaped, JsonNameStruct.builder(), settings).getUnicodeName())
+                .isEqualTo("value");
+        assertThat(serde.deserialize(raw, JsonNameStruct.builder(), settings).getUnicodeName())
+                .isEqualTo("value");
+    }
+
+    @Test
+    void supportsBorrowedOutput() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var value = SimpleStruct.builder().name("x").age(1).build();
+        var sink = new ByteArrayOutputStream();
+
+        assertThat(serde.serializeTo(value, sink, SETTINGS)).isTrue();
+        assertThat(sink.toString(StandardCharsets.UTF_8)).isEqualTo("{\"name\":\"x\",\"age\":1}");
+    }
+
+    @Test
+    void serializesMemberSubsetsLikeDispatch() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var value = SimpleStruct.builder()
+                .name("name")
+                .age(42)
+                .active(true)
+                .build();
+        MemberSubsetCodec.MemberSubset subset =
+                (struct, member) -> member.memberName().equals("name") || member.memberName().equals("active");
+
+        byte[] generated = bytes(serde.serialize(value, SETTINGS, subset));
+        byte[] interpreted = bytes(new SmithyJsonSerdeProvider()
+                .serialize(new SimpleSubsetProxy(value, subset), SETTINGS));
+
+        assertThat(generated).containsExactly(interpreted);
+        assertThat(new String(generated, StandardCharsets.UTF_8))
+                .isEqualTo("{\"name\":\"name\",\"active\":true}");
+    }
+
+    @Test
+    void deserializesMemberSubsetsIntoConcreteBuilder() {
+        var serde = new SmithyGeneratedJsonSerde();
+        ShapeBuilder<SimpleStruct> builder = SimpleStruct.builder().age(7);
+        MemberSubsetCodec.MemberSubset subset =
+                (struct, member) -> member.memberName().equals("name");
+        ByteBuffer source = ByteBuffer.wrap(
+                "{\"name\":\"body\",\"age\":999,\"active\":true}".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(serde.deserialize(builder.schema(), builder, source, SETTINGS, subset)).isTrue();
+        assertThat(builder.build()).isEqualTo(SimpleStruct.builder().name("body").age(7).build());
+    }
+
+    @Test
+    void serializesEmptyMemberSubsetAsEmptyObject() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var value = SimpleStruct.builder().name("name").age(42).build();
+        MemberSubsetCodec.MemberSubset none = (struct, member) -> false;
+
+        byte[] generated = bytes(serde.serialize(value, SETTINGS, none));
+        byte[] interpreted = bytes(new SmithyJsonSerdeProvider()
+                .serialize(new SimpleSubsetProxy(value, none), SETTINGS));
+
+        assertThat(generated).containsExactly(interpreted);
+        assertThat(new String(generated, StandardCharsets.UTF_8)).isEqualTo("{}");
+    }
+
+    @Test
+    void declinesMemberSubsetsPastTheCacheBound() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var value = SimpleStruct.builder().name("name").age(42).build();
+
+        for (int i = 0; i < 16; i++) {
+            MemberSubsetCodec.MemberSubset subset = new MemberSubsetCodec.MemberSubset() {
+                @Override
+                public boolean includes(Schema struct, Schema member) {
+                    return member.memberIndex() == 0;
+                }
+            };
+            assertThat(serde.serialize(value, FALLBACK_SETTINGS, subset)).isNotNull();
+        }
+        MemberSubsetCodec.MemberSubset overflow = new MemberSubsetCodec.MemberSubset() {
+            @Override
+            public boolean includes(Schema struct, Schema member) {
+                return member.memberIndex() == 0;
+            }
+        };
+        assertThat(serde.serialize(value, FALLBACK_SETTINGS, overflow)).isNull();
+    }
+
+    @Test
+    void customRootBuilderFallsBackInsteadOfReachingGeneratedCast() {
+        byte[] payload = "{\"name\":\"value\",\"age\":7}".getBytes(StandardCharsets.UTF_8);
+        var direct = new SmithyGeneratedJsonSerde();
+
+        assertThat(direct.deserialize(payload, wrappingSimpleBuilder(), FALLBACK_SETTINGS)).isNull();
+
+        try (var codec = JsonCodec.builder()
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .runtimeCodegen(false)
+                .build()) {
+            assertThat(codec.deserializeShape(payload, wrappingSimpleBuilder()))
+                    .isEqualTo(SimpleStruct.builder().name("value").age(7).build());
+        }
+    }
+
+    @Test
+    void malformedInputDoesNotRetryThroughFallback() {
+        var serde = new SmithyGeneratedJsonSerde();
+
+        assertThrows(
+                SerializationException.class,
+                () -> serde.deserialize(
+                        "{\"name\":\"x\",\"age\":01}".getBytes(StandardCharsets.UTF_8),
+                        SimpleStruct.builder(),
+                        SETTINGS));
+        assertThrows(
+                SerializationException.class,
+                () -> serde.deserialize(
+                        "{\"name\":\"x\"".getBytes(StandardCharsets.UTF_8),
+                        SimpleStruct.builder(),
+                        SETTINGS));
+    }
+
+    @Test
+    void rejectsTrailingContent() {
+        var serde = new SmithyGeneratedJsonSerde();
+
+        assertThrows(
+                SerializationException.class,
+                () -> serde.deserialize(
+                        "{\"name\":\"x\",\"age\":1} trailing".getBytes(StandardCharsets.UTF_8),
+                        SimpleStruct.builder(),
+                        SETTINGS));
+    }
+
+    @Test
+    void rejectsExcessiveGeneratedNesting() {
+        var serde = new SmithyGeneratedJsonSerde();
+        StringBuilder payload = new StringBuilder();
+        for (int i = 0; i < 1_100; i++) {
+            payload.append("{\"value\":\"x\",\"child\":");
+        }
+        payload.append("{\"value\":\"leaf\"}");
+        payload.append("}".repeat(1_100));
+
+        assertThrows(
+                SerializationException.class,
+                () -> serde.deserialize(
+                        payload.toString().getBytes(StandardCharsets.UTF_8),
+                        RecursiveStruct.builder(),
+                        SETTINGS));
+    }
+
+    @Test
+    void disambiguatesCollidingFieldHashes() {
+        var serde = new SmithyGeneratedJsonSerde();
+        byte[] payload = """
+                {"bB":"second","aa":"first"}
+                """.getBytes(StandardCharsets.UTF_8);
+
+        HashCollisionStruct result = serde.deserialize(payload, HashCollisionStruct.builder(), SETTINGS);
+
+        assertThat(result.getAa()).isEqualTo("first");
+        assertThat(result.getBB()).isEqualTo("second");
+    }
+
+    @Test
+    void generatedDoubleIntegerFastPathPreservesNumberSemantics() {
+        var serde = new SmithyGeneratedJsonSerde();
+
+        NumericStruct negativeZero = serde.deserialize(
+                "{\"doubleVal\":-0}".getBytes(StandardCharsets.UTF_8),
+                NumericStruct.builder(),
+                SETTINGS);
+        assertThat(Double.doubleToRawLongBits(negativeZero.getDoubleVal()))
+                .isEqualTo(Double.doubleToRawLongBits(-0.0d));
+
+        for (String value : List.of(
+                "123456789012345678",
+                "9223372036854775808",
+                "1.25",
+                "15e2")) {
+            NumericStruct result = serde.deserialize(
+                    ("{\"doubleVal\":" + value + "}").getBytes(StandardCharsets.UTF_8),
+                    NumericStruct.builder(),
+                    SETTINGS);
+            assertThat(result.getDoubleVal()).isEqualTo(Double.parseDouble(value));
+        }
+
+        assertThrows(
+                SerializationException.class,
+                () -> serde.deserialize(
+                        "{\"doubleVal\":01}".getBytes(StandardCharsets.UTF_8),
+                        NumericStruct.builder(),
+                        SETTINGS));
+    }
+
+    @Test
+    void coversScalarBoundariesEscapingBlobsTimestampsAndRecursion() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var numeric = NumericStruct.builder()
+                .byteVal(Byte.MIN_VALUE)
+                .shortVal(Short.MAX_VALUE)
+                .intVal(Integer.MIN_VALUE)
+                .longVal(Long.MAX_VALUE)
+                .floatVal(Float.MAX_VALUE)
+                .doubleVal(Double.MIN_NORMAL)
+                .bigIntVal(new BigInteger("123456789012345678901234567890"))
+                .bigDecVal(new BigDecimal("-1234567890.0123456789"))
+                .build();
+        var string = StringStruct.builder().value("quote=\" slash=\\ newline=\n emoji=\ud83d\ude03").build();
+        var blob = BlobStruct.builder().data(ByteBuffer.wrap(new byte[] {0, 1, -1})).build();
+        Instant instant = Instant.parse("2025-01-15T10:30:00Z");
+        var timestamps = TimestampStruct.builder()
+                .epochSeconds(instant)
+                .dateTime(instant)
+                .httpDate(instant)
+                .build();
+        var recursive = RecursiveStruct.builder()
+                .value("root")
+                .child(RecursiveStruct.builder().value("leaf").build())
+                .build();
+
+        assertRoundTrip(serde, numeric, NumericStruct.builder());
+        assertRoundTrip(serde, string, StringStruct.builder());
+        assertRoundTrip(serde, blob, BlobStruct.builder());
+        assertRoundTrip(serde, timestamps, TimestampStruct.builder());
+        assertRoundTrip(serde, recursive, RecursiveStruct.builder());
+    }
+
+    @Test
+    void roundTripsComplexAggregateGraph() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var inner = InnerStruct.builder().value("inner").numbers(List.of(1, 2, 3)).build();
+        var nested = NestedStruct.builder().field1("nested").field2(2).inner(inner).build();
+        var sparseMap = new HashMap<String, String>();
+        sparseMap.put("present", "value");
+        sparseMap.put("null", null);
+        var metadata = new HashMap<String, String>();
+        metadata.put("quote\"slash\\", "escaped");
+        metadata.put("snowman-\u2603", "unicode");
+        metadata.put("line\nbreak", "control");
+        var value = ComplexStruct.builder()
+                .id("id")
+                .count(1)
+                .enabled(true)
+                .ratio(1.5)
+                .score(2.5f)
+                .bigCount(99)
+                .tags(List.of("a", "b", "c", "d", "e", "f"))
+                .intList(List.of(1, 2))
+                .metadata(metadata)
+                .intMap(Map.of("n", 3))
+                .nested(nested)
+                .optionalNested(nested)
+                .structList(List.of(nested, nested, nested))
+                .structMap(Map.of("nested", nested))
+                .choice(new BenchUnion.StructValueMember(nested))
+                .color(Color.GREEN)
+                .colorList(List.of(Color.RED, Color.BLUE))
+                .sparseStrings(Arrays.asList("a", null, "b"))
+                .sparseMap(sparseMap)
+                .bigIntValue(new BigInteger("12345678901234567890"))
+                .bigDecValue(new BigDecimal("1234.50"))
+                .freeformData(Document.of(Map.of("key", Document.of("value"))))
+                .build();
+
+        ByteBuffer encoded = serde.serialize(value, SETTINGS);
+        assertThat(encoded).isNotNull();
+        byte[] bytes = new byte[encoded.remaining()];
+        encoded.get(bytes);
+        assertThat(serde.deserialize(bytes, ComplexStruct.builder(), SETTINGS)).isEqualTo(value);
+    }
+
+    @Test
+    void denseCollectionsRejectNullOnReadAndWriteLikeDispatch() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var dispatch = new SmithyJsonSerdeProvider();
+        byte[] denseList = "{\"tags\":[\"a\",null]}".getBytes(StandardCharsets.UTF_8);
+        byte[] denseMap = "{\"metadata\":{\"key\":null}}".getBytes(StandardCharsets.UTF_8);
+
+        for (byte[] payload : List.of(denseList, denseMap)) {
+            assertThatThrownBy(() -> serde.deserialize(payload, ComplexStruct.builder(), SETTINGS))
+                    .isInstanceOf(SerializationException.class);
+            assertThatThrownBy(() -> dispatch(payload, ComplexStruct.builder()))
+                    .isInstanceOf(SerializationException.class);
+        }
+
+        var nested = NestedStruct.builder().field1("nested").field2(2).build();
+        var listWithNull = ComplexStruct.builder()
+                .id("id")
+                .count(1)
+                .nested(nested)
+                .tags(Arrays.asList("a", null))
+                .build();
+        var mapWithNull = new HashMap<String, String>();
+        mapWithNull.put("key", null);
+        var valueWithNullMap = ComplexStruct.builder()
+                .id("id")
+                .count(1)
+                .nested(nested)
+                .metadata(mapWithNull)
+                .build();
+
+        for (ComplexStruct value : List.of(listWithNull, valueWithNullMap)) {
+            assertThatThrownBy(() -> serde.serialize(value, SETTINGS))
+                    .isInstanceOf(SerializationException.class);
+            assertThatThrownBy(() -> dispatch.serialize(value, SETTINGS))
+                    .isInstanceOf(RuntimeException.class);
+        }
+    }
+
+    @Test
+    void sparseCollectionsAllowNullOnReadAndWriteLikeDispatch() {
+        var serde = new SmithyGeneratedJsonSerde();
+        byte[] payload = ("{\"id\":\"id\",\"count\":1,"
+                + "\"nested\":{\"field1\":\"nested\",\"field2\":2},"
+                + "\"sparseStrings\":[\"a\",null,\"b\"],"
+                + "\"sparseMap\":{\"present\":\"value\",\"absent\":null}}")
+                .getBytes(StandardCharsets.UTF_8);
+
+        ComplexStruct generated = serde.deserialize(payload, ComplexStruct.builder(), SETTINGS);
+        ComplexStruct interpreted = dispatch(payload, ComplexStruct.builder());
+
+        assertThat(generated).isEqualTo(interpreted);
+        assertThat(generated.getSparseStrings()).containsExactly("a", null, "b");
+        assertThat(generated.getSparseMap()).containsEntry("present", "value").containsEntry("absent", null);
+        assertThat(bytes(serde.serialize(generated, SETTINGS)))
+                .containsExactly(bytes(new SmithyJsonSerdeProvider().serialize(interpreted, SETTINGS)));
+    }
+
+    @Test
+    void declinesMapsWhoseKeysAreNotPlainStrings() {
+        withProperty("smithy-java.runtime-codegen.json", "enabled", () -> {
+            var serde = new SmithyGeneratedJsonSerde();
+            var value = new EnumKeyedMapModel.Value(
+                    Map.of(new EnumKeyedMapModel.Key("A"), "value"));
+
+            assertThat(serde.serialize(value, FALLBACK_SETTINGS)).isNull();
+            assertThat(serde.deserialize(
+                    "{\"values\":{\"A\":\"value\"}}".getBytes(StandardCharsets.UTF_8),
+                    new EnumKeyedMapModel.Value.Builder(),
+                    FALLBACK_SETTINGS))
+                    .isNull();
+        });
+    }
+
+    @Test
+    void preservesTypedDocumentDiscriminator() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var nested = NestedStruct.builder().field1("nested").field2(2).build();
+        var value = ComplexStruct.builder()
+                .id("id")
+                .count(1)
+                .nested(nested)
+                .freeformData(Document.of(nested))
+                .build();
+
+        String json = StandardCharsets.UTF_8.decode(serde.serialize(value, SETTINGS)).toString();
+
+        assertThat(json).contains("\"freeformData\":{\"__type\":\"smithy.java.json.bench#NestedStruct\"");
+    }
+
+    @Test
+    void supportsMultipleSettingsInstances() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var value = SimpleStruct.builder()
+                .name("value")
+                .age(1)
+                .createdAt(Instant.EPOCH)
+                .build();
+        JsonSettings dateTime = JsonSettings.builder()
+                .defaultTimestampFormat(TimestampFormatter.Prelude.DATE_TIME)
+                .build();
+
+        String epoch = StandardCharsets.UTF_8.decode(serde.serialize(value, SETTINGS)).toString();
+        String iso8601 = StandardCharsets.UTF_8.decode(serde.serialize(value, dateTime)).toString();
+
+        assertThat(epoch).contains("\"createdAt\":0");
+        assertThat(iso8601).contains("\"createdAt\":\"1970-01-01T00:00:00Z\"");
+    }
+
+    @Test
+    void concurrentlySwitchesSettingsWithoutCrossContamination() throws Exception {
+        var serde = new SmithyGeneratedJsonSerde();
+        var value = JsonNameStruct.builder()
+                .id("id")
+                .displayName("display")
+                .unicodeName("unicode")
+                .normalField("normal")
+                .build();
+        JsonSettings memberNames = JsonSettings.builder().useJsonName(false).build();
+        JsonSettings jsonNames = JsonSettings.builder().useJsonName(true).build();
+        String expectedMembers = StandardCharsets.UTF_8
+                .decode(serde.serialize(value, memberNames))
+                .toString();
+        String expectedJsonNames = StandardCharsets.UTF_8
+                .decode(serde.serialize(value, jsonNames))
+                .toString();
+        var start = new CountDownLatch(1);
+
+        try (var executor = Executors.newFixedThreadPool(8)) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int thread = 0; thread < 8; thread++) {
+                JsonSettings settings = (thread & 1) == 0 ? memberNames : jsonNames;
+                String expected = (thread & 1) == 0 ? expectedMembers : expectedJsonNames;
+                futures.add(executor.submit(() -> {
+                    start.await();
+                    for (int i = 0; i < 1_000; i++) {
+                        String actual = StandardCharsets.UTF_8
+                                .decode(serde.serialize(value, settings))
+                                .toString();
+                        assertThat(actual).isEqualTo(expected);
+                    }
+                    return null;
+                }));
+            }
+            start.countDown();
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        }
+    }
+
+    @Test
+    void generatedAndDispatchInteroperateForComplexGraph() {
+        var generated = new SmithyGeneratedJsonSerde();
+        var dispatch = new SmithyJsonSerdeProvider();
+        var nested = NestedStruct.builder()
+                .field1("nested")
+                .field2(2)
+                .inner(InnerStruct.builder().value("inner").numbers(List.of(1, 2, 3)).build())
+                .build();
+        var value = ComplexStruct.builder()
+                .id("id")
+                .count(1)
+                .enabled(true)
+                .ratio(1.5)
+                .score(2.5f)
+                .bigCount(99)
+                .tags(List.of("a", "b"))
+                .metadata(Map.of("key", "value"))
+                .nested(nested)
+                .choice(new BenchUnion.StructValueMember(nested))
+                .color(Color.GREEN)
+                .build();
+
+        ByteBuffer generatedBytes = generated.serialize(value, SETTINGS);
+        ByteBuffer dispatchBytes = dispatch.serialize(value, SETTINGS);
+        byte[] generatedPayload = new byte[generatedBytes.remaining()];
+        generatedBytes.duplicate().get(generatedPayload);
+        byte[] dispatchPayload = new byte[dispatchBytes.remaining()];
+        dispatchBytes.duplicate().get(dispatchPayload);
+
+        assertThat(generated.deserialize(dispatchPayload, ComplexStruct.builder(), SETTINGS)).isEqualTo(value);
+        try (var dispatchCodec = JsonCodec.builder()
+                .overrideSerdeProvider(dispatch)
+                .runtimeCodegen(false)
+                .useTimestampFormat(true)
+                .build()) {
+            assertThat(dispatchCodec.deserializeShape(generatedPayload, ComplexStruct.builder())).isEqualTo(value);
+        }
+    }
+
+    @Test
+    void clonedCodegenSettingsRetainTimestampConfiguration() {
+        JsonSettings original = JsonSettings.builder()
+                .defaultTimestampFormat(TimestampFormatter.Prelude.DATE_TIME)
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .runtimeCodegen(true)
+                .build();
+        JsonSettings cloned = original.toBuilder().build();
+        var value = SimpleStruct.builder().name("value").age(1).build();
+
+        assertThat(original.runtimeCodegen()).isTrue();
+        assertThat(cloned).isEqualTo(original);
+        assertThat(cloned.timestampResolver().defaultFormat())
+                .isEqualTo(TimestampFormatter.Prelude.DATE_TIME);
+        assertThat(original.provider().serialize(value, original)).isNotNull();
+        assertThat(cloned.provider().serialize(value, cloned)).isNotNull();
+    }
+
+    @Test
+    void rejectsRuntimeCodegenWithCustomProvider() {
+        assumeTrue(RuntimeCodegenFeature.available());
+        assertThatThrownBy(() -> JsonCodec.builder()
+                .overrideSerdeProvider(new JacksonJsonSerdeProvider())
+                .runtimeCodegen(true)
+                .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("native Smithy provider");
+    }
+
+    @Test
+    void runtimeCodegenKillSwitchDisablesProviderValidation() {
+        withProperty("smithy-java.runtime-codegen.json", "disabled", () -> {
+            JsonSettings settings = JsonSettings.builder()
+                    .overrideSerdeProvider(new JacksonJsonSerdeProvider())
+                    .runtimeCodegen(true)
+                    .build();
+
+            assertThat(settings.runtimeCodegen()).isFalse();
+            assertThat(settings.provider()).isInstanceOf(JacksonJsonSerdeProvider.class);
+        });
+    }
+
+    @Test
+    void strictRuntimeCodegenRejectsCustomProviderFallback() {
+        withProperty("smithy-java.runtime-codegen.json", "strict", () -> {
+            assertThatThrownBy(() -> JsonSettings.builder()
+                    .overrideSerdeProvider(new JacksonJsonSerdeProvider())
+                    .build())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("cannot fall back");
+        });
+    }
+
+    @Test
+    void explicitDisableWinsOverEnabledProperty() {
+        withProperty("smithy-java.runtime-codegen.json", "enabled", () -> {
+            JsonSettings settings = JsonSettings.builder()
+                    .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                    .runtimeCodegen(false)
+                    .build();
+
+            assertThat(settings.runtimeCodegen()).isFalse();
+        });
+    }
+
+    @Test
+    void strictPropertyStillEnablesExplicitCodegen() {
+        assumeTrue(RuntimeCodegenFeature.available());
+        withProperty("smithy-java.runtime-codegen.json", "strict", () -> {
+            JsonSettings settings = JsonSettings.builder()
+                    .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                    .runtimeCodegen(true)
+                    .build();
+
+            assertThat(settings.runtimeCodegen()).isTrue();
+        });
+    }
+
+    @Test
+    void readsKnownEscapedAndUnknownEnums() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var nested = NestedStruct.builder().field1("nested").field2(2).build();
+        var value = ComplexStruct.builder()
+                .id("id")
+                .count(1)
+                .nested(nested)
+                .color(Color.GREEN)
+                .build();
+        ByteBuffer encoded = serde.serialize(value, SETTINGS);
+        String json = StandardCharsets.UTF_8.decode(encoded).toString();
+
+        String escapedGreen = "\"GR" + "\\" + "u0045EN\"";
+        byte[] escaped = json.replace("\"GREEN\"", escapedGreen)
+                .getBytes(StandardCharsets.UTF_8);
+        assertThat(serde.deserialize(escaped, ComplexStruct.builder(), SETTINGS).getColor())
+                .isSameAs(Color.GREEN);
+
+        byte[] unknown = json.replace("\"GREEN\"", "\"PURPLE\"")
+                .getBytes(StandardCharsets.UTF_8);
+        assertThat(serde.deserialize(unknown, ComplexStruct.builder(), SETTINGS).getColor().getValue())
+                .isEqualTo("PURPLE");
+    }
+
+    @Test
+    void readsEveryEnumWireLengthBranch() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var nested = NestedStruct.builder().field1("nested").field2(2).build();
+        List<WireLengthEnum> all = List.of(
+                WireLengthEnum.ONE,
+                WireLengthEnum.SEVEN,
+                WireLengthEnum.EIGHT,
+                WireLengthEnum.NINE,
+                WireLengthEnum.SIXTEEN,
+                WireLengthEnum.SEVENTEEN,
+                WireLengthEnum.LONG,
+                WireLengthEnum.SHARED_PREFIX_EIGHT,
+                WireLengthEnum.SHARED_PREFIX_NINE,
+                WireLengthEnum.SHARED_PREFIX_LONG,
+                WireLengthEnum.QUOTE,
+                WireLengthEnum.BACKSLASH,
+                WireLengthEnum.NON_ASCII_SHORT,
+                WireLengthEnum.NON_ASCII);
+
+        for (WireLengthEnum value : all) {
+            var single = ComplexStruct.builder()
+                    .id("id")
+                    .count(1)
+                    .nested(nested)
+                    .wireLength(value)
+                    .build();
+            assertRoundTrip(serde, single, ComplexStruct.builder());
+        }
+        var batch = ComplexStruct.builder()
+                .id("id")
+                .count(1)
+                .nested(nested)
+                .wireLengthList(all)
+                .build();
+        assertRoundTrip(serde, batch, ComplexStruct.builder());
+
+        for (WireLengthEnum value : all) {
+            byte[] payload = ("{\"id\":\"id\",\"count\":1,\"nested\":{\"field1\":\"n\",\"field2\":2},"
+                    + "\"wireLength\":" + quoteJson(value.getValue()) + "}")
+                    .getBytes(StandardCharsets.UTF_8);
+            assertThat(serde.deserialize(payload, ComplexStruct.builder(), SETTINGS).getWireLength())
+                    .isSameAs(value);
+        }
+
+        byte[] unknown = ("{\"id\":\"id\",\"count\":1,\"nested\":{\"field1\":\"n\",\"field2\":2},"
+                + "\"wireLength\":\"abcdefgy\"}").getBytes(StandardCharsets.UTF_8);
+        assertThat(serde.deserialize(unknown, ComplexStruct.builder(), SETTINGS).getWireLength().getValue())
+                .isEqualTo("abcdefgy");
+    }
+
+    @Test
+    void readsAndWritesIntEnumsAtEveryLoweringSite() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var nested = NestedStruct.builder().field1("nested").field2(2).build();
+        List<Priority> all = List.of(
+                Priority.MIN,
+                Priority.NEGATIVE,
+                Priority.ZERO,
+                Priority.ONE,
+                Priority.HUNDRED,
+                Priority.MAX);
+
+        for (Priority value : all) {
+            var single = ComplexStruct.builder()
+                    .id("id")
+                    .count(1)
+                    .nested(nested)
+                    .priority(value)
+                    .build();
+            assertRoundTrip(serde, single, ComplexStruct.builder());
+        }
+
+        Map<String, Priority> byName = new HashMap<>();
+        for (Priority value : all) {
+            byName.put(String.valueOf(value.getValue()), value);
+        }
+        var batch = ComplexStruct.builder()
+                .id("id")
+                .count(1)
+                .nested(nested)
+                .priorityList(all)
+                .priorityMap(byName)
+                .build();
+        assertRoundTrip(serde, batch, ComplexStruct.builder());
+
+        for (Priority value : all) {
+            byte[] payload = ("{\"id\":\"id\",\"count\":1,\"nested\":{\"field1\":\"n\",\"field2\":2},"
+                    + "\"priority\":" + value.getValue() + "}")
+                    .getBytes(StandardCharsets.UTF_8);
+            assertThat(serde.deserialize(payload, ComplexStruct.builder(), SETTINGS).getPriority())
+                    .isSameAs(value);
+        }
+
+        byte[] unknown = ("{\"id\":\"id\",\"count\":1,\"nested\":{\"field1\":\"n\",\"field2\":2},"
+                + "\"priority\":4242}").getBytes(StandardCharsets.UTF_8);
+        assertThat(serde.deserialize(unknown, ComplexStruct.builder(), SETTINGS).getPriority().getValue())
+                .isEqualTo(4242);
+    }
+
+    @Test
+    void structuresWithIntEnumMembersAreGeneratedRatherThanFallingBack() {
+        withProperty("smithy-java.runtime-codegen.json", "strict", () -> {
+            var serde = new SmithyGeneratedJsonSerde();
+            JsonSettings freshSettings = JsonSettings.builder()
+                    .useTimestampFormat(true)
+                    .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                    .build();
+            var value = ComplexStruct.builder()
+                    .id("id")
+                    .count(1)
+                    .nested(NestedStruct.builder().field1("n").field2(2).build())
+                    .priority(Priority.HUNDRED)
+                    .priorityList(List.of(Priority.MIN, Priority.MAX))
+                    .build();
+
+            ByteBuffer encoded = serde.serialize(value, freshSettings);
+            byte[] bytes = new byte[encoded.remaining()];
+            encoded.get(bytes);
+            assertThat(serde.deserialize(bytes, ComplexStruct.builder(), freshSettings)).isEqualTo(value);
+        });
+    }
+
+    private static String quoteJson(String value) {
+        StringBuilder sb = new StringBuilder(value.length() + 2).append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                default -> sb.append(c);
+            }
+        }
+        return sb.append('"').toString();
+    }
+
+    @Test
+    void skipsUnionTypeDiscriminatorWhereverItAppears() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var expected = new BenchUnion.StringValueMember("value");
+
+        for (String union : List.of(
+                "{\"__type\":\"smithy.java.json.bench#BenchUnion\",\"stringValue\":\"value\"}",
+                "{\"stringValue\":\"value\",\"__type\":\"smithy.java.json.bench#BenchUnion\"}",
+                "{\"__type\":\"a\",\"stringValue\":\"value\",\"__type\":\"b\"}")) {
+            byte[] root = union.getBytes(StandardCharsets.UTF_8);
+            assertThat(serde.deserialize(root, BenchUnion.builder(), SETTINGS)).isEqualTo(expected);
+            assertThat(serde.deserialize(root, BenchUnion.builder(), SETTINGS))
+                    .isEqualTo(dispatch(root, BenchUnion.builder()));
+
+            byte[] nested = wrapChoice(union);
+            assertThat(serde.deserialize(nested, ComplexStruct.builder(), SETTINGS).getChoice())
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void treatsNullUnionMembersAsAbsent() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var expected = new BenchUnion.IntValueMember(42);
+
+        for (String union : List.of(
+                "{\"stringValue\":null,\"intValue\":42}",
+                "{\"intValue\":42,\"stringValue\":null}",
+                "{\"structValue\":null,\"intValue\":42,\"stringValue\":null}")) {
+            byte[] root = union.getBytes(StandardCharsets.UTF_8);
+            assertThat(serde.deserialize(root, BenchUnion.builder(), SETTINGS)).isEqualTo(expected);
+            assertThat(serde.deserialize(root, BenchUnion.builder(), SETTINGS))
+                    .isEqualTo(dispatch(root, BenchUnion.builder()));
+
+            byte[] nested = wrapChoice(union);
+            assertThat(serde.deserialize(nested, ComplexStruct.builder(), SETTINGS).getChoice())
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void rejectsUnionsCarryingNoMemberOrMoreThanOne() {
+        var serde = new SmithyGeneratedJsonSerde();
+
+        for (String union : List.of(
+                "{}",
+                "{\"__type\":\"x\"}",
+                "{\"stringValue\":null}",
+                "{\"stringValue\":\"a\",\"intValue\":1}",
+                "{\"stringValue\":\"a\",\"future\":1}",
+                "{\"future\":1,\"stringValue\":\"a\"}")) {
+            byte[] root = union.getBytes(StandardCharsets.UTF_8);
+            assertThatThrownBy(() -> serde.deserialize(root, BenchUnion.builder(), SETTINGS))
+                    .isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> dispatch(root, BenchUnion.builder()))
+                    .isInstanceOf(RuntimeException.class);
+
+            byte[] nested = wrapChoice(union);
+            assertThatThrownBy(() -> serde.deserialize(nested, ComplexStruct.builder(), SETTINGS))
+                    .isInstanceOf(SerializationException.class);
+        }
+    }
+
+    @Test
+    void preservesUnknownUnionMembers() {
+        var serde = new SmithyGeneratedJsonSerde();
+        byte[] payload = "{\"future\":{\"nested\":[1,2]}}".getBytes(StandardCharsets.UTF_8);
+
+        BenchUnion generated = serde.deserialize(payload, BenchUnion.builder(), SETTINGS);
+
+        assertThat(generated).isInstanceOf(BenchUnion.$Unknown.class);
+        assertThat((String) generated.getValue()).isEqualTo("future");
+        assertThat(generated).isEqualTo(dispatch(payload, BenchUnion.builder()));
+
+        BenchUnion nested = serde.deserialize(wrapChoice("{\"future\":1}"), ComplexStruct.builder(), SETTINGS)
+                .getChoice();
+        assertThat(nested).isInstanceOf(BenchUnion.$Unknown.class);
+        assertThat((String) nested.getValue()).isEqualTo("future");
+    }
+
+    @Test
+    void forbidsUnknownUnionMembersInGeneratedRootAndNestedReaders() {
+        var serde = new SmithyGeneratedJsonSerde();
+        JsonSettings forbid = JsonSettings.builder()
+                .forbidUnknownUnionMembers(true)
+                .build();
+        byte[] root = "{\"future\":1}".getBytes(StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> serde.deserialize(root, BenchUnion.builder(), forbid))
+                .isInstanceOf(SerializationException.class)
+                .hasMessageContaining("Unknown union member");
+        assertThatThrownBy(() -> serde.deserialize(
+                wrapChoice("{\"future\":1}"),
+                ComplexStruct.builder(),
+                forbid))
+                .isInstanceOf(SerializationException.class)
+                .hasMessageContaining("Unknown union member");
+    }
+
+    @Test
+    void treatsNullPrimitiveMembersAsAbsentLikeDispatch() {
+        var serde = new SmithyGeneratedJsonSerde();
+        byte[] payload = ("{\"id\":\"id\",\"count\":1,\"enabled\":null,\"ratio\":null,\"score\":null,"
+                + "\"bigCount\":null,\"optionalInt\":null,\"nested\":{\"field1\":\"n\",\"field2\":2}}")
+                .getBytes(StandardCharsets.UTF_8);
+
+        ComplexStruct generated = serde.deserialize(payload, ComplexStruct.builder(), SETTINGS);
+
+        assertThat(generated).isEqualTo(dispatch(payload, ComplexStruct.builder()));
+        assertThat(generated.isEnabled()).isFalse();
+        assertThat(generated.getBigCount()).isZero();
+    }
+
+    @Test
+    void refusesToGenerateSerdeForErrorShapes() {
+        withProperty("smithy-java.runtime-codegen.json", "enabled", () -> {
+            var serde = new SmithyGeneratedJsonSerde();
+            var value = BenchError.builder().message("boom").code(7).build();
+            byte[] payload = "{\"message\":\"boom\",\"code\":7}".getBytes(StandardCharsets.UTF_8);
+
+            assertThat(serde.serialize(value, FALLBACK_SETTINGS)).isNull();
+            assertThat(serde.deserialize(payload, BenchError.builder(), FALLBACK_SETTINGS)).isNull();
+
+            try (var codec = JsonCodec.builder()
+                    .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                    .runtimeCodegen(true)
+                    .useTimestampFormat(true)
+                    .build()) {
+                BenchError result = codec.deserializeShape(payload, BenchError.builder());
+                assertThat(result.getMessage()).isEqualTo("boom");
+                assertThat(result.getCode()).isEqualTo(7);
+                assertThat(result.deserialized()).isTrue();
+            }
+        });
+    }
+
+    private static byte[] wrapChoice(String union) {
+        return ("{\"id\":\"id\",\"count\":1,\"nested\":{\"field1\":\"n\",\"field2\":2},\"choice\":" + union + "}")
+                .getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static <T extends SerializableShape> T dispatch(byte[] payload, ShapeBuilder<T> builder) {
+        try (var codec = JsonCodec.builder()
+                .overrideSerdeProvider(new SmithyJsonSerdeProvider())
+                .runtimeCodegen(false)
+                .useTimestampFormat(true)
+                .build()) {
+            return codec.deserializeShape(payload, builder);
+        }
+    }
+
+    @Test
+    void supportsStructureEncodedSealedInterfaceUnions() {
+        var serde = new SmithyGeneratedJsonSerde();
+        var value = StructureEncodedUnionModel.Envelope.builder()
+                .attribute(new StructureEncodedUnionModel.Value.SMember("value"))
+                .build();
+
+        assertRoundTrip(serde, value, StructureEncodedUnionModel.Envelope.builder());
+    }
+
+    private static <T extends SerializableShape> void assertRoundTrip(
+            SmithyGeneratedJsonSerde serde,
+            T value,
+            ShapeBuilder<T> builder
+    ) {
+        ByteBuffer encoded = serde.serialize((SerializableStruct) value, SETTINGS);
+        assertThat(encoded).isNotNull();
+        byte[] generated = bytes(encoded);
+        byte[] interpreted = bytes(new SmithyJsonSerdeProvider().serialize(value, SETTINGS));
+        assertThat(generated).containsExactly(interpreted);
+        assertThat(serde.deserialize(generated, builder, SETTINGS)).isEqualTo(value);
+    }
+
+    private static ShapeBuilder<SimpleStruct> wrappingSimpleBuilder() {
+        ShapeBuilder<SimpleStruct> delegate = SimpleStruct.builder();
+        return new ShapeBuilder<>() {
+            @Override
+            public SimpleStruct build() {
+                return delegate.build();
+            }
+
+            @Override
+            public ShapeBuilder<SimpleStruct> deserialize(ShapeDeserializer decoder) {
+                delegate.deserialize(decoder);
+                return this;
+            }
+
+            @Override
+            public Schema schema() {
+                return delegate.schema();
+            }
+        };
+    }
+
+    private static byte[] bytes(ByteBuffer buffer) {
+        byte[] result = new byte[buffer.remaining()];
+        buffer.duplicate().get(result);
+        return result;
+    }
+
+    private static byte[] stream(JsonCodec codec, SerializableStruct value) {
+        var sink = new ByteArrayOutputStream();
+        try (ShapeSerializer serializer = codec.createSerializer(sink)) {
+            value.serialize(serializer);
+        }
+        return sink.toByteArray();
+    }
+
+    private static void withProperty(String name, String value, Runnable action) {
+        String previous = System.getProperty(name);
+        try {
+            System.setProperty(name, value);
+            action.run();
+        } finally {
+            if (previous == null) {
+                System.clearProperty(name);
+            } else {
+                System.setProperty(name, previous);
+            }
+        }
+    }
+
+    private record SimpleSubsetProxy(
+            SimpleStruct value,
+            MemberSubsetCodec.MemberSubset subset) implements SerializableStruct {
+        @Override
+        public Schema schema() {
+            return value.schema();
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            Schema schema = schema();
+            Schema name = schema.member("name");
+            Schema age = schema.member("age");
+            Schema active = schema.member("active");
+            Schema score = schema.member("score");
+            Schema createdAt = schema.member("createdAt");
+            if (subset.includes(schema, name)) {
+                serializer.writeString(name, value.getName());
+            }
+            if (subset.includes(schema, age)) {
+                serializer.writeInteger(age, value.getAge());
+            }
+            if (subset.includes(schema, active) && value.isActive() != null) {
+                serializer.writeBoolean(active, value.isActive());
+            }
+            if (subset.includes(schema, score) && value.getScore() != null) {
+                serializer.writeDouble(score, value.getScore());
+            }
+            if (subset.includes(schema, createdAt) && value.getCreatedAt() != null) {
+                serializer.writeTimestamp(createdAt, value.getCreatedAt());
+            }
+        }
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return value.getMemberValue(member);
+        }
+    }
+
+}

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/SchubfachTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/SchubfachTest.java
@@ -25,7 +25,7 @@ class SchubfachTest {
     private static final SmithyJsonSerdeProvider SMITHY = new SmithyJsonSerdeProvider();
 
     private String serializeDouble(double v) throws Exception {
-        try (var codec = JsonCodec.builder().overrideSerdeProvider(SMITHY).build();
+        try (var codec = JsonCodec.builder().overrideSerdeProvider(SMITHY).runtimeCodegen(false).build();
                 var output = new ByteArrayOutputStream()) {
             try (var serializer = codec.createSerializer(output)) {
                 serializer.writeDouble(PreludeSchemas.DOUBLE, v);
@@ -35,7 +35,7 @@ class SchubfachTest {
     }
 
     private String serializeFloat(float v) throws Exception {
-        try (var codec = JsonCodec.builder().overrideSerdeProvider(SMITHY).build();
+        try (var codec = JsonCodec.builder().overrideSerdeProvider(SMITHY).runtimeCodegen(false).build();
                 var output = new ByteArrayOutputStream()) {
             try (var serializer = codec.createSerializer(output)) {
                 serializer.writeFloat(PreludeSchemas.FLOAT, v);

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/StructureEncodedUnionModel.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/StructureEncodedUnionModel.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json;
+
+import java.util.Objects;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class StructureEncodedUnionModel {
+    private StructureEncodedUnionModel() {}
+
+    public sealed interface Value extends SerializableStruct permits Value.SMember, Value.$Unknown {
+        Schema SCHEMA = Schema.structureBuilder(ShapeId.from("codegen.json#StructureEncodedUnion"))
+                .shapeClass(Value.class)
+                .builderSupplier(Builder::new)
+                .putMember("S", PreludeSchemas.STRING)
+                .build();
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        @Override
+        default Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        default <T> T getMemberValue(Schema member) {
+            return (T) ((SMember) this).s();
+        }
+
+        record SMember(String s) implements Value {
+            @Override
+            public void serializeMembers(ShapeSerializer serializer) {
+                serializer.writeString(SCHEMA.member("S"), s);
+            }
+        }
+
+        record $Unknown(String memberName) implements Value {
+            @Override
+            public void serializeMembers(ShapeSerializer serializer) {}
+        }
+
+        final class Builder implements ShapeBuilder<Value> {
+            private Value value;
+
+            public Builder s(String value) {
+                this.value = new SMember(value);
+                return this;
+            }
+
+            @Override
+            public Value build() {
+                return value;
+            }
+
+            @Override
+            public ShapeBuilder<Value> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return SCHEMA;
+            }
+        }
+    }
+
+    public static final class Envelope implements SerializableStruct {
+        private static final Schema SCHEMA =
+                Schema.structureBuilder(ShapeId.from("codegen.json#StructureUnionEnvelope"))
+                        .shapeClass(Envelope.class)
+                        .builderSupplier(Builder::new)
+                        .putMember("attribute", Value.SCHEMA)
+                        .build();
+        private final Value attribute;
+
+        private Envelope(Builder builder) {
+            attribute = builder.attribute;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Value getAttribute() {
+            return attribute;
+        }
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            serializer.writeStruct(SCHEMA.member("attribute"), attribute);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) attribute;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Envelope that && Objects.equals(attribute, that.attribute);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(attribute);
+        }
+
+        public static final class Builder implements ShapeBuilder<Envelope> {
+            private Value attribute;
+
+            public Builder attribute(Value attribute) {
+                this.attribute = attribute;
+                return this;
+            }
+
+            @Override
+            public Envelope build() {
+                return new Envelope(this);
+            }
+
+            @Override
+            public ShapeBuilder<Envelope> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return SCHEMA;
+            }
+        }
+    }
+}

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyJsonGeneratedFieldTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyJsonGeneratedFieldTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.json.JsonSettings;
+
+final class SmithyJsonGeneratedFieldTest {
+    @Test
+    void nextFieldFastPathsAcceptWhitespaceAfterComma() {
+        byte[] source = """
+                {"a":1,
+                  "mediumName":2,\t "aFieldNameLongerThan16":3}
+                """.getBytes(StandardCharsets.UTF_8);
+        var reader = new SmithyJsonDeserializer(source, 0, source.length, JsonSettings.builder().build());
+        byte[] shortToken = token("a");
+        byte[] mediumToken = token("mediumName");
+        byte[] longToken = token("aFieldNameLongerThan16");
+
+        try {
+            assertThat(reader.generatedBeginObject()).isTrue();
+            assertThat(reader.generatedTryReadField8(
+                    pack(token("wrong"), 0, token("wrong").length),
+                    mask(token("wrong").length),
+                    token("wrong").length))
+                    .isFalse();
+            assertThat(reader.generatedTryReadField8(
+                    pack(shortToken, 0, shortToken.length),
+                    mask(shortToken.length),
+                    shortToken.length))
+                    .isTrue();
+            assertThat(reader.generatedReadInteger()).isEqualTo(1);
+            assertThat(reader.generatedTryReadNextField16(
+                    pack(mediumToken, 0, Long.BYTES),
+                    pack(mediumToken, Long.BYTES, mediumToken.length - Long.BYTES),
+                    mask(mediumToken.length - Long.BYTES),
+                    mediumToken.length))
+                    .isTrue();
+            assertThat(reader.generatedReadInteger()).isEqualTo(2);
+            assertThat(reader.generatedTryReadNextField(longToken)).isTrue();
+            assertThat(reader.generatedReadInteger()).isEqualTo(3);
+            assertThat(reader.generatedObjectHasNext()).isFalse();
+        } finally {
+            reader.close();
+        }
+    }
+
+    private static byte[] token(String name) {
+        return ('"' + name + "\":").getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static long pack(byte[] value, int offset, int length) {
+        long result = 0;
+        for (int i = 0; i < length; i++) {
+            result |= (long) (value[offset + i] & 0xff) << (i << 3);
+        }
+        return result;
+    }
+
+    private static long mask(int length) {
+        return length == Long.BYTES ? -1L : (1L << (length << 3)) - 1;
+    }
+}

--- a/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyJsonSchemaExtensionsTest.java
+++ b/codecs/json-codec/src/test/java/software/amazon/smithy/java/json/smithy/SmithyJsonSchemaExtensionsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.json.smithy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+
+final class SmithyJsonSchemaExtensionsTest {
+    @Test
+    void precomputesEscapedFieldTokens() {
+        Schema schema = Schema.structureBuilder(ShapeId.from("example#EscapedNames"))
+                .putMember(
+                        "value",
+                        PreludeSchemas.STRING,
+                        new JsonNameTrait("quoted\"slash\\line\n"))
+                .build();
+
+        var memberExtension = schema.member("value").getExtension(SmithyJsonSchemaExtensions.KEY);
+        var structureExtension = schema.getExtension(SmithyJsonSchemaExtensions.KEY);
+
+        assertThat(new String(memberExtension.jsonNameBytes(), StandardCharsets.UTF_8))
+                .isEqualTo("\"quoted\\\"slash\\\\line\\n\":");
+        assertThat(structureExtension.jsonFieldNameTable()[0])
+                .containsExactly(memberExtension.jsonNameBytes());
+    }
+}

--- a/scripts/run-remote-benchmarks.sh
+++ b/scripts/run-remote-benchmarks.sh
@@ -13,8 +13,13 @@
 #
 # Options:
 #   --fast                    Fast mode (1 warmup @ 5s, 3 measurement @ 5s)
+#   --warmup-iterations <n>   Override the warmup iteration count
+#   --iterations <n>          Override the measurement iteration count
+#   --warmup-time <t>         Override the per-warmup-iteration time (e.g. 2s)
+#   --iteration-time <t>      Override the per-measurement-iteration time (e.g. 3s)
 #   --includes <regex>        JMH benchmark filter (e.g. RpcV2CborSerialize)
 #   --test-case-id <id>       Filter to a single test case ID
+#   --implementation <list>   Runtime codegen arms, e.g. generic,generated
 #   --profilers <list>        Comma-separated JMH profilers (e.g. gc,stack)
 #   --skip-build              Skip local jar build (use existing jar)
 #   --remote-java <path>      Path to java on remote host (default: java)
@@ -30,8 +35,13 @@ LOCAL_RESULTS="$PROJECT_ROOT/benchmarks/serde-benchmarks/build/results/jmh"
 
 # Defaults
 FAST=false
+WARMUP_ITERS=""
+MEASURE_ITERS=""
+WARMUP_TIME=""
+MEASURE_TIME=""
 INCLUDES=""
 TEST_CASE_ID=""
+IMPLEMENTATION=""
 PROFILERS=""
 SKIP_BUILD=false
 REMOTE_JAVA="java"
@@ -49,8 +59,13 @@ SSH_HOST="$1"; shift
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --fast)           FAST=true; shift ;;
+        --warmup-iterations) WARMUP_ITERS="$2"; shift 2 ;;
+        --iterations)     MEASURE_ITERS="$2"; shift 2 ;;
+        --warmup-time)    WARMUP_TIME="$2"; shift 2 ;;
+        --iteration-time) MEASURE_TIME="$2"; shift 2 ;;
         --includes)       INCLUDES="$2"; shift 2 ;;
         --test-case-id)   TEST_CASE_ID="$2"; shift 2 ;;
+        --implementation) IMPLEMENTATION="$2"; shift 2 ;;
         --profilers)      PROFILERS="$2"; shift 2 ;;
         --skip-build)     SKIP_BUILD=true; shift ;;
         --remote-java)    REMOTE_JAVA="$2"; shift 2 ;;
@@ -95,13 +110,14 @@ JVM_ARGS="-Xms1g -Xmx1g -XX:+UseG1GC -XX:+AlwaysPreTouch -Dsmithy-java.json-prov
 JMH_ARGS="-bm sample -tu ns -f 1 -rf json -rff $REMOTE_DIR/results.json"
 JMH_ARGS="$JMH_ARGS -jvmArgs \"$JVM_ARGS\""
 if [[ "$FAST" == true ]]; then
-    JMH_ARGS="$JMH_ARGS -wi 1 -w 5s -i 3 -r 5s"
+    JMH_ARGS="$JMH_ARGS -wi ${WARMUP_ITERS:-1} -w ${WARMUP_TIME:-5s} -i ${MEASURE_ITERS:-3} -r ${MEASURE_TIME:-5s}"
 else
-    JMH_ARGS="$JMH_ARGS -wi 5 -w 2s -i 10 -r 5s"
+    JMH_ARGS="$JMH_ARGS -wi ${WARMUP_ITERS:-5} -w ${WARMUP_TIME:-2s} -i ${MEASURE_ITERS:-10} -r ${MEASURE_TIME:-5s}"
 fi
 
 [[ -n "$INCLUDES" ]] && JMH_ARGS="$JMH_ARGS $INCLUDES"
 [[ -n "$TEST_CASE_ID" ]] && JMH_ARGS="$JMH_ARGS -p testCaseId=$TEST_CASE_ID"
+[[ -n "$IMPLEMENTATION" ]] && JMH_ARGS="$JMH_ARGS -p implementation=$IMPLEMENTATION"
 [[ -n "$PROFILERS" ]] && JMH_ARGS="$JMH_ARGS -prof $PROFILERS"
 # Register this last so its measurement excludes other profilers' setup and
 # teardown, matching the Gradle JMH configuration.


### PR DESCRIPTION
### What behavior changes?

- `JsonCodec` can now generate per-shape serializers and deserializers as bytecode at runtime. Generation is opt-in via `JsonCodec.builder().runtimeCodegen(true)` or the `smithy-java.runtime-codegen` / `smithy-java.runtime-codegen.json` system property, and requires JDK 25+. Default behavior is unchanged.
- Two modes govern shapes that cannot be generated: `enabled` falls back transparently to the dispatch serde, and `strict` throws instead of falling back. The property and a builder's explicit setting combine by severity: `disabled` on either side wins, then `strict` escalates. The property is therefore both the default for codecs that set nothing and an operational kill switch for codecs that opted in through code.
- Generated programs are defined as hidden classes and cached per (schema, settings) in the shared registry from #1353.
- restJson1 bodies reach generated programs through `MemberSubsetCodec` bridging on both the serialize and deserialize sides, so the HTTP binding's member-subset body path is covered in addition to full-struct codecs.
- The stock JSON JMH benchmarks gain an `implementation={generic,generated}` param that A/Bs this same production path through `RestJsonClientProtocol` and `AwsJson1Protocol` (run with `-Pjmh.implementation=generic,generated`).

### Why is this change needed?

Performance. The dispatch serde pays per-member schema dispatch through megamorphic call sites, repeated member-name handling, and intermediate allocation on every operation. A generated program per shape is straight-line, monomorphic code with pre-encoded field-name bytes. The CPU-efficiency gains run ahead of the latency gains because lower allocation also cuts GC work per operation.

### How was this validated?

- `DifferentialRuntimeCodegenJsonFuzzTest`: the generated and interpreted codecs produce byte-identical output and fail on identical inputs across the fuzz corpus. The codegen arm runs in strict mode, so a silent fallback fails the fuzz instead of quietly comparing dispatch against dispatch.
- `RuntimeJsonCodegenTest` and `RuntimeCodecRegistryTest`: generation across shape types, caching, strict semantics, and property handling.
- `RuntimeCodegenStrictCoverageTest`: every benchmark case drives the real client protocols under strict mode, so a backend change that stops generating for a benchmark shape fails CI rather than silently skewing a benchmark run.
- Existing protocol test suites pass with the provider enabled.
- JMH A/B on EC2 (below).

### Benchmark Results

> Environment: m7i.xlarge, Corretto 25 (JDK 25), G1GC, 1G heap, nanosecond precision. Latency columns are p50 and p99 ns/op from JMH sample mode, single fork, both arms in one run via `-p implementation=generic,generated`, driving the real protocol entry points. ops/CPU-s is operations per process CPU-second (a custom profiler; it includes GC threads, so allocation savings show up here); higher is better. The generated arm flips this PR's JSON backend together with the generated HTTP binding pass from #1358; the two switch as a unit.

#### Summary

```
Protocol / Direction             p50    p99   ops/CPU-s
──────────────────────────────────────────────────────────────────────────
restJson1 deserialization       -22%   -15%   █████████████  +29%
restJson1 serialization         -14%    -7%   ███████        +16%
awsJson1.0 deserialization      -17%   -26%   █████████      +20%
awsJson1.0 serialization        -11%    -6%   █████          +13%
```

#### restJson1 deserialization

```
Benchmark                      Generic Generated    p50    p99   ops/CPU-s
────────────────────────────────────────────────────────────────────────────────────────────────
CopyObjectOutput_M                 767       551   -28%   -47%   ███████████              +48%
WideTypesResponse_L              4,616     3,336   -28%   -42%   █████████                +39%
CopyObjectOutput_OutOfOrder      1,228       900   -27%   -40%   █████████                +37%
WideTypesResponse_M              2,448     1,796   -27%   -15%   ████████                 +34%
WideTypesResponse_S              1,366     1,060   -22%   -44%   ███████                  +29%
CopyObjectOutput_Baseline           75        79    +5%    -9%   ██                        +9%
GetObject_M                        189       175    -7%    +9%   █                         +6%
GetObject_L                        192       190    -1%    +9%   ░                         -0%
GetObject_S                        172       178    +3%    -4%   ░                         -2%
```

#### restJson1 serialization

```
Benchmark                      Generic Generated    p50    p99   ops/CPU-s
────────────────────────────────────────────────────────────────────────────────────────────────
WideTypesRequest_L               2,980     2,104   -29%   -26%   ██████████               +41%
WideTypesRequest_M               1,588     1,168   -26%   -10%   █████████                +37%
PutMetricDataRequest_S             212       161   -24%   -26%   ████████                 +34%
WideTypesRequest_S                 918       752   -18%   +11%   █████                    +23%
PutObject_M                        180       155   -14%    -7%   ████                     +19%
PutMetricDataRequest_M             940       810   -14%   -26%   ████                     +16%
PutMetricDataRequest_L           8,192     7,328   -11%   -29%   ███                      +13%
PutObject_L                        174       153   -12%    -2%   ███                      +12%
PutObject_S                        163       152    -7%    +3%   ██                        +7%
CopyObjectRequest_M                842       810    -4%    +5%   ░                         +2%
CopyObjectRequest_Baseline         187       183    -2%    -1%   ░                         +1%
```

#### awsJson1.0 deserialization

```
Benchmark                      Generic Generated    p50    p99   ops/CPU-s
────────────────────────────────────────────────────────────────────────────────────────────────
HealthcheckResponse_Example         51        39   -24%   -46%   ███████████████████████  +99%
GetItemOutput_Baseline              51        41   -20%   -52%   ███████████████          +66%
WideTypesResponse_L              4,200     3,336   -21%   -28%   ██████                   +26%
GetItemOutputBinary_L           18,080    14,496   -20%   -19%   ██████                   +25%
GetItemOutput_OutOfOrder         2,592     2,148   -17%   -23%   █████                    +21%
WideTypesResponse_M              2,164     1,788   -17%   -10%   █████                    +21%
GetItemOutputBinary_S              602       506   -16%   -39%   █████                    +20%
GetItemOutput_S                    559       477   -15%   -34%   ████                     +19%
GetItemOutputBinary_M            2,572     2,204   -14%   -20%   ████                     +17%
GetItemOutput_M                  2,232     1,932   -13%   -20%   ████                     +16%
GetItemOutput_L                 14,800    12,912   -13%   -33%   ████                     +16%
WideTypesResponse_S              1,084     1,092    +1%    -9%   ░                         -1%
```

#### awsJson1.0 serialization

```
Benchmark                      Generic Generated    p50    p99   ops/CPU-s
────────────────────────────────────────────────────────────────────────────────────────────────
PutItemRequest_Nested_L            867       530   -39%   -43%   ███████████████          +63%
PutItemRequest_ShallowMap_S        395       256   -35%   -45%   ██████████████           +58%
PutItemRequest_Nested_M            294       208   -29%   -27%   ████████████             +49%
PutItemRequest_ShallowMap_M      1,748     1,324   -24%    +7%   ████████                 +32%
PutItemRequest_ShallowMap_L      5,400     4,040   -25%   -16%   ███████                  +32%
WideTypesRequest_L               2,444     2,048   -16%   -15%   █████                    +20%
PutItemRequest_MixedItem_S         416       352   -15%    +4%   █████                    +20%
PutItemRequest_MixedItem_M       1,794     1,574   -12%    +5%   ████                     +15%
PutItemRequest_BinaryData_S        183       166    -9%   -31%   ███                      +13%
PutItemRequest_MixedItem_L       5,144     4,560   -11%    -1%   ███                      +12%
WideTypesRequest_M               1,150     1,034   -10%    +8%   ██                       +10%
WideTypesRequest_S                 674       624    -7%   -25%   ██                        +8%
GetItemInput_Baseline              140       129    -8%   -12%   █                         +5%
PutItemRequest_BinaryData_M      1,484     1,414    -5%    -4%   █                         +5%
PutItemRequest_BinaryData_L     12,032    11,584    -4%    -6%   █                         +5%
PutItemRequest_Baseline            135       131    -3%    -3%   ░                         +2%
HealthcheckRequest_Example         105       108    +3%    +1%   ░                        -10%
```

> Reading notes: the `GetObject_*` response cases and the `Baseline`/`CopyObjectRequest*` rows run identical or near-identical code on both arms (payload bodies bypass the codec and empty bodies are dropped before it), so they calibrate this run's noise floor: roughly ±7% on p50 and ±10% on p99, which is the noisiest column at this run length. `WideTypesResponse_S` under awsJson1.0 reads flat while its M and L siblings read -17% and -21%; treat it as a noisy fork pending a full-rigor rerun. `HealthcheckRequest_Example` (+3%) shows the real cost profile: a small fixed overhead that only matters on a near-empty serialize. Median ops per process CPU-second (which includes GC threads) improved +18.6% across the 49 cases.

### What should reviewers focus on?

- The fallback boundaries: `enabled` must never change observable behavior, and `strict` must never silently fall back.
- `JsonRuntimeCodegenBackend`: how each shape type is lowered, and where it declines.
- The `MemberSubsetCodec` bridging in both directions, which is what lets restJson1 bodies use generated programs.

### Additional Links

- #1353 adds the shared registry, hidden-class definition, and mode resolution this builds on.
- #1358 generates the HTTP binding pass; the benchmark A/B above measures the two stacked together.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
