### PR TITLE
Generate the HTTP binding pass at runtime

### DIFF
--- a/core/src/main/java/software/amazon/smithy/java/core/serde/MemberSubsetCodec.java
+++ b/core/src/main/java/software/amazon/smithy/java/core/serde/MemberSubsetCodec.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.core.serde;
+
+import java.nio.ByteBuffer;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/** Optional {@link Codec} capability for coding selected structure members. */
+@SmithyInternalApi
+public interface MemberSubsetCodec {
+    /**
+     * Deserializes a complete structure directly into {@code builder}.
+     *
+     * @return true if consumed; false must leave {@code source} reusable.
+     */
+    default boolean deserialize(
+            Schema schema,
+            ShapeBuilder<?> builder,
+            ByteBuffer source
+    ) {
+        return false;
+    }
+
+    /** Returns selected members serialized, or null when unsupported. */
+    ByteBuffer serialize(SerializableStruct struct, MemberSubset subset);
+
+    /**
+     * Deserializes only the members {@code subset} includes directly into {@code builder}.
+     *
+     * @return true if consumed; false must leave {@code source} reusable.
+     */
+    default boolean deserialize(
+            Schema schema,
+            ShapeBuilder<?> builder,
+            ByteBuffer source,
+            MemberSubset subset
+    ) {
+        return false;
+    }
+
+    /** Stable, reusable selector for structure members. */
+    @FunctionalInterface
+    interface MemberSubset {
+        boolean includes(Schema struct, Schema member);
+    }
+}

--- a/http/http-binding/build.gradle.kts
+++ b/http/http-binding/build.gradle.kts
@@ -12,6 +12,43 @@ dependencies {
     api(project(":core"))
     api(project(":http:http-api"))
     implementation(project(":logging"))
+    implementation(project(":codecs:codec-commons", configuration = "shadow"))
 
     testImplementation(project(":codecs:json-codec", configuration = "shadow"))
+}
+
+val jdk25CodegenTest =
+    tasks.register<Test>("jdk25CodegenTest") {
+        description = "Run strict HTTP binding runtime-codegen coverage tests."
+        group = "verification"
+
+        testClassesDirs = sourceSets.test.get().output.classesDirs
+        classpath = sourceSets.test.get().runtimeClasspath
+        javaLauncher =
+            javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        systemProperty("smithy-java.runtime-codegen.http-binding", "strict")
+        useJUnitPlatform {
+            includeTags("runtime-codegen-strict")
+        }
+    }
+
+val jdk25CodegenCompatibilityTest =
+    tasks.register<Test>("jdk25CodegenCompatibilityTest") {
+        description = "Run the HTTP binding test suite with runtime code generation and fallback enabled."
+        group = "verification"
+
+        testClassesDirs = sourceSets.test.get().output.classesDirs
+        classpath = sourceSets.test.get().runtimeClasspath
+        javaLauncher =
+            javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        systemProperty("smithy-java.runtime-codegen.http-binding", "enabled")
+        useJUnitPlatform()
+    }
+
+tasks.named("check") {
+    dependsOn(jdk25CodegenTest, jdk25CodegenCompatibilityTest)
 }

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/BodyMemberSubset.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/BodyMemberSubset.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.binding;
+
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
+
+enum BodyMemberSubset implements MemberSubsetCodec.MemberSubset {
+    REQUEST {
+        @Override
+        public boolean includes(Schema struct, Schema member) {
+            return HttpBindingSchemaExtensions.structBindingsOf(struct)
+                    .request().bindings[member.memberIndex()] == HttpBindingSchemaExtensions.Binding.BODY;
+        }
+    },
+    RESPONSE {
+        @Override
+        public boolean includes(Schema struct, Schema member) {
+            return HttpBindingSchemaExtensions.structBindingsOf(struct)
+                    .response().bindings[member.memberIndex()] == HttpBindingSchemaExtensions.Binding.BODY;
+        }
+    };
+
+    static BodyMemberSubset of(boolean isResponse) {
+        return isResponse ? RESPONSE : REQUEST;
+    }
+}

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBinding.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBinding.java
@@ -5,14 +5,29 @@
 
 package software.amazon.smithy.java.http.binding;
 
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenFeature;
 import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.serde.RuntimeCodegenMode;
 
 /**
  * Entry point for handling HTTP bindings.
  */
 public final class HttpBinding {
 
-    public HttpBinding() {}
+    private final RuntimeCodegenMode runtimeCodegen;
+
+    public HttpBinding() {
+        this(RuntimeCodegenFeature.resolve(null, HttpBindingCodegen.ID));
+    }
+
+    private HttpBinding(RuntimeCodegenMode runtimeCodegen) {
+        this.runtimeCodegen = runtimeCodegen;
+    }
+
+    /** Returns a configurable HTTP binding builder. */
+    public static Builder builder() {
+        return new Builder();
+    }
 
     /**
      * Create an HTTP binding request serializer.
@@ -20,7 +35,7 @@ public final class HttpBinding {
      * @return Returns the serializer.
      */
     public RequestSerializer requestSerializer() {
-        return new RequestSerializer();
+        return new RequestSerializer(runtimeCodegen);
     }
 
     /**
@@ -29,7 +44,7 @@ public final class HttpBinding {
      * @return Returns the serializer.
      */
     public ResponseSerializer responseSerializer() {
-        return new ResponseSerializer();
+        return new ResponseSerializer(runtimeCodegen);
     }
 
     /**
@@ -60,5 +75,32 @@ public final class HttpBinding {
      */
     public boolean hasStructPayload(Schema inputSchema) {
         return HttpBindingSchemaExtensions.structBindingsOf(inputSchema).request().hasStructPayload;
+    }
+
+    /** Builds an {@link HttpBinding}. */
+    public static final class Builder {
+
+        private RuntimeCodegenMode runtimeCodegen;
+
+        private Builder() {}
+
+        /** Sets runtime codegen mode, or null to use system properties. */
+        public Builder runtimeCodegen(RuntimeCodegenMode runtimeCodegen) {
+            this.runtimeCodegen = runtimeCodegen;
+            return this;
+        }
+
+        /** Returns whether runtime codegen resolves as enabled. */
+        public boolean resolvedRuntimeCodegen() {
+            return resolve() != RuntimeCodegenMode.DISABLED;
+        }
+
+        public HttpBinding build() {
+            return new HttpBinding(resolve());
+        }
+
+        private RuntimeCodegenMode resolve() {
+            return RuntimeCodegenFeature.resolve(runtimeCodegen, HttpBindingCodegen.ID);
+        }
     }
 }

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingCodegen.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingCodegen.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.binding;
+
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodecBackend;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodecRegistry;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenFeature;
+import software.amazon.smithy.java.core.schema.Schema;
+
+final class HttpBindingCodegen {
+
+    static final String ID = "http-binding";
+
+    private static final Object SETTINGS = new Object();
+
+    private static final RuntimeCodecRegistry<HttpBindingWriter> REQUEST =
+            new RuntimeCodecRegistry<>(new HttpBindingRuntimeCodegenBackend(false));
+    private static final RuntimeCodecRegistry<HttpBindingWriter> RESPONSE =
+            new RuntimeCodecRegistry<>(new HttpBindingRuntimeCodegenBackend(true));
+
+    static final HttpBindingWriter NO_BINDING_WRITER = (struct, sink) -> {
+        throw new UnsupportedOperationException("No generated HTTP binding writer");
+    };
+
+    private HttpBindingCodegen() {}
+
+    static HttpBindingWriter writerOrSentinel(Schema schema, boolean isResponse, boolean strict) {
+        if (!RuntimeCodegenFeature.available()) {
+            if (strict) {
+                throw new IllegalStateException(
+                        "Runtime HTTP binding generation requires Java 25 or later; strict mode forbids fallback");
+            }
+            return NO_BINDING_WRITER;
+        }
+        HttpBindingWriter writer = (isResponse ? RESPONSE : REQUEST)
+                .get(schema, SETTINGS, Selector.of(isResponse), strict);
+        return writer == null ? NO_BINDING_WRITER : writer;
+    }
+
+    enum Selector implements RuntimeCodecBackend.MemberSelector {
+        REQUEST(false),
+        RESPONSE(true);
+
+        private final boolean isResponse;
+
+        Selector(boolean isResponse) {
+            this.isResponse = isResponse;
+        }
+
+        static Selector of(boolean isResponse) {
+            return isResponse ? RESPONSE : REQUEST;
+        }
+
+        @Override
+        public boolean select(Schema root, Schema member) {
+            return isSupported(bindings(root, isResponse)[member.memberIndex()]);
+        }
+    }
+
+    static HttpBindingSchemaExtensions.Binding[] bindings(Schema struct, boolean isResponse) {
+        var structBindings = HttpBindingSchemaExtensions.structBindingsOf(struct);
+        return isResponse ? structBindings.response().bindings : structBindings.request().bindings;
+    }
+
+    static HttpBindingSchemaExtensions.MemberBinding[] memberBindings(Schema struct, boolean isResponse) {
+        var structBindings = HttpBindingSchemaExtensions.structBindingsOf(struct);
+        return isResponse
+                ? structBindings.response().memberBindings
+                : structBindings.request().memberBindings;
+    }
+
+    static boolean isSupported(HttpBindingSchemaExtensions.Binding binding) {
+        return switch (binding) {
+            case HEADER, QUERY, PREFIX_HEADERS, QUERY_PARAMS, PAYLOAD, STATUS -> true;
+            default -> false;
+        };
+    }
+}

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializer.java
@@ -11,8 +11,10 @@ import java.util.Map;
 import java.util.Objects;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
 import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.SpecificShapeDeserializer;
@@ -44,6 +46,7 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
     private final DataStream body;
     private final EventDecoderFactory<?> eventDecoderFactory;
     private final String payloadMediaType;
