### PR TITLE
Encode base64 into a reusable scratch buffer

### DIFF
--- a/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonSerializer.java
+++ b/codecs/json-codec/src/main/java/software/amazon/smithy/java/json/smithy/SmithyJsonSerializer.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.java.core.serde.ShapeSerializer;
 import software.amazon.smithy.java.core.serde.SpecificShapeSerializer;
 import software.amazon.smithy.java.core.serde.TimestampFormatter;
 import software.amazon.smithy.java.core.serde.document.Document;
+import software.amazon.smithy.java.io.ByteBufferUtils;
 import software.amazon.smithy.java.json.JsonFieldMapper;
 import software.amazon.smithy.java.json.JsonSettings;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -36,11 +37,12 @@ final class SmithyJsonSerializer implements ShapeSerializer {
 
     private static final int MAX_DEPTH = 64;
     private static final int DEFAULT_BUF_SIZE = 8192;
-    private static final int MAX_CACHEABLE_BUF = DEFAULT_BUF_SIZE * 4;
+    private static final int MAX_CACHEABLE_BUF = DEFAULT_BUF_SIZE * 16;
 
     private static final StripedPool<SmithyJsonSerializer, JsonSettings> POOL = new JsonStripedPool();
 
     private byte[] buf;
+    private byte[] base64Scratch;
     private int pos;
     private final OutputStream sink;
     private final JsonSettings settings;
@@ -222,14 +224,36 @@ final class SmithyJsonSerializer implements ShapeSerializer {
 
     @Override
     public void writeBlob(Schema schema, byte[] value) {
-        ensureCapacity(JsonWriteUtils.maxBase64Bytes(value.length));
-        pos = JsonWriteUtils.writeBase64String(buf, pos, value, 0, value.length);
+        writeBlobValue(ByteBuffer.wrap(value));
     }
 
     @Override
     public void writeBlob(Schema schema, ByteBuffer value) {
-        ensureCapacity(JsonWriteUtils.maxBase64Bytes(value.remaining()));
+        writeBlobValue(value);
+    }
+
+    private void writeBlobValue(ByteBuffer value) {
+        int remaining = value.remaining();
+        ensureCapacity(ByteBufferUtils.base64EncodedSize(remaining) + 2);
+        if (remaining >= 32) {
+            byte[] b = buf;
+            int p = pos;
+            b[p++] = '"';
+            p += ByteBufferUtils.base64EncodeTo(value, b, p, base64Scratch(remaining));
+            b[p++] = '"';
+            pos = p;
+            return;
+        }
         pos = JsonWriteUtils.writeBase64String(buf, pos, value);
+    }
+
+    private byte[] base64Scratch(int dataLen) {
+        int capacity = ByteBufferUtils.base64EncodedSize(dataLen);
+        byte[] scratch = base64Scratch;
+        if (scratch == null || scratch.length < capacity) {
+            scratch = base64Scratch = new byte[capacity];
+        }
+        return scratch;
     }
 
     @Override
@@ -398,6 +422,9 @@ final class SmithyJsonSerializer implements ShapeSerializer {
         protected void prepareForPool(SmithyJsonSerializer s) {
             if (s.buf.length > MAX_CACHEABLE_BUF) {
                 s.buf = new byte[DEFAULT_BUF_SIZE];
+            }
+            if (s.base64Scratch != null && s.base64Scratch.length > MAX_CACHEABLE_BUF) {
+                s.base64Scratch = null;
             }
         }
 

--- a/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/SmithyXmlSerializer.java
+++ b/codecs/xml-codec/src/main/java/software/amazon/smithy/java/xml/SmithyXmlSerializer.java
@@ -41,6 +41,7 @@ final class SmithyXmlSerializer extends InterceptingSerializer {
     private static final StripedPool<SmithyXmlSerializer, AcquireContext> POOL = new XmlStripedPool();
 
     private byte[] buf;
+    private byte[] base64Scratch;
     private int pos;
     private OutputStream sink;
     private XmlNamespaceTrait defaultNamespace;
@@ -108,6 +109,15 @@ final class SmithyXmlSerializer extends InterceptingSerializer {
 
     private void grow(int needed) {
         buf = Arrays.copyOf(buf, Math.max(buf.length * 2, pos + needed));
+    }
+
+    private byte[] base64Scratch(int dataLen) {
+        int capacity = ByteBufferUtils.base64EncodedSize(dataLen);
+        byte[] scratch = base64Scratch;
+        if (scratch == null || scratch.length < capacity) {
+            scratch = base64Scratch = new byte[capacity];
+        }
+        return scratch;
     }
 
     @Override
@@ -265,6 +275,9 @@ final class SmithyXmlSerializer extends InterceptingSerializer {
         protected void prepareForPool(SmithyXmlSerializer s) {
             if (s.buf.length > MAX_CACHEABLE_BUF) {
                 s.buf = new byte[DEFAULT_BUF_SIZE];
+            }
+            if (s.base64Scratch != null && s.base64Scratch.length > MAX_CACHEABLE_BUF) {
+                s.base64Scratch = null;
             }
         }
 
@@ -600,10 +613,9 @@ final class SmithyXmlSerializer extends InterceptingSerializer {
         @Override
         public void writeBlob(Schema schema, ByteBuffer value) {
             closePendingTag();
-            byte[] encoded = ByteBufferUtils.base64EncodeToBytes(value);
-            ensureCapacity(encoded.length);
-            System.arraycopy(encoded, 0, buf, pos, encoded.length);
-            pos += encoded.length;
+            int remaining = value.remaining();
+            ensureCapacity(ByteBufferUtils.base64EncodedSize(remaining));
+            pos += ByteBufferUtils.base64EncodeTo(value, buf, pos, base64Scratch(remaining));
         }
 
         @Override

--- a/io/src/main/java/software/amazon/smithy/java/io/ByteBufferUtils.java
+++ b/io/src/main/java/software/amazon/smithy/java/io/ByteBufferUtils.java
@@ -28,6 +28,38 @@ public final class ByteBufferUtils {
                 : BASE64_ENCODER.encode(buffer.duplicate()).array();
     }
 
+    /**
+     * Number of bytes {@link #base64EncodeTo} writes for {@code dataLen} bytes of input.
+     */
+    public static int base64EncodedSize(int dataLen) {
+        return ((dataLen + 2) / 3) * 4;
+    }
+
+    /**
+     * Base64-encodes {@code buffer} into {@code scratch} starting at index 0, returning the number
+     * of bytes written. {@code scratch} must be at least {@link #base64EncodedSize} of the buffer's
+     * remaining bytes. The buffer's position is not consumed.
+     */
+    public static int base64EncodeInto(ByteBuffer buffer, byte[] scratch) {
+        if (isExact(buffer)) {
+            return BASE64_ENCODER.encode(buffer.array(), scratch);
+        }
+        byte[] encoded = BASE64_ENCODER.encode(buffer.duplicate()).array();
+        System.arraycopy(encoded, 0, scratch, 0, encoded.length);
+        return encoded.length;
+    }
+
+    /**
+     * Base64-encodes {@code buffer} into {@code dst} starting at {@code dstOffset}, returning the
+     * number of bytes written. The buffer's position is not consumed. {@code scratch} follows the
+     * {@link #base64EncodeInto} contract.
+     */
+    public static int base64EncodeTo(ByteBuffer buffer, byte[] dst, int dstOffset, byte[] scratch) {
+        int written = base64EncodeInto(buffer, scratch);
+        System.arraycopy(scratch, 0, dst, dstOffset, written);
+        return written;
+    }
+
     public static String getUTF8String(ByteBuffer buffer) {
         var bytes = getBytes(buffer);
         return new String(bytes, StandardCharsets.UTF_8);

--- a/io/src/test/java/software/amazon/smithy/java/io/ByteBufferUtilsTest.java
+++ b/io/src/test/java/software/amazon/smithy/java/io/ByteBufferUtilsTest.java
@@ -34,4 +34,43 @@ public class ByteBufferUtilsTest {
         assertThat(ByteBufferUtils.base64EncodeToBytes(buffer)).isEqualTo(expected);
         assertThat(buffer.position()).isEqualTo(position);
     }
+
+    @Test
+    public void base64EncodeToWritesAtOffsetForAllBufferShapes() {
+        byte[] data = "prefix-hello-suffix".getBytes(StandardCharsets.UTF_8);
+        byte[] expected = Base64.getEncoder()
+                .encode("hello".getBytes(StandardCharsets.UTF_8));
+
+        assertEncodeTo(expected, ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+        assertEncodeTo(expected, ByteBuffer.wrap(data, 7, 5));
+        assertEncodeTo(expected, ByteBuffer.wrap(data, 7, 5).asReadOnlyBuffer());
+
+        ByteBuffer direct = ByteBuffer.allocateDirect(data.length);
+        direct.put(data).position(7).limit(12);
+        assertEncodeTo(expected, direct);
+    }
+
+    @Test
+    public void base64EncodedSizeMatchesJdkOutput() {
+        for (int len = 0; len < 12; len++) {
+            byte[] encoded = Base64.getEncoder().encode(new byte[len]);
+            assertThat(ByteBufferUtils.base64EncodedSize(len)).isEqualTo(encoded.length);
+        }
+    }
+
+    private static void assertEncodeTo(byte[] expected, ByteBuffer buffer) {
+        int position = buffer.position();
+        byte[] scratch = new byte[ByteBufferUtils.base64EncodedSize(buffer.remaining())];
+        byte[] dst = new byte[expected.length + 3];
+        dst[0] = '<';
+        int written = ByteBufferUtils.base64EncodeTo(buffer, dst, 1, scratch);
+
+        assertThat(written).isEqualTo(expected.length);
+        byte[] region = new byte[written];
+        System.arraycopy(dst, 1, region, 0, written);
+        assertThat(region).isEqualTo(expected);
+        assertThat(dst[0]).isEqualTo((byte) '<');
+        assertThat(dst[written + 1]).isEqualTo((byte) 0);
+        assertThat(buffer.position()).isEqualTo(position);
+    }
 }


### PR DESCRIPTION
### What behavior changes?
The pooled JSON and XML dispatch serializers encode base64 into a reusable per-serializer scratch buffer, and `SmithyJsonSerializer` keeps grown buffers in its pool. Serialized output stays byte-identical.

### Why is this change needed?
Performance. The JDK base64 encoder returns a fresh array per call; on large blobs that intermediate array plus per-op buffer regrowth dominates time and allocation (429 KB/op on BinaryData_L).

### How was this validated?
New `ByteBufferUtilsTest`, plus a JMH A/B against the parent commit on EC2 (4 vCPU, Corretto 25, sample mode, 1 fork, 1x5s warmup + 3x5s measurement, `-prof gc`):

| case | p50 before | p50 after | Δ p50 | ops/cpu-s before | ops/cpu-s after | Δ ops | alloc before | alloc after | Δ alloc |
|---|---|---|---|---|---|---|---|---|---|
| awsJson1_0 PutItem BinaryData_S | 182 ns | 179 ns | -1.6% | 6,099,810 | 6,338,596 | +3.9% | 784 B/op | 648 B/op | **-17.3%** |
| awsJson1_0 PutItem BinaryData_M | 2,112 ns | 1,474 ns | **-30.2%** | 454,598 | 662,256 | **+45.7%** | 20,056 B/op | 10,296 B/op | **-48.7%** |
| awsJson1_0 PutItem BinaryData_L | 37,760 ns | 12,064 ns | **-68.1%** | 25,433 | 79,242 | **+211.6%** | 429,042 B/op | 87,361 B/op | **-79.6%** |
| restXml WideTypesRequest_L | 5,112 ns | 5,176 ns | +1.3% | 187,852 | 185,954 | -1.0% | 6,856 B/op | 6,728 B/op | -1.9% |

BinaryData_S validates the sub-32B skip path: time stays flat and small blobs still drop 17% of their allocation. restXml WideTypesRequest_L serves as a no-regression check; its blobs are ~10 B, under the scratch threshold, so the XML scratch path awaits a benchmark case with larger in-body blobs.

### What should reviewers focus on?
The `ByteBufferUtils.base64EncodeInto`/`base64EncodeTo` contract, the scratch lifecycle in the pooled serializers (sizing, the 32 B threshold, drop-on-release when oversized), and the raised buffer-pool retention cap in `SmithyJsonSerializer`.

### Additional Links
None.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
