### PR TITLE
Serialize maps with Map.forEach in generated serializers

### DIFF
--- a/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
+++ b/codegen/codegen-core/src/main/java/software/amazon/smithy/java/codegen/generators/MapGenerator.java
@@ -59,14 +59,12 @@ public final class MapGenerator
                                                 @Override
                                                 public void accept(${shape:T} values, ${mapSerializer:T} serializer) {
                                                     var $$k = ${keySchema:L}.mapKeyMember();
-                                                    for (var valueEntry : values.entrySet()) {
-                                                        serializer.writeEntry(
-                                                            $$k,
-                                                            valueEntry.getKey()${?enumKey}.getValue()${/enumKey},
-                                                            valueEntry.getValue(),
-                                                            ${name:U}$$ValueSerializer.INSTANCE
-                                                        );
-                                                    }
+                                                    values.forEach((k, v) -> serializer.writeEntry(
+                                                        $$k,
+                                                        k${?enumKey}.getValue()${/enumKey},
+                                                        v,
+                                                        ${name:U}$$ValueSerializer.INSTANCE
+                                                    ));
                                                 }
                                             }
 

--- a/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/expected/SharedSerde.java
+++ b/codegen/codegen-plugin/src/test/resources/software/amazon/smithy/java/codegen/types/test-cases/sparse-vs-dense-collections/expected/SharedSerde.java
@@ -24,14 +24,12 @@ final class SharedSerde {
         @Override
         public void accept(Map<String, String> values, MapSerializer serializer) {
             var $k = Schemas.SPARSE_MAP.mapKeyMember();
-            for (var valueEntry : values.entrySet()) {
-                serializer.writeEntry(
-                    $k,
-                    valueEntry.getKey(),
-                    valueEntry.getValue(),
-                    SparseMap$ValueSerializer.INSTANCE
-                );
-            }
+            values.forEach((k, v) -> serializer.writeEntry(
+                $k,
+                k,
+                v,
+                SparseMap$ValueSerializer.INSTANCE
+            ));
         }
     }
 
@@ -121,14 +119,12 @@ final class SharedSerde {
         @Override
         public void accept(Map<String, String> values, MapSerializer serializer) {
             var $k = Schemas.DENSE_MAP.mapKeyMember();
-            for (var valueEntry : values.entrySet()) {
-                serializer.writeEntry(
-                    $k,
-                    valueEntry.getKey(),
-                    valueEntry.getValue(),
-                    DenseMap$ValueSerializer.INSTANCE
-                );
-            }
+            values.forEach((k, v) -> serializer.writeEntry(
+                $k,
+                k,
+                v,
+                DenseMap$ValueSerializer.INSTANCE
+            ));
         }
     }
 


### PR DESCRIPTION
### What behavior changes?
Generated map serializers iterate with `Map.forEach` instead of `entrySet()`. Serialized output stays byte-identical.

### Why is this change needed?
Performance. `entrySet()` on the unmodifiable map wrappers walks a six-call iterator chain and wraps each entry in a view object. `forEach` delegates straight to the backing map and hands the key and value over directly.

### How was this validated?
Updated codegen expected-file tests, plus a JMH A/B against the parent commit on EC2 (4 vCPU, Corretto 25, sample mode, 1 fork, 1x5s warmup + 3x5s measurement, `-prof gc`):

| case | p50 before | p50 after | Δ p50 | ops/cpu-s before | ops/cpu-s after | Δ ops | alloc before | alloc after | Δ alloc |
|---|---|---|---|---|---|---|---|---|---|
| awsJson1_0 PutItem ShallowMap_M | 2,064 ns | 1,898 ns | **-8.0%** | 472,025 | 511,446 | +8.4% | 2,496 B/op | 2,488 B/op | -8 B |
| awsJson1_0 PutItem ShallowMap_L | 7,112 ns | 5,624 ns | **-20.9%** | 141,567 | 172,114 | +21.6% | 7,160 B/op | 7,152 B/op | -8 B |
| awsJson1_0 PutItem Nested_L | 1,062 ns | 736 ns | **-30.7%** | 944,196 | 1,364,554 | +44.5% | 1,416 B/op | 1,288 B/op | -128 B |
| rpcv2Cbor PutItem ShallowMap_L | 5,968 ns | 5,504 ns | **-7.8%** | 160,843 | 175,791 | +9.3% | 5,744 B/op | 5,744 B/op | 0 B |

The speedup comes from cutting iterator call-chain CPU. Allocation stays nearly flat because escape analysis already scalar-replaces most entry views.

### What should reviewers focus on?
The template change in `MapGenerator.java`. The capturing lambda is intentional: each generated lambda class keeps the value-serializer call site monomorphic, and a zero-allocation shared-callback variant benchmarked 17-38% slower.

### Additional Links
Part of the serde optimization stack. Sits between the wide-type benchmarks (#1360, the base branch) and the runtime-codegen serde work.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