+    private final ShapeBuilder<?> directBodyBuilder;
 
     private HttpBindingDeserializer(Builder builder) {
         this.payloadCodec = Objects.requireNonNull(builder.payloadCodec, "payloadSerializer not set");
@@ -55,6 +58,7 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
         this.responseStatus = builder.responseStatus;
         this.requestPathLabels = builder.requestPathLabels;
         this.payloadMediaType = builder.payloadMediaType;
+        this.directBodyBuilder = builder.directBodyBuilder;
     }
 
     static Builder builder() {
@@ -203,6 +207,15 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
     ) {
         validateMediaType();
         ByteBuffer bb = bodyAsByteBuffer();
+        if (state == directBodyBuilder
+                && payloadCodec instanceof MemberSubsetCodec subsetCodec
+                && subsetCodec.deserialize(
+                        schema,
+                        directBodyBuilder,
+                        bb,
+                        BodyMemberSubset.of(isResponse))) {
+            return;
+        }
         // The codec's readStruct callback receives every member; filter to body members using the direction-specific
         // bindings array (which was already chosen by the caller).
         payloadCodec.createDeserializer(bb).readStruct(schema, bindings, (body, m, de) -> {
@@ -233,7 +246,7 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
             // Read the payload into a byte buffer to deserialize a shape in the body.
             ByteBuffer bb = bodyAsByteBuffer();
             if (bb.remaining() > 0) {
-                structMemberConsumer.accept(state, member, payloadCodec.createDeserializer(bb));
+                structMemberConsumer.accept(state, member, new PayloadDeserializer(payloadCodec, body));
             }
         } else if (body != null && body.contentLength() != 0) {
             structMemberConsumer.accept(state, member, new PayloadDeserializer(payloadCodec, body));
@@ -305,6 +318,7 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
         private EventDecoderFactory<?> eventDecoderFactory;
         private String payloadMediaType;
         private boolean isResponse;
+        private ShapeBuilder<?> directBodyBuilder;
 
         private Builder() {}
 
@@ -397,6 +411,11 @@ final class HttpBindingDeserializer extends SpecificShapeDeserializer implements
 
         Builder isResponse(boolean isResponse) {
             this.isResponse = isResponse;
+            return this;
+        }
+
+        Builder directBodyBuilder(ShapeBuilder<?> directBodyBuilder) {
+            this.directBodyBuilder = directBodyBuilder;
             return this;
         }
     }

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingRuntimeCodegenBackend.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingRuntimeCodegenBackend.java
@@ -1,0 +1,762 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.binding;
+
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenBytecode.emitDefaultConstructor;
+import static software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenBytecode.invoke;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodecBackend;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodecPlan;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.UnsupportedSchemaException;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.ClassWriter;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Label;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.MethodVisitor;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Opcodes;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.classfile.Type;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.SmithyEnum;
+import software.amazon.smithy.java.core.schema.SmithyIntEnum;
+import software.amazon.smithy.java.core.schema.TraitKey;
+import software.amazon.smithy.java.core.serde.TimestampFormatter;
+import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.core.serde.event.EventStream;
+import software.amazon.smithy.java.http.api.HeaderName;
+import software.amazon.smithy.java.io.ByteBufferUtils;
+import software.amazon.smithy.java.io.datastream.DataStream;
+import software.amazon.smithy.model.shapes.ShapeType;
+
+final class HttpBindingRuntimeCodegenBackend implements RuntimeCodecBackend<HttpBindingWriter>, Opcodes {
+
+    private static final Budgets BUDGETS =
+            new Budgets(Integer.MAX_VALUE, Integer.MAX_VALUE, 8, Integer.MAX_VALUE);
+    private static final String WRITER = Type.getInternalName(HttpBindingWriter.class);
+    private static final String SINK = Type.getInternalName(HttpBindingSerializer.class);
+    private static final String STRUCT = Type.getInternalName(SerializableStruct.class);
+    private static final String SMITHY_ENUM = Type.getInternalName(SmithyEnum.class);
+    private static final String SMITHY_INT_ENUM = Type.getInternalName(SmithyIntEnum.class);
+    private static final String BYTE_BUFFER = Type.getInternalName(ByteBuffer.class);
+    private static final String INSTANT = Type.getInternalName(Instant.class);
+    private static final String FORMATTER = Type.getInternalName(TimestampFormatter.class);
+    private static final String PRELUDE = Type.getInternalName(TimestampFormatter.Prelude.class);
+    private static final String HEADER_NAME = Type.getInternalName(HeaderName.class);
+    private static final String BUFFER_UTILS = Type.getInternalName(ByteBufferUtils.class);
+    private static final String BASE64 = Type.getInternalName(Base64.class);
+    private static final String BASE64_ENCODER = Type.getInternalName(Base64.Encoder.class);
+    private static final String STRING = "java/lang/String";
+    private static final String STRING_DESCRIPTOR = "Ljava/lang/String;";
+    private static final String BIND_DESCRIPTOR = "(Ljava/lang/String;Ljava/lang/String;)V";
+    private static final String WRITE_DESCRIPTOR = "(L" + STRUCT + ";L" + SINK + ";)V";
+
+    private static final int SHAPE_LOCAL = 3;
+    private static final int VALUE_LOCAL = 4;
+    private static final int ITERATOR_LOCAL = 5;
+    private static final int ELEMENT_LOCAL = 6;
+
+    private final boolean isResponse;
+
+    HttpBindingRuntimeCodegenBackend(boolean isResponse) {
+        this.isResponse = isResponse;
+    }
+
+    @Override
+    public String id() {
+        return HttpBindingCodegen.ID;
+    }
+
+    @Override
+    public String variant() {
+        return isResponse ? "Response" : "Request";
+    }
+
+    @Override
+    public Class<HttpBindingWriter> codecType() {
+        return HttpBindingWriter.class;
+    }
+
+    @Override
+    public Class<?> lookupHost() {
+        return HttpBindingWriter.class;
+    }
+
+    @Override
+    public Mode mode() {
+        return Mode.WRITE_ONLY;
+    }
+
+    @Override
+    public Budgets budgets() {
+        return BUDGETS;
+    }
+
+    @Override
+    public MemberSelector memberSelector() {
+        return HttpBindingCodegen.Selector.of(isResponse);
+    }
+
+    @Override
+    public Emission emit(RuntimeCodecPlan plan, String generatedName) {
+        return new Generator(plan, generatedName, isResponse).generate();
+    }
+
+    private static final class Generator implements Opcodes {
+        private final RuntimeCodecPlan plan;
+        private final String className;
+        private final boolean isResponse;
+        private final List<RuntimeCodecPlan.MemberPlan> members;
+        private final HttpBindingSchemaExtensions.Binding[] bindings;
+        private final HttpBindingSchemaExtensions.MemberBinding[] memberBindings;
+        private final ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+        private int methodCount;
+
+        Generator(RuntimeCodecPlan plan, String className, boolean isResponse) {
+            this.plan = plan;
+            this.className = className;
+            this.isResponse = isResponse;
+            RuntimeCodecPlan.StructPlan root = plan.rootStructure();
+            if (root.union()) {
+                throw new UnsupportedSchemaException("Cannot bind a union to HTTP: " + plan.root().id());
+            }
+            this.members = root.members();
+            this.bindings = HttpBindingCodegen.bindings(plan.root(), isResponse);
+            this.memberBindings = HttpBindingCodegen.memberBindings(plan.root(), isResponse);
+        }
+
+        Emission generate() {
+            writer.visit(V17, ACC_FINAL | ACC_SUPER, className, null, "java/lang/Object", new String[] {WRITER});
+            emitFields();
+            emitDefaultConstructor(writer);
+            methodCount++;
+            emitClassInitializer();
+            emitWrite();
+            writer.visitEnd();
+            return new Emission(writer.toByteArray(), methodCount);
+        }
+
+        private void emitFields() {
+            for (int i = 0; i < members.size(); i++) {
+                if (kindOf(i) == HttpBindingSchemaExtensions.Binding.HEADER) {
+                    writer.visitField(
+                            ACC_PRIVATE | ACC_STATIC | ACC_FINAL,
+                            "H" + i,
+                            STRING_DESCRIPTOR,
+                            null,
+                            null).visitEnd();
+                }
+            }
+        }
+
+        private void emitClassInitializer() {
+            boolean any = false;
+            for (int i = 0; i < members.size(); i++) {
+                if (kindOf(i) == HttpBindingSchemaExtensions.Binding.HEADER) {
+                    any = true;
+                    break;
+                }
+            }
+            if (!any) {
+                return;
+            }
+            MethodVisitor method = writer.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
+            method.visitCode();
+            for (int i = 0; i < members.size(); i++) {
+                if (kindOf(i) != HttpBindingSchemaExtensions.Binding.HEADER) {
+                    continue;
+                }
+                // Preserve canonical header-name identity.
+                method.visitLdcInsn(headerName(i));
+                method.visitMethodInsn(
+                        INVOKESTATIC,
+                        HEADER_NAME,
+                        "canonicalize",
+                        "(Ljava/lang/String;)Ljava/lang/String;",
+                        false);
+                method.visitFieldInsn(PUTSTATIC, className, "H" + i, STRING_DESCRIPTOR);
+            }
+            method.visitInsn(RETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+        }
+
+        private void emitWrite() {
+            MethodVisitor method = writer.visitMethod(ACC_PUBLIC, "write", WRITE_DESCRIPTOR, null, null);
+            method.visitCode();
+            if (!members.isEmpty()) {
+                method.visitVarInsn(ALOAD, 1);
+                method.visitTypeInsn(CHECKCAST, Type.getInternalName(plan.rootStructure().shapeClass()));
+                method.visitVarInsn(ASTORE, SHAPE_LOCAL);
+                List<RuntimeCodecPlan.MethodRange> chunks = plan.rootStructure().writerChunks();
+                for (int chunk = 0; chunk < chunks.size(); chunk++) {
+                    method.visitVarInsn(ALOAD, 0);
+                    method.visitVarInsn(ALOAD, SHAPE_LOCAL);
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitMethodInsn(
+                            INVOKESPECIAL,
+                            className,
+                            writeChunkName(chunk),
+                            writeChunkDescriptor(),
+                            false);
+                }
+            }
+            method.visitInsn(RETURN);
+            method.visitMaxs(0, 0);
+            method.visitEnd();
+            methodCount++;
+
+            List<RuntimeCodecPlan.MethodRange> chunks = plan.rootStructure().writerChunks();
+            for (int chunk = 0; chunk < chunks.size() && !members.isEmpty(); chunk++) {
+                RuntimeCodecPlan.MethodRange range = chunks.get(chunk);
+                MethodVisitor chunkMethod = writer.visitMethod(
+                        ACC_PRIVATE,
+                        writeChunkName(chunk),
+                        writeChunkDescriptor(),
+                        null,
+                        null);
+                chunkMethod.visitCode();
+                chunkMethod.visitVarInsn(ALOAD, 1);
+                chunkMethod.visitVarInsn(ASTORE, SHAPE_LOCAL);
+                for (int i = range.startInclusive(); i < range.endExclusive(); i++) {
+                    emitMember(chunkMethod, i);
+                }
+                chunkMethod.visitInsn(RETURN);
+                chunkMethod.visitMaxs(0, 0);
+                chunkMethod.visitEnd();
+                methodCount++;
+            }
+        }
+
+        private static String writeChunkName(int chunk) {
+            return "writeChunk" + chunk;
+        }
+
+        private String writeChunkDescriptor() {
+            return "(L"
+                    + Type.getInternalName(plan.rootStructure().shapeClass())
+                    + ";L"
+                    + SINK
+                    + ";)V";
+        }
+
+        private void emitMember(MethodVisitor method, int index) {
+            RuntimeCodecPlan.MemberPlan member = members.get(index);
+            Label skip = new Label();
+
+            if (member.presence() != null) {
+                method.visitVarInsn(ALOAD, SHAPE_LOCAL);
+                invoke(method, member.presence());
+                method.visitJumpInsn(IFEQ, skip);
+            }
+
+            Class<?> javaType = member.getter().getReturnType();
+            if (javaType.isPrimitive()) {
+                emitBind(method, index, javaType, () -> {
+                    method.visitVarInsn(ALOAD, SHAPE_LOCAL);
+                    invoke(method, member.getter());
+                });
+                method.visitLabel(skip);
+                return;
+            }
+
+            method.visitVarInsn(ALOAD, SHAPE_LOCAL);
+            invoke(method, member.getter());
+            method.visitVarInsn(ASTORE, VALUE_LOCAL);
+            method.visitVarInsn(ALOAD, VALUE_LOCAL);
+            method.visitJumpInsn(IFNULL, skip);
+
+            ShapeType targetType = member.target().type();
+            var binding = kindOf(index);
+            if ((targetType == ShapeType.LIST || targetType == ShapeType.SET)
+                    && (binding == HttpBindingSchemaExtensions.Binding.HEADER
+                            || binding == HttpBindingSchemaExtensions.Binding.QUERY)) {
+                emitListMember(method, index);
+            } else {
+                emitBind(method, index, javaType, () -> method.visitVarInsn(ALOAD, VALUE_LOCAL));
+            }
+            method.visitLabel(skip);
+        }
+
+        private void emitListMember(MethodVisitor method, int index) {
+            RuntimeCodecPlan.MemberPlan member = members.get(index);
+            Schema list = member.target();
+            boolean sparse = list.hasTrait(TraitKey.SPARSE_TRAIT);
+            method.visitVarInsn(ALOAD, VALUE_LOCAL);
+            method.visitTypeInsn(CHECKCAST, "java/util/List");
+            method.visitMethodInsn(INVOKEINTERFACE, "java/util/List", "iterator", "()Ljava/util/Iterator;", true);
+            method.visitVarInsn(ASTORE, ITERATOR_LOCAL);
+            Label loop = new Label();
+            Label end = new Label();
+            method.visitLabel(loop);
+            method.visitVarInsn(ALOAD, ITERATOR_LOCAL);
+            method.visitMethodInsn(INVOKEINTERFACE, "java/util/Iterator", "hasNext", "()Z", true);
+            method.visitJumpInsn(IFEQ, end);
+            method.visitVarInsn(ALOAD, ITERATOR_LOCAL);
+            method.visitMethodInsn(INVOKEINTERFACE, "java/util/Iterator", "next", "()Ljava/lang/Object;", true);
+            method.visitVarInsn(ASTORE, ELEMENT_LOCAL);
+            Label next = new Label();
+            if (sparse) {
+                method.visitVarInsn(ALOAD, ELEMENT_LOCAL);
+                Label nonNull = new Label();
+                method.visitJumpInsn(IFNONNULL, nonNull);
+                method.visitVarInsn(ALOAD, 2);
+                method.visitMethodInsn(INVOKEVIRTUAL, SINK, "bindNull", "()V", false);
+                method.visitJumpInsn(GOTO, next);
+                method.visitLabel(nonNull);
+            }
+            emitBindValue(
+                    method,
+                    index,
+                    list.listMember().memberTarget(),
+                    Object.class,
+                    () -> method.visitVarInsn(ALOAD, ELEMENT_LOCAL));
+            method.visitLabel(next);
+            method.visitJumpInsn(GOTO, loop);
+            method.visitLabel(end);
+        }
+
+        private void emitBind(MethodVisitor method, int index, Class<?> javaType, Runnable loadValue) {
+            emitBindValue(method, index, members.get(index).target(), javaType, loadValue);
+        }
+
+        private void emitBindValue(
+                MethodVisitor method,
+                int index,
+                Schema target,
+                Class<?> javaType,
+                Runnable loadValue
+        ) {
+            var kind = kindOf(index);
+            switch (kind) {
+                case HEADER -> {
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitFieldInsn(GETSTATIC, className, "H" + index, STRING_DESCRIPTOR);
+                    boolean trusted = emitStringValue(method, index, target, javaType, loadValue, true);
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            SINK,
+                            trusted ? "bindHeaderTrusted" : "bindHeader",
+                            BIND_DESCRIPTOR,
+                            false);
+                }
+                case QUERY -> {
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitLdcInsn(wireName(index));
+                    emitStringValue(method, index, target, javaType, loadValue, false);
+                    method.visitMethodInsn(INVOKEVIRTUAL, SINK, "bindQuery", BIND_DESCRIPTOR, false);
+                }
+                case PREFIX_HEADERS -> {
+                    requireTarget(index, target, ShapeType.MAP);
+                    method.visitVarInsn(ALOAD, 2);
+                    method.visitLdcInsn(wireName(index));
+                    loadValue.run();
+                    checkCast(method, javaType, Type.getInternalName(Map.class));
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            SINK,
+                            "bindPrefixHeaders",
+                            "(Ljava/lang/String;Ljava/util/Map;)V",
+                            false);
+                }
+                case QUERY_PARAMS -> {
+                    requireTarget(index, target, ShapeType.MAP);
+                    method.visitVarInsn(ALOAD, 2);
+                    loadValue.run();
+                    checkCast(method, javaType, Type.getInternalName(Map.class));
+                    method.visitMethodInsn(
+                            INVOKEVIRTUAL,
+                            SINK,
+                            "bindQueryParams",
+                            "(Ljava/util/Map;)V",
+                            false);
+                }
+                case PAYLOAD -> emitPayloadValue(method, index, target, javaType, loadValue);
+                case STATUS -> {
+                    method.visitVarInsn(ALOAD, 2);
+                    emitIntValue(method, index, target, javaType, loadValue);
+                    method.visitMethodInsn(INVOKEVIRTUAL, SINK, "bindStatus", "(I)V", false);
+                }
+                default -> throw new UnsupportedSchemaException(
+                        "HTTP binding runtime codegen cannot write " + kind + " at "
+                                + members.get(index).schema().id());
+            }
+        }
+
+        private void emitPayloadValue(
+                MethodVisitor method,
+                int index,
+                Schema target,
+                Class<?> javaType,
+                Runnable loadValue
+        ) {
+            method.visitVarInsn(ALOAD, 2);
+
+            if (DataStream.class.isAssignableFrom(javaType)) {
+                loadReference(method, javaType, loadValue, DataStream.class);
+                invokePayload(method, Type.getDescriptor(DataStream.class));
+                return;
+            }
+            if (EventStream.class.isAssignableFrom(javaType)) {
+                loadReference(method, javaType, loadValue, EventStream.class);
+                invokePayload(method, Type.getDescriptor(EventStream.class));
+                return;
+            }
+
+            switch (target.type()) {
+                case STRING -> {
+                    loadReference(method, javaType, loadValue, String.class);
+                    invokePayload(method, Type.getDescriptor(String.class));
+                }
+                case ENUM -> {
+                    loadValue.run();
+                    method.visitTypeInsn(CHECKCAST, SMITHY_ENUM);
+                    method.visitMethodInsn(
+                            INVOKEINTERFACE,
+                            SMITHY_ENUM,
+                            "getValue",
+                            "()Ljava/lang/String;",
+                            true);
+                    invokePayload(method, Type.getDescriptor(String.class));
+                }
+                case BLOB -> {
+                    if (javaType == byte[].class) {
+                        loadReference(method, javaType, loadValue, byte[].class);
+                        invokePayload(method, Type.getDescriptor(byte[].class));
+                    } else {
+                        loadReference(method, javaType, loadValue, ByteBuffer.class);
+                        invokePayload(method, Type.getDescriptor(ByteBuffer.class));
+                    }
+                }
+                case TIMESTAMP -> {
+                    loadReference(method, javaType, loadValue, Instant.class);
+                    invokePayload(method, Type.getDescriptor(Instant.class));
+                }
+                case STRUCTURE, UNION -> {
+                    loadReference(method, javaType, loadValue, SerializableStruct.class);
+                    invokePayload(method, Type.getDescriptor(SerializableStruct.class));
+                }
+                case DOCUMENT -> {
+                    loadReference(method, javaType, loadValue, Document.class);
+                    invokePayload(method, Type.getDescriptor(Document.class));
+                }
+                default -> throw new UnsupportedSchemaException(
+                        "HTTP payload runtime codegen cannot write "
+                                + target.type()
+                                + " at "
+                                + members.get(index).schema().id());
+            }
+        }
+
+        private void loadReference(
+                MethodVisitor method,
+                Class<?> javaType,
+                Runnable loadValue,
+                Class<?> expectedType
+        ) {
+            loadValue.run();
+            checkCast(method, javaType, Type.getInternalName(expectedType));
+        }
+
+        private void invokePayload(MethodVisitor method, String valueDescriptor) {
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    SINK,
+                    "bindPayload",
+                    "(" + valueDescriptor + ")V",
+                    false);
+        }
+
+        private void requireTarget(int index, Schema target, ShapeType expected) {
+            if (target.type() != expected) {
+                throw new UnsupportedSchemaException(
+                        kindOf(index) + " must target " + expected + " at " + members.get(index).schema().id());
+            }
+        }
+
+        private boolean emitStringValue(
+                MethodVisitor method,
+                int index,
+                Schema target,
+                Class<?> javaType,
+                Runnable loadValue,
+                boolean isHeader
+        ) {
+            switch (target.type()) {
+                case BOOLEAN -> {
+                    emitToString(method, javaType, loadValue, Boolean.class, boolean.class, "(Z)");
+                    return true;
+                }
+                case BYTE -> {
+                    emitToString(method, javaType, loadValue, Byte.class, byte.class, "(B)");
+                    return true;
+                }
+                case SHORT -> {
+                    emitToString(method, javaType, loadValue, Short.class, short.class, "(S)");
+                    return true;
+                }
+                case INTEGER -> {
+                    emitToString(method, javaType, loadValue, Integer.class, int.class, "(I)");
+                    return true;
+                }
+                case LONG -> {
+                    emitToString(method, javaType, loadValue, Long.class, long.class, "(J)");
+                    return true;
+                }
+                case FLOAT -> {
+                    emitToString(method, javaType, loadValue, Float.class, float.class, "(F)");
+                    return true;
+                }
+                case DOUBLE -> {
+                    emitToString(method, javaType, loadValue, Double.class, double.class, "(D)");
+                    return true;
+                }
+                case BIG_INTEGER -> {
+                    emitInstanceToString(method, javaType, loadValue, BigInteger.class);
+                    return true;
+                }
+                case BIG_DECIMAL -> {
+                    emitInstanceToString(method, javaType, loadValue, BigDecimal.class);
+                    return true;
+                }
+                case STRING -> {
+                    boolean base64 = isHeader && hasMediaType(index);
+                    if (base64) {
+                        emitBase64Encoder(method);
+                    }
+                    loadValue.run();
+                    checkCast(method, javaType, STRING);
+                    if (base64) {
+                        emitBase64OfString(method);
+                        return true;
+                    }
+                    return false;
+                }
+                case ENUM -> {
+                    boolean base64 = isHeader && hasMediaType(index);
+                    if (base64) {
+                        emitBase64Encoder(method);
+                    }
+                    loadValue.run();
+                    method.visitTypeInsn(CHECKCAST, SMITHY_ENUM);
+                    method.visitMethodInsn(
+                            INVOKEINTERFACE,
+                            SMITHY_ENUM,
+                            "getValue",
+                            "()Ljava/lang/String;",
+                            true);
+                    if (base64) {
+                        emitBase64OfString(method);
+                        return true;
+                    }
+                    // An unknown enum variant carries whatever string the caller put in it.
+                    return false;
+                }
+                case INT_ENUM -> {
+                    loadValue.run();
+                    method.visitTypeInsn(CHECKCAST, SMITHY_INT_ENUM);
+                    method.visitMethodInsn(INVOKEINTERFACE, SMITHY_INT_ENUM, "getValue", "()I", true);
+                    method.visitMethodInsn(
+                            INVOKESTATIC,
+                            "java/lang/Integer",
+                            "toString",
+                            "(I)Ljava/lang/String;",
+                            false);
+                    return true;
+                }
+                case BLOB -> {
+                    loadValue.run();
+                    checkCast(method, javaType, BYTE_BUFFER);
+                    method.visitMethodInsn(
+                            INVOKESTATIC,
+                            BUFFER_UTILS,
+                            "base64Encode",
+                            "(L" + BYTE_BUFFER + ";)Ljava/lang/String;",
+                            false);
+                    return true;
+                }
+                case TIMESTAMP -> {
+                    emitFormatterConstant(method, index);
+                    loadValue.run();
+                    checkCast(method, javaType, INSTANT);
+                    method.visitMethodInsn(
+                            INVOKEINTERFACE,
+                            FORMATTER,
+                            "writeString",
+                            "(L" + INSTANT + ";)Ljava/lang/String;",
+                            true);
+                    return true;
+                }
+                default -> throw new UnsupportedSchemaException(
+                        "HTTP binding runtime codegen cannot write "
+                                + target.type()
+                                + " at "
+                                + members.get(index).schema().id());
+            }
+        }
+
+        private void emitIntValue(
+                MethodVisitor method,
+                int index,
+                Schema target,
+                Class<?> javaType,
+                Runnable loadValue
+        ) {
+            String boxed;
+            String unboxer;
+            String descriptor;
+            switch (target.type()) {
+                case BYTE -> {
+                    boxed = "java/lang/Byte";
+                    unboxer = "byteValue";
+                    descriptor = "()B";
+                }
+                case SHORT -> {
+                    boxed = "java/lang/Short";
+                    unboxer = "shortValue";
+                    descriptor = "()S";
+                }
+                case INTEGER -> {
+                    boxed = "java/lang/Integer";
+                    unboxer = "intValue";
+                    descriptor = "()I";
+                }
+                default -> throw new UnsupportedSchemaException(
+                        "An HTTP response code cannot be a "
+                                + target.type()
+                                + " at "
+                                + members.get(index).schema().id());
+            }
+            loadValue.run();
+            if (!javaType.isPrimitive()) {
+                method.visitTypeInsn(CHECKCAST, boxed);
+                method.visitMethodInsn(INVOKEVIRTUAL, boxed, unboxer, descriptor, false);
+            }
+        }
+
+        private void emitToString(
+                MethodVisitor method,
+                Class<?> javaType,
+                Runnable loadValue,
+                Class<?> boxedType,
+                Class<?> primitiveType,
+                String argumentDescriptor
+        ) {
+            loadValue.run();
+            String boxed = Type.getInternalName(boxedType);
+            if (javaType.isPrimitive()) {
+                if (javaType != primitiveType) {
+                    throw new UnsupportedSchemaException(
+                            "Expected a " + primitiveType + " accessor but found " + javaType);
+                }
+                method.visitMethodInsn(
+                        INVOKESTATIC,
+                        boxed,
+                        "toString",
+                        argumentDescriptor + "Ljava/lang/String;",
+                        false);
+            } else {
+                checkCast(method, javaType, boxed);
+                method.visitMethodInsn(INVOKEVIRTUAL, boxed, "toString", "()Ljava/lang/String;", false);
+            }
+        }
+
+        private void emitInstanceToString(
+                MethodVisitor method,
+                Class<?> javaType,
+                Runnable loadValue,
+                Class<?> type
+        ) {
+            loadValue.run();
+            String owner = Type.getInternalName(type);
+            checkCast(method, javaType, owner);
+            method.visitMethodInsn(INVOKEVIRTUAL, owner, "toString", "()Ljava/lang/String;", false);
+        }
+
+        private void emitBase64Encoder(MethodVisitor method) {
+            method.visitMethodInsn(INVOKESTATIC, BASE64, "getEncoder", "()L" + BASE64_ENCODER + ";", false);
+        }
+
+        private void emitBase64OfString(MethodVisitor method) {
+            method.visitFieldInsn(
+                    GETSTATIC,
+                    Type.getInternalName(StandardCharsets.class),
+                    "UTF_8",
+                    "Ljava/nio/charset/Charset;");
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    STRING,
+                    "getBytes",
+                    "(Ljava/nio/charset/Charset;)[B",
+                    false);
+            method.visitMethodInsn(
+                    INVOKEVIRTUAL,
+                    BASE64_ENCODER,
+                    "encodeToString",
+                    "([B)Ljava/lang/String;",
+                    false);
+        }
+
+        private void emitFormatterConstant(MethodVisitor method, int index) {
+            TimestampFormatter formatter = memberBinding(index).timestampFormatter();
+            TimestampFormatter.Prelude prelude = null;
+            for (TimestampFormatter.Prelude candidate : TimestampFormatter.Prelude.values()) {
+                if (candidate == formatter) {
+                    prelude = candidate;
+                    break;
+                }
+            }
+            if (prelude == null) {
+                // Generated bytecode can reference only named prelude formatters.
+                throw new UnsupportedSchemaException(
+                        "Cannot name the timestamp format at " + members.get(index).schema().id());
+            }
+            method.visitFieldInsn(GETSTATIC, PRELUDE, prelude.name(), "L" + PRELUDE + ";");
+        }
+
+        private static void checkCast(MethodVisitor method, Class<?> javaType, String expected) {
+            if (!Type.getInternalName(javaType).equals(expected)) {
+                method.visitTypeInsn(CHECKCAST, expected);
+            }
+        }
+
+        private HttpBindingSchemaExtensions.Binding kindOf(int index) {
+            return bindings[members.get(index).schema().memberIndex()];
+        }
+
+        private HttpBindingSchemaExtensions.MemberBinding memberBinding(int index) {
+            return memberBindings[members.get(index).schema().memberIndex()];
+        }
+
+        private String headerName(int index) {
+            HeaderName name = memberBinding(index).headerName();
+            if (name == null) {
+                throw new UnsupportedSchemaException(
+                        "No resolved header name for " + members.get(index).schema().id());
+            }
+            return name.name();
+        }
+
+        private String wireName(int index) {
+            String name = memberBinding(index).wireName();
+            if (name == null) {
+                throw new UnsupportedSchemaException(
+                        "No resolved wire name for " + members.get(index).schema().id());
+            }
+            return name;
+        }
+
+        private boolean hasMediaType(int index) {
+            return memberBinding(index).hasMediaType();
+        }
+    }
+}

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSchemaExtensions.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSchemaExtensions.java
@@ -204,6 +204,7 @@ public final class HttpBindingSchemaExtensions
         final int headerCount;
         // Lazy PathSerializer — built on first request through {@link #pathSerializer}.
         private volatile PathSerializer pathSerializer;
+        private volatile HttpBindingWriter bindingWriter;
 
         RequestBinding(
                 Binding[] bindings,
@@ -251,6 +252,22 @@ public final class HttpBindingSchemaExtensions
             p = new PathSerializer(httpTrait, inputSchema);
             pathSerializer = p;
             return p;
+        }
+
+        HttpBindingWriter bindingWriter(Schema schema, boolean strict) {
+            var w = bindingWriter;
+            if (w == null) {
+                w = HttpBindingCodegen.writerOrSentinel(schema, false, strict);
+                bindingWriter = w;
+            }
+            if (w == HttpBindingCodegen.NO_BINDING_WRITER) {
+                if (strict) {
+                    // Surface the cached decline or generation failure.
+                    HttpBindingCodegen.writerOrSentinel(schema, false, true);
+                }
+                return null;
+            }
+            return w;
         }
 
         boolean writeBody(boolean omitEmptyPayload) {
@@ -309,6 +326,7 @@ public final class HttpBindingSchemaExtensions
         // Lazy cache for the codec output of an empty struct (no body members + no payload + force-write-empty).
         // Bytes are determined by codec + schema, so caching once and duplicating views per request is safe.
         private volatile ByteBuffer cachedEmptyBody;
+        private volatile HttpBindingWriter bindingWriter;
 
         ResponseBinding(
                 Binding[] bindings,
@@ -351,6 +369,22 @@ public final class HttpBindingSchemaExtensions
                 cachedEmptyBody = b;
             }
             return b.duplicate();
+        }
+
+        HttpBindingWriter bindingWriter(Schema schema, boolean strict) {
+            var w = bindingWriter;
+            if (w == null) {
+                w = HttpBindingCodegen.writerOrSentinel(schema, true, strict);
+                bindingWriter = w;
+            }
+            if (w == HttpBindingCodegen.NO_BINDING_WRITER) {
+                if (strict) {
+                    // Surface the cached decline or generation failure.
+                    HttpBindingCodegen.writerOrSentinel(schema, true, true);
+                }
+                return null;
+            }
+            return w;
         }
     }
 
@@ -574,8 +608,7 @@ public final class HttpBindingSchemaExtensions
         Schema[] queryArr = toArray(queries);
         String[] queryWireNames = queryWireNames(queryArr);
 
-        // +4 covers auto-set headers (Content-Type, Content-Length, …); cap at 32 to avoid
-        // over-allocating for AWS-S3-style structs that declare 50+ headers but populate few.
+        // +4 covers auto-set headers; cap at 32 to avoid over-allocating sparse, wide inputs.
         int headerCount = Math.min(headers.size() + prefixHeaders.size() + 4, 32);
 
         // True iff the @httpPayload member targets a STRUCTURE shape

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSerializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingSerializer.java
@@ -24,6 +24,8 @@ import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.MapSerializer;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
+import software.amazon.smithy.java.core.serde.RuntimeCodegenMode;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.java.core.serde.document.Document;
@@ -49,6 +51,8 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
     private static final String DEFAULT_STRING_CONTENT_TYPE = "text/plain";
 
     private final Codec payloadCodec;
+    // Preserves the concrete struct type for codecs that support member subsets.
+    private final MemberSubsetCodec subsetCodec;
     private final String payloadMediaType;
     private final boolean omitEmptyPayload;
     private final boolean isFailure;
@@ -76,10 +80,14 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
     private ByteBuffer shapeBodyBuffer;
     private DataStream httpPayload;
     private EventStream<? extends SerializableStruct> eventStream;
+    private Schema payloadMember;
+    private PayloadSerializer payloadSerializer;
+    private Schema payloadSchema;
     private int responseStatus;
     private boolean contentTypeHeaderInInput;
 
     private final boolean isResponse;
+    private final RuntimeCodegenMode runtimeCodegen;
     private final HttpBindingSchemaExtensions.OperationBinding operationBinding;
 
     HttpBindingSerializer(
@@ -91,11 +99,14 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
             boolean isFailure,
             boolean allowEmptyStructPayload,
             HeaderErrorSerializer headerErrorSerializer,
-            Context context
+            Context context,
+            RuntimeCodegenMode runtimeCodegen
     ) {
         this.operationBinding = operationBinding;
+        this.runtimeCodegen = runtimeCodegen;
         responseStatus = operationBinding.defaultResponseStatus();
         this.payloadCodec = payloadCodec;
+        this.subsetCodec = payloadCodec instanceof MemberSubsetCodec c ? c : null;
         this.isResponse = isResponse;
         this.payloadMediaType = payloadMediaType;
         this.omitEmptyPayload = omitEmptyPayload;
@@ -113,11 +124,24 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
         boolean writeBody;
         boolean hasBodyMembers;
         int headerCount;
+        // Generated writers cast to the schema's concrete shape class.
+        boolean canGenerate = runtimeCodegen != RuntimeCodegenMode.DISABLED && struct.schema() == schema;
+        if (runtimeCodegen == RuntimeCodegenMode.STRICT && !canGenerate) {
+            throw new IllegalStateException(
+                    "Strict HTTP binding runtime codegen requires the value's schema to be the operation schema: "
+                            + struct.schema().id()
+                            + " != "
+                            + schema.id());
+        }
+        boolean strictCodegen = runtimeCodegen == RuntimeCodegenMode.STRICT;
+        HttpBindingWriter generatedWriter;
         if (isResponse) {
             var resp = bindings.response();
+            generatedWriter = canGenerate ? resp.bindingWriter(schema, strictCodegen) : null;
             activeBindings = resp.bindings;
             memberBindings = resp.memberBindings;
             namesFromHttpHeader = resp.headerWireNames;
+            payloadMember = resp.payloadMember;
             headerCount = resp.headerCount;
             hasBodyMembers = resp.hasBody;
             if (resp.defaultStatus != -1) {
@@ -130,9 +154,11 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
             }
         } else {
             var req = bindings.request();
+            generatedWriter = canGenerate ? req.bindingWriter(schema, strictCodegen) : null;
             activeBindings = req.bindings;
             memberBindings = req.memberBindings;
             namesFromHttpHeader = req.headerWireNames;
+            payloadMember = req.payloadMember;
             headerCount = req.headerCount;
             hasBodyMembers = req.hasBody;
             contentTypeHeaderInInput = req.inputContentTypeHeader;
@@ -157,7 +183,7 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
 
         if (writeBody) {
             if (hasBodyMembers) {
-                shapeBodyBuffer = payloadCodec.serialize(new StructBodyProxy(struct, activeBindings));
+                shapeBodyBuffer = serializeBody(schema, struct);
             }
             // Empty-body case (shapeBodyBuffer was set above from the cached empty bytes).
             headers.setHeader(HeaderName.CONTENT_TYPE, payloadMediaType);
@@ -167,9 +193,116 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
             prepareError(schema);
         }
 
-        var bindingSerializer = new BindingSerializer();
-        struct.serializeMembers(bindingSerializer);
-        bindingSerializer.flushPayload();
+        if (generatedWriter != null) {
+            generatedWriter.write(struct, this);
+        } else {
+            struct.serializeMembers(new BindingSerializer());
+        }
+        flushPayload();
+    }
+
+    void bindHeader(String name, String value) {
+        if (value != null) {
+            headers.addHeaderCanonical(name, value);
+        }
+    }
+
+    // Only values produced by the writer may bypass header validation.
+    void bindHeaderTrusted(String name, String value) {
+        if (value != null) {
+            headers.addHeaderTrusted(name, value);
+        }
+    }
+
+    void bindQuery(String name, String value) {
+        queryStringParams().add(name, value);
+    }
+
+    void bindPrefixHeaders(String prefix, Map<?, ?> values) {
+        for (var entry : values.entrySet()) {
+            Object key = entry.getKey();
+            Object value = entry.getValue();
+            if (key == null || value == null) {
+                bindNull();
+            }
+            String headerName = prefix + (String) key;
+            // A statically named @httpHeader member takes precedence over a prefix-header entry.
+            if (!namesFromHttpHeader.contains(headerName)) {
+                headers.addHeader(headerName, (String) value);
+            }
+        }
+    }
+
+    void bindQueryParams(Map<?, ?> values) {
+        QueryStringBuilder builder = queryStringParams();
+        for (var entry : values.entrySet()) {
+            Object key = entry.getKey();
+            Object value = entry.getValue();
+            if (key == null || value == null) {
+                bindNull();
+            }
+            String name = (String) key;
+            if (value instanceof List<?> list) {
+                for (Object element : list) {
+                    if (element == null) {
+                        bindNull();
+                    }
+                    builder.addForQueryParams(name, (String) element);
+                }
+            } else {
+                builder.addForQueryParams(name, (String) value);
+            }
+        }
+    }
+
+    void bindStatus(int status) {
+        responseStatus = status;
+    }
+
+    void bindPayload(String value) {
+        payload(payloadMember).writeString(payloadMember, value);
+    }
+
+    void bindPayload(ByteBuffer value) {
+        payload(payloadMember).writeBlob(payloadMember, value);
+    }
+
+    void bindPayload(byte[] value) {
+        payload(payloadMember).writeBlob(payloadMember, value);
+    }
+
+    void bindPayload(Instant value) {
+        payload(payloadMember).writeTimestamp(payloadMember, value);
+    }
+
+    void bindPayload(SerializableStruct value) {
+        payload(payloadMember).writeStruct(payloadMember, value);
+    }
+
+    void bindPayload(Document value) {
+        payload(payloadMember).writeDocument(payloadMember, value);
+    }
+
+    void bindPayload(DataStream value) {
+        setHttpPayload(payloadMember, value);
+    }
+
+    void bindPayload(EventStream<? extends SerializableStruct> value) {
+        setEventStream(value);
+    }
+
+    void bindNull() {
+        throw new IllegalStateException("Unexpected null value written for an HTTP binding");
+    }
+
+    private ByteBuffer serializeBody(Schema schema, SerializableStruct struct) {
+        if (subsetCodec != null && struct.schema() == schema) {
+            ByteBuffer body = subsetCodec.serialize(struct, BodyMemberSubset.of(isResponse));
+            if (body != null) {
+                return body;
+            }
+        }
+        return payloadCodec.serialize(new StructBodyProxy(struct, activeBindings));
     }
 
     private void prepareError(Schema schema) {
@@ -269,11 +402,23 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
         headers.setHeader(HeaderName.CONTENT_TYPE, contentType);
     }
 
+    private PayloadSerializer payload(Schema schema) {
+        if (payloadSerializer == null) {
+            payloadSerializer = new PayloadSerializer(this, payloadCodec);
+            payloadSchema = schema;
+        }
+        return payloadSerializer;
+    }
+
+    private void flushPayload() {
+        if (payloadSerializer != null && !payloadSerializer.isPayloadWritten()) {
+            payloadSerializer.flush();
+            setHttpPayload(payloadSchema, DataStream.ofByteBuffer(payloadSerializer.toByteBuffer()));
+        }
+    }
+
     @SuppressWarnings("resource")
     private final class BindingSerializer extends SpecificShapeSerializer {
-        private PayloadSerializer payloadSerializer;
-        private Schema payloadSchema;
-
         @Override
         public void writeBoolean(Schema schema, boolean value) {
             int idx = schema.memberIndex();
@@ -505,29 +650,6 @@ final class HttpBindingSerializer extends SpecificShapeSerializer implements Sha
 
         private void writeQuery(HttpBindingSchemaExtensions.MemberBinding binding, String value) {
             queryStringParams().add(binding.wireName(), value);
-        }
-
-        /**
-         * Lazy-allocate the payload buffer the first time we hit a non-streaming PAYLOAD member.
-         * The buffered bytes are flushed and attached to the request/response in {@link #flushPayload()}.
-         */
-        private PayloadSerializer payload(Schema schema) {
-            if (payloadSerializer == null) {
-                payloadSerializer = new PayloadSerializer(HttpBindingSerializer.this, payloadCodec);
-                payloadSchema = schema;
-            }
-            return payloadSerializer;
-        }
-
-        /**
-         * If a PAYLOAD member was buffered, attach the bytes to the request/response.
-         * Called once after {@code serializeMembers}.
-         */
-        void flushPayload() {
-            if (payloadSerializer != null && !payloadSerializer.isPayloadWritten()) {
-                payloadSerializer.flush();
-                setHttpPayload(payloadSchema, DataStream.ofByteBuffer(payloadSerializer.toByteBuffer()));
-            }
         }
 
         /**

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingWriter.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/HttpBindingWriter.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.binding;
+
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+
+interface HttpBindingWriter {
+    void write(SerializableStruct struct, HttpBindingSerializer sink);
+}

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PayloadDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PayloadDeserializer.java
@@ -11,7 +11,9 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.document.Document;
 import software.amazon.smithy.java.io.datastream.DataStream;
@@ -31,6 +33,10 @@ final class PayloadDeserializer implements ShapeDeserializer {
 
     private ShapeDeserializer createDeserializer() {
         return payloadCodec.createDeserializer(resolveBodyBytes());
+    }
+
+    private ShapeDeserializer createDeserializer(ByteBuffer source) {
+        return payloadCodec.createDeserializer(source);
     }
 
     @Override
@@ -154,7 +160,13 @@ final class PayloadDeserializer implements ShapeDeserializer {
     @Override
     public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> consumer) {
         if (!isNull()) {
-            try (var deser = createDeserializer()) {
+            ByteBuffer source = resolveBodyBytes();
+            if (state instanceof ShapeBuilder<?> builder
+                    && payloadCodec instanceof MemberSubsetCodec direct
+                    && direct.deserialize(schema, builder, source.duplicate())) {
+                return;
+            }
+            try (var deser = createDeserializer(source)) {
                 deser.readStruct(schema, state, consumer);
             }
         }

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PayloadSerializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/PayloadSerializer.java
@@ -18,6 +18,7 @@ import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.TraitKey;
 import software.amazon.smithy.java.core.serde.Codec;
 import software.amazon.smithy.java.core.serde.MapSerializer;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
 import software.amazon.smithy.java.core.serde.SerializationException;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.TimestampFormatter;
@@ -110,7 +111,9 @@ final class PayloadSerializer implements ShapeSerializer {
     @Override
     public void writeStruct(Schema schema, SerializableStruct struct) {
         serializer.writePayloadContentType();
-        codecResult = codec.serialize(ser -> ser.writeStruct(schema, struct));
+        codecResult = codec instanceof MemberSubsetCodec
+                ? codec.serialize(struct)
+                : codec.serialize(ser -> ser.writeStruct(schema, struct));
     }
 
     @Override

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/RequestDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/RequestDeserializer.java
@@ -98,7 +98,7 @@ public final class RequestDeserializer {
             throw new IllegalStateException("inputShapeBuilder must be set");
         }
 
-        deserBuilder.isResponse(false);
+        deserBuilder.isResponse(false).directBodyBuilder(inputShapeBuilder);
         HttpBindingDeserializer deserializer = deserBuilder.build();
 
         inputShapeBuilder.deserialize(deserializer);

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/RequestSerializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/RequestSerializer.java
@@ -11,6 +11,7 @@ import software.amazon.smithy.java.core.schema.ApiOperation;
 import software.amazon.smithy.java.core.schema.SerializableShape;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.RuntimeCodegenMode;
 import software.amazon.smithy.java.core.serde.event.EventEncoderFactory;
 import software.amazon.smithy.java.core.serde.event.Frame;
 import software.amazon.smithy.java.core.serde.event.ProtocolEventStreamWriter;
@@ -30,8 +31,11 @@ public final class RequestSerializer {
     private EventEncoderFactory<?> eventStreamEncodingFactory;
     private boolean omitEmptyPayload = false;
     private boolean allowEmptyStructPayload = false;
+    private final RuntimeCodegenMode runtimeCodegen;
 
-    RequestSerializer() {}
+    RequestSerializer(RuntimeCodegenMode runtimeCodegen) {
+        this.runtimeCodegen = runtimeCodegen;
+    }
 
     /**
      * Schema of the operation to serialize.
@@ -140,7 +144,8 @@ public final class RequestSerializer {
                 false,
                 allowEmptyStructPayload,
                 HeaderErrorSerializer.NONE,
-                Context.empty());
+                Context.empty(),
+                runtimeCodegen);
         shapeValue.serialize(serializer);
         serializer.flush();
 

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseDeserializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseDeserializer.java
@@ -119,10 +119,9 @@ public final class ResponseDeserializer {
             throw new IllegalStateException("Either errorShapeBuilder or outputShapeBuilder must be set");
         }
 
-        deserBuilder.isResponse(true);
-
-        HttpBindingDeserializer deserializer = deserBuilder.build();
         var target = outputShapeBuilder != null ? outputShapeBuilder : errorShapeBuilder;
+        deserBuilder.isResponse(true).directBodyBuilder(target);
+        HttpBindingDeserializer deserializer = deserBuilder.build();
         Throwable failure = null;
         try {
             target.deserialize(deserializer);

--- a/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseSerializer.java
+++ b/http/http-binding/src/main/java/software/amazon/smithy/java/http/binding/ResponseSerializer.java
@@ -12,6 +12,7 @@ import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableShape;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.RuntimeCodegenMode;
 import software.amazon.smithy.java.core.serde.event.EventEncoderFactory;
 import software.amazon.smithy.java.core.serde.event.Frame;
 import software.amazon.smithy.java.core.serde.event.ProtocolEventStreamWriter;
@@ -31,8 +32,11 @@ public final class ResponseSerializer {
     private boolean omitEmptyPayload = false;
     private HeaderErrorSerializer headerErrorSerializer = HeaderErrorSerializer.AMZN_ERROR_HEADER;
     private Context context = Context.empty();
+    private final RuntimeCodegenMode runtimeCodegen;
 
-    ResponseSerializer() {}
+    ResponseSerializer(RuntimeCodegenMode runtimeCodegen) {
+        this.runtimeCodegen = runtimeCodegen;
+    }
 
     /**
      * Schema of the operation response to serialize.
@@ -160,7 +164,8 @@ public final class ResponseSerializer {
                 isFailure,
                 false,
                 headerErrorSerializer,
-                context);
+                context,
+                runtimeCodegen);
         shapeValue.serialize(serializer);
         serializer.flush();
 

--- a/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializerTest.java
+++ b/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/HttpBindingDeserializerTest.java
@@ -16,12 +16,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
 import software.amazon.smithy.java.core.schema.Schema;
 import software.amazon.smithy.java.core.schema.SerializableStruct;
 import software.amazon.smithy.java.core.schema.ShapeBuilder;
 import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.MemberSubsetCodec;
 import software.amazon.smithy.java.core.serde.ShapeDeserializer;
 import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.SpecificShapeDeserializer;
 import software.amazon.smithy.java.http.api.HttpHeaders;
 import software.amazon.smithy.java.http.api.HttpResponse;
 import software.amazon.smithy.java.http.api.HttpVersion;
@@ -105,6 +108,73 @@ public class HttpBindingDeserializerTest {
 
         Assertions.assertSame(body, builder.body);
         Assertions.assertEquals(0, body.discardCount);
+    }
+
+    @Test
+    void directBodyDeserializationRequiresExplicitBuilderOptIn() {
+        var codec = new SubsetCodec(true);
+        var builder = new BodyOutput.Builder();
+        var deserializer = HttpBindingDeserializer.builder()
+                .payloadCodec(codec)
+                .headers(HttpHeaders.of(Map.of()))
+                .body(DataStream.ofString("body"))
+                .isResponse(true)
+                .build();
+
+        builder.deserialize(deserializer);
+
+        Assertions.assertEquals(0, codec.directCalls);
+        Assertions.assertEquals(1, codec.fallbackCalls);
+        Assertions.assertEquals("fallback", builder.value);
+    }
+
+    @Test
+    void declinedDirectBodyDeserializationLeavesFallbackBufferReusable() {
+        var codec = new SubsetCodec(false);
+        var builder = new BodyOutput.Builder();
+
+        new ResponseDeserializer()
+                .payloadCodec(codec)
+                .response(response(DataStream.ofString("body")))
+                .outputShapeBuilder(builder)
+                .deserialize();
+
+        Assertions.assertEquals(1, codec.directCalls);
+        Assertions.assertEquals(1, codec.fallbackCalls);
+        Assertions.assertEquals(0, codec.fallbackPosition);
+        Assertions.assertEquals("fallback", builder.value);
+    }
+
+    @Test
+    void explicitlyOptedInBuilderCanBePopulatedDirectly() {
+        var codec = new SubsetCodec(true);
+        var builder = new BodyOutput.Builder();
+
+        new ResponseDeserializer()
+                .payloadCodec(codec)
+                .response(response(DataStream.ofString("body")))
+                .outputShapeBuilder(builder)
+                .deserialize();
+
+        Assertions.assertEquals(1, codec.directCalls);
+        Assertions.assertEquals(0, codec.fallbackCalls);
+        Assertions.assertEquals("direct", builder.value);
+    }
+
+    @Test
+    void structuredPayloadCanPopulateItsConcreteBuilderDirectly() {
+        var codec = new WholeShapeCodec();
+        var builder = new PayloadOutput.Builder();
+
+        new ResponseDeserializer()
+                .payloadCodec(codec)
+                .response(response(DataStream.ofString("{\"value\":\"direct\"}")))
+                .outputShapeBuilder(builder)
+                .deserialize();
+
+        Assertions.assertEquals(1, codec.directCalls);
+        Assertions.assertEquals(0, codec.fallbackCalls);
+        Assertions.assertEquals("direct", builder.payload.value());
     }
 
     private static HttpResponse response(DataStream body) {
@@ -226,6 +296,184 @@ public class HttpBindingDeserializerTest {
             public Schema schema() {
                 return SCHEMA;
             }
+        }
+    }
+
+    private record BodyOutput(String value) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#BodyOutput"))
+                .shapeClass(BodyOutput.class)
+                .putMember("value", PreludeSchemas.STRING)
+                .builderSupplier(Builder::new)
+                .build();
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return null;
+        }
+
+        private static final class Builder implements ShapeBuilder<BodyOutput> {
+            private String value;
+
+            @Override
+            public BodyOutput build() {
+                return new BodyOutput(value);
+            }
+
+            @Override
+            public ShapeBuilder<BodyOutput> deserialize(ShapeDeserializer decoder) {
+                decoder.readStruct(SCHEMA,
+                        this,
+                        (builder, member, deserializer) -> builder.value = deserializer.readString(member));
+                return this;
+            }
+
+            @Override
+            public Schema schema() {
+                return SCHEMA;
+            }
+        }
+    }
+
+    private record PayloadOutput(BodyOutput payload) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#PayloadOutput"))
+                .putMember("payload", BodyOutput.SCHEMA, new HttpPayloadTrait())
+                .builderSupplier(Builder::new)
+                .build();
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {}
+
+        @Override
+        public <T> T getMemberValue(Schema member) {
+            return null;
+        }
+
+        private static final class Builder implements ShapeBuilder<PayloadOutput> {
+            private BodyOutput payload;
+
+            @Override
+            public PayloadOutput build() {
+                return new PayloadOutput(payload);
+            }
+
+            @Override
+            public ShapeBuilder<PayloadOutput> deserialize(ShapeDeserializer decoder) {
+                decoder.readStruct(SCHEMA, this, (builder, member, deserializer) -> {
+                    var payloadBuilder = new BodyOutput.Builder();
+                    payloadBuilder.deserialize(deserializer);
+                    builder.payload = payloadBuilder.build();
+                });
+                return this;
+            }
+
+            @Override
+            public Schema schema() {
+                return SCHEMA;
+            }
+        }
+    }
+
+    private static final class WholeShapeCodec implements Codec, MemberSubsetCodec {
+        private int directCalls;
+        private int fallbackCalls;
+
+        @Override
+        public ByteBuffer serialize(SerializableStruct struct, MemberSubset subset) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean deserialize(Schema schema, ShapeBuilder<?> builder, ByteBuffer source) {
+            directCalls++;
+            ((BodyOutput.Builder) builder).value = "direct";
+            return true;
+        }
+
+        @Override
+        public ShapeSerializer createSerializer(OutputStream sink) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ShapeDeserializer createDeserializer(ByteBuffer source) {
+            fallbackCalls++;
+            return new SpecificShapeDeserializer() {
+                @Override
+                public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> consumer) {
+                    consumer.accept(state, schema.member("value"), new SpecificShapeDeserializer() {
+                        @Override
+                        public String readString(Schema schema) {
+                            return "fallback";
+                        }
+                    });
+                }
+            };
+        }
+    }
+
+    private static final class SubsetCodec implements Codec, MemberSubsetCodec {
+        private final boolean directResult;
+        private int directCalls;
+        private int fallbackCalls;
+        private int fallbackPosition = -1;
+
+        private SubsetCodec(boolean directResult) {
+            this.directResult = directResult;
+        }
+
+        @Override
+        public ByteBuffer serialize(SerializableStruct struct, MemberSubset subset) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean deserialize(
+                Schema schema,
+                ShapeBuilder<?> builder,
+                ByteBuffer source,
+                MemberSubset subset
+        ) {
+            directCalls++;
+            if (directResult) {
+                source.get();
+                ((BodyOutput.Builder) builder).value = "direct";
+            }
+            return directResult;
+        }
+
+        @Override
+        public ShapeSerializer createSerializer(OutputStream sink) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ShapeDeserializer createDeserializer(ByteBuffer source) {
+            return new SpecificShapeDeserializer() {
+                @Override
+                public <T> void readStruct(Schema schema, T state, StructMemberConsumer<T> consumer) {
+                    fallbackCalls++;
+                    fallbackPosition = source.position();
+                    consumer.accept(state, schema.member("value"), new SpecificShapeDeserializer() {
+                        @Override
+                        public String readString(Schema schema) {
+                            return "fallback";
+                        }
+                    });
+                }
+            };
         }
     }
 }

--- a/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/HttpBindingWriterTest.java
+++ b/http/http-binding/src/test/java/software/amazon/smithy/java/http/binding/HttpBindingWriterTest.java
@@ -1,0 +1,1402 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.java.http.binding;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URLDecoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodecPlan;
+import software.amazon.smithy.java.codecs.commons.internal.codegen.RuntimeCodegenFeature;
+import software.amazon.smithy.java.core.schema.ApiOperation;
+import software.amazon.smithy.java.core.schema.ApiService;
+import software.amazon.smithy.java.core.schema.PreludeSchemas;
+import software.amazon.smithy.java.core.schema.Schema;
+import software.amazon.smithy.java.core.schema.SerializableStruct;
+import software.amazon.smithy.java.core.schema.ShapeBuilder;
+import software.amazon.smithy.java.core.schema.SmithyEnum;
+import software.amazon.smithy.java.core.schema.SmithyIntEnum;
+import software.amazon.smithy.java.core.serde.Codec;
+import software.amazon.smithy.java.core.serde.RuntimeCodegenMode;
+import software.amazon.smithy.java.core.serde.ShapeDeserializer;
+import software.amazon.smithy.java.core.serde.ShapeSerializer;
+import software.amazon.smithy.java.core.serde.TypeRegistry;
+import software.amazon.smithy.java.http.api.HttpHeaders;
+import software.amazon.smithy.java.http.api.HttpRequest;
+import software.amazon.smithy.java.http.api.HttpResponse;
+import software.amazon.smithy.java.io.uri.SmithyUri;
+import software.amazon.smithy.java.json.JsonCodec;
+import software.amazon.smithy.model.pattern.UriPattern;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.HttpHeaderTrait;
+import software.amazon.smithy.model.traits.HttpLabelTrait;
+import software.amazon.smithy.model.traits.HttpPayloadTrait;
+import software.amazon.smithy.model.traits.HttpPrefixHeadersTrait;
+import software.amazon.smithy.model.traits.HttpQueryParamsTrait;
+import software.amazon.smithy.model.traits.HttpQueryTrait;
+import software.amazon.smithy.model.traits.HttpResponseCodeTrait;
+import software.amazon.smithy.model.traits.HttpTrait;
+import software.amazon.smithy.model.traits.MediaTypeTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
+import software.amazon.smithy.model.traits.SparseTrait;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+
+public class HttpBindingWriterTest {
+
+    private static final Codec CODEC = JsonCodec.builder().build();
+    private static final SmithyUri ENDPOINT = SmithyUri.of("https://example.com");
+    private static final Instant WHEN = Instant.parse("2026-08-16T01:02:03Z");
+
+    @BeforeAll
+    public static void requireCodegen() {
+        assumeTrue(
+                RuntimeCodegenFeature.available(),
+                "Runtime code generation is not available in this JVM");
+    }
+
+    @Test
+    public void writesEveryBoundTypeAsAHeader() {
+        var headers = generated(fullyPopulated()).headers();
+
+        assertThat(headers.firstValue("x-text"), equalTo("plain"));
+        assertThat(headers.firstValue("x-flag"), equalTo("true"));
+        assertThat(headers.firstValue("x-byte"), equalTo("7"));
+        assertThat(headers.firstValue("x-short"), equalTo("-9"));
+        assertThat(headers.firstValue("x-int"), equalTo("11"));
+        assertThat(headers.firstValue("x-long"), equalTo("12345678901"));
+        assertThat(headers.firstValue("x-float"), equalTo("1.5"));
+        assertThat(headers.firstValue("x-double"), equalTo("2.25"));
+        assertThat(headers.firstValue("x-bigint"), equalTo("170141183460469231731687303715884105727"));
+        assertThat(headers.firstValue("x-bigdec"), equalTo("1.7500"));
+        assertThat(headers.firstValue("x-blob"), equalTo(base64("blobby")));
+        assertThat(headers.firstValue("x-media"), equalTo(base64("{\"k\":1}")));
+        assertThat(headers.firstValue("x-date"), equalTo("Sun, 16 Aug 2026 01:02:03 GMT"));
+        assertThat(headers.firstValue("x-epoch"), equalTo("1786842123"));
+    }
+
+    @Test
+    public void writesListHeadersAsRepeatedValues() {
+        var headers = generated(fullyPopulated()).headers();
+
+        assertThat(headers.allValues("x-tags"), contains("a", "b", "c"));
+    }
+
+    @Test
+    public void writesQueryParameters() {
+        var query = generated(fullyPopulated()).uri().getQuery();
+
+        assertThat(parseQuery(query),
+                equalTo(Map.of(
+                        "q",
+                        List.of("needle"),
+                        "nums",
+                        List.of("1", "2"),
+                        "qtime",
+                        List.of("2026-08-16T01:02:03Z"))));
+    }
+
+    @Test
+    public void leavesLabelsAndBodyMembersToTheirOwners() {
+        var request = generated(fullyPopulated());
+
+        assertThat(request.uri().getPath(), equalTo("/op/id-1"));
+        assertThat(utf8(request.body().asByteBuffer()), equalTo("{\"note\":\"hi\"}"));
+    }
+
+    @Test
+    public void omitsAbsentMembers() {
+        var request = generated(new Bound.Builder().id("id-1").text("plain").build());
+
+        assertThat(request.headers().firstValue("x-text"), equalTo("plain"));
+        assertThat(request.headers().firstValue("x-flag"), nullValue());
+        assertThat(request.headers().firstValue("x-tags"), nullValue());
+        assertThat(request.headers().firstValue("x-date"), nullValue());
+        assertThat(request.uri().getQuery(), nullValue());
+    }
+
+    @Test
+    public void omitsEmptyListHeaders() {
+        var request = generated(populated(b -> b.tags(List.of()).nums(List.of())));
+
+        assertThat(request.headers().firstValue("x-tags"), nullValue());
+        assertThat(parseQuery(request.uri().getQuery()),
+                equalTo(Map.of(
+                        "q",
+                        List.of("needle"),
+                        "qtime",
+                        List.of("2026-08-16T01:02:03Z"))));
+    }
+
+    @Test
+    public void generatedBindingsMatchInterpretedBindings() {
+        var backend = new HttpBindingRuntimeCodegenBackend(false);
+        var plan = RuntimeCodecPlan.analyze(
+                Bound.SCHEMA,
+                backend.budgets(),
+                backend.mode(),
+                backend.memberSelector());
+        assertThat(plan.rootStructure().writerChunks().size(), greaterThan(1));
+
+        for (var input : List.of(fullyPopulated(), populated(b -> b.text(null).tags(List.of("solo"))))) {
+            var generatedRequest = generated(input);
+            var interpretedRequest = interpreted(input);
+
+            assertThat(headerMap(generatedRequest.headers()), equalTo(headerMap(interpretedRequest.headers())));
+            assertThat(
+                    parseQuery(generatedRequest.uri().getQuery()),
+                    equalTo(parseQuery(interpretedRequest.uri().getQuery())));
+            assertThat(generatedRequest.uri().getPath(), equalTo(interpretedRequest.uri().getPath()));
+            assertThat(
+                    utf8(generatedRequest.body().asByteBuffer()),
+                    equalTo(utf8(interpretedRequest.body().asByteBuffer())));
+        }
+    }
+
+    @Test
+    @Tag("runtime-codegen-strict")
+    public void boundShapesUseGeneratedWriters() {
+        var writer = requestWriter(Bound.SCHEMA);
+        assertThat(writer, notNullValue());
+        assertThat(writer.getClass().isHidden(), equalTo(true));
+    }
+
+    @Test
+    public void rejectsHeaderInjectionThroughStrings() {
+        var injected = populated(b -> b.text("ok\r\nX-Injected: yes"));
+
+        assertThrows(IllegalArgumentException.class, () -> generated(injected));
+        assertThrows(IllegalArgumentException.class, () -> interpreted(injected));
+    }
+
+    @Test
+    public void rejectsHeaderValuesOutsideObsText() {
+        var invalid = populated(b -> b.text("not-http-\u20ac"));
+
+        assertThrows(IllegalArgumentException.class, () -> generated(invalid));
+        assertThrows(IllegalArgumentException.class, () -> interpreted(invalid));
+    }
+
+    @Test
+    public void allowsLatin1ObsTextInHeaders() {
+        var input = populated(b -> b.text("caf\u00e9"));
+
+        assertThat(generated(input).headers().firstValue("x-text"), equalTo("caf\u00e9"));
+        assertThat(interpreted(input).headers().firstValue("x-text"), equalTo("caf\u00e9"));
+    }
+
+    @Test
+    public void rejectsHeaderInjectionThroughListElements() {
+        var injected = populated(b -> b.tags(List.of("fine", "bad\nX-Injected: yes")));
+
+        assertThrows(IllegalArgumentException.class, () -> generated(injected));
+        assertThrows(IllegalArgumentException.class, () -> interpreted(injected));
+    }
+
+    @Test
+    public void rejectsHeaderInjectionThroughEnums() {
+        var injected = populated(b -> b.mood(new Mood("bad\r\nX-Injected: yes")));
+
+        assertThrows(IllegalArgumentException.class, () -> generated(injected));
+        assertThrows(IllegalArgumentException.class, () -> interpreted(injected));
+    }
+
+    @Test
+    public void trimsWhitespaceFromCallerSuppliedHeaders() {
+        var padded = populated(b -> b.text("  padded  "));
+
+        assertThat(generated(padded).headers().firstValue("x-text"), equalTo("padded"));
+        assertThat(interpreted(padded).headers().firstValue("x-text"), equalTo("padded"));
+    }
+
+    @Test
+    public void writesEnumsByValue() {
+        var headers = generated(populated(b -> b.mood(new Mood("happy")).level(new Level(42)))).headers();
+
+        assertThat(headers.firstValue("x-mood"), equalTo("happy"));
+        assertThat(headers.firstValue("x-level"), equalTo("42"));
+    }
+
+    @Test
+    public void writesTheResponseStatus() {
+        assertThat(response(new Status(204, "hi"), true).statusCode(), equalTo(204));
+        assertThat(response(new Status(204, "hi"), false).statusCode(), equalTo(204));
+        assertThat(utf8(generated(Status.OPERATION, new Status(204, "hi")).body().asByteBuffer()),
+                equalTo("{\"code\":204,\"note\":\"hi\"}"));
+    }
+
+    @Test
+    @Tag("runtime-codegen-strict")
+    public void generatesEveryValidBindingKind() {
+        assertThat(requestWriter(WithPayload.SCHEMA), notNullValue());
+        assertThat(requestWriter(WithPrefixHeaders.SCHEMA), notNullValue());
+        assertThat(requestWriter(WithQueryParams.SCHEMA), notNullValue());
+        assertThat(requestWriter(WithSparseHeaderList.SCHEMA), notNullValue());
+    }
+
+    @Test
+    public void generatedPrefixHeadersWriteTheirBindings() {
+        var request =
+                generated(WithPrefixHeaders.OPERATION, new WithPrefixHeaders("tok", Map.of("a", " 1\t")));
+
+        assertThat(request.headers().firstValue("x-token"), equalTo("tok"));
+        assertThat(request.headers().firstValue("x-meta-a"), equalTo("1"));
+    }
+
+    @Test
+    public void generatedQueryParamsWriteTheirBindings() {
+        var request = generated(
+                WithQueryParams.OPERATION,
+                new WithQueryParams("tok", Map.of("one", "1", "spaced", "hello world")));
+
+        assertThat(request.headers().firstValue("x-token"), equalTo("tok"));
+        assertThat(parseQuery(request.uri().getQuery()),
+                equalTo(Map.of(
+                        "one",
+                        List.of("1"),
+                        "spaced",
+                        List.of("hello world"))));
+    }
+
+    @Test
+    public void generatedPayloadWritesTheBody() {
+        var request = generated(WithPayload.OPERATION, new WithPayload("tok", "payload"));
+
+        assertThat(request.headers().firstValue("x-token"), equalTo("tok"));
+        assertThat(utf8(request.body().asByteBuffer()), equalTo("payload"));
+    }
+
+    @Test
+    public void generatedBlobPayloadWritesTheBody() {
+        var request = generated(
+                WithBlobPayload.OPERATION,
+                new WithBlobPayload(ByteBuffer.wrap("blob".getBytes(StandardCharsets.UTF_8))));
+
+        assertThat(utf8(request.body().asByteBuffer()), equalTo("blob"));
+        assertThat(request.headers().firstValue("content-type"), equalTo("application/octet-stream"));
+    }
+
+    @Test
+    public void generatedQueryParamsWriteListValues() {
+        var request = generated(
+                WithQueryListParams.OPERATION,
+                new WithQueryListParams(Map.of("tag", List.of("a", "b"))));
+
+        assertThat(parseQuery(request.uri().getQuery()), equalTo(Map.of("tag", List.of("a", "b"))));
+    }
+
+    @Test
+    public void generatedSparseHeaderListsWriteValues() {
+        var request = generated(
+                WithSparseHeaderList.OPERATION,
+                new WithSparseHeaderList(List.of("a", "b")));
+
+        assertThat(request.headers().allValues("x-tags"), contains("a", "b"));
+    }
+
+    @Test
+    public void generatedSparseHeaderListsRejectNulls() {
+        var input = new WithSparseHeaderList(Arrays.asList("a", null, "b"));
+
+        assertThrows(IllegalStateException.class, () -> generated(WithSparseHeaderList.OPERATION, input));
+        assertThrows(IllegalStateException.class, () -> request(WithSparseHeaderList.OPERATION, input, false));
+    }
+
+    @Test
+    @Tag("runtime-codegen-strict")
+    public void strictModeGeneratesDynamicBindings() {
+        var strict = HttpBinding.builder().runtimeCodegen(RuntimeCodegenMode.STRICT).build();
+        var request = strict.requestSerializer()
+                .operation(WithPrefixHeaders.OPERATION)
+                .payloadCodec(CODEC)
+                .payloadMediaType("application/json")
+                .shapeValue(new WithPrefixHeaders("tok", Map.of("a", "1")))
+                .endpoint(ENDPOINT)
+                .omitEmptyPayload(true)
+                .serializeRequest();
+
+        assertThat(request.headers().firstValue("x-token"), equalTo("tok"));
+        assertThat(request.headers().firstValue("x-meta-a"), equalTo("1"));
+
+        var bound = strict.requestSerializer()
+                .operation(Bound.OPERATION)
+                .payloadCodec(CODEC)
+                .payloadMediaType("application/json")
+                .shapeValue(populated(b -> b))
+                .endpoint(ENDPOINT)
+                .omitEmptyPayload(true)
+                .serializeRequest();
+        assertThat(bound.headers().firstValue("x-text"), equalTo("plain"));
+    }
+
+    @Test
+    public void generatedPrefixHeadersRejectInjection() {
+        var input = new WithPrefixHeaders("tok", Map.of("a", "safe\r\ninjected: yes"));
+
+        assertThrows(IllegalArgumentException.class, () -> generated(WithPrefixHeaders.OPERATION, input));
+        assertThrows(IllegalArgumentException.class, () -> request(WithPrefixHeaders.OPERATION, input, false));
+    }
+
+    @Test
+    public void bodyOnlyShapesGetAnEmptyWriter() {
+        var writer = requestWriter(BodyOnly.SCHEMA);
+
+        assertThat(writer, notNullValue());
+        assertThat(writer.getClass().isHidden(), equalTo(true));
+        var request = generated(BodyOnly.OPERATION, new BodyOnly("hi"));
+        assertThat(utf8(request.body().asByteBuffer()), equalTo("{\"note\":\"hi\"}"));
+    }
+
+    private static HttpBindingWriter requestWriter(Schema schema) {
+        return HttpBindingSchemaExtensions.structBindingsOf(schema).request().bindingWriter(schema, false);
+    }
+
+    private static Bound fullyPopulated() {
+        return populated(b -> b);
+    }
+
+    private static Bound populated(UnaryOperator<Bound.Builder> customize) {
+        var builder = new Bound.Builder()
+                .id("id-1")
+                .text("plain")
+                .media("{\"k\":1}")
+                .tags(List.of("a", "b", "c"))
+                .flag(true)
+                .byteValue((byte) 7)
+                .shortValue((short) -9)
+                .intValue(11)
+                .longValue(12345678901L)
+                .floatValue(1.5f)
+                .doubleValue(2.25d)
+                .bigInt(new BigInteger("170141183460469231731687303715884105727"))
+                .bigDec(new BigDecimal("1.7500"))
+                .blob(ByteBuffer.wrap("blobby".getBytes(StandardCharsets.UTF_8)))
+                .date(WHEN)
+                .epoch(WHEN)
+                .q("needle")
+                .nums(List.of(1, 2))
+                .qtime(WHEN)
+                .note("hi");
+        return customize.apply(builder).build();
+    }
+
+    private static HttpRequest generated(SerializableStruct input) {
+        return generated(Bound.OPERATION, input);
+    }
+
+    private static HttpRequest interpreted(SerializableStruct input) {
+        return request(Bound.OPERATION, input, false);
+    }
+
+    private static HttpRequest generated(ApiOperation<?, ?> operation, SerializableStruct input) {
+        return request(operation, input, true);
+    }
+
+    private static HttpRequest request(ApiOperation<?, ?> operation, SerializableStruct input, boolean codegen) {
+        return binding(codegen).requestSerializer()
+                .operation(operation)
+                .payloadCodec(CODEC)
+                .payloadMediaType("application/json")
+                .shapeValue(input)
+                .endpoint(ENDPOINT)
+                .omitEmptyPayload(true)
+                .serializeRequest();
+    }
+
+    private static HttpResponse response(SerializableStruct output, boolean codegen) {
+        return binding(codegen).responseSerializer()
+                .operation(Status.OPERATION)
+                .payloadCodec(CODEC)
+                .payloadMediaType("application/json")
+                .shapeValue(output)
+                .serializeResponse();
+    }
+
+    private static HttpBinding binding(boolean codegen) {
+        var builder = HttpBinding.builder()
+                .runtimeCodegen(codegen ? RuntimeCodegenMode.ENABLED : RuntimeCodegenMode.DISABLED);
+        if (codegen && !builder.resolvedRuntimeCodegen()) {
+            throw new IllegalStateException("Runtime codegen unavailable on " + Runtime.version());
+        }
+        return builder.build();
+    }
+
+    private static Map<String, List<String>> headerMap(HttpHeaders headers) {
+        Map<String, List<String>> result = new TreeMap<>();
+        headers.forEachEntry(result,
+                (map, name, value) -> map.computeIfAbsent(name, k -> new ArrayList<>())
+                        .add(value));
+        return result;
+    }
+
+    private static Map<String, List<String>> parseQuery(String query) {
+        Map<String, List<String>> result = new TreeMap<>();
+        if (query == null || query.isEmpty()) {
+            return result;
+        }
+        for (String pair : query.split("&")) {
+            int eq = pair.indexOf('=');
+            String name = eq < 0 ? pair : pair.substring(0, eq);
+            String value = eq < 0 ? "" : urlDecode(pair.substring(eq + 1));
+            result.computeIfAbsent(name, k -> new ArrayList<>()).add(value);
+        }
+        return result;
+    }
+
+    private static String urlDecode(String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String base64(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String utf8(ByteBuffer buffer) {
+        var bytes = new byte[buffer.remaining()];
+        buffer.duplicate().get(bytes);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    public record Mood(String value) implements SmithyEnum {
+        static final Schema SCHEMA = Schema.createEnum(
+                ShapeId.from("smithy.example#Mood"),
+                Set.of("happy", "sad"),
+                Mood.class);
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public record Level(int value) implements SmithyIntEnum {
+        static final Schema SCHEMA = Schema.createIntEnum(
+                ShapeId.from("smithy.example#Level"),
+                Set.of(1, 42),
+                Level.class);
+
+        @Override
+        public int getValue() {
+            return value;
+        }
+    }
+
+    public static final class Bound implements SerializableStruct {
+
+        private static final Schema TAGS = Schema.listBuilder(ShapeId.from("smithy.example#Tags"))
+                .putMember("member", PreludeSchemas.STRING)
+                .build();
+        private static final Schema NUMS = Schema.listBuilder(ShapeId.from("smithy.example#Nums"))
+                .putMember("member", PreludeSchemas.INTEGER)
+                .build();
+        private static final Schema JSON_STRING = Schema.createString(
+                ShapeId.from("smithy.example#JsonString"),
+                new MediaTypeTrait("application/json"));
+
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#Bound"))
+                .shapeClass(Bound.class)
+                .builderSupplier(Builder::new)
+                .putMember("id", PreludeSchemas.STRING, new HttpLabelTrait(), new RequiredTrait())
+                .putMember("text", PreludeSchemas.STRING, new HttpHeaderTrait("x-text"))
+                .putMember("media", JSON_STRING, new HttpHeaderTrait("x-media"))
+                .putMember("tags", TAGS, new HttpHeaderTrait("x-tags"))
+                .putMember("flag", PreludeSchemas.BOOLEAN, new HttpHeaderTrait("x-flag"))
+                .putMember("byteValue", PreludeSchemas.BYTE, new HttpHeaderTrait("x-byte"))
+                .putMember("shortValue", PreludeSchemas.SHORT, new HttpHeaderTrait("x-short"))
+                .putMember("intValue", PreludeSchemas.INTEGER, new HttpHeaderTrait("x-int"))
+                .putMember("longValue", PreludeSchemas.LONG, new HttpHeaderTrait("x-long"))
+                .putMember("floatValue", PreludeSchemas.FLOAT, new HttpHeaderTrait("x-float"))
+                .putMember("doubleValue", PreludeSchemas.DOUBLE, new HttpHeaderTrait("x-double"))
+                .putMember("bigInt", PreludeSchemas.BIG_INTEGER, new HttpHeaderTrait("x-bigint"))
+                .putMember("bigDec", PreludeSchemas.BIG_DECIMAL, new HttpHeaderTrait("x-bigdec"))
+                .putMember("blob", PreludeSchemas.BLOB, new HttpHeaderTrait("x-blob"))
+                .putMember("date", PreludeSchemas.TIMESTAMP, new HttpHeaderTrait("x-date"))
+                .putMember(
+                        "epoch",
+                        PreludeSchemas.TIMESTAMP,
+                        new HttpHeaderTrait("x-epoch"),
+                        new TimestampFormatTrait(TimestampFormatTrait.EPOCH_SECONDS))
+                .putMember("mood", Mood.SCHEMA, new HttpHeaderTrait("x-mood"))
+                .putMember("level", Level.SCHEMA, new HttpHeaderTrait("x-level"))
+                .putMember("q", PreludeSchemas.STRING, new HttpQueryTrait("q"))
+                .putMember("nums", NUMS, new HttpQueryTrait("nums"))
+                .putMember("qtime", PreludeSchemas.TIMESTAMP, new HttpQueryTrait("qtime"))
+                .putMember("note", PreludeSchemas.STRING)
+                .build();
+        static final ApiOperation<?, ?> OPERATION = operation("BoundOperation", SCHEMA, "/op/{id}");
+
+        private final String id;
+        private final String text;
+        private final String media;
+        private final List<String> tags;
+        private final Boolean flag;
+        private final Byte byteValue;
+        private final Short shortValue;
+        private final Integer intValue;
+        private final Long longValue;
+        private final Float floatValue;
+        private final Double doubleValue;
+        private final BigInteger bigInt;
+        private final BigDecimal bigDec;
+        private final ByteBuffer blob;
+        private final Instant date;
+        private final Instant epoch;
+        private final Mood mood;
+        private final Level level;
+        private final String q;
+        private final List<Integer> nums;
+        private final Instant qtime;
+        private final String note;
+
+        @SuppressWarnings("checkstyle:ParameterNumber")
+        Bound(
+                String id,
+                String text,
+                String media,
+                List<String> tags,
+                Boolean flag,
+                Byte byteValue,
+                Short shortValue,
+                Integer intValue,
+                Long longValue,
+                Float floatValue,
+                Double doubleValue,
+                BigInteger bigInt,
+                BigDecimal bigDec,
+                ByteBuffer blob,
+                Instant date,
+                Instant epoch,
+                Mood mood,
+                Level level,
+                String q,
+                List<Integer> nums,
+                Instant qtime,
+                String note
+        ) {
+            this.id = id;
+            this.text = text;
+            this.media = media;
+            this.tags = tags;
+            this.flag = flag;
+            this.byteValue = byteValue;
+            this.shortValue = shortValue;
+            this.intValue = intValue;
+            this.longValue = longValue;
+            this.floatValue = floatValue;
+            this.doubleValue = doubleValue;
+            this.bigInt = bigInt;
+            this.bigDec = bigDec;
+            this.blob = blob;
+            this.date = date;
+            this.epoch = epoch;
+            this.mood = mood;
+            this.level = level;
+            this.q = q;
+            this.nums = nums;
+            this.qtime = qtime;
+            this.note = note;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public String text() {
+            return text;
+        }
+
+        public String media() {
+            return media;
+        }
+
+        public List<String> tags() {
+            return tags;
+        }
+
+        public Boolean flag() {
+            return flag;
+        }
+
+        public Byte byteValue() {
+            return byteValue;
+        }
+
+        public Short shortValue() {
+            return shortValue;
+        }
+
+        public Integer intValue() {
+            return intValue;
+        }
+
+        public Long longValue() {
+            return longValue;
+        }
+
+        public Float floatValue() {
+            return floatValue;
+        }
+
+        public Double doubleValue() {
+            return doubleValue;
+        }
+
+        public BigInteger bigInt() {
+            return bigInt;
+        }
+
+        public BigDecimal bigDec() {
+            return bigDec;
+        }
+
+        public ByteBuffer blob() {
+            return blob;
+        }
+
+        public Instant date() {
+            return date;
+        }
+
+        public Instant epoch() {
+            return epoch;
+        }
+
+        public Mood mood() {
+            return mood;
+        }
+
+        public Level level() {
+            return level;
+        }
+
+        public String q() {
+            return q;
+        }
+
+        public List<Integer> nums() {
+            return nums;
+        }
+
+        public Instant qtime() {
+            return qtime;
+        }
+
+        public String note() {
+            return note;
+        }
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (id != null) {
+                serializer.writeString(SCHEMA.member("id"), id);
+            }
+            if (text != null) {
+                serializer.writeString(SCHEMA.member("text"), text);
+            }
+            if (media != null) {
+                serializer.writeString(SCHEMA.member("media"), media);
+            }
+            if (tags != null) {
+                serializer.writeList(SCHEMA.member("tags"), tags, tags.size(), (values, ser) -> {
+                    for (String value : values) {
+                        ser.writeString(TAGS.listMember(), value);
+                    }
+                });
+            }
+            if (flag != null) {
+                serializer.writeBoolean(SCHEMA.member("flag"), flag);
+            }
+            if (byteValue != null) {
+                serializer.writeByte(SCHEMA.member("byteValue"), byteValue);
+            }
+            if (shortValue != null) {
+                serializer.writeShort(SCHEMA.member("shortValue"), shortValue);
+            }
+            if (intValue != null) {
+                serializer.writeInteger(SCHEMA.member("intValue"), intValue);
+            }
+            if (longValue != null) {
+                serializer.writeLong(SCHEMA.member("longValue"), longValue);
+            }
+            if (floatValue != null) {
+                serializer.writeFloat(SCHEMA.member("floatValue"), floatValue);
+            }
+            if (doubleValue != null) {
+                serializer.writeDouble(SCHEMA.member("doubleValue"), doubleValue);
+            }
+            if (bigInt != null) {
+                serializer.writeBigInteger(SCHEMA.member("bigInt"), bigInt);
+            }
+            if (bigDec != null) {
+                serializer.writeBigDecimal(SCHEMA.member("bigDec"), bigDec);
+            }
+            if (blob != null) {
+                serializer.writeBlob(SCHEMA.member("blob"), blob);
+            }
+            if (date != null) {
+                serializer.writeTimestamp(SCHEMA.member("date"), date);
+            }
+            if (epoch != null) {
+                serializer.writeTimestamp(SCHEMA.member("epoch"), epoch);
+            }
+            if (mood != null) {
+                serializer.writeString(SCHEMA.member("mood"), mood.getValue());
+            }
+            if (level != null) {
+                serializer.writeInteger(SCHEMA.member("level"), level.getValue());
+            }
+            if (q != null) {
+                serializer.writeString(SCHEMA.member("q"), q);
+            }
+            if (nums != null) {
+                serializer.writeList(SCHEMA.member("nums"), nums, nums.size(), (values, ser) -> {
+                    for (Integer value : values) {
+                        ser.writeInteger(NUMS.listMember(), value);
+                    }
+                });
+            }
+            if (qtime != null) {
+                serializer.writeTimestamp(SCHEMA.member("qtime"), qtime);
+            }
+            if (note != null) {
+                serializer.writeString(SCHEMA.member("note"), note);
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) switch (member.memberName()) {
+                case "id" -> id;
+                case "text" -> text;
+                case "media" -> media;
+                case "tags" -> tags;
+                case "flag" -> flag;
+                case "byteValue" -> byteValue;
+                case "shortValue" -> shortValue;
+                case "intValue" -> intValue;
+                case "longValue" -> longValue;
+                case "floatValue" -> floatValue;
+                case "doubleValue" -> doubleValue;
+                case "bigInt" -> bigInt;
+                case "bigDec" -> bigDec;
+                case "blob" -> blob;
+                case "date" -> date;
+                case "epoch" -> epoch;
+                case "mood" -> mood;
+                case "level" -> level;
+                case "q" -> q;
+                case "nums" -> nums;
+                case "qtime" -> qtime;
+                case "note" -> note;
+                default -> null;
+            };
+        }
+
+        public static final class Builder implements ShapeBuilder<Bound> {
+            private String id;
+            private String text;
+            private String media;
+            private List<String> tags;
+            private Boolean flag;
+            private Byte byteValue;
+            private Short shortValue;
+            private Integer intValue;
+            private Long longValue;
+            private Float floatValue;
+            private Double doubleValue;
+            private BigInteger bigInt;
+            private BigDecimal bigDec;
+            private ByteBuffer blob;
+            private Instant date;
+            private Instant epoch;
+            private Mood mood;
+            private Level level;
+            private String q;
+            private List<Integer> nums;
+            private Instant qtime;
+            private String note;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder text(String text) {
+                this.text = text;
+                return this;
+            }
+
+            public Builder media(String media) {
+                this.media = media;
+                return this;
+            }
+
+            public Builder tags(List<String> tags) {
+                this.tags = tags;
+                return this;
+            }
+
+            public Builder flag(Boolean flag) {
+                this.flag = flag;
+                return this;
+            }
+
+            public Builder byteValue(Byte byteValue) {
+                this.byteValue = byteValue;
+                return this;
+            }
+
+            public Builder shortValue(Short shortValue) {
+                this.shortValue = shortValue;
+                return this;
+            }
+
+            public Builder intValue(Integer intValue) {
+                this.intValue = intValue;
+                return this;
+            }
+
+            public Builder longValue(Long longValue) {
+                this.longValue = longValue;
+                return this;
+            }
+
+            public Builder floatValue(Float floatValue) {
+                this.floatValue = floatValue;
+                return this;
+            }
+
+            public Builder doubleValue(Double doubleValue) {
+                this.doubleValue = doubleValue;
+                return this;
+            }
+
+            public Builder bigInt(BigInteger bigInt) {
+                this.bigInt = bigInt;
+                return this;
+            }
+
+            public Builder bigDec(BigDecimal bigDec) {
+                this.bigDec = bigDec;
+                return this;
+            }
+
+            public Builder blob(ByteBuffer blob) {
+                this.blob = blob;
+                return this;
+            }
+
+            public Builder date(Instant date) {
+                this.date = date;
+                return this;
+            }
+
+            public Builder epoch(Instant epoch) {
+                this.epoch = epoch;
+                return this;
+            }
+
+            public Builder mood(Mood mood) {
+                this.mood = mood;
+                return this;
+            }
+
+            public Builder level(Level level) {
+                this.level = level;
+                return this;
+            }
+
+            public Builder q(String q) {
+                this.q = q;
+                return this;
+            }
+
+            public Builder nums(List<Integer> nums) {
+                this.nums = nums;
+                return this;
+            }
+
+            public Builder qtime(Instant qtime) {
+                this.qtime = qtime;
+                return this;
+            }
+
+            public Builder note(String note) {
+                this.note = note;
+                return this;
+            }
+
+            @Override
+            public Bound build() {
+                return new Bound(
+                        id,
+                        text,
+                        media,
+                        tags,
+                        flag,
+                        byteValue,
+                        shortValue,
+                        intValue,
+                        longValue,
+                        floatValue,
+                        doubleValue,
+                        bigInt,
+                        bigDec,
+                        blob,
+                        date,
+                        epoch,
+                        mood,
+                        level,
+                        q,
+                        nums,
+                        qtime,
+                        note);
+            }
+
+            @Override
+            public ShapeBuilder<Bound> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return SCHEMA;
+            }
+        }
+    }
+
+    public record Status(Integer code, String note) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#Status"))
+                .shapeClass(Status.class)
+                .builderSupplier(Builder::new)
+                .putMember("code", PreludeSchemas.INTEGER, new HttpResponseCodeTrait())
+                .putMember("note", PreludeSchemas.STRING)
+                .build();
+        static final ApiOperation<?, ?> OPERATION = operation("StatusOperation", SCHEMA, "/status");
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (code != null) {
+                serializer.writeInteger(SCHEMA.member("code"), code);
+            }
+            if (note != null) {
+                serializer.writeString(SCHEMA.member("note"), note);
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) switch (member.memberName()) {
+                case "code" -> code;
+                case "note" -> note;
+                default -> null;
+            };
+        }
+
+        public static final class Builder implements ShapeBuilder<Status> {
+            private Integer code;
+            private String note;
+
+            public Builder code(Integer code) {
+                this.code = code;
+                return this;
+            }
+
+            public Builder note(String note) {
+                this.note = note;
+                return this;
+            }
+
+            @Override
+            public Status build() {
+                return new Status(code, note);
+            }
+
+            @Override
+            public ShapeBuilder<Status> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return SCHEMA;
+            }
+        }
+    }
+
+    public record BodyOnly(String note) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#BodyOnly"))
+                .shapeClass(BodyOnly.class)
+                .builderSupplier(Builder::new)
+                .putMember("note", PreludeSchemas.STRING)
+                .build();
+        static final ApiOperation<?, ?> OPERATION = operation("BodyOnlyOperation", SCHEMA, "/body");
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (note != null) {
+                serializer.writeString(SCHEMA.member("note"), note);
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return "note".equals(member.memberName()) ? (T) note : null;
+        }
+
+        public static final class Builder implements ShapeBuilder<BodyOnly> {
+            private String note;
+
+            public Builder note(String note) {
+                this.note = note;
+                return this;
+            }
+
+            @Override
+            public BodyOnly build() {
+                return new BodyOnly(note);
+            }
+
+            @Override
+            public ShapeBuilder<BodyOnly> deserialize(ShapeDeserializer decoder) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return SCHEMA;
+            }
+        }
+    }
+
+    public record WithPayload(String token, String body) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#WithPayload"))
+                .shapeClass(WithPayload.class)
+                .putMember("token", PreludeSchemas.STRING, new HttpHeaderTrait("x-token"))
+                .putMember("body", PreludeSchemas.STRING, new HttpPayloadTrait())
+                .build();
+        static final ApiOperation<?, ?> OPERATION = operation("PayloadOperation", SCHEMA, "/payload");
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (token != null) {
+                serializer.writeString(SCHEMA.member("token"), token);
+            }
+            if (body != null) {
+                serializer.writeString(SCHEMA.member("body"), body);
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) switch (member.memberName()) {
+                case "token" -> token;
+                case "body" -> body;
+                default -> null;
+            };
+        }
+    }
+
+    public record WithPrefixHeaders(String token, Map<String, String> meta) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#WithPrefixHeaders"))
+                .shapeClass(WithPrefixHeaders.class)
+                .putMember("token", PreludeSchemas.STRING, new HttpHeaderTrait("x-token"))
+                .putMember("meta", STRING_MAP, new HttpPrefixHeadersTrait("x-meta-"))
+                .build();
+        static final ApiOperation<?, ?> OPERATION = operation("PrefixOperation", SCHEMA, "/prefix");
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (token != null) {
+                serializer.writeString(SCHEMA.member("token"), token);
+            }
+            if (meta != null) {
+                serializer.writeMap(SCHEMA.member("meta"), meta, meta.size(), (values, mapSerializer) -> {
+                    for (var entry : values.entrySet()) {
+                        mapSerializer.writeEntry(
+                                STRING_MAP.mapKeyMember(),
+                                entry.getKey(),
+                                entry.getValue(),
+                                (value, ser) -> ser.writeString(STRING_MAP.mapValueMember(), value));
+                    }
+                });
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) switch (member.memberName()) {
+                case "token" -> token;
+                case "meta" -> meta;
+                default -> null;
+            };
+        }
+    }
+
+    public record WithBlobPayload(ByteBuffer body) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#WithBlobPayload"))
+                .shapeClass(WithBlobPayload.class)
+                .putMember("body", PreludeSchemas.BLOB, new HttpPayloadTrait())
+                .build();
+        static final ApiOperation<?, ?> OPERATION = operation("BlobPayloadOperation", SCHEMA, "/blob-payload");
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (body != null) {
+                serializer.writeBlob(SCHEMA.member("body"), body);
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return "body".equals(member.memberName()) ? (T) body : null;
+        }
+    }
+
+    public record WithQueryParams(String token, Map<String, String> params) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#WithQueryParams"))
+                .shapeClass(WithQueryParams.class)
+                .putMember("token", PreludeSchemas.STRING, new HttpHeaderTrait("x-token"))
+                .putMember("params", STRING_MAP, new HttpQueryParamsTrait())
+                .build();
+        static final ApiOperation<?, ?> OPERATION = operation("QueryParamsOperation", SCHEMA, "/query-params");
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (token != null) {
+                serializer.writeString(SCHEMA.member("token"), token);
+            }
+            if (params != null) {
+                serializer.writeMap(SCHEMA.member("params"), params, params.size(), (values, mapSerializer) -> {
+                    for (var entry : values.entrySet()) {
+                        mapSerializer.writeEntry(
+                                STRING_MAP.mapKeyMember(),
+                                entry.getKey(),
+                                entry.getValue(),
+                                (value, ser) -> ser.writeString(STRING_MAP.mapValueMember(), value));
+                    }
+                });
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return (T) switch (member.memberName()) {
+                case "token" -> token;
+                case "params" -> params;
+                default -> null;
+            };
+        }
+    }
+
+    public record WithQueryListParams(Map<String, List<String>> params) implements SerializableStruct {
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#WithQueryListParams"))
+                .shapeClass(WithQueryListParams.class)
+                .putMember("params", STRING_LIST_MAP, new HttpQueryParamsTrait())
+                .build();
+        static final ApiOperation<?, ?> OPERATION =
+                operation("QueryListParamsOperation", SCHEMA, "/query-list-params");
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (params != null) {
+                serializer.writeMap(SCHEMA.member("params"), params, params.size(), (values, mapSerializer) -> {
+                    for (var entry : values.entrySet()) {
+                        mapSerializer.writeEntry(
+                                STRING_LIST_MAP.mapKeyMember(),
+                                entry.getKey(),
+                                entry.getValue(),
+                                (value, ser) -> ser.writeList(
+                                        STRING_LIST_MAP.mapValueMember(),
+                                        value,
+                                        value.size(),
+                                        (elements, elementSerializer) -> {
+                                            for (String element : elements) {
+                                                elementSerializer.writeString(STRING_LIST.listMember(), element);
+                                            }
+                                        }));
+                    }
+                });
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return "params".equals(member.memberName()) ? (T) params : null;
+        }
+    }
+
+    public record WithSparseHeaderList(List<String> tags) implements SerializableStruct {
+        private static final Schema SPARSE_TAGS = Schema
+                .listBuilder(ShapeId.from("smithy.example#SparseTags"), new SparseTrait())
+                .putMember("member", PreludeSchemas.STRING)
+                .build();
+        static final Schema SCHEMA = Schema.structureBuilder(ShapeId.from("smithy.example#WithSparseHeaderList"))
+                .shapeClass(WithSparseHeaderList.class)
+                .putMember("tags", SPARSE_TAGS, new HttpHeaderTrait("x-tags"))
+                .build();
+        static final ApiOperation<?, ?> OPERATION = operation("SparseHeadersOperation", SCHEMA, "/sparse");
+
+        @Override
+        public Schema schema() {
+            return SCHEMA;
+        }
+
+        @Override
+        public void serializeMembers(ShapeSerializer serializer) {
+            if (tags != null) {
+                serializer.writeList(SCHEMA.member("tags"), tags, tags.size(), (values, elementSerializer) -> {
+                    for (String value : values) {
+                        if (value == null) {
+                            elementSerializer.writeNull(SPARSE_TAGS.listMember());
+                        } else {
+                            elementSerializer.writeString(SPARSE_TAGS.listMember(), value);
+                        }
+                    }
+                });
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getMemberValue(Schema member) {
+            return "tags".equals(member.memberName()) ? (T) tags : null;
+        }
+    }
+
+    private static final Schema STRING_MAP = Schema.mapBuilder(ShapeId.from("smithy.example#StringMap"))
+            .putMember("key", PreludeSchemas.STRING)
+            .putMember("value", PreludeSchemas.STRING)
+            .build();
+    private static final Schema STRING_LIST = Schema.listBuilder(ShapeId.from("smithy.example#StringList"))
+            .putMember("member", PreludeSchemas.STRING)
+            .build();
+    private static final Schema STRING_LIST_MAP =
+            Schema.mapBuilder(ShapeId.from("smithy.example#StringListMap"))
+                    .putMember("key", PreludeSchemas.STRING)
+                    .putMember("value", STRING_LIST)
+                    .build();
+
+    private static ApiOperation<?, ?> operation(String name, Schema inputSchema, String uri) {
+        var httpTrait = HttpTrait.builder().method("POST").uri(UriPattern.parse(uri)).code(200).build();
+        var operationSchema = Schema.createOperation(ShapeId.from("smithy.example#" + name), httpTrait);
+        return new ApiOperation<>() {
+            @Override
+            public ShapeBuilder<SerializableStruct> inputBuilder() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ShapeBuilder<SerializableStruct> outputBuilder() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Schema schema() {
+                return operationSchema;
+            }
+
+            @Override
+            public Schema inputSchema() {
+                return inputSchema;
+            }
+
+            @Override
+            public Schema outputSchema() {
+                return inputSchema;
+            }
+
+            @Override
+            public TypeRegistry errorRegistry() {
+                return TypeRegistry.builder().build();
+            }
+
+            @Override
+            public List<ShapeId> effectiveAuthSchemes() {
+                return List.of();
+            }
+
+            @Override
+            public List<Schema> errorSchemas() {
+                return List.of();
+            }
+
+            @Override
+            public ApiService service() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
### What behavior changes?
Adds opt-in runtime-generated HTTP binding writers and `MemberSubsetCodec`; wire output remains unchanged, with fallback unless strict mode is selected.

### Why is this change needed?
Removes per-member binding-table lookup and type dispatch from HTTP serialization; `restJson1_CopyObjectRequest_M` improved from 992 to 902 ns/op mean on an m7i.xlarge.

### How was this validated?
The HTTP binding suite runs on JDK 25 in strict mode, with focused tests for wire formats, dynamic bindings, payloads, body subsets, and header-injection validation.

### What should reviewers focus on?
Review trusted versus validated header values, generated type formatting, and fallback behavior for body subset serialization and direct deserialization.

### Additional Links
Stacked on #1353.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.